### PR TITLE
Fix Playwright web e2e terminal launch reliability

### DIFF
--- a/src/tabula/web/pty.py
+++ b/src/tabula/web/pty.py
@@ -46,8 +46,18 @@ class LocalPtyTransport(PtyTransport):
         if pid == 0:
             try:
                 os.chdir(cwd)
+                os.environ["TERM"] = "xterm-256color"
                 shell = os.environ.get("SHELL", "/bin/bash")
-                os.execvp(shell, ["-" + os.path.basename(shell)])
+                shell_name = os.path.basename(shell)
+                # Keep an interactive prompt, but avoid shell startup files that
+                # commonly rewrite PATH and break deterministic command resolution.
+                if shell_name in {"bash", "rbash"}:
+                    args = [shell_name, "--noprofile", "--norc", "-i"]
+                elif shell_name == "zsh":
+                    args = [shell_name, "-f", "-i"]
+                else:
+                    args = [shell_name, "-i"]
+                os.execvp(shell, args)
             except BaseException:
                 os._exit(1)
         os.set_blocking(master_fd, False)

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+SCREENSHOT_DIR = Path("/tmp/tabula-e2e")
+TEST_PASSWORD = "e2e-test-pw-42"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def screenshot_dir() -> Path:
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    return SCREENSHOT_DIR
+
+
+@pytest.fixture(scope="session")
+def mock_bin_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    bin_dir = tmp_path_factory.mktemp("mock-bin")
+
+    claude_script = bin_dir / "claude"
+    claude_script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys, urllib.request\n"
+        "cfg = None\n"
+        "for i, arg in enumerate(sys.argv):\n"
+        "    if arg == '--mcp-config' and i + 1 < len(sys.argv):\n"
+        "        cfg = json.loads(sys.argv[i + 1])\n"
+        "        break\n"
+        "if cfg:\n"
+        "    url = cfg['mcpServers']['tabula-canvas']['url']\n"
+        "    req = urllib.request.Request(\n"
+        "        url, method='POST',\n"
+        "        headers={'Content-Type': 'application/json'},\n"
+        "        data=json.dumps({\n"
+        '            "jsonrpc": "2.0", "id": 1, "method": "initialize",\n'
+        '            "params": {"protocolVersion": "2024-11-05",\n'
+        '                       "capabilities": {},\n'
+        '                       "clientInfo": {"name": "mock-claude"}}\n'
+        "        }).encode(),\n"
+        "    )\n"
+        "    urllib.request.urlopen(req, timeout=5)\n"
+        "print('MOCK_CLAUDE_OK')\n"
+    )
+    claude_script.chmod(0o755)
+
+    codex_script = bin_dir / "codex"
+    codex_script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys, urllib.request\n"
+        "url = None\n"
+        "for i, arg in enumerate(sys.argv):\n"
+        "    if arg == '-c' and i + 1 < len(sys.argv):\n"
+        "        val = sys.argv[i + 1]\n"
+        "        if 'mcp_servers' in val:\n"
+        "            url = val.split('=', 1)[1].strip('\"')\n"
+        "            break\n"
+        "if url:\n"
+        "    req = urllib.request.Request(\n"
+        "        url, method='POST',\n"
+        "        headers={'Content-Type': 'application/json'},\n"
+        "        data=json.dumps({\n"
+        '            "jsonrpc": "2.0", "id": 1, "method": "initialize",\n'
+        '            "params": {"protocolVersion": "2024-11-05",\n'
+        '                       "capabilities": {},\n'
+        '                       "clientInfo": {"name": "mock-codex"}}\n'
+        "        }).encode(),\n"
+        "    )\n"
+        "    urllib.request.urlopen(req, timeout=5)\n"
+        "print('MOCK_CODEX_OK')\n"
+    )
+    codex_script.chmod(0o755)
+
+    return bin_dir
+
+
+@pytest.fixture(scope="session")
+def server_info(tmp_path_factory: pytest.TempPathFactory, mock_bin_dir: Path) -> dict:
+    from aiohttp import web
+
+    import tabula.web.server as srv_mod
+    from tabula.web.server import TabulaWebApp
+
+    daemon_port = _free_port()
+    original_daemon_port = srv_mod.DAEMON_PORT
+    srv_mod.DAEMON_PORT = daemon_port
+
+    original_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{mock_bin_dir}:{original_path}"
+
+    data_dir = tmp_path_factory.mktemp("e2e-data")
+    project_dir = tmp_path_factory.mktemp("e2e-project")
+    web_port = _free_port()
+
+    loop = asyncio.new_event_loop()
+    runner_holder: list[web.AppRunner] = []
+    ready = threading.Event()
+
+    async def _boot() -> None:
+        web_app = TabulaWebApp(data_dir=data_dir, local_project_dir=project_dir)
+        app = web_app.create_app()
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", web_port)
+        await site.start()
+        runner_holder.append(runner)
+
+    def _thread_main() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(_boot())
+        ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=_thread_main, daemon=True)
+    thread.start()
+    ready.wait(timeout=30)
+
+    yield {
+        "base_url": f"http://127.0.0.1:{web_port}",
+        "daemon_port": daemon_port,
+        "project_dir": str(project_dir),
+    }
+
+    if runner_holder:
+        future = asyncio.run_coroutine_threadsafe(
+            runner_holder[0].cleanup(), loop
+        )
+        future.result(timeout=10)
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+    srv_mod.DAEMON_PORT = original_daemon_port
+    os.environ["PATH"] = original_path
+
+
+@pytest.fixture(scope="session")
+def base_url(server_info: dict) -> str:
+    return server_info["base_url"]

