### PR TITLE
fix: [A3] Generic Review/Annotation - Highlight immediate comment pop (fixes #20)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -342,6 +342,7 @@ function closeReviewCommentPopover() {
     e.text._reviewPopoverEl.parentNode.removeChild(e.text._reviewPopoverEl);
   }
   e.text._reviewPopoverEl = null;
+  e.text._reviewPopoverSource = null;
 }
 
 function positionReviewCommentPopover(popover, root, x, y) {
@@ -358,10 +359,40 @@ function positionReviewCommentPopover(popover, root, x, y) {
   popover.style.top = `${top}px`;
 }
 
-function openReviewCommentPopover(eventId, contextmenuEvent) {
+function selectionTargetFromDraftMark(eventId) {
+  if (!draftMark || draftMark.event_id !== eventId) return null;
+  const rects = Array.isArray(draftMark.rects) ? draftMark.rects : [];
+  let pointX = 12;
+  let pointY = 12;
+  if (rects.length > 0 && Array.isArray(rects[rects.length - 1])) {
+    const anchor = rects[rects.length - 1];
+    pointX = Number(anchor[0]) + Math.max(8, Number(anchor[2] || 0) / 2);
+    pointY = Number(anchor[1]) + Math.max(12, Number(anchor[3] || 0)) + 8;
+  }
+  return {
+    lineStart: Number(draftMark.line_start || 1),
+    lineEnd: Number(draftMark.line_end || 1),
+    startOffset: Number(draftMark.start_offset || 0),
+    endOffset: Number(draftMark.end_offset || 0),
+    rects,
+    pointX,
+    pointY,
+    markType: draftMark.type || 'highlight',
+  };
+}
+
+function openReviewCommentPopover(eventId, options = {}) {
   const e = getEls();
   if (!e.text) return;
-  const target = pointTargetFromClientPoint(e.text, contextmenuEvent.clientX, contextmenuEvent.clientY);
+  let target = null;
+  if (options.source === 'selection') {
+    target = selectionTargetFromDraftMark(eventId);
+    if (!target) return;
+  } else {
+    const pointEvent = options.contextmenuEvent;
+    if (!pointEvent) return;
+    target = pointTargetFromClientPoint(e.text, pointEvent.clientX, pointEvent.clientY);
+  }
   closeReviewCommentPopover();
 
   const popover = document.createElement('form');
@@ -388,6 +419,9 @@ function openReviewCommentPopover(eventId, contextmenuEvent) {
     cancelBtn.addEventListener('click', (ev) => {
       ev.preventDefault();
       closeReviewCommentPopover();
+      if (typeof options.onCancel === 'function') {
+        options.onCancel();
+      }
     });
   }
 
@@ -401,7 +435,7 @@ function openReviewCommentPopover(eventId, contextmenuEvent) {
       session_id: state?.sessionId || '',
       artifact_id: eventId,
       intent: 'draft',
-      type: 'comment_point',
+      type: options.source === 'selection' ? (target.markType || 'highlight') : 'comment_point',
       target_kind: 'text_range',
       target: {
         line_start: target.lineStart,
@@ -412,12 +446,18 @@ function openReviewCommentPopover(eventId, contextmenuEvent) {
       },
       comment,
     });
+    if (options.source === 'selection' && draftMark && draftMark.event_id === eventId) {
+      draftMark.comment = comment;
+    }
     closeReviewCommentPopover();
   });
 
   const outsideHandler = (ev) => {
     if (!popover.contains(ev.target)) {
       closeReviewCommentPopover();
+      if (typeof options.onCancel === 'function') {
+        options.onCancel();
+      }
     }
   };
   document.addEventListener('pointerdown', outsideHandler, true);
@@ -427,11 +467,15 @@ function openReviewCommentPopover(eventId, contextmenuEvent) {
     if (ev.key === 'Escape') {
       ev.preventDefault();
       closeReviewCommentPopover();
+      if (typeof options.onCancel === 'function') {
+        options.onCancel();
+      }
     }
   };
   document.addEventListener('keydown', keyDownHandler, true);
   e.text._reviewPopoverKeyDownHandler = keyDownHandler;
   e.text._reviewPopoverEl = popover;
+  e.text._reviewPopoverSource = options.source || 'point';
 }
 
 function sendSelectionFeedback(payload) {
@@ -1953,6 +1997,8 @@ function renderMailArtifact(eventId, context) {
 function setupTextSelection(eventId) {
   const e = getEls();
   clearSelectionInteractionHandlers();
+  let autoPopoverSelectionKey = '';
+  let pendingSelectionFinalize = false;
 
   const clearDraftSelection = () => {
     if (draftMark && draftMark.event_id === eventId) {
@@ -1964,11 +2010,21 @@ function setupTextSelection(eventId) {
         session_id: state?.sessionId || '',
         artifact_id: eventId,
       });
+      closeReviewCommentPopover();
     }
+    autoPopoverSelectionKey = '';
   };
 
-  const handleSelection = () => {
+  const handleSelection = (finalizeSelection) => {
+    if (e.text._reviewPopoverEl && e.text._reviewPopoverSource === 'selection') {
+      return;
+    }
     const selection = window.getSelection();
+    const popover = e.text._reviewPopoverEl;
+    const anchorNode = selection?.anchorNode || null;
+    if (popover && anchorNode && popover.contains(anchorNode)) {
+      return;
+    }
     if (!selection || selection.isCollapsed || !isSelectionInside(e.text, selection)) {
       clearDraftSelection();
       return;
@@ -2017,15 +2073,31 @@ function setupTextSelection(eventId) {
       mark_type: markType,
       comment: getMarkComment(),
     });
+
+    if (markType === 'highlight' && finalizeSelection) {
+      const key = `${eventId}:${startOffset}:${endOffset}:${text}`;
+      if (autoPopoverSelectionKey !== key) {
+        autoPopoverSelectionKey = key;
+        openReviewCommentPopover(eventId, {
+          source: 'selection',
+          onCancel: clearDraftSelection,
+        });
+      }
+    }
   };
 
-  const handler = () => {
+  const handler = (ev) => {
     if (e.text._selectionRaf) {
       cancelAnimationFrame(e.text._selectionRaf);
     }
+    const triggerType = ev?.type || '';
+    if (triggerType === 'mouseup' || triggerType === 'keyup') {
+      pendingSelectionFinalize = true;
+    }
     e.text._selectionRaf = requestAnimationFrame(() => {
       e.text._selectionRaf = null;
-      handleSelection();
+      handleSelection(pendingSelectionFinalize);
+      pendingSelectionFinalize = false;
     });
   };
 
@@ -2044,7 +2116,10 @@ function setupTextSelection(eventId) {
     if (target.closest('[data-review-popover]')) return;
     if (target.closest('button,input,textarea,select,a,[contenteditable="true"]')) return;
     ev.preventDefault();
-    openReviewCommentPopover(eventId, ev);
+    openReviewCommentPopover(eventId, {
+      source: 'point',
+      contextmenuEvent: ev,
+    });
   };
   e.text._reviewContextMenuHandler = onContextMenu;
   e.text.addEventListener('contextmenu', onContextMenu);

--- a/tests/playwright/review-mode.spec.ts
+++ b/tests/playwright/review-mode.spec.ts
@@ -90,6 +90,7 @@ async function selectTextFromSelector(page: Page, selector: string) {
     selection.removeAllRanges();
     selection.addRange(range);
     document.dispatchEvent(new Event('selectionchange'));
+    root.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     return true;
   }, selector);
   if (!selected) throw new Error(`unable to select text from ${selector}`);
@@ -179,6 +180,43 @@ test('right-click inline comment popover submits a comment_point draft mark', as
   expect(markSet.comment).toBe('Check this sentence.');
   expect(Number((markSet.target as any).line_start)).toBeGreaterThanOrEqual(1);
   expect(Number((markSet.target as any).start_offset)).toBeGreaterThanOrEqual(0);
+});
+
+test('highlight selection opens immediate comment popover and submits a highlight draft mark', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-highlight-1', '# Notes\nHighlight this sentence now'));
+  await selectTextFromSelector(page, '#canvas-text');
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('input').fill('Add context to this highlight.');
+  await popover.locator('button[type="submit"]').click();
+  await expect(popover).toHaveCount(0);
+
+  const markSet = await waitForLastMessageOfKind(page, 'mark_set');
+  expect(markSet.artifact_id).toBe('evt-highlight-1');
+  expect(markSet.intent).toBe('draft');
+  expect(markSet.type).toBe('highlight');
+  expect(markSet.target_kind).toBe('text_range');
+  expect(markSet.comment).toBe('Add context to this highlight.');
+  expect(Number((markSet.target as any).line_start)).toBeGreaterThanOrEqual(1);
+  expect(Number((markSet.target as any).end_offset)).toBeGreaterThan(Number((markSet.target as any).start_offset));
+});
+
+test('highlight selection cancel clears draft without creating a mark', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-highlight-2', '# Notes\nCancel this highlighted draft'));
+  await selectTextFromSelector(page, '#canvas-text');
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('button[data-review-cancel]').click();
+  await expect(popover).toHaveCount(0);
+
+  await page.waitForTimeout(50);
+  const messages = await getHarnessMessages(page);
+  expect(messages.filter((m) => m.kind === 'mark_set')).toHaveLength(0);
+  const clearDrafts = messages.filter((m) => m.kind === 'mark_clear_draft');
+  expect(clearDrafts.length).toBeGreaterThan(0);
+  expect((clearDrafts[clearDrafts.length - 1] as any).artifact_id).toBe('evt-highlight-2');
 });
 
 test('right-click inline comment popover cancel and outside click do not create marks', async ({ page }) => {


### PR DESCRIPTION
## Summary
- auto-open the review comment popover when a `highlight` selection is finalized
- allow the popover submit path to emit a `highlight` `mark_set` with the selected text range and comment
- ensure cancel on selection-driven popovers clears the draft (`mark_clear_draft`) and removes the draft overlay
- add Playwright coverage for immediate popup, submit, and cancel behaviors

## Verification
Issue #20 requirements mapped to evidence:

1. Given silent mode and highlighted text, when selection ends, then comment popover opens immediately.
- Evidence: `tests/playwright/review-mode.spec.ts:185` (`highlight selection opens immediate comment popover and submits a highlight draft mark`) passes.

2. Given submit, when comment is entered, then highlight mark with comment is persisted.
- Evidence: same test asserts emitted `mark_set` has `type: "highlight"`, `target_kind: "text_range"`, and expected comment.

3. Given cancel, when popover closes, then no committed mark exists.
- Evidence: `tests/playwright/review-mode.spec.ts:205` (`highlight selection cancel clears draft without creating a mark`) passes and asserts zero `mark_set` plus `mark_clear_draft` emitted.

Command and output excerpt:

```bash
npm run test:e2e -- tests/playwright/review-mode.spec.ts 2>&1 | tee /tmp/test-pass.log
```

```text
✓ tests/playwright/review-mode.spec.ts:185:5 › highlight selection opens immediate comment popover and submits a highlight draft mark
✓ tests/playwright/review-mode.spec.ts:205:5 › highlight selection cancel clears draft without creating a mark
7 passed (2.2s)
```
