### PR TITLE
fix: [B4] Action-Assist Reply - Reply assist tests (fixes #27)

### DIFF
--- a/internal/web/server_mail_actions_test.go
+++ b/internal/web/server_mail_actions_test.go
@@ -293,6 +293,7 @@ func TestMailActionRejectsNonMCPPath(t *testing.T) {
 
 func TestMailDraftReplyUsesProducerDraftTool(t *testing.T) {
 	calls := []string{}
+	callArgs := []map[string]any{}
 	producer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var req map[string]any
@@ -302,6 +303,8 @@ func TestMailDraftReplyUsesProducerDraftTool(t *testing.T) {
 		params, _ := req["params"].(map[string]any)
 		name, _ := params["name"].(string)
 		calls = append(calls, name)
+		args, _ := params["arguments"].(map[string]any)
+		callArgs = append(callArgs, args)
 		if name != "draft_reply" {
 			t.Fatalf("unexpected tool call: %s", name)
 		}
@@ -342,6 +345,25 @@ func TestMailDraftReplyUsesProducerDraftTool(t *testing.T) {
 	}
 	if len(calls) != 1 || calls[0] != "draft_reply" {
 		t.Fatalf("unexpected producer tool calls: %#v", calls)
+	}
+	if len(callArgs) != 1 {
+		t.Fatalf("expected one argument payload, got %#v", callArgs)
+	}
+	args := callArgs[0]
+	if got := args["provider"]; got != "gmail" {
+		t.Fatalf("expected provider=gmail, got %#v", got)
+	}
+	if got := args["message_id"]; got != "m42" {
+		t.Fatalf("expected message_id=m42, got %#v", got)
+	}
+	if got := args["subject"]; got != "Question" {
+		t.Fatalf("expected subject=Question, got %#v", got)
+	}
+	if got := args["sender"]; got != "Alice <alice@example.com>" {
+		t.Fatalf("expected sender=Alice <alice@example.com>, got %#v", got)
+	}
+	if got := args["selection_text"]; got != "Can you reply by Friday?" {
+		t.Fatalf("expected selection_text forwarded, got %#v", got)
 	}
 }
 

--- a/tests/playwright/mail-actions.spec.ts
+++ b/tests/playwright/mail-actions.spec.ts
@@ -356,6 +356,105 @@ test('draft reply assist uses shared action_id handler with state transitions in
   expect(mutateCalls).toBe(0);
 });
 
+test('draft reply assist shows consistent backend errors in list/detail', async ({ page }) => {
+  let mutateCalls = 0;
+  const readCalls: string[] = [];
+  const markReadCalls: string[] = [];
+  const draftCalls: Array<Record<string, unknown>> = [];
+
+  await page.route('**/api/mail/action-capabilities', async (route) => {
+    await route.fulfill({
+      json: {
+        capabilities: {
+          provider: 'gmail',
+          supports_open: true,
+          supports_archive: true,
+          supports_delete_to_trash: true,
+          supports_native_defer: true,
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/mail/action', async (route) => {
+    mutateCalls += 1;
+    await route.fulfill({ json: { result: { status: 'ok' } } });
+  });
+
+  await page.route('**/api/mail/read', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    readCalls.push(String(body.message_id || ''));
+    await route.fulfill({
+      json: {
+        message: {
+          ID: body.message_id,
+          Subject: `Subject ${body.message_id}`,
+          Sender: 'Alice <alice@example.com>',
+          Recipients: ['Bob <bob@example.com>'],
+          Date: '2026-02-20T09:00:00Z',
+          BodyText: `Full message body ${body.message_id}`,
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/mail/mark-read', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    markReadCalls.push(String(body.message_id || ''));
+    await route.fulfill({ json: { marked: 1 } });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    draftCalls.push(body);
+    await route.fulfill({
+      status: 502,
+      json: {
+        error: 'draft backend unavailable',
+      },
+    });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm12', date: '2026-02-20T07:00:00Z', sender: 'Alice <alice@example.com>', subject: 'First' },
+    { id: 'm13', date: '2026-02-20T06:00:00Z', sender: 'Bob <bob@example.com>', subject: 'Second' },
+  ]);
+
+  await page.click('tr[data-message-id="m12"] button[data-mail-action="draft-reply"]');
+  const promptInput = page.locator('[data-mail-draft-panel] [data-mail-draft-prompt]');
+  await expect(promptInput).toBeFocused();
+  await promptInput.fill('List prompt should fail.');
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-generate"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('error');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-error')).toBe('draft backend unavailable');
+  await expect(page.locator('[data-mail-draft-panel]')).toBeHidden();
+  await expect(page.locator('tr[data-message-id="m12"] [data-mail-row-status]')).toContainText('draft backend unavailable');
+
+  await page.click('tr[data-message-id="m13"] button[data-mail-action="open"]');
+  await expect.poll(() => readCalls.length).toBe(1);
+  await expect.poll(() => markReadCalls.length).toBe(1);
+  await expect(page.locator('[data-mail-detail-root]')).toHaveAttribute('data-message-id', 'm13');
+  await page.click('.mail-detail-actions button[data-mail-action="draft-reply"]');
+  await expect(promptInput).toBeFocused();
+  await promptInput.fill('Detail prompt should also fail.');
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-generate"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('error');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-error')).toBe('draft backend unavailable');
+  await expect(page.locator('[data-mail-draft-panel]')).toBeHidden();
+  await expect(page.locator('[data-mail-detail-status]')).toContainText('draft backend unavailable');
+
+  expect(draftCalls).toHaveLength(2);
+  expect(draftCalls.map((c) => c.message_id)).toEqual(['m12', 'm13']);
+  expect(draftCalls.map((c) => c.selection_text)).toEqual([
+    'List prompt should fail.',
+    'Detail prompt should also fail.',
+  ]);
+  expect(Object.keys(draftCalls[0] || {}).sort()).toEqual(Object.keys(draftCalls[1] || {}).sort());
+  expect(readCalls).toEqual(['m13']);
+  expect(markReadCalls).toEqual(['m13']);
+  expect(mutateCalls).toBe(0);
+});
+
 test('detail navigation cancels pending draft capture and keeps draft context on current message', async ({ page }) => {
   let mutateCalls = 0;
   const readCalls: string[] = [];


### PR DESCRIPTION
## Summary
- Added a Playwright scenario that mocks `/api/mail/draft-reply` backend failures and verifies consistent error handling for both list and detail Draft Reply triggers.
- Kept parity assertions for list/detail request shape and no-mutation behavior during assist flows.
- Strengthened `TestMailDraftReplyUsesProducerDraftTool` to assert forwarded `draft_reply` tool arguments (`provider`, `message_id`, `subject`, `sender`, `selection_text`).

## Verification
- Requirement: Given list reply assist, when executed, then draft appears with expected state transitions.
  - Evidence command: `npx playwright test tests/playwright/mail-actions.spec.ts --grep 'draft reply assist uses shared action_id handler with state transitions in list/detail|draft reply assist shows consistent backend errors in list/detail'`
  - Evidence excerpt: `✓ tests/playwright/mail-actions.spec.ts:260:5 › draft reply assist uses shared action_id handler with state transitions in list/detail`
- Requirement: Given detail reply assist, when executed, then same state transitions and output structure occur.
  - Evidence command: same as above.
  - Evidence excerpt: same passing test (`:260:5`) covers detail trigger and asserts equal payload key structure across list/detail calls.
- Requirement: Given failures, when mocked backend errors occur, then consistent error handling is shown.
  - Evidence command: same as above.
  - Evidence excerpt: `✓ tests/playwright/mail-actions.spec.ts:359:5 › draft reply assist shows consistent backend errors in list/detail`
- Requirement: Unit coverage for `mail.draft_reply` handler/tool invocation path.
  - Evidence command: `go test ./internal/web -run 'TestMailDraftReply'`
  - Evidence excerpt: `ok github.com/krystophny/tabula/internal/web 0.007s`
  - Evidence detail: `TestMailDraftReplyUsesProducerDraftTool` now verifies forwarded arguments to producer `draft_reply`.
