### PR TITLE
fix: [A2] Generic Review/Annotation - Right-click inline comment popo (fixes #19)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -272,6 +272,168 @@ function lineFromOffset(lines, charOffset) {
   return Math.max(1, lines.length);
 }
 
+function textRangeFromClientPoint(clientX, clientY) {
+  if (typeof document.caretRangeFromPoint === 'function') {
+    return document.caretRangeFromPoint(clientX, clientY);
+  }
+  if (typeof document.caretPositionFromPoint === 'function') {
+    const caret = document.caretPositionFromPoint(clientX, clientY);
+    if (!caret) return null;
+    const range = document.createRange();
+    range.setStart(caret.offsetNode, caret.offset);
+    range.collapse(true);
+    return range;
+  }
+  return null;
+}
+
+function pointTargetFromClientPoint(root, clientX, clientY) {
+  const rootRect = root.getBoundingClientRect();
+  const pointX = clientX - rootRect.left + root.scrollLeft;
+  const pointY = clientY - rootRect.top + root.scrollTop;
+  const fallback = {
+    lineStart: 1,
+    lineEnd: 1,
+    startOffset: 0,
+    endOffset: 0,
+    rects: [[pointX - 5, pointY - 5, 10, 10]],
+    pointX,
+    pointY,
+  };
+
+  const range = textRangeFromClientPoint(clientX, clientY);
+  if (!range || !root.contains(range.startContainer)) {
+    return fallback;
+  }
+
+  try {
+    const startProbe = range.cloneRange();
+    startProbe.selectNodeContents(root);
+    startProbe.setEnd(range.startContainer, range.startOffset);
+    const offset = startProbe.toString().length;
+    const lines = (root.textContent || '').split('\n');
+    const line = lineFromOffset(lines, offset);
+    return {
+      lineStart: line,
+      lineEnd: line,
+      startOffset: offset,
+      endOffset: offset,
+      rects: fallback.rects,
+      pointX,
+      pointY,
+    };
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function closeReviewCommentPopover() {
+  const e = getEls();
+  if (!e.text) return;
+  if (e.text._reviewPopoverOutsideHandler) {
+    document.removeEventListener('pointerdown', e.text._reviewPopoverOutsideHandler, true);
+    e.text._reviewPopoverOutsideHandler = null;
+  }
+  if (e.text._reviewPopoverKeyDownHandler) {
+    document.removeEventListener('keydown', e.text._reviewPopoverKeyDownHandler, true);
+    e.text._reviewPopoverKeyDownHandler = null;
+  }
+  if (e.text._reviewPopoverEl && e.text._reviewPopoverEl.parentNode) {
+    e.text._reviewPopoverEl.parentNode.removeChild(e.text._reviewPopoverEl);
+  }
+  e.text._reviewPopoverEl = null;
+}
+
+function positionReviewCommentPopover(popover, root, x, y) {
+  const pad = 10;
+  const width = popover.offsetWidth || 260;
+  const height = popover.offsetHeight || 120;
+  const minX = root.scrollLeft + pad;
+  const minY = root.scrollTop + pad;
+  const maxX = root.scrollLeft + Math.max(pad, root.clientWidth - width - pad);
+  const maxY = root.scrollTop + Math.max(pad, root.clientHeight - height - pad);
+  const left = Math.min(Math.max(minX, x), maxX);
+  const top = Math.min(Math.max(minY, y), maxY);
+  popover.style.left = `${left}px`;
+  popover.style.top = `${top}px`;
+}
+
+function openReviewCommentPopover(eventId, contextmenuEvent) {
+  const e = getEls();
+  if (!e.text) return;
+  const target = pointTargetFromClientPoint(e.text, contextmenuEvent.clientX, contextmenuEvent.clientY);
+  closeReviewCommentPopover();
+
+  const popover = document.createElement('form');
+  popover.className = 'canvas-review-popover';
+  popover.dataset.reviewPopover = 'true';
+  popover.innerHTML = `
+    <label class="sr-only" for="review-comment-input">Comment</label>
+    <input id="review-comment-input" type="text" maxlength="500" placeholder="Add comment (optional)">
+    <div class="canvas-review-popover-actions">
+      <button type="submit">Add Comment</button>
+      <button type="button" data-review-cancel>Cancel</button>
+    </div>
+  `;
+  e.text.appendChild(popover);
+  positionReviewCommentPopover(popover, e.text, target.pointX, target.pointY);
+  requestAnimationFrame(() => {
+    positionReviewCommentPopover(popover, e.text, target.pointX, target.pointY);
+    const input = popover.querySelector('#review-comment-input');
+    if (input && typeof input.focus === 'function') input.focus();
+  });
+
+  const cancelBtn = popover.querySelector('[data-review-cancel]');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      closeReviewCommentPopover();
+    });
+  }
+
+  popover.addEventListener('submit', (ev) => {
+    ev.preventDefault();
+    const input = popover.querySelector('#review-comment-input');
+    const comment = String(input?.value || '').trim();
+    const state = window._tabulaApp?.getState?.();
+    sendSelectionFeedback({
+      kind: 'mark_set',
+      session_id: state?.sessionId || '',
+      artifact_id: eventId,
+      intent: 'draft',
+      type: 'comment_point',
+      target_kind: 'text_range',
+      target: {
+        line_start: target.lineStart,
+        line_end: target.lineEnd,
+        start_offset: target.startOffset,
+        end_offset: target.endOffset,
+        rects: target.rects,
+      },
+      comment,
+    });
+    closeReviewCommentPopover();
+  });
+
+  const outsideHandler = (ev) => {
+    if (!popover.contains(ev.target)) {
+      closeReviewCommentPopover();
+    }
+  };
+  document.addEventListener('pointerdown', outsideHandler, true);
+  e.text._reviewPopoverOutsideHandler = outsideHandler;
+
+  const keyDownHandler = (ev) => {
+    if (ev.key === 'Escape') {
+      ev.preventDefault();
+      closeReviewCommentPopover();
+    }
+  };
+  document.addEventListener('keydown', keyDownHandler, true);
+  e.text._reviewPopoverKeyDownHandler = keyDownHandler;
+  e.text._reviewPopoverEl = popover;
+}
+
 function sendSelectionFeedback(payload) {
   const { getState } = window._tabulaApp || {};
   if (!getState) return;
@@ -340,6 +502,7 @@ function resetMailAssistDomState() {
 
 function clearSelectionInteractionHandlers() {
   const e = getEls();
+  closeReviewCommentPopover();
   if (e.text._selectionHandler) {
     document.removeEventListener('selectionchange', e.text._selectionHandler);
     e.text._selectionHandler = null;
@@ -359,6 +522,10 @@ function clearSelectionInteractionHandlers() {
   if (e.text._scrollHandler) {
     e.text.removeEventListener('scroll', e.text._scrollHandler);
     e.text._scrollHandler = null;
+  }
+  if (e.text._reviewContextMenuHandler) {
+    e.text.removeEventListener('contextmenu', e.text._reviewContextMenuHandler);
+    e.text._reviewContextMenuHandler = null;
   }
 }
 
@@ -1869,10 +2036,26 @@ function setupTextSelection(eventId) {
   e.text.addEventListener('mouseup', handler);
   e.text.addEventListener('keyup', handler);
 
+  const onContextMenu = (ev) => {
+    if (activeTextEventId !== eventId) return;
+    const target = ev.target;
+    if (!(target instanceof Element)) return;
+    if (!e.text.contains(target)) return;
+    if (target.closest('[data-review-popover]')) return;
+    if (target.closest('button,input,textarea,select,a,[contenteditable="true"]')) return;
+    ev.preventDefault();
+    openReviewCommentPopover(eventId, ev);
+  };
+  e.text._reviewContextMenuHandler = onContextMenu;
+  e.text.addEventListener('contextmenu', onContextMenu);
+
   if (e.text._scrollHandler) {
     e.text.removeEventListener('scroll', e.text._scrollHandler);
   }
-  e.text._scrollHandler = () => renderDraftOverlay();
+  e.text._scrollHandler = () => {
+    renderDraftOverlay();
+    closeReviewCommentPopover();
+  };
   e.text.addEventListener('scroll', e.text._scrollHandler);
 }
 

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -317,6 +317,32 @@ body.desktop-canvas-only #panel-canvas {
 .canvas-mark-squiggly { background: rgba(89, 206, 143, 0.25); border-bottom: 2px dotted #59ce8f; opacity: 0.9; }
 .canvas-mark-comment_point { background: rgba(255, 170, 0, 0.5); border: 1px solid #ffb022; opacity: 0.95; }
 
+.canvas-review-popover {
+  position: absolute;
+  z-index: 12;
+  min-width: 220px;
+  max-width: min(360px, calc(100% - 20px));
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.canvas-review-popover input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.canvas-review-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/tests/playwright/review-mode.spec.ts
+++ b/tests/playwright/review-mode.spec.ts
@@ -106,6 +106,17 @@ async function waitForLastSelectionMessage(page: Page): Promise<HarnessMessage> 
   return selections[selections.length - 1];
 }
 
+async function waitForLastMessageOfKind(page: Page, kind: string): Promise<HarnessMessage> {
+  await expect.poll(async () => {
+    const messages = await getHarnessMessages(page);
+    return messages.filter((m) => m.kind === kind).length;
+  }).toBeGreaterThan(0);
+
+  const messages = await getHarnessMessages(page);
+  const matches = messages.filter((m) => m.kind === kind);
+  return matches[matches.length - 1];
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/tests/playwright/harness.html');
   await clearHarnessMessages(page);
@@ -150,6 +161,47 @@ test('mail text artifacts keep the same review selection behavior', async ({ pag
   expect(Number(msg.line_start)).toBeGreaterThanOrEqual(1);
 });
 
+test('right-click inline comment popover submits a comment_point draft mark', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-comment-1', '# Notes\nInline comment target text'));
+  await page.click('#canvas-text', { button: 'right', position: { x: 80, y: 64 } });
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('input').fill('Check this sentence.');
+  await popover.locator('button[type="submit"]').click();
+  await expect(popover).toHaveCount(0);
+
+  const markSet = await waitForLastMessageOfKind(page, 'mark_set');
+  expect(markSet.artifact_id).toBe('evt-comment-1');
+  expect(markSet.intent).toBe('draft');
+  expect(markSet.type).toBe('comment_point');
+  expect(markSet.target_kind).toBe('text_range');
+  expect(markSet.comment).toBe('Check this sentence.');
+  expect(Number((markSet.target as any).line_start)).toBeGreaterThanOrEqual(1);
+  expect(Number((markSet.target as any).start_offset)).toBeGreaterThanOrEqual(0);
+});
+
+test('right-click inline comment popover cancel and outside click do not create marks', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-comment-2', '# Notes\nCancel path text'));
+
+  await page.click('#canvas-text', { button: 'right', position: { x: 82, y: 66 } });
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('button[data-review-cancel]').click();
+  await expect(popover).toHaveCount(0);
+  await page.waitForTimeout(50);
+  let messages = await getHarnessMessages(page);
+  expect(messages.filter((m) => m.kind === 'mark_set')).toHaveLength(0);
+
+  await page.click('#canvas-text', { button: 'right', position: { x: 96, y: 86 } });
+  await expect(popover).toBeVisible();
+  await page.click('#canvas-header');
+  await expect(popover).toHaveCount(0);
+  await page.waitForTimeout(50);
+  messages = await getHarnessMessages(page);
+  expect(messages.filter((m) => m.kind === 'mark_set')).toHaveLength(0);
+});
+
 test('switching artifacts tears down stale review and mail handlers', async ({ page }) => {
   await renderArtifact(page, mailEvent('evt-mail-2', 'gmail', [
     { id: 'm1', date: '2026-02-20T09:00:00Z', sender: 'a@example.com', subject: 'Switch Test' },
@@ -162,12 +214,14 @@ test('switching artifacts tears down stale review and mail handlers', async ({ p
       hasMailClickHandler: Boolean(root?._mailClickHandler),
       hasMailPointerDownHandler: Boolean(root?._mailPointerDownHandler),
       hasMailDetailKeyDownHandler: Boolean(root?._mailDetailKeyDownHandler),
+      hasReviewContextMenuHandler: Boolean(root?._reviewContextMenuHandler),
       hasMailClass: root?.classList.contains('mail-artifact') || false,
     };
   });
   expect(before.hasSelectionHandler).toBe(true);
   expect(before.hasMailClickHandler).toBe(true);
   expect(before.hasMailPointerDownHandler).toBe(true);
+  expect(before.hasReviewContextMenuHandler).toBe(true);
   expect(before.hasMailClass).toBe(true);
 
   await clearHarnessMessages(page);
@@ -180,6 +234,7 @@ test('switching artifacts tears down stale review and mail handlers', async ({ p
       hasMailClickHandler: Boolean(root?._mailClickHandler),
       hasMailPointerDownHandler: Boolean(root?._mailPointerDownHandler),
       hasMailDetailKeyDownHandler: Boolean(root?._mailDetailKeyDownHandler),
+      hasReviewContextMenuHandler: Boolean(root?._reviewContextMenuHandler),
       hasMailClass: root?.classList.contains('mail-artifact') || false,
     };
   });
@@ -187,6 +242,7 @@ test('switching artifacts tears down stale review and mail handlers', async ({ p
   expect(after.hasMailClickHandler).toBe(false);
   expect(after.hasMailPointerDownHandler).toBe(false);
   expect(after.hasMailDetailKeyDownHandler).toBe(false);
+  expect(after.hasReviewContextMenuHandler).toBe(false);
   expect(after.hasMailClass).toBe(false);
 
   await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- add a contextmenu-only inline annotation popover for text artifacts in `internal/web/static/canvas.js`
- submit creates `mark_set` payloads as `comment_point` draft marks with optional comment text
- close the popover on cancel, outside click, `Esc`, scroll, and artifact teardown; remove handler wiring on teardown
- add Playwright coverage for open/submit, cancel/outside-close, and contextmenu handler wiring/unwiring

## Verification
1. Requirement: bind `contextmenu` only inside canvas text artifact surface.
- Evidence: `tests/playwright/review-mode.spec.ts:205` (`switching artifacts tears down stale review and mail handlers`) asserts `_reviewContextMenuHandler` is present on text artifacts and removed after switching artifacts.

2. Requirement: right-click on text artifact opens annotation popover at cursor.
- Evidence: `tests/playwright/review-mode.spec.ts:164` right-clicks `#canvas-text` and verifies `[data-review-popover="true"]` becomes visible.

3. Requirement: submit creates one `comment_point` mark with optional comment text.
- Evidence: `tests/playwright/review-mode.spec.ts:164` submits popover and asserts emitted `mark_set` has `type=comment_point`, `target_kind=text_range`, and comment payload.

4. Requirement: outside click/cancel closes popover without creating mark.
- Evidence: `tests/playwright/review-mode.spec.ts:184` verifies cancel and outside click both close the popover and keep `mark_set` count at 0.

Command run:
```bash
npm run test:e2e -- tests/playwright/review-mode.spec.ts 2>&1 | tee /tmp/test.log
```

Output excerpt:
```text
✓ 3 tests/playwright/review-mode.spec.ts:164:5 › right-click inline comment popover submits a comment_point draft mark
✓ 4 tests/playwright/review-mode.spec.ts:184:5 › right-click inline comment popover cancel and outside click do not create marks
✓ 5 tests/playwright/review-mode.spec.ts:205:5 › switching artifacts tears down stale review and mail handlers
5 passed (1.9s)
```
