### PR TITLE
fix: [B1] Action-Assist Reply - Registry foundation (fixes #24)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -118,6 +118,14 @@ const DETAIL_SWIPE_NAV_THRESHOLD_PX = 90;
 const UNDO_TIMEOUT_MS = Number(window.__TABULA_UNDO_TIMEOUT_MS || 5000);
 
 let pendingUndoAction = null;
+const MAIL_ASSIST_STATE = Object.freeze({
+  IDLE: 'idle',
+  CAPTURING: 'capturing',
+  GENERATING: 'generating',
+  READY: 'ready',
+  ERROR: 'error',
+});
+const mailAssistActionRegistry = new Map();
 
 function getEls() {
   if (!els.empty) {
@@ -318,6 +326,16 @@ function flushPendingUndoAction() {
   void pending.execute();
 }
 
+function resetMailAssistDomState() {
+  const e = getEls();
+  if (!e.text) return;
+  delete e.text.dataset.mailAssistState;
+  delete e.text.dataset.mailAssistActionId;
+  delete e.text.dataset.mailAssistMessageId;
+  delete e.text.dataset.mailAssistError;
+  delete e.text.dataset.mailAssistHistory;
+}
+
 function clearSelectionInteractionHandlers() {
   const e = getEls();
   if (e.text._selectionHandler) {
@@ -367,6 +385,7 @@ function clearMailInteractionHandlers() {
     e.text._mailDetailKeyDownHandler = null;
   }
   closeDraftPanel();
+  resetMailAssistDomState();
   e.text.classList.remove('mail-artifact');
   activeMailContext = null;
 }
@@ -644,9 +663,166 @@ function getMailViewState(context) {
       detailMessage: null,
       detailStatus: '',
       detailStatusTone: 'info',
+      assist: {
+        state: MAIL_ASSIST_STATE.IDLE,
+        actionId: '',
+        messageId: '',
+        error: '',
+        transitions: [MAIL_ASSIST_STATE.IDLE],
+      },
     };
   }
   return context.viewState;
+}
+
+function setMailAssistDomState(context) {
+  const e = getEls();
+  const assist = getMailViewState(context).assist;
+  if (!assist) {
+    resetMailAssistDomState();
+    return;
+  }
+  e.text.dataset.mailAssistState = assist.state || MAIL_ASSIST_STATE.IDLE;
+  e.text.dataset.mailAssistActionId = assist.actionId || '';
+  e.text.dataset.mailAssistMessageId = assist.messageId || '';
+  if (assist.error) {
+    e.text.dataset.mailAssistError = assist.error;
+  } else {
+    delete e.text.dataset.mailAssistError;
+  }
+  e.text.dataset.mailAssistHistory = (assist.transitions || []).join('>');
+}
+
+function setMailAssistState(context, nextState, details = {}) {
+  const state = getMailViewState(context);
+  if (!state.assist) {
+    state.assist = {
+      state: MAIL_ASSIST_STATE.IDLE,
+      actionId: '',
+      messageId: '',
+      error: '',
+      transitions: [MAIL_ASSIST_STATE.IDLE],
+    };
+  }
+  const assist = state.assist;
+  assist.state = nextState || MAIL_ASSIST_STATE.IDLE;
+  assist.actionId = String(details.actionId ?? assist.actionId ?? '').trim();
+  assist.messageId = String(details.messageId ?? assist.messageId ?? '').trim();
+  assist.error = String(details.error ?? '').trim();
+  if (!Array.isArray(assist.transitions)) {
+    assist.transitions = [MAIL_ASSIST_STATE.IDLE];
+  }
+  const last = assist.transitions[assist.transitions.length - 1];
+  if (last !== assist.state) {
+    assist.transitions.push(assist.state);
+    if (assist.transitions.length > 12) {
+      assist.transitions = assist.transitions.slice(-12);
+    }
+  }
+  setMailAssistDomState(context);
+}
+
+function setMailAssistStatus(context, row, inDetail, text, tone) {
+  if (row) {
+    setMailRowStatus(row, text, tone);
+    return;
+  }
+  if (inDetail) {
+    setMailDetailStatus(context, text, tone);
+  }
+}
+
+function setMailAssistBusy(row, inDetail, busy) {
+  if (row) {
+    setMailRowBusy(row, busy);
+  }
+  if (inDetail) {
+    setMailDetailBusy(busy);
+  }
+}
+
+function resolveMailAssistActionID(button, action) {
+  const explicit = String(button?.dataset?.mailActionId || '').trim();
+  if (explicit) return explicit;
+  if (action === 'draft-reply') return 'mail.draft_reply';
+  return '';
+}
+
+function registerMailAssistAction(actionId, handler) {
+  const key = String(actionId || '').trim();
+  if (!key || !handler || typeof handler.prepare !== 'function' || typeof handler.execute !== 'function') {
+    return;
+  }
+  mailAssistActionRegistry.set(key, handler);
+}
+
+async function dispatchMailAssistAction(eventId, context, invocation) {
+  const actionId = String(invocation?.actionId || '').trim();
+  const row = invocation?.row || null;
+  const inDetail = Boolean(invocation?.inDetail && !row);
+  const messageID = String(invocation?.messageID || '').trim();
+  const handler = mailAssistActionRegistry.get(actionId);
+  if (!handler) {
+    const msg = `Unsupported assist action_id: ${actionId || '(empty)'}`;
+    setMailAssistState(context, MAIL_ASSIST_STATE.ERROR, { actionId, messageId: messageID, error: msg });
+    setMailAssistStatus(context, row, inDetail, msg, 'error');
+    return;
+  }
+
+  setMailAssistBusy(row, inDetail, true);
+  try {
+    setMailAssistState(context, MAIL_ASSIST_STATE.CAPTURING, { actionId, messageId: messageID, error: '' });
+    if (typeof handler.onCapturing === 'function') {
+      handler.onCapturing({ context, row, inDetail, messageID, actionId });
+    } else {
+      setMailAssistStatus(context, row, inDetail, 'Capturing assist context...', 'info');
+    }
+
+    const prepared = await handler.prepare({
+      context,
+      eventId,
+      row,
+      inDetail,
+      messageID,
+      actionId,
+      selectionText: window.getSelection()?.toString?.() || '',
+    });
+    if (activeTextEventId !== eventId) return;
+
+    setMailAssistState(context, MAIL_ASSIST_STATE.GENERATING, { actionId, messageId: messageID, error: '' });
+    if (typeof handler.onGenerating === 'function') {
+      handler.onGenerating({ context, row, inDetail, messageID, actionId, prepared });
+    } else {
+      setMailAssistStatus(context, row, inDetail, 'Generating assist output...', 'info');
+    }
+
+    const payload = await handler.execute(prepared, { context, eventId, row, inDetail, messageID, actionId });
+    if (activeTextEventId !== eventId) return;
+
+    if (typeof handler.onReady === 'function') {
+      handler.onReady(payload, prepared, { context, row, inDetail, messageID, actionId });
+    } else {
+      setMailAssistStatus(context, row, inDetail, 'Assist output ready.', 'success');
+    }
+    setMailAssistState(context, MAIL_ASSIST_STATE.READY, { actionId, messageId: messageID, error: '' });
+  } catch (err) {
+    if (activeTextEventId !== eventId) return;
+    const message = String(err?.message || err || 'assist action failed');
+    if (typeof handler.onError === 'function') {
+      handler.onError(message, { context, row, inDetail, messageID, actionId });
+    } else {
+      setMailAssistStatus(context, row, inDetail, message, 'error');
+    }
+    setMailAssistState(context, MAIL_ASSIST_STATE.ERROR, { actionId, messageId: messageID, error: message });
+  } finally {
+    if (activeTextEventId !== eventId) return;
+    if (row && row.isConnected) {
+      setMailRowBusy(row, false);
+    }
+    if (inDetail) {
+      setMailDetailBusy(false);
+    }
+  }
 }
 
 function openDraftPanel(content, sourceLabel) {
@@ -676,6 +852,44 @@ function closeDraftPanel() {
   }
   panel.hidden = true;
 }
+
+function registerDefaultMailAssistActions() {
+  registerMailAssistAction('mail.draft_reply', {
+    onCapturing() {
+      openDraftPanel('', 'Preparing draft assist...');
+    },
+    prepare({ context, messageID, selectionText }) {
+      const header = findMailHeader(context, messageID);
+      return {
+        context,
+        message: {
+          id: messageID,
+          sender: header?.sender || '',
+          subject: header?.subject || '',
+          selectionText: selectionText || '',
+        },
+      };
+    },
+    onGenerating() {
+      openDraftPanel('', 'Generating...');
+    },
+    execute(prepared) {
+      return callDraftReply(prepared.context, prepared.message);
+    },
+    onReady(payload, _prepared, invocation) {
+      const draftText = String(payload?.draft_text || '').trim();
+      const source = String(payload?.source || 'llm').trim();
+      openDraftPanel(draftText, source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)');
+      setMailAssistStatus(invocation.context, invocation.row, invocation.inDetail, 'Draft ready. Review and edit before sending.', 'success');
+    },
+    onError(message, invocation) {
+      closeDraftPanel();
+      setMailAssistStatus(invocation.context, invocation.row, invocation.inDetail, message, 'error');
+    },
+  });
+}
+
+registerDefaultMailAssistActions();
 
 function firstMailField(message, keys) {
   if (!message || typeof message !== 'object') return '';
@@ -707,7 +921,7 @@ function renderMailListHtml(context) {
           <button type="button" data-mail-action="archive">Archive</button>
           <button type="button" data-mail-action="delete">Delete</button>
           <button type="button" data-mail-action="defer">Defer</button>
-          <button type="button" data-mail-action="draft-reply">Draft Reply</button>
+          <button type="button" data-mail-action="draft-reply" data-mail-action-id="mail.draft_reply">Draft Reply</button>
         </div>
         <div class="mail-defer-controls" data-mail-defer-controls hidden>
           <input type="datetime-local" data-mail-defer-input>
@@ -794,7 +1008,7 @@ function renderMailDetailHtml(context) {
         <button type="button" data-mail-action="archive">Archive</button>
         <button type="button" data-mail-action="delete">Delete</button>
         <button type="button" data-mail-action="defer">Defer</button>
-        <button type="button" data-mail-action="draft-reply">Draft Reply</button>
+        <button type="button" data-mail-action="draft-reply" data-mail-action-id="mail.draft_reply">Draft Reply</button>
       </div>
       <div class="mail-defer-controls" data-mail-detail-defer-controls hidden>
         <input type="datetime-local" data-mail-detail-defer-input>
@@ -1229,6 +1443,7 @@ function setupMailActionHandlers(eventId, context) {
     }
     if (action === 'draft-cancel') {
       closeDraftPanel();
+      setMailAssistState(context, MAIL_ASSIST_STATE.IDLE, { actionId: '', messageId: '', error: '' });
       return;
     }
     if (action === 'draft-copy') {
@@ -1247,50 +1462,9 @@ function setupMailActionHandlers(eventId, context) {
     const messageID = row ? (row.dataset.messageId || '') : String(detailRoot?.dataset.messageId || '');
     if (!messageID) return;
 
-    if (action === 'draft-reply') {
-      const header = findMailHeader(context, messageID);
-      const message = {
-        id: messageID,
-        sender: header?.sender || '',
-        subject: header?.subject || '',
-        selectionText: window.getSelection()?.toString?.() || '',
-      };
-      if (row) {
-        setMailRowBusy(row, true);
-        setMailRowStatus(row, 'Generating draft reply...', 'info');
-      } else {
-        setMailDetailBusy(true);
-        setMailDetailStatus(context, 'Generating draft reply...', 'info');
-      }
-      openDraftPanel('', 'Generating...');
-      void callDraftReply(context, message)
-        .then((payload) => {
-          if (activeTextEventId !== eventId) return;
-          const draftText = String(payload.draft_text || '').trim();
-          const source = String(payload.source || 'llm').trim();
-          openDraftPanel(draftText, source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)');
-          if (row) {
-            setMailRowStatus(row, 'Draft ready. Review and edit before sending.', 'success');
-          } else {
-            setMailDetailStatus(context, 'Draft ready. Review and edit before sending.', 'success');
-          }
-        })
-        .catch((err) => {
-          if (activeTextEventId !== eventId) return;
-          closeDraftPanel();
-          if (row) {
-            setMailRowStatus(row, String(err?.message || err || 'draft generation failed'), 'error');
-          } else {
-            setMailDetailStatus(context, String(err?.message || err || 'draft generation failed'), 'error');
-          }
-        })
-        .finally(() => {
-          if (activeTextEventId !== eventId) return;
-          if (row && row.isConnected) {
-            setMailRowBusy(row, false);
-          }
-          setMailDetailBusy(false);
-        });
+    const assistActionId = resolveMailAssistActionID(button, action);
+    if (assistActionId) {
+      void dispatchMailAssistAction(eventId, context, { actionId: assistActionId, row, inDetail, messageID });
       return;
     }
 
@@ -1453,6 +1627,7 @@ function renderMailArtifact(eventId, context) {
       state.currentIndex = Math.max(0, Math.min(state.currentIndex, context.headers.length - 1));
     }
     e.text.innerHTML = renderMailDetailHtml(context);
+    setMailAssistDomState(context);
     setupMailActionHandlers(eventId, context);
     setupMailGestureHandlers(eventId, context);
     setupMailDetailKeyboardHandlers(eventId, context);
@@ -1461,6 +1636,7 @@ function renderMailArtifact(eventId, context) {
     return;
   }
   e.text.innerHTML = renderMailListHtml(context);
+  setMailAssistDomState(context);
   setupMailActionHandlers(eventId, context);
   setupMailGestureHandlers(eventId, context);
   setCapabilityHint(context);

--- a/tests/playwright/mail-actions.spec.ts
+++ b/tests/playwright/mail-actions.spec.ts
@@ -257,7 +257,93 @@ test('swipe thresholds map to archive/delete exactly once', async ({ page }) => 
   expect(actionCalls.filter((a) => a === 'delete')).toHaveLength(1);
 });
 
-test('draft reply shows editable unsent draft and cancel does not trigger action mutate', async ({ page }) => {
+test('draft reply assist uses shared action_id handler with state transitions in list/detail', async ({ page }) => {
+  let mutateCalls = 0;
+  const draftCalls: Array<Record<string, unknown>> = [];
+
+  await page.route('**/api/mail/action-capabilities', async (route) => {
+    await route.fulfill({
+      json: {
+        capabilities: {
+          provider: 'gmail',
+          supports_open: true,
+          supports_archive: true,
+          supports_delete_to_trash: true,
+          supports_native_defer: true,
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/mail/action', async (route) => {
+    mutateCalls += 1;
+    await route.fulfill({ json: { result: { status: 'ok' } } });
+  });
+
+  await page.route('**/api/mail/read', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    await route.fulfill({
+      json: {
+        message: {
+          ID: body.message_id,
+          Subject: `Subject ${body.message_id}`,
+          Sender: 'Alice <alice@example.com>',
+          Recipients: ['Bob <bob@example.com>'],
+          Date: '2026-02-20T09:00:00Z',
+          BodyText: `Full message body ${body.message_id}`,
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/mail/mark-read', async (route) => {
+    await route.fulfill({ json: { marked: 1 } });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    draftCalls.push(body);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await route.fulfill({
+      json: {
+        source: 'llm',
+        draft_text: `Draft for ${body.message_id}`,
+      },
+    });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm3', date: '2026-02-20T07:00:00Z', sender: 'Alice <alice@example.com>', subject: 'Status' },
+    { id: 'm4', date: '2026-02-20T06:00:00Z', sender: 'Bob <bob@example.com>', subject: 'Follow-up' },
+  ]);
+
+  await expect(page.locator('tr[data-message-id="m3"] button[data-mail-action="draft-reply"]')).toHaveAttribute('data-mail-action-id', 'mail.draft_reply');
+  await page.click('tr[data-message-id="m3"] button[data-mail-action="draft-reply"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-history')).toContain('capturing>generating');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('ready');
+  const draftText = page.locator('[data-mail-draft-panel] [data-mail-draft-text]');
+  await expect(draftText).toHaveValue(/Draft for m3/);
+  await expect(page.locator('tr[data-message-id="m3"] [data-mail-row-status]')).toContainText('Draft ready');
+
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-cancel"]');
+  await expect(page.locator('[data-mail-draft-panel]')).toBeHidden();
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('idle');
+
+  await page.click('tr[data-message-id="m4"] button[data-mail-action="open"]');
+  await expect(page.locator('[data-mail-detail-root]')).toBeVisible();
+  await expect(page.locator('.mail-detail-actions button[data-mail-action="draft-reply"]')).toHaveAttribute('data-mail-action-id', 'mail.draft_reply');
+  await page.click('.mail-detail-actions button[data-mail-action="draft-reply"]');
+  await expect(draftText).toHaveValue(/Draft for m4/);
+  await expect(page.locator('[data-mail-detail-status]')).toContainText('Draft ready');
+
+  expect(draftCalls).toHaveLength(2);
+  expect(draftCalls.map((c) => c.message_id)).toEqual(['m3', 'm4']);
+  expect(Object.keys(draftCalls[0] || {}).sort()).toEqual(Object.keys(draftCalls[1] || {}).sort());
+  expect(mutateCalls).toBe(0);
+});
+
+test('unregistered assist action_id returns deterministic error without network call', async ({ page }) => {
+  let draftCalls = 0;
   let mutateCalls = 0;
 
   await page.route('**/api/mail/action-capabilities', async (route) => {
@@ -280,23 +366,24 @@ test('draft reply shows editable unsent draft and cancel does not trigger action
   });
 
   await page.route('**/api/mail/draft-reply', async (route) => {
-    await route.fulfill({
-      json: {
-        source: 'llm',
-        draft_text: 'Hi Alice,\\n\\nThanks for the update.\\n\\nBest,\\nMe',
-      },
-    });
+    draftCalls += 1;
+    await route.fulfill({ json: { source: 'llm', draft_text: 'unexpected call' } });
   });
 
   await renderMail(page, 'gmail', [
-    { id: 'm3', date: '2026-02-20T07:00:00Z', sender: 'Alice <alice@example.com>', subject: 'Status' },
+    { id: 'm5', date: '2026-02-20T05:00:00Z', sender: 'Eve <eve@example.com>', subject: 'Question' },
   ]);
 
-  await page.click('tr[data-message-id="m3"] button[data-mail-action="draft-reply"]');
-  const draftText = page.locator('[data-mail-draft-panel] [data-mail-draft-text]');
-  await expect(draftText).toHaveValue(/Thanks for the update/);
+  await page.evaluate(() => {
+    const btn = document.querySelector('tr[data-message-id="m5"] button[data-mail-action="draft-reply"]');
+    if (btn) {
+      btn.setAttribute('data-mail-action-id', 'mail.unknown');
+    }
+  });
 
-  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-cancel"]');
-  await expect(page.locator('[data-mail-draft-panel]')).toBeHidden();
+  await page.click('tr[data-message-id="m5"] button[data-mail-action="draft-reply"]');
+  await expect(page.locator('tr[data-message-id="m5"] [data-mail-row-status]')).toContainText('Unsupported assist action_id: mail.unknown');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('error');
+  expect(draftCalls).toBe(0);
   expect(mutateCalls).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Introduced a reusable `action_id` assist registry in `internal/web/static/canvas.js`.
- Added a shared assist state machine (`idle -> capturing -> generating -> ready/error`) with DOM-visible state for deterministic behavior and tests.
- Wired `Draft Reply` to the registry as `mail.draft_reply` from both list and detail views.
- Added deterministic fallback for unknown/unregistered `action_id`.
- Expanded Playwright coverage for registry dispatch/state transitions and unregistered fallback behavior.

## Verification
- Requirement: registered handler trigger starts shared pipeline.
  - Evidence: `npm run test:e2e -- tests/playwright/mail-actions.spec.ts -g "draft reply assist uses shared action_id handler|unregistered assist action_id"`
  - Output excerpt: `1) draft reply assist uses shared action_id handler with state transitions in list/detail ... passed`
  - Test assertions verify transition history includes `capturing>generating` and final `data-mail-assist-state=ready`.

- Requirement: unregistered `action_id` yields deterministic error/fallback.
  - Evidence: same command/output (`2 passed`).
  - Test `unregistered assist action_id returns deterministic error without network call` asserts row status contains `Unsupported assist action_id: mail.unknown`, final state is `error`, and draft/action network calls remain zero.

- Requirement: list/detail use same `action_id` and handler contract.
  - Evidence: same command/output (`2 passed`).
  - Test asserts both list and detail Draft Reply buttons expose `data-mail-action-id="mail.draft_reply"`, and both flows call the same endpoint with identical request key contracts.
