### PR TITLE
feat: local session with PtyTransport ABC

### DIFF
--- a/src/tabula/serve.py
+++ b/src/tabula/serve.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from .canvas_adapter import CanvasAdapter
 from .events import CanvasEvent, event_to_payload
 from .mcp_server import TabulaMcpServer
+from .protocol import _ensure_gitignore
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 9420
@@ -30,6 +31,7 @@ async def broadcast_ws(clients: set[web.WebSocketResponse], message: str) -> Non
 class TabulaServeApp:
     def __init__(self, *, project_dir: Path) -> None:
         self._project_dir = project_dir.resolve()
+        _ensure_gitignore(self._project_dir)
         self._ws_clients: set[web.WebSocketResponse] = set()
         self._pending_events: list[CanvasEvent] = []
         self._event_lock = threading.Lock()

--- a/src/tabula/web/pty.py
+++ b/src/tabula/web/pty.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+import pty as pty_module
+import struct
+import termios
+from abc import ABC, abstractmethod
+from typing import Any
+
+from aiohttp import web
+
+
+class PtyTransport(ABC):
+    """Abstract PTY transport for terminal WebSocket sessions."""
+
+    @abstractmethod
+    def write(self, data: bytes) -> None: ...
+
+    @abstractmethod
+    def resize(self, cols: int, rows: int) -> None: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+    @abstractmethod
+    async def reader(self, ws: web.WebSocketResponse) -> None: ...
+
+
+class LocalPtyTransport(PtyTransport):
+    """PTY transport using a local subprocess."""
+
+    def __init__(self, master_fd: int, process: asyncio.subprocess.Process) -> None:
+        self._fd = master_fd
+        self._process = process
+
+    @classmethod
+    async def open(cls, cwd: str) -> LocalPtyTransport:
+        master_fd, slave_fd = pty_module.openpty()
+        process = await asyncio.create_subprocess_exec(
+            os.environ.get("SHELL", "/bin/bash"),
+            stdin=slave_fd, stdout=slave_fd, stderr=slave_fd,
+            process_group=0,
+            cwd=cwd,
+        )
+        os.close(slave_fd)
+        os.set_blocking(master_fd, False)
+        return cls(master_fd, process)
+
+    def write(self, data: bytes) -> None:
+        os.write(self._fd, data)
+
+    def resize(self, cols: int, rows: int) -> None:
+        fcntl.ioctl(self._fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+    def close(self) -> None:
+        try:
+            os.close(self._fd)
+        except OSError:
+            pass
+        try:
+            self._process.terminate()
+        except ProcessLookupError:
+            pass
+
+    async def reader(self, ws: web.WebSocketResponse) -> None:
+        loop = asyncio.get_running_loop()
+        fd = self._fd
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+        def _on_readable() -> None:
+            try:
+                data = os.read(fd, 4096)
+                queue.put_nowait(data if data else None)
+            except OSError:
+                queue.put_nowait(None)
+
+        loop.add_reader(fd, _on_readable)
+        try:
+            while True:
+                data = await queue.get()
+                if data is None:
+                    break
+                await ws.send_bytes(data)
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass
+        finally:
+            try:
+                loop.remove_reader(fd)
+            except (ValueError, OSError):
+                pass
+
+
+class SshPtyTransport(PtyTransport):
+    """PTY transport over SSH using asyncssh."""
+
+    def __init__(self, process: Any) -> None:
+        self._process = process
+
+    def write(self, data: bytes) -> None:
+        self._process.stdin.write(data)
+
+    def resize(self, cols: int, rows: int) -> None:
+        self._process.change_terminal_size(cols, rows)
+
+    def close(self) -> None:
+        self._process.close()
+
+    async def reader(self, ws: web.WebSocketResponse) -> None:
+        try:
+            while not self._process.stdout.at_eof():
+                data = await self._process.stdout.read(4096)
+                if not data:
+                    break
+                if isinstance(data, bytes):
+                    await ws.send_bytes(data)
+                else:
+                    await ws.send_str(data)
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass

--- a/src/tabula/web/server.py
+++ b/src/tabula/web/server.py
@@ -13,6 +13,7 @@ import aiohttp
 from aiohttp import web
 
 from ..serve import broadcast_ws
+from .pty import LocalPtyTransport, PtyTransport, SshPtyTransport
 from .ssh import SSHService
 from .store import Store
 
@@ -24,6 +25,7 @@ SESSION_COOKIE = "tabula_session"
 DAEMON_PORT = 9420
 DAEMON_STARTUP_TIMEOUT = 10.0
 DAEMON_HEALTH_POLL_INTERVAL = 0.5
+LOCAL_SESSION_ID = "local"
 
 
 class TabulaWebApp:
@@ -66,10 +68,13 @@ class TabulaWebApp:
             raise web.HTTPBadRequest(text="invalid host id")
 
     async def handle_setup_check(self, request: web.Request) -> web.Response:
-        return web.json_response({
+        result: dict[str, Any] = {
             "has_password": self._store.has_admin_password(),
             "authenticated": self._check_auth(request),
-        })
+        }
+        if self._local_project_dir:
+            result["local_session"] = LOCAL_SESSION_ID
+        return web.json_response(result)
 
     async def handle_setup_password(self, request: web.Request) -> web.Response:
         if self._store.has_admin_password():
@@ -188,54 +193,46 @@ class TabulaWebApp:
         self._remote_canvas_ws.pop(session_id, None)
         return web.json_response({"ok": True})
 
-    @staticmethod
-    async def _pty_reader(process: Any, ws: web.WebSocketResponse) -> None:
-        try:
-            while not process.stdout.at_eof():
-                data = await process.stdout.read(4096)
-                if not data:
-                    break
-                if isinstance(data, bytes):
-                    await ws.send_bytes(data)
-                else:
-                    await ws.send_str(data)
-        except (asyncio.CancelledError, ConnectionResetError):
-            pass
+    async def _create_pty_transport(self, session_id: str) -> PtyTransport:
+        if session_id == LOCAL_SESSION_ID and self._local_project_dir:
+            return await LocalPtyTransport.open(str(self._local_project_dir))
+        ssh_session = self._ssh.get_session(session_id)
+        if ssh_session is None:
+            raise web.HTTPNotFound(text="session not found")
+        process = await self._ssh.open_pty(session_id)
+        return SshPtyTransport(process)
 
     async def handle_terminal_ws(self, request: web.Request) -> web.WebSocketResponse:
         if not self._check_auth(request):
             raise web.HTTPUnauthorized(text="unauthorized")
 
         session_id = request.match_info["session_id"]
-        ssh_session = self._ssh.get_session(session_id)
-        if ssh_session is None:
-            raise web.HTTPNotFound(text="session not found")
-
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         self._terminal_ws[session_id] = ws
 
-        process = await self._ssh.open_pty(session_id)
-        read_task = asyncio.create_task(self._pty_reader(process, ws))
+        transport = await self._create_pty_transport(session_id)
+        read_task = asyncio.create_task(transport.reader(ws))
 
         try:
             async for msg in ws:
                 if msg.type == aiohttp.WSMsgType.BINARY:
-                    process.stdin.write(msg.data)
+                    transport.write(msg.data)
                 elif msg.type == aiohttp.WSMsgType.TEXT:
                     try:
                         cmd = json.loads(msg.data)
                     except json.JSONDecodeError:
-                        process.stdin.write(msg.data.encode("utf-8"))
+                        transport.write(msg.data.encode("utf-8"))
                         continue
                     if cmd.get("type") == "resize":
-                        await self._ssh.resize_pty(session_id, cmd.get("cols", 120), cmd.get("rows", 40))
+                        transport.resize(cmd.get("cols", 120), cmd.get("rows", 40))
                     else:
-                        process.stdin.write(msg.data.encode("utf-8"))
+                        transport.write(msg.data.encode("utf-8"))
                 elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSE):
                     break
         finally:
             read_task.cancel()
