### PR TITLE
fix: [B3] Action-Assist Reply - Silent typed prompt capture (fixes #26)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -126,6 +126,8 @@ const MAIL_ASSIST_STATE = Object.freeze({
   ERROR: 'error',
 });
 const mailAssistActionRegistry = new Map();
+const DRAFT_PROMPT_CANCELLED_CODE = 'draft_prompt_cancelled';
+let pendingDraftPromptCapture = null;
 
 function getEls() {
   if (!els.empty) {
@@ -769,7 +771,7 @@ async function dispatchMailAssistAction(eventId, context, invocation) {
     return;
   }
 
-  setMailAssistBusy(row, inDetail, true);
+  let assistBusy = false;
   try {
     setMailAssistState(context, MAIL_ASSIST_STATE.CAPTURING, { actionId, messageId: messageID, error: '' });
     if (typeof handler.onCapturing === 'function') {
@@ -795,6 +797,8 @@ async function dispatchMailAssistAction(eventId, context, invocation) {
     } else {
       setMailAssistStatus(context, row, inDetail, 'Generating assist output...', 'info');
     }
+    setMailAssistBusy(row, inDetail, true);
+    assistBusy = true;
 
     const payload = await handler.execute(prepared, { context, eventId, row, inDetail, messageID, actionId });
     if (activeTextEventId !== eventId) return;
@@ -807,6 +811,10 @@ async function dispatchMailAssistAction(eventId, context, invocation) {
     setMailAssistState(context, MAIL_ASSIST_STATE.READY, { actionId, messageId: messageID, error: '' });
   } catch (err) {
     if (activeTextEventId !== eventId) return;
+    if (err && typeof err === 'object' && err.code === DRAFT_PROMPT_CANCELLED_CODE) {
+      setMailAssistState(context, MAIL_ASSIST_STATE.IDLE, { actionId: '', messageId: '', error: '' });
+      return;
+    }
     const message = String(err?.message || err || 'assist action failed');
     if (typeof handler.onError === 'function') {
       handler.onError(message, { context, row, inDetail, messageID, actionId });
@@ -816,70 +824,189 @@ async function dispatchMailAssistAction(eventId, context, invocation) {
     setMailAssistState(context, MAIL_ASSIST_STATE.ERROR, { actionId, messageId: messageID, error: message });
   } finally {
     if (activeTextEventId !== eventId) return;
-    if (row && row.isConnected) {
-      setMailRowBusy(row, false);
-    }
-    if (inDetail) {
-      setMailDetailBusy(false);
+    if (assistBusy) {
+      if (row && row.isConnected) {
+        setMailRowBusy(row, false);
+      }
+      if (inDetail) {
+        setMailDetailBusy(false);
+      }
     }
   }
 }
 
-function openDraftPanel(content, sourceLabel) {
+function createDraftPromptCancelledError(message) {
+  const err = new Error(message || 'Draft prompt capture cancelled.');
+  err.code = DRAFT_PROMPT_CANCELLED_CODE;
+  return err;
+}
+
+function cancelPendingDraftPromptCapture(message) {
+  if (!pendingDraftPromptCapture) return false;
+  const pending = pendingDraftPromptCapture;
+  pendingDraftPromptCapture = null;
+  pending.reject(createDraftPromptCancelledError(message));
+  return true;
+}
+
+function submitPendingDraftPromptCapture() {
+  if (!pendingDraftPromptCapture) return false;
+  const pending = pendingDraftPromptCapture;
+  const panel = document.querySelector('[data-mail-draft-panel]');
+  const promptInput = panel ? panel.querySelector('[data-mail-draft-prompt]') : null;
+  const generateBtn = panel ? panel.querySelector('button[data-mail-action="draft-generate"]') : null;
+  const promptText = String(promptInput?.value || '').trim();
+  if (!promptText) {
+    setMailAssistStatus(pending.context, pending.row, pending.inDetail, 'Enter a prompt before generating.', 'warning');
+    if (promptInput && typeof promptInput.focus === 'function') {
+      promptInput.focus();
+    }
+    return true;
+  }
+  if (promptInput) {
+    promptInput.disabled = true;
+  }
+  if (generateBtn) {
+    generateBtn.disabled = true;
+  }
+  pendingDraftPromptCapture = null;
+  pending.resolve(promptText);
+  return true;
+}
+
+function waitForDraftPromptCapture(context, row, inDetail, messageID, actionId) {
+  cancelPendingDraftPromptCapture('superseded by new draft prompt');
+  openDraftPanel('', 'Add prompt, then generate.', {
+    showPrompt: true,
+    focusPrompt: true,
+    promptText: '',
+    promptDisabled: false,
+    generateDisabled: false,
+  });
+  setMailAssistStatus(context, row, inDetail, 'Add a prompt, then choose Generate.', 'info');
+  return new Promise((resolve, reject) => {
+    pendingDraftPromptCapture = {
+      resolve,
+      reject,
+      context,
+      row,
+      inDetail,
+      messageID,
+      actionId,
+    };
+  });
+}
+
+function openDraftPanel(content, sourceLabel, options = {}) {
   const panel = document.querySelector('[data-mail-draft-panel]');
   if (!panel) return;
   const textarea = panel.querySelector('[data-mail-draft-text]');
   const source = panel.querySelector('[data-mail-draft-source]');
+  const promptWrap = panel.querySelector('[data-mail-draft-prompt-wrap]');
+  const promptInput = panel.querySelector('[data-mail-draft-prompt]');
+  const generateBtn = panel.querySelector('button[data-mail-action="draft-generate"]');
+  const showPrompt = Boolean(options.showPrompt);
   if (textarea) {
     textarea.value = content || '';
   }
   if (source) {
     source.textContent = sourceLabel || '';
   }
+  if (promptWrap) {
+    promptWrap.hidden = !showPrompt;
+  }
+  if (promptInput) {
+    promptInput.disabled = Boolean(options.promptDisabled);
+    if (options.promptText !== undefined) {
+      promptInput.value = String(options.promptText || '');
+    }
+  }
+  if (generateBtn) {
+    generateBtn.hidden = !showPrompt;
+    generateBtn.disabled = Boolean(options.generateDisabled);
+  }
   panel.hidden = false;
+  if (showPrompt && options.focusPrompt && promptInput && typeof promptInput.focus === 'function') {
+    setTimeout(() => promptInput.focus(), 0);
+  }
 }
 
 function closeDraftPanel() {
+  cancelPendingDraftPromptCapture('draft reply cancelled by user');
   const panel = document.querySelector('[data-mail-draft-panel]');
   if (!panel) return;
   const textarea = panel.querySelector('[data-mail-draft-text]');
   const source = panel.querySelector('[data-mail-draft-source]');
+  const promptWrap = panel.querySelector('[data-mail-draft-prompt-wrap]');
+  const promptInput = panel.querySelector('[data-mail-draft-prompt]');
+  const generateBtn = panel.querySelector('button[data-mail-action="draft-generate"]');
   if (textarea) {
     textarea.value = '';
   }
   if (source) {
     source.textContent = '';
   }
+  if (promptWrap) {
+    promptWrap.hidden = true;
+  }
+  if (promptInput) {
+    promptInput.value = '';
+    promptInput.disabled = false;
+  }
+  if (generateBtn) {
+    generateBtn.hidden = true;
+    generateBtn.disabled = false;
+  }
   panel.hidden = true;
 }
 
 function registerDefaultMailAssistActions() {
   registerMailAssistAction('mail.draft_reply', {
-    onCapturing() {
-      openDraftPanel('', 'Preparing draft assist...');
+    onCapturing(invocation) {
+      openDraftPanel('', 'Preparing draft assist...', {
+        showPrompt: true,
+        focusPrompt: true,
+        promptText: '',
+        promptDisabled: false,
+        generateDisabled: false,
+      });
+      setMailAssistStatus(invocation.context, invocation.row, invocation.inDetail, 'Capturing assist context...', 'info');
     },
-    prepare({ context, messageID, selectionText }) {
+    async prepare({ context, row, inDetail, messageID, actionId, selectionText }) {
       const header = findMailHeader(context, messageID);
+      const promptText = await waitForDraftPromptCapture(context, row, inDetail, messageID, actionId);
       return {
         context,
         message: {
           id: messageID,
           sender: header?.sender || '',
           subject: header?.subject || '',
-          selectionText: selectionText || '',
+          selectionText: promptText || selectionText || '',
+          promptText,
         },
       };
     },
-    onGenerating() {
-      openDraftPanel('', 'Generating...');
+    onGenerating({ prepared }) {
+      const promptText = prepared?.message?.promptText || '';
+      openDraftPanel('', 'Generating...', {
+        showPrompt: true,
+        promptText,
+        promptDisabled: true,
+        generateDisabled: true,
+      });
     },
     execute(prepared) {
       return callDraftReply(prepared.context, prepared.message);
     },
-    onReady(payload, _prepared, invocation) {
+    onReady(payload, prepared, invocation) {
       const draftText = String(payload?.draft_text || '').trim();
       const source = String(payload?.source || 'llm').trim();
-      openDraftPanel(draftText, source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)');
+      openDraftPanel(draftText, source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)', {
+        showPrompt: true,
+        promptText: prepared?.message?.promptText || '',
+        promptDisabled: false,
+        generateDisabled: false,
+      });
       setMailAssistStatus(invocation.context, invocation.row, invocation.inDetail, 'Draft ready. Review and edit before sending.', 'success');
     },
     onError(message, invocation) {
@@ -959,8 +1086,13 @@ function renderMailListHtml(context) {
         <strong>Draft Reply</strong>
         <span data-mail-draft-source></span>
       </div>
+      <div class="mail-draft-prompt" data-mail-draft-prompt-wrap hidden>
+        <label>Prompt</label>
+        <textarea data-mail-draft-prompt placeholder="Add context or intent for this reply"></textarea>
+      </div>
       <textarea data-mail-draft-text placeholder="Draft reply will appear here"></textarea>
       <div class="mail-draft-actions">
+        <button type="button" data-mail-action="draft-generate" hidden>Generate</button>
         <button type="button" data-mail-action="draft-copy">Copy</button>
         <button type="button" data-mail-action="draft-cancel">Cancel</button>
       </div>
@@ -1022,8 +1154,13 @@ function renderMailDetailHtml(context) {
           <strong>Draft Reply</strong>
           <span data-mail-draft-source></span>
         </div>
+        <div class="mail-draft-prompt" data-mail-draft-prompt-wrap hidden>
+          <label>Prompt</label>
+          <textarea data-mail-draft-prompt placeholder="Add context or intent for this reply"></textarea>
+        </div>
         <textarea data-mail-draft-text placeholder="Draft reply will appear here"></textarea>
         <div class="mail-draft-actions">
+          <button type="button" data-mail-action="draft-generate" hidden>Generate</button>
           <button type="button" data-mail-action="draft-copy">Copy</button>
           <button type="button" data-mail-action="draft-cancel">Cancel</button>
         </div>
@@ -1444,6 +1581,10 @@ function setupMailActionHandlers(eventId, context) {
     if (action === 'draft-cancel') {
       closeDraftPanel();
       setMailAssistState(context, MAIL_ASSIST_STATE.IDLE, { actionId: '', messageId: '', error: '' });
+      return;
+    }
+    if (action === 'draft-generate') {
+      submitPendingDraftPromptCapture();
       return;
     }
     if (action === 'draft-copy') {

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -559,6 +559,29 @@ body.desktop-canvas-only #panel-canvas {
   font-size: 0.8rem;
 }
 
+.mail-draft-prompt {
+  margin-bottom: 0.4rem;
+}
+
+.mail-draft-prompt label {
+  display: block;
+  margin-bottom: 0.2rem;
+  font-size: 0.74rem;
+  color: var(--text-dim);
+}
+
+.mail-draft-prompt textarea {
+  width: 100%;
+  min-height: 70px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 0.8rem;
+  padding: 0.4rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+
 .mail-draft-panel textarea {
   width: 100%;
   min-height: 140px;

--- a/tests/playwright/mail-actions.spec.ts
+++ b/tests/playwright/mail-actions.spec.ts
@@ -319,7 +319,12 @@ test('draft reply assist uses shared action_id handler with state transitions in
 
   await expect(page.locator('tr[data-message-id="m3"] button[data-mail-action="draft-reply"]')).toHaveAttribute('data-mail-action-id', 'mail.draft_reply');
   await page.click('tr[data-message-id="m3"] button[data-mail-action="draft-reply"]');
-  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-history')).toContain('capturing>generating');
+  const promptInput = page.locator('[data-mail-draft-panel] [data-mail-draft-prompt]');
+  await expect(promptInput).toBeFocused();
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('capturing');
+  await promptInput.fill('Keep this short and ask for Friday confirmation.');
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-generate"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-history')).toContain('capturing>generating>ready');
   await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('ready');
   const draftText = page.locator('[data-mail-draft-panel] [data-mail-draft-text]');
   await expect(draftText).toHaveValue(/Draft for m3/);
@@ -333,12 +338,65 @@ test('draft reply assist uses shared action_id handler with state transitions in
   await expect(page.locator('[data-mail-detail-root]')).toBeVisible();
   await expect(page.locator('.mail-detail-actions button[data-mail-action="draft-reply"]')).toHaveAttribute('data-mail-action-id', 'mail.draft_reply');
   await page.click('.mail-detail-actions button[data-mail-action="draft-reply"]');
+  await expect(promptInput).toBeFocused();
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('capturing');
+  await promptInput.fill('Reply with a polite acknowledgement and next step.');
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-generate"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('ready');
   await expect(draftText).toHaveValue(/Draft for m4/);
   await expect(page.locator('[data-mail-detail-status]')).toContainText('Draft ready');
 
   expect(draftCalls).toHaveLength(2);
   expect(draftCalls.map((c) => c.message_id)).toEqual(['m3', 'm4']);
+  expect(draftCalls.map((c) => c.selection_text)).toEqual([
+    'Keep this short and ask for Friday confirmation.',
+    'Reply with a polite acknowledgement and next step.',
+  ]);
   expect(Object.keys(draftCalls[0] || {}).sort()).toEqual(Object.keys(draftCalls[1] || {}).sort());
+  expect(mutateCalls).toBe(0);
+});
+
+test('draft reply prompt capture focuses input and cancel keeps state idle without mutations', async ({ page }) => {
+  let draftCalls = 0;
+  let mutateCalls = 0;
+
+  await page.route('**/api/mail/action-capabilities', async (route) => {
+    await route.fulfill({
+      json: {
+        capabilities: {
+          provider: 'gmail',
+          supports_open: true,
+          supports_archive: true,
+          supports_delete_to_trash: true,
+          supports_native_defer: true,
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/mail/action', async (route) => {
+    mutateCalls += 1;
+    await route.fulfill({ json: { result: { status: 'ok' } } });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    draftCalls += 1;
+    await route.fulfill({ json: { source: 'llm', draft_text: 'unexpected call' } });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm6', date: '2026-02-20T04:00:00Z', sender: 'Frank <frank@example.com>', subject: 'Update' },
+  ]);
+
+  await page.click('tr[data-message-id="m6"] button[data-mail-action="draft-reply"]');
+  const promptInput = page.locator('[data-mail-draft-panel] [data-mail-draft-prompt]');
+  await expect(promptInput).toBeFocused();
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('capturing');
+
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-cancel"]');
+  await expect(page.locator('[data-mail-draft-panel]')).toBeHidden();
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('idle');
+  expect(draftCalls).toBe(0);
   expect(mutateCalls).toBe(0);
 });
 


### PR DESCRIPTION
## Summary
- implement typed prompt capture for `Draft Reply` using the shared `mail.draft_reply` action handler
- require explicit prompt submit (`Generate`) before calling `/api/mail/draft-reply`
- keep generated draft editable and treat cancel during capture as `idle` instead of `error`
- add Playwright coverage for focus/submit/cancel behavior and list/detail parity

## Verification
- Requirement: Given silent mode and Draft Reply click, when panel opens, prompt input is focused.
  - Evidence: `tests/playwright/mail-actions.spec.ts:320` and `tests/playwright/mail-actions.spec.ts:391` assert `toBeFocused()` on `[data-mail-draft-prompt]` right after clicking Draft Reply.
  - Command: `npm run test:e2e -- tests/playwright/mail-actions.spec.ts 2>&1 | tee /tmp/test.log`
  - Output excerpt: `/tmp/test.log` contains `✓  5 tests/playwright/mail-actions.spec.ts:260:5` and `✓  6 tests/playwright/mail-actions.spec.ts:359:5`.
- Requirement: Given prompt text submit, when generation completes, editable draft is shown.
  - Evidence: `tests/playwright/mail-actions.spec.ts:324`, `tests/playwright/mail-actions.spec.ts:328`, `tests/playwright/mail-actions.spec.ts:343`, `tests/playwright/mail-actions.spec.ts:347` fill prompt, click `Generate`, assert `data-mail-assist-state=ready`, and assert draft textarea content in list and detail flows.
  - Command: `npm run test:e2e -- tests/playwright/mail-actions.spec.ts 2>&1 | tee /tmp/test.log`
  - Output excerpt: `/tmp/test.log` contains `✓  5 tests/playwright/mail-actions.spec.ts:260:5`.
- Requirement: Given cancel, when triggered, no mail mutation occurs.
  - Evidence: `tests/playwright/mail-actions.spec.ts:395`, `tests/playwright/mail-actions.spec.ts:398`, `tests/playwright/mail-actions.spec.ts:400`, `tests/playwright/mail-actions.spec.ts:401` cancel during capture and assert hidden panel + idle state + `draftCalls === 0` + `mutateCalls === 0`.
  - Command: `npm run test:e2e -- tests/playwright/mail-actions.spec.ts 2>&1 | tee /tmp/test.log`
  - Output excerpt: `/tmp/test.log` contains `✓  6 tests/playwright/mail-actions.spec.ts:359:5`.
- Output artifact verification (UI): Playwright validates rendered panel/state artifacts (`[data-mail-draft-prompt]`, `[data-mail-draft-text]`, `data-mail-assist-state`, `data-mail-assist-history`) in `tests/playwright/mail-actions.spec.ts`; captured run result: `7 passed (3.7s)`.