--- a/tests/gui/test_web_e2e.py
+++ b/tests/gui/test_web_e2e.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright")
+from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError, expect
+
+TEST_PASSWORD = "e2e-test-pw-42"
+TERMINAL_READY_TIMEOUT = 15_000
+MARKER_TIMEOUT = 20_000
+
+_TERM_BUFFER_JS = """() => {
+    const term = window._tabulaTerminal;
+    if (!term) return '';
+    const lines = [];
+    for (let i = 0; i < term.buffer.active.length; i++) {
+        const line = term.buffer.active.getLine(i);
+        if (line) lines.push(line.translateToString(true));
+    }
+    return lines.join('\\n');
+}"""
+
+
+def _login(page: Page, base_url: str) -> None:
+    page.goto(base_url)
+    page.wait_for_selector("#view-auth", state="visible", timeout=5_000)
+    page.fill("#auth-password", TEST_PASSWORD)
+    page.click("#auth-submit")
+    page.wait_for_selector("#view-main", state="visible", timeout=10_000)
+
+
+def _wait_terminal_ready(page: Page) -> None:
+    page.wait_for_function(
+        """() => {
+            const term = window._tabulaTerminal;
+            if (!term) return false;
+            for (let i = 0; i < term.rows; i++) {
+                const line = term.buffer.active.getLine(i);
+                if (line && line.translateToString(true).trim().length > 0)
+                    return true;
+            }
+            return false;
+        }""",
+        timeout=TERMINAL_READY_TIMEOUT,
+    )
+
+
+def _wait_for_marker(page: Page, marker: str, timeout: int = MARKER_TIMEOUT) -> None:
+    try:
+        page.wait_for_function(
+            f"""(marker) => {{
+                const term = window._tabulaTerminal;
+                if (!term) return false;
+                for (let i = 0; i < term.buffer.active.length; i++) {{
+                    const line = term.buffer.active.getLine(i);
+                    if (line && line.translateToString(true).includes(marker))
+                        return true;
+                }}
+                return false;
+            }}""",
+            arg=marker,
+            timeout=timeout,
+        )
+    except PlaywrightTimeoutError as exc:
+        buf = page.evaluate(_TERM_BUFFER_JS)
+        tail = "\n".join(buf.splitlines()[-30:])
+        raise AssertionError(
+            f"marker '{marker}' not found in terminal output tail:\n{tail}"
+        ) from exc
+
+
+def _type_in_terminal(page: Page, text: str) -> None:
+    page.click("#terminal-container")
+    page.keyboard.type(text, delay=30)
+
+
+def _screenshot(page: Page, name: str, screenshot_dir: Path) -> None:
+    page.screenshot(path=str(screenshot_dir / name))
+
+
+def test_setup_password_flow(page: Page, base_url: str, screenshot_dir: Path) -> None:
+    page.goto(base_url)
+    page.wait_for_selector("#view-auth", state="visible", timeout=5_000)
+
+    expect(page.locator("#auth-subtitle")).to_contain_text("Set up")
+    expect(page.locator("#auth-submit")).to_have_text("Set Password")
+    _screenshot(page, "auth_setup.png", screenshot_dir)
+
+    page.fill("#auth-password", TEST_PASSWORD)
+    page.click("#auth-submit")
+    page.wait_for_selector("#view-main", state="visible", timeout=10_000)
+    _screenshot(page, "main_after_setup.png", screenshot_dir)
+
+
+def test_login_flow(page: Page, base_url: str, screenshot_dir: Path) -> None:
+    page.goto(base_url)
+    page.wait_for_selector("#view-auth", state="visible", timeout=5_000)
+
+    expect(page.locator("#auth-subtitle")).to_contain_text("Enter your admin password")
+    expect(page.locator("#auth-submit")).to_have_text("Login")
+    _screenshot(page, "login.png", screenshot_dir)
+
+    page.fill("#auth-password", TEST_PASSWORD)
+    page.click("#auth-submit")
+    page.wait_for_selector("#view-main", state="visible", timeout=10_000)
+    _screenshot(page, "main_after_login.png", screenshot_dir)
+
+
+def test_local_terminal_renders(page: Page, base_url: str, screenshot_dir: Path) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+
+    expect(page.locator("#terminal-container .xterm")).to_be_visible()
+    _screenshot(page, "terminal_prompt.png", screenshot_dir)
+
+
+def test_terminal_echo(page: Page, base_url: str, screenshot_dir: Path) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+
+    _type_in_terminal(page, "echo PLAYWRIGHT_MARKER\n")
+    _wait_for_marker(page, "PLAYWRIGHT_MARKER")
+    _screenshot(page, "terminal_echo.png", screenshot_dir)
+
+
+def test_terminal_resize_on_connect(
+    page: Page, base_url: str, screenshot_dir: Path
+) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+
+    dims = page.evaluate(
+        "() => ({ rows: window._tabulaTerminal.rows, cols: window._tabulaTerminal.cols })"
+    )
+
+    _type_in_terminal(page, "stty size\n")
+
+    expected = f"{dims['rows']} {dims['cols']}"
+    _wait_for_marker(page, expected)
+    _screenshot(page, "terminal_resize.png", screenshot_dir)
+
+
+def test_launch_claude(
+    page: Page, base_url: str, screenshot_dir: Path, server_info: dict
+) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+
+    page.select_option("#assistant-select", "claude")
+    page.click("#btn-launch-ai")
+    _wait_for_marker(page, "MOCK_CLAUDE_OK")
+    _screenshot(page, "launch_claude.png", screenshot_dir)
+
+
+def test_launch_codex(
+    page: Page, base_url: str, screenshot_dir: Path, server_info: dict
+) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+
+    page.select_option("#assistant-select", "codex")
+    page.click("#btn-launch-ai")
+    _wait_for_marker(page, "MOCK_CODEX_OK")
+    _screenshot(page, "launch_codex.png", screenshot_dir)
+
+
+def test_canvas_artifact_display(
+    page: Page, base_url: str, screenshot_dir: Path, server_info: dict
+) -> None:
+    _login(page, base_url)
+    _wait_terminal_ready(page)
+    page.wait_for_timeout(1_000)
+
+    daemon_url = f"http://127.0.0.1:{server_info['daemon_port']}/mcp"
+
+    def _mcp_call(msg_id: int, method: str, params: dict) -> None:
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params}
+        ).encode()
+        req = urllib.request.Request(
+            daemon_url,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            data=body,
+        )
+        urllib.request.urlopen(req, timeout=5)
+
+    _mcp_call(
+        1,
+        "initialize",
+        {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "e2e-test"},
+        },
+    )
+    _mcp_call(
+        2,
+        "tools/call",
+        {
+            "name": "canvas_render_text",
+            "arguments": {
+                "session_id": "e2e-test",
+                "title": "E2E Test Artifact",
+                "markdown_or_text": "# Hello Playwright\n\nThis is a test artifact.",
+            },
+        },
+    )
+
+    page.wait_for_selector("#canvas-text", state="visible", timeout=10_000)
+    page.wait_for_function(
+        """() => {
+            const el = document.getElementById('canvas-text');
+            return el && el.textContent.includes('Hello Playwright');
+        }""",
+        timeout=10_000,
+    )
+    expect(page.locator("#canvas-mode")).to_have_text("review")
+    _screenshot(page, "canvas_artifact.png", screenshot_dir)
+
+
+def test_mobile_viewport(page: Page, base_url: str, screenshot_dir: Path) -> None:
+    page.set_viewport_size({"width": 375, "height": 812})
+    _login(page, base_url)
+
+    direction = page.evaluate(
+        "() => getComputedStyle(document.getElementById('workspace')).flexDirection"
+    )
+    assert direction == "column", f"expected column layout, got {direction}"
+    _screenshot(page, "mobile_layout.png", screenshot_dir)
+
+
+def test_logout_clears_session(
+    page: Page, base_url: str, screenshot_dir: Path
+) -> None:
+    _login(page, base_url)
+    page.click("#btn-logout")
+    page.wait_for_selector("#view-auth", state="visible", timeout=5_000)
+    _screenshot(page, "after_logout.png", screenshot_dir)


### PR DESCRIPTION
## Summary
- add Playwright web e2e suite + fixtures under `tests/gui/`
- fix local PTY shell startup to keep an interactive prompt while preventing rc/profile PATH rewrites
- make terminal visibility assertion match the current xterm DOM renderer

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/gui`
- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/unit/test_pty_transport.py tests/system/test_pty_system.py tests/system/test_ai_launch.py -k 'pty_launches_claude_with_mcp_config or local_pty_echo or local_pty_resize or pty_open_and_echo or pty_resize'`
- manual visual inspection of all generated screenshots in `/tmp/tabula-e2e`, including `launch_claude.png` and `launch_codex.png` for terminal rendering correctness