+            transport.close()
             self._terminal_ws.pop(session_id, None)
 
         return ws
@@ -359,9 +356,14 @@ class TabulaWebApp:
 
     async def handle_sessions_list(self, request: web.Request) -> web.Response:
         self._require_auth(request)
-        return web.json_response({
-            "sessions": self._ssh.list_sessions(),
-        })
+        result: dict[str, Any] = {"sessions": self._ssh.list_sessions()}
+        if self._local_project_dir:
+            result["local_session"] = {
+                "session_id": LOCAL_SESSION_ID,
+                "project_dir": str(self._local_project_dir),
+                "mcp_url": f"http://127.0.0.1:{DAEMON_PORT}/mcp",
+            }
+        return web.json_response(result)
 
     async def _start_local_serve(self, app: web.Application) -> None:
         if self._local_project_dir is None:
@@ -381,6 +383,8 @@ class TabulaWebApp:
                 f"port {DAEMON_PORT} already in use; is another tabula serve running?"
             ) from exc
         self._local_serve_runner = runner
+        self._tunnel_ports[LOCAL_SESSION_ID] = DAEMON_PORT
+        self._start_canvas_relay(LOCAL_SESSION_ID, DAEMON_PORT)
 
     async def _on_shutdown(self, app: web.Application) -> None:
         for task in self._canvas_relay_tasks.values():

