### PR TITLE
fix: [A5] Generic Review/Annotation - Review mark lifecycle hardening (fixes #22)

### DIFF
--- a/internal/canvas/adapter.go
+++ b/internal/canvas/adapter.go
@@ -122,6 +122,7 @@ func (a *Adapter) ensureSession(sessionID string) *SessionRecord {
 		return r
 	}
 	r = newSessionRecord(true)
+	a.loadPersistedAnnotationsLocked(sessionID, r)
 	a.sessions[sessionID] = r
 	return r
 }
@@ -256,9 +257,14 @@ func (a *Adapter) CanvasMarkSet(sessionID, markID, artifactID string, intent Mar
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	m, exists := r.Marks[markID]
+	oldArtifactID := ""
+	oldIntent := MarkIntent("")
 	if !exists {
 		m = &Mark{MarkID: markID, CreatedAt: now, State: "active"}
 		r.Marks[markID] = m
+	} else {
+		oldArtifactID = m.ArtifactID
+		oldIntent = m.Intent
 	}
 	m.SessionID = sessionID
 	m.ArtifactID = artifactID
@@ -270,9 +276,17 @@ func (a *Adapter) CanvasMarkSet(sessionID, markID, artifactID string, intent Mar
 	m.Author = author
 	m.UpdatedAt = now
 
+	if oldIntent == IntentDraft && (intent != IntentDraft || oldArtifactID != artifactID) {
+		if r.DraftByArtifactID[oldArtifactID] == markID {
+			delete(r.DraftByArtifactID, oldArtifactID)
+		}
+	}
 	if intent == IntentDraft {
 		r.DraftByArtifactID[artifactID] = markID
+	} else {
+		removeDraftIndexForMarkLocked(r, markID)
 	}
+	pruneDraftIndexLocked(r)
 
 	return map[string]interface{}{"mark": m}, nil
 }
@@ -281,17 +295,8 @@ func (a *Adapter) CanvasMarkDelete(sessionID, markID string) (map[string]interfa
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	r := a.ensureSession(sessionID)
-	if _, ok := r.Marks[markID]; !ok {
+	if !deleteMarkLocked(r, markID) {
 		return nil, fmt.Errorf("mark not found: %s", markID)
-	}
-	delete(r.Marks, markID)
-	for artifactID, did := range r.DraftByArtifactID {
-		if did == markID {
-			delete(r.DraftByArtifactID, artifactID)
-		}
-	}
-	if r.FocusedMarkID == markID {
-		r.FocusedMarkID = ""
 	}
 	return map[string]interface{}{"deleted": true, "mark_id": markID}, nil
 }
@@ -359,9 +364,11 @@ func (a *Adapter) CanvasCommit(sessionID, artifactID string, includeDraft bool) 
 		if includeDraft && m.Intent == IntentDraft {
 			m.Intent = IntentPersistent
 			m.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+			removeDraftIndexForMarkLocked(r, m.MarkID)
 			persistent++
 		}
 	}
+	pruneDraftIndexLocked(r)
 	path, err := a.writeAnnotationsFile(sessionID, r)
 	if err != nil {
 		return nil, err
@@ -390,13 +397,11 @@ func countPersistent(r *SessionRecord, artifactID string) int {
 }
 
 func (a *Adapter) writeAnnotationsFile(sessionID string, r *SessionRecord) (string, error) {
-	h := sha256.Sum256([]byte(sessionID))
-	name := hex8(h[:]) + ".annotations.json"
-	dir := filepath.Join(a.projectDir, ".tabula", "artifacts", "annotations")
+	path := a.annotationsPath(sessionID)
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(dir, name)
 	marks := make([]*Mark, 0, len(r.Marks))
 	for _, m := range r.Marks {
 		marks = append(marks, m)
@@ -558,6 +563,7 @@ func (a *Adapter) clearDraft(sessionID, artifactID string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	r := a.ensureSession(sessionID)
+	var toDelete []string
 	for id, m := range r.Marks {
 		if m.Intent != IntentDraft {
 			continue
@@ -565,8 +571,19 @@ func (a *Adapter) clearDraft(sessionID, artifactID string) {
 		if artifactID != "" && m.ArtifactID != artifactID {
 			continue
 		}
-		delete(r.Marks, id)
+		toDelete = append(toDelete, id)
 	}
+	for _, id := range toDelete {
+		deleteMarkLocked(r, id)
+	}
+	if artifactID != "" {
+		if markID, ok := r.DraftByArtifactID[artifactID]; ok {
+			if _, exists := r.Marks[markID]; !exists {
+				delete(r.DraftByArtifactID, artifactID)
+			}
+		}
+	}
+	pruneDraftIndexLocked(r)
 }
 
 func asString(v interface{}) string {
@@ -607,4 +624,76 @@ func (a *Adapter) ListSessions() []string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.listSessions()
+}
+
+func (a *Adapter) annotationsPath(sessionID string) string {
+	h := sha256.Sum256([]byte(sessionID))
+	name := hex8(h[:]) + ".annotations.json"
+	return filepath.Join(a.projectDir, ".tabula", "artifacts", "annotations", name)
+}
+
+func (a *Adapter) loadPersistedAnnotationsLocked(sessionID string, r *SessionRecord) {
+	path := a.annotationsPath(sessionID)
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var payload struct {
+		Marks []*Mark `json:"marks"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, m := range payload.Marks {
+		if m == nil || strings.TrimSpace(m.MarkID) == "" {
+			continue
+		}
+		if m.SessionID == "" {
+			m.SessionID = sessionID
+		}
+		if m.State == "" {
+			m.State = "active"
+		}
+		if m.CreatedAt == "" {
+			m.CreatedAt = now
+		}
+		if m.UpdatedAt == "" {
+			m.UpdatedAt = m.CreatedAt
+		}
+		r.Marks[m.MarkID] = m
+		if m.Intent == IntentDraft && m.ArtifactID != "" {
+			r.DraftByArtifactID[m.ArtifactID] = m.MarkID
+		}
+	}
+	pruneDraftIndexLocked(r)
+}
+
+func removeDraftIndexForMarkLocked(r *SessionRecord, markID string) {
+	for artifactID, draftID := range r.DraftByArtifactID {
+		if draftID == markID {
+			delete(r.DraftByArtifactID, artifactID)
+		}
+	}
+}
+
+func pruneDraftIndexLocked(r *SessionRecord) {
+	for artifactID, draftID := range r.DraftByArtifactID {
+		m, ok := r.Marks[draftID]
+		if !ok || m.Intent != IntentDraft || m.ArtifactID != artifactID {
+			delete(r.DraftByArtifactID, artifactID)
+		}
+	}
+}
+
+func deleteMarkLocked(r *SessionRecord, markID string) bool {
+	if _, ok := r.Marks[markID]; !ok {
+		return false
+	}
+	delete(r.Marks, markID)
+	removeDraftIndexForMarkLocked(r, markID)
+	if r.FocusedMarkID == markID {
+		r.FocusedMarkID = ""
+	}
+	return true
 }

--- a/internal/canvas/adapter_test.go
+++ b/internal/canvas/adapter_test.go
@@ -1,0 +1,279 @@
+package canvas
+
+import (
+	"testing"
+)
+
+func marksFromResult(t *testing.T, resp map[string]interface{}) []*Mark {
+	t.Helper()
+	list, ok := resp["marks"].([]*Mark)
+	if !ok {
+		t.Fatalf("expected []*Mark in marks result, got %T", resp["marks"])
+	}
+	return list
+}
+
+func TestClearDraftRemovesFocusedMarkAndDraftIndex(t *testing.T) {
+	a := NewAdapter(t.TempDir(), nil, true)
+	sessionID := "s-clear-draft"
+
+	_, err := a.CanvasMarkSet(
+		sessionID,
+		"draft-a",
+		"artifact-a",
+		IntentDraft,
+		MarkHighlight,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 1, "line_end": 1},
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("set draft mark a: %v", err)
+	}
+	_, err = a.CanvasMarkSet(
+		sessionID,
+		"draft-b",
+		"artifact-b",
+		IntentDraft,
+		MarkHighlight,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 2, "line_end": 2},
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("set draft mark b: %v", err)
+	}
+	if _, err := a.CanvasMarkFocus(sessionID, "draft-a"); err != nil {
+		t.Fatalf("focus draft mark: %v", err)
+	}
+
+	a.HandleFeedback(`{"kind":"mark_clear_draft","session_id":"s-clear-draft","artifact_id":"artifact-a"}`)
+
+	marks := marksFromResult(t, a.CanvasMarksList(sessionID, "", "", 0))
+	if len(marks) != 1 || marks[0].MarkID != "draft-b" {
+		t.Fatalf("expected only draft-b to remain, got %#v", marks)
+	}
+	status := a.CanvasStatus(sessionID)
+	if status["focused_mark_id"] != nil {
+		t.Fatalf("expected focused_mark_id to clear after draft deletion, got %#v", status["focused_mark_id"])
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	record := a.sessions[sessionID]
+	if record == nil {
+		t.Fatalf("missing session record")
+	}
+	if _, ok := record.DraftByArtifactID["artifact-a"]; ok {
+		t.Fatalf("artifact-a draft index should be removed")
+	}
+	if got := record.DraftByArtifactID["artifact-b"]; got != "draft-b" {
+		t.Fatalf("expected artifact-b draft index to remain draft-b, got %q", got)
+	}
+}
+
+func TestCanvasCommitConvertsDraftAndCleansDraftIndex(t *testing.T) {
+	a := NewAdapter(t.TempDir(), nil, true)
+	sessionID := "s-commit"
+
+	_, err := a.CanvasMarkSet(
+		sessionID,
+		"draft-a",
+		"artifact-a",
+		IntentDraft,
+		MarkHighlight,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 1, "line_end": 1},
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("set draft mark: %v", err)
+	}
+	_, err = a.CanvasMarkSet(
+		sessionID,
+		"persist-a",
+		"artifact-a",
+		IntentPersistent,
+		MarkCommentPoint,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 1, "line_end": 1},
+		"keep",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("set persistent mark: %v", err)
+	}
+
+	resp, err := a.CanvasCommit(sessionID, "artifact-a", true)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if got, _ := resp["converted_to_persistent"].(int); got != 1 {
+		t.Fatalf("expected converted_to_persistent=1, got %#v", resp["converted_to_persistent"])
+	}
+	if got, _ := resp["persistent_count"].(int); got != 2 {
+		t.Fatalf("expected persistent_count=2, got %#v", resp["persistent_count"])
+	}
+	sidecarPath, _ := resp["sidecar_path"].(string)
+	if sidecarPath == "" {
+		t.Fatalf("expected sidecar path from commit response")
+	}
+
+	a.mu.RLock()
+	record := a.sessions[sessionID]
+	a.mu.RUnlock()
+	if record == nil {
+		t.Fatalf("missing session record")
+	}
+	if _, ok := record.DraftByArtifactID["artifact-a"]; ok {
+		t.Fatalf("artifact-a should not remain in draft index after commit")
+	}
+
+	marks := marksFromResult(t, a.CanvasMarksList(sessionID, "artifact-a", "", 0))
+	if len(marks) != 2 {
+		t.Fatalf("expected 2 marks for artifact-a, got %d", len(marks))
+	}
+	for _, m := range marks {
+		if m.Intent != IntentPersistent {
+			t.Fatalf("expected mark %s to be persistent after commit, got %q", m.MarkID, m.Intent)
+		}
+	}
+}
+
+func TestCanvasSessionOpenLoadsPersistedAnnotations(t *testing.T) {
+	tmpDir := t.TempDir()
+	const sessionID = "s-reload"
+
+	writer := NewAdapter(tmpDir, nil, true)
+	if _, err := writer.CanvasMarkSet(
+		sessionID,
+		"draft-to-persist",
+		"artifact-1",
+		IntentDraft,
+		MarkHighlight,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 3, "line_end": 3},
+		"",
+		"",
+	); err != nil {
+		t.Fatalf("set draft mark: %v", err)
+	}
+	if _, err := writer.CanvasMarkSet(
+		sessionID,
+		"persist-existing",
+		"artifact-2",
+		IntentPersistent,
+		MarkCommentPoint,
+		TargetTextRange,
+		map[string]interface{}{"line_start": 4, "line_end": 4},
+		"saved",
+		"",
+	); err != nil {
+		t.Fatalf("set persistent mark: %v", err)
+	}
+	if _, err := writer.CanvasCommit(sessionID, "", true); err != nil {
+		t.Fatalf("commit persisted annotations: %v", err)
+	}
+
+	reloaded := NewAdapter(tmpDir, nil, true)
+	openResp := reloaded.CanvasSessionOpen(sessionID, "")
+	if got, _ := openResp["marks_total"].(int); got != 2 {
+		t.Fatalf("expected marks_total=2 on open, got %#v", openResp["marks_total"])
+	}
+
+	marks := marksFromResult(t, reloaded.CanvasMarksList(sessionID, "", "", 0))
+	if len(marks) != 2 {
+		t.Fatalf("expected 2 reloaded marks, got %d", len(marks))
+	}
+	byID := map[string]*Mark{}
+	for _, m := range marks {
+		byID[m.MarkID] = m
+	}
+	if byID["draft-to-persist"] == nil || byID["persist-existing"] == nil {
+		t.Fatalf("reloaded mark ids mismatch: %#v", byID)
+	}
+	for id, m := range byID {
+		if m.Intent != IntentPersistent {
+			t.Fatalf("expected reloaded mark %s to be persistent, got %q", id, m.Intent)
+		}
+	}
+
+	reloaded.mu.RLock()
+	defer reloaded.mu.RUnlock()
+	record := reloaded.sessions[sessionID]
+	if record == nil {
+		t.Fatalf("missing reloaded session record")
+	}
+	if len(record.DraftByArtifactID) != 0 {
+		t.Fatalf("expected empty draft index after reload, got %#v", record.DraftByArtifactID)
+	}
+}
+
+func TestCanvasMarkLifecycleForPDFAndImageArtifacts(t *testing.T) {
+	a := NewAdapter(t.TempDir(), nil, true)
+	const sessionID = "s-media"
+
+	pdfShown, err := a.CanvasArtifactShow(sessionID, "pdf", "Doc", "", "/tmp/doc.pdf", 0, "", nil)
+	if err != nil {
+		t.Fatalf("show pdf artifact: %v", err)
+	}
+	pdfArtifactID, _ := pdfShown["artifact_id"].(string)
+	if pdfArtifactID == "" {
+		t.Fatalf("expected pdf artifact_id")
+	}
+	if _, err := a.CanvasMarkSet(
+		sessionID,
+		"pdf-draft",
+		pdfArtifactID,
+		IntentDraft,
+		MarkHighlight,
+		TargetPDFQuads,
+		map[string]interface{}{"page": 1, "quads": []interface{}{map[string]interface{}{"x1": 1.0}}},
+		"",
+		"",
+	); err != nil {
+		t.Fatalf("set pdf draft mark: %v", err)
+	}
+	if _, err := a.CanvasCommit(sessionID, pdfArtifactID, true); err != nil {
+		t.Fatalf("commit pdf mark: %v", err)
+	}
+	pdfMarks := marksFromResult(t, a.CanvasMarksList(sessionID, pdfArtifactID, "", 0))
+	if len(pdfMarks) != 1 {
+		t.Fatalf("expected 1 pdf mark after commit, got %d", len(pdfMarks))
+	}
+	if pdfMarks[0].Intent != IntentPersistent {
+		t.Fatalf("expected committed pdf mark to be persistent, got %q", pdfMarks[0].Intent)
+	}
+
+	imageShown, err := a.CanvasArtifactShow(sessionID, "image", "Image", "", "/tmp/image.png", 0, "", nil)
+	if err != nil {
+		t.Fatalf("show image artifact: %v", err)
+	}
+	imageArtifactID, _ := imageShown["artifact_id"].(string)
+	if imageArtifactID == "" {
+		t.Fatalf("expected image artifact_id")
+	}
+	if _, err := a.CanvasMarkSet(
+		sessionID,
+		"image-draft",
+		imageArtifactID,
+		IntentDraft,
+		MarkCommentPoint,
+		TargetPDFPoint,
+		map[string]interface{}{"x": 12.5, "y": 24.0},
+		"point",
+		"",
+	); err != nil {
+		t.Fatalf("set image draft mark: %v", err)
+	}
+	if _, err := a.CanvasMarkDelete(sessionID, "image-draft"); err != nil {
+		t.Fatalf("delete image draft mark: %v", err)
+	}
+	imageMarks := marksFromResult(t, a.CanvasMarksList(sessionID, imageArtifactID, "", 0))
+	if len(imageMarks) != 0 {
+		t.Fatalf("expected deleted image mark to be gone, got %#v", imageMarks)
+	}
+}


### PR DESCRIPTION
## Summary
- harden canvas mark lifecycle bookkeeping so draft clear/commit/delete paths keep focus and draft index state consistent
- load persisted annotation sidecar data when opening a session to restore marks on reopen/reload
- add focused adapter unit tests for lifecycle, persistence reload, and PDF/image non-regression paths

## Verification
- Requirement: draft vs committed lifecycle consistency (set/focus/delete/commit)
  - Evidence: `TestClearDraftRemovesFocusedMarkAndDraftIndex` and `TestCanvasCommitConvertsDraftAndCleansDraftIndex` in `internal/canvas/adapter_test.go`
  - Command: `go test ./internal/canvas -count=1 2>&1 | tee /tmp/test.log`
  - Output excerpt: `ok   github.com/krystophny/tabula/internal/canvas  0.002s`
- Requirement: persisted annotations + reload/reopen reconstruction
  - Evidence: `TestCanvasSessionOpenLoadsPersistedAnnotations` verifies `CanvasCommit` writes sidecar data and a new adapter instance restores marks via `CanvasSessionOpen`
  - Artifact path: `.tabula/artifacts/annotations/<sha256(session_id)[:16]>.annotations.json` (implemented via `annotationsPath`)
  - Command: `go test ./internal/canvas -count=1 2>&1 | tee /tmp/test.log`
  - Output excerpt: `ok   github.com/krystophny/tabula/internal/canvas  0.002s`
- Requirement: no regression on PDF/image annotation paths
  - Evidence: `TestCanvasMarkLifecycleForPDFAndImageArtifacts` covers mark set/commit on PDF and set/delete on image artifacts
  - Command: `go test ./internal/canvas -count=1 2>&1 | tee /tmp/test.log`
  - Output excerpt: `ok   github.com/krystophny/tabula/internal/canvas  0.002s`