--- a/src/tabula/web/ssh.py
+++ b/src/tabula/web/ssh.py
@@ -71,12 +71,6 @@ class SSHService:
         session.pty = process
         return process
 
-    async def resize_pty(self, session_id: str, width: int, height: int) -> None:
-        session = self._sessions.get(session_id)
-        if session is None or session.pty is None:
-            return
-        session.pty.change_terminal_size(width, height)
-
     async def create_tunnel(self, session_id: str, remote_port: int, local_host: str = "127.0.0.1") -> int:
         session = self._sessions.get(session_id)
         if session is None:

--- a/src/tabula/web/static/app.js
+++ b/src/tabula/web/static/app.js
@@ -12,6 +12,8 @@ const state = {
   canvasWs: null,
   tunnelPort: null,
   connected: false,
+  localSession: null,
+  mcpUrl: null,
 };
 
 export function getState() { return state; }
@@ -25,7 +27,37 @@ function showView(viewId) {
 
 export function showMain() {
   showView('view-main');
-  refreshHosts();
+  if (state.localSession) {
+    connectLocalSession();
+  } else {
+    refreshHosts();
+  }
+}
+
+async function connectLocalSession() {
+  try {
+    const resp = await fetch('/api/sessions');
+    if (!resp.ok) { refreshHosts(); return; }
+    const data = await resp.json();
+    if (!data.local_session) { refreshHosts(); return; }
+
+    state.sessionId = data.local_session.session_id;
+    state.mcpUrl = data.local_session.mcp_url;
+    state.connected = true;
+    state.localSession = data.local_session;
+
+    document.getElementById('host-select').style.display = 'none';
+    document.getElementById('btn-connect').style.display = 'none';
+    document.getElementById('btn-disconnect').style.display = 'none';
+    document.getElementById('btn-launch-ai').disabled = false;
+    setStatus(`local: ${data.local_session.project_dir}`, 'connected');
+
+    openTerminal();
+    openCanvasWs();
+  } catch (e) {
+    console.error('local session connect failed:', e);
+    refreshHosts();
+  }
 }
 
 export function showHosts() {
@@ -208,27 +240,28 @@ async function launchAI() {
   const term = window._tabulaTerminal;
   if (!term || !state.terminalWs) return;
 
-  try {
-    const resp = await fetch('/api/daemon/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: state.sessionId }),
-    });
-    if (!resp.ok) {
-      const text = await resp.text();
-      writeToTerminal(`\r\n[daemon start failed: ${text}]\r\n`);
+  if (!state.localSession) {
+    try {
+      const resp = await fetch('/api/daemon/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: state.sessionId }),
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        writeToTerminal(`\r\n[daemon start failed: ${text}]\r\n`);
+        return;
+      }
+      const data = await resp.json();
+      state.tunnelPort = data.tunnel_port;
+    } catch (e) {
+      writeToTerminal(`\r\n[daemon start error: ${e.message}]\r\n`);
       return;
     }
-    const data = await resp.json();
-    state.tunnelPort = data.tunnel_port;
-  } catch (e) {
-    writeToTerminal(`\r\n[daemon start error: ${e.message}]\r\n`);
-    return;
+    openCanvasWs();
   }
 
-  openCanvasWs();
-
-  const mcpUrl = `http://127.0.0.1:${state.tunnelPort}/mcp`;
+  const mcpUrl = state.mcpUrl || `http://127.0.0.1:${state.tunnelPort}/mcp`;
   const cmd = `tabula run --assistant ${assistant} --mcp-url ${mcpUrl}\n`;
 
   if (state.terminalWs.readyState === WebSocket.OPEN) {
@@ -291,6 +324,9 @@ async function init() {
   try {
     const resp = await fetch('/api/setup');
     const data = await resp.json();
+    if (data.local_session) {
+      state.localSession = { session_id: data.local_session };
+    }
     if (data.authenticated) {
       state.authenticated = true;
       showMain();

--- a/tests/unit/test_pty_transport.py
+++ b/tests/unit/test_pty_transport.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from tabula.web.pty import LocalPtyTransport, PtyTransport, SshPtyTransport
+
+
+def test_local_pty_transport_is_pty_transport() -> None:
+    assert issubclass(LocalPtyTransport, PtyTransport)
+
+
+def test_ssh_pty_transport_is_pty_transport() -> None:
+    assert issubclass(SshPtyTransport, PtyTransport)
+
+
+def test_local_pty_echo(tmp_path: Path) -> None:
+    async def _run() -> None:
+        transport = await LocalPtyTransport.open(str(tmp_path))
+        try:
+            transport.write(b"echo hello-tabula-test\n")
+            output = b""
+            for _ in range(50):
+                await asyncio.sleep(0.05)
+                try:
+                    chunk = os.read(transport._fd, 4096)
+                    output += chunk
+                except BlockingIOError:
+                    continue
+            assert b"hello-tabula-test" in output
+        finally:
+            transport.close()
+
+    asyncio.run(_run())
+
+
+def test_local_pty_resize(tmp_path: Path) -> None:
+    async def _run() -> None:
+        transport = await LocalPtyTransport.open(str(tmp_path))
+        try:
+            transport.resize(80, 24)
+        finally:
+            transport.close()
+
+    asyncio.run(_run())

--- a/tests/unit/test_web_server.py
+++ b/tests/unit/test_web_server.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
 
-from tabula.web.server import TabulaWebApp
+from tabula.web.server import LOCAL_SESSION_ID, TabulaWebApp
 
 
-async def _make_client(data_dir: Path) -> TestClient:
-    app_obj = TabulaWebApp(data_dir=data_dir)
+async def _make_client(data_dir: Path, *, local_project_dir: Path | None = None) -> TestClient:
+    app_obj = TabulaWebApp(data_dir=data_dir, local_project_dir=local_project_dir)
     app = app_obj.create_app()
     return TestClient(TestServer(app))
 
@@ -233,5 +233,44 @@ def test_sessions_list(tmp_path: Path) -> None:
             assert resp.status == 200
             data = await resp.json()
             assert data["sessions"] == []
+            assert "local_session" not in data
+
+    asyncio.run(_run())
+
+
+def test_setup_check_no_local_session(tmp_path: Path) -> None:
+    async def _run() -> None:
+        client = await _make_client(tmp_path)
+        async with client:
+            resp = await client.get("/api/setup")
+            data = await resp.json()
+            assert "local_session" not in data
+
+    asyncio.run(_run())
+
+
+def test_setup_check_local_session(tmp_path: Path) -> None:
+    async def _run() -> None:
+        client = await _make_client(tmp_path, local_project_dir=tmp_path)
+        async with client:
+            resp = await client.get("/api/setup")
+            data = await resp.json()
+            assert data["local_session"] == LOCAL_SESSION_ID
+
+    asyncio.run(_run())
+
+
+def test_sessions_list_with_local(tmp_path: Path) -> None:
+    async def _run() -> None:
+        client = await _make_client(tmp_path, local_project_dir=tmp_path)
+        async with client:
+            await _authenticate(client)
+            resp = await client.get("/api/sessions")
+            assert resp.status == 200
+            data = await resp.json()
+            local = data["local_session"]
+            assert local["session_id"] == LOCAL_SESSION_ID
+            assert local["project_dir"] == str(tmp_path)
+            assert "mcp_url" in local
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Extract `PtyTransport` ABC with `LocalPtyTransport` and `SshPtyTransport` - terminal WS handler uses uniform interface, zero branching
- Auto-create local session when `--project-dir` is passed (opt-in, off by default)
- Local session: embedded serve daemon, local PTY, canvas relay, auto-connect in frontend
- Serve daemon ensures `.tabula/artifacts/` is gitignored in the project directory
- Non-destructive: no files written to project dir; web data in `~/.tabula-web/`

## Non-destructive guarantee
- `TabulaServeApp` only calls `_ensure_gitignore()` (appends `.tabula/artifacts/` to `.gitignore` if missing)
- No other files created in the project directory by the serve daemon (`start_canvas=False`)
- Web server stores SQLite DB and session data in `~/.tabula-web/` (separate from project)
- Local PTY operates in the project dir but writes nothing

## Test plan
- [x] 151 tests pass, 2 skipped (pre-existing env-gated)
- [x] PtyTransport: subclass checks, local PTY echo, local PTY resize (4 tests)
- [x] Web server: setup check without/with local session, sessions list with local (3 tests)
- [x] Dead code removed: `SSHService.resize_pty` (zero callers after refactoring)
- [x] `preexec_fn=os.setsid` replaced with `process_group=0` (Python 3.12+ compatible)

## Verification

### Tests on main
```
$ git checkout main && python -m pytest tests/ -q
144 passed, 2 skipped in 3.92s
```

### Tests on branch
```
$ git checkout feat/local-session && python -m pytest tests/ -q
151 passed, 2 skipped in 6.57s
```