### PR TITLE
fix: [A4] Generic Review/Annotation - Unified popover + accessibility (fixes #21)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -330,6 +330,7 @@ function pointTargetFromClientPoint(root, clientX, clientY) {
 function closeReviewCommentPopover() {
   const e = getEls();
   if (!e.text) return;
+  const restoreFocusEl = e.text._reviewPopoverPreviousFocusEl;
   if (e.text._reviewPopoverOutsideHandler) {
     document.removeEventListener('pointerdown', e.text._reviewPopoverOutsideHandler, true);
     e.text._reviewPopoverOutsideHandler = null;
@@ -343,6 +344,18 @@ function closeReviewCommentPopover() {
   }
   e.text._reviewPopoverEl = null;
   e.text._reviewPopoverSource = null;
+  e.text._reviewPopoverPreviousFocusEl = null;
+  if (!restoreFocusEl && !e.text.hasAttribute('tabindex')) {
+    e.text.setAttribute('tabindex', '-1');
+  }
+  const focusTarget = restoreFocusEl || e.text;
+  if (focusTarget && document.contains(focusTarget) && typeof focusTarget.focus === 'function') {
+    try {
+      focusTarget.focus({ preventScroll: true });
+    } catch (_) {
+      focusTarget.focus();
+    }
+  }
 }
 
 function positionReviewCommentPopover(popover, root, x, y) {
@@ -384,6 +397,8 @@ function selectionTargetFromDraftMark(eventId) {
 function openReviewCommentPopover(eventId, options = {}) {
   const e = getEls();
   if (!e.text) return;
+  const activeEl = document.activeElement;
+  const previousFocusEl = activeEl instanceof HTMLElement && activeEl !== document.body ? activeEl : null;
   let target = null;
   if (options.source === 'selection') {
     target = selectionTargetFromDraftMark(eventId);
@@ -395,12 +410,16 @@ function openReviewCommentPopover(eventId, options = {}) {
   }
   closeReviewCommentPopover();
 
+  e.text._reviewPopoverPreviousFocusEl = previousFocusEl;
   const popover = document.createElement('form');
   popover.className = 'canvas-review-popover';
   popover.dataset.reviewPopover = 'true';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-label', 'Add comment');
+  const inputId = `review-comment-input-${Math.random().toString(36).slice(2, 8)}`;
   popover.innerHTML = `
-    <label class="sr-only" for="review-comment-input">Comment</label>
-    <input id="review-comment-input" type="text" maxlength="500" placeholder="Add comment (optional)">
+    <label class="sr-only" for="${inputId}">Comment</label>
+    <input id="${inputId}" type="text" maxlength="500" placeholder="Add comment (optional)">
     <div class="canvas-review-popover-actions">
       <button type="submit">Add Comment</button>
       <button type="button" data-review-cancel>Cancel</button>
@@ -410,8 +429,14 @@ function openReviewCommentPopover(eventId, options = {}) {
   positionReviewCommentPopover(popover, e.text, target.pointX, target.pointY);
   requestAnimationFrame(() => {
     positionReviewCommentPopover(popover, e.text, target.pointX, target.pointY);
-    const input = popover.querySelector('#review-comment-input');
-    if (input && typeof input.focus === 'function') input.focus();
+    const input = popover.querySelector(`#${CSS.escape(inputId)}`);
+    if (input && typeof input.focus === 'function') {
+      try {
+        input.focus({ preventScroll: true });
+      } catch (_) {
+        input.focus();
+      }
+    }
   });
 
   const cancelBtn = popover.querySelector('[data-review-cancel]');
@@ -427,7 +452,7 @@ function openReviewCommentPopover(eventId, options = {}) {
 
   popover.addEventListener('submit', (ev) => {
     ev.preventDefault();
-    const input = popover.querySelector('#review-comment-input');
+    const input = popover.querySelector(`#${CSS.escape(inputId)}`);
     const comment = String(input?.value || '').trim();
     const state = window._tabulaApp?.getState?.();
     sendSelectionFeedback({

--- a/tests/playwright/review-mode.spec.ts
+++ b/tests/playwright/review-mode.spec.ts
@@ -182,14 +182,14 @@ test('right-click inline comment popover submits a comment_point draft mark', as
   expect(Number((markSet.target as any).start_offset)).toBeGreaterThanOrEqual(0);
 });
 
-test('highlight selection opens immediate comment popover and submits a highlight draft mark', async ({ page }) => {
+test('highlight selection popover submits with Enter key as a highlight draft mark', async ({ page }) => {
   await renderArtifact(page, plainTextEvent('evt-highlight-1', '# Notes\nHighlight this sentence now'));
   await selectTextFromSelector(page, '#canvas-text');
 
   const popover = page.locator('[data-review-popover="true"]');
   await expect(popover).toBeVisible();
   await popover.locator('input').fill('Add context to this highlight.');
-  await popover.locator('button[type="submit"]').click();
+  await popover.locator('input').press('Enter');
   await expect(popover).toHaveCount(0);
 
   const markSet = await waitForLastMessageOfKind(page, 'mark_set');
@@ -200,6 +200,34 @@ test('highlight selection opens immediate comment popover and submits a highligh
   expect(markSet.comment).toBe('Add context to this highlight.');
   expect(Number((markSet.target as any).line_start)).toBeGreaterThanOrEqual(1);
   expect(Number((markSet.target as any).end_offset)).toBeGreaterThan(Number((markSet.target as any).start_offset));
+});
+
+test('popover Escape cancels and returns focus to the review canvas', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-comment-esc', '# Notes\nEscape key should cancel this popover'));
+  await page.evaluate(() => {
+    const existing = document.getElementById('review-focus-anchor');
+    if (existing) existing.remove();
+    const focusAnchor = document.createElement('button');
+    focusAnchor.id = 'review-focus-anchor';
+    focusAnchor.type = 'button';
+    focusAnchor.textContent = 'focus anchor';
+    document.body.appendChild(focusAnchor);
+    focusAnchor.focus();
+  });
+
+  await page.click('#canvas-text', { button: 'right', position: { x: 88, y: 72 } });
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await expect(popover.locator('input')).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(popover).toHaveCount(0);
+  await page.waitForTimeout(50);
+
+  const activeElementId = await page.evaluate(() => document.activeElement?.id || '');
+  expect(activeElementId).toBe('canvas-text');
+  const messages = await getHarnessMessages(page);
+  expect(messages.filter((m) => m.kind === 'mark_set')).toHaveLength(0);
 });
 
 test('highlight selection cancel clears draft without creating a mark', async ({ page }) => {
@@ -238,6 +266,45 @@ test('right-click inline comment popover cancel and outside click do not create 
   await page.waitForTimeout(50);
   messages = await getHarnessMessages(page);
   expect(messages.filter((m) => m.kind === 'mark_set')).toHaveLength(0);
+});
+
+test('popover opened near viewport edge stays within visible text canvas bounds', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-comment-edge', '# Notes\nEdge positioning test text'));
+
+  const box = await page.locator('#canvas-text').boundingBox();
+  if (!box) throw new Error('expected #canvas-text to have a bounding box');
+
+  await page.click('#canvas-text', {
+    button: 'right',
+    position: { x: Math.max(2, box.width - 2), y: Math.max(2, box.height - 2) },
+  });
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+
+  const bounds = await page.evaluate(() => {
+    const root = document.getElementById('canvas-text');
+    const overlay = root?.querySelector('[data-review-popover="true"]');
+    if (!root || !overlay) return null;
+    const rootRect = root.getBoundingClientRect();
+    const overlayRect = overlay.getBoundingClientRect();
+    return {
+      rootLeft: rootRect.left,
+      rootTop: rootRect.top,
+      rootRight: rootRect.right,
+      rootBottom: rootRect.bottom,
+      overlayLeft: overlayRect.left,
+      overlayTop: overlayRect.top,
+      overlayRight: overlayRect.right,
+      overlayBottom: overlayRect.bottom,
+    };
+  });
+  if (!bounds) throw new Error('expected popover bounds to be measurable');
+
+  expect(bounds.overlayLeft).toBeGreaterThanOrEqual(bounds.rootLeft);
+  expect(bounds.overlayTop).toBeGreaterThanOrEqual(bounds.rootTop);
+  expect(bounds.overlayRight).toBeLessThanOrEqual(bounds.rootRight);
+  expect(bounds.overlayBottom).toBeLessThanOrEqual(bounds.rootBottom);
 });
 
 test('switching artifacts tears down stale review and mail handlers', async ({ page }) => {


### PR DESCRIPTION
## Summary
- hardened the shared review comment popover lifecycle in `canvas.js` with explicit dialog semantics and focus management
- preserved one reusable popover path for both right-click point comments and highlight-selection comments
- added Playwright coverage for keyboard submit/cancel, focus behavior, and viewport-edge positioning

## Verification
- Requirement: shared popover works for right-click and highlight flows.
  - Evidence: `npm run test:e2e -- tests/playwright/review-mode.spec.ts -g "right-click inline comment popover submits a comment_point draft mark|highlight selection popover submits with Enter key as a highlight draft mark|popover Escape cancels and returns focus to the review canvas|popover opened near viewport edge stays within visible text canvas bounds" 2>&1 | tee /tmp/test-issue21.log`
  - Output excerpt: `4 passed (1.6s)` with passing cases for both point (`comment_point`) and selection (`highlight`) popover submit paths.
- Requirement: Enter submits popover.
  - Evidence: passing test `tests/playwright/review-mode.spec.ts:185` (`highlight selection popover submits with Enter key as a highlight draft mark`).
- Requirement: Esc cancels popover.
  - Evidence: passing test `tests/playwright/review-mode.spec.ts:205` (`popover Escape cancels and returns focus to the review canvas`) asserts popover closes and no `mark_set` is emitted.
- Requirement: focus management on close.
  - Evidence: same test at `tests/playwright/review-mode.spec.ts:205` asserts focus returns to `#canvas-text` after `Escape`.
- Requirement: popover remains visible/usable near viewport edge.
  - Evidence: passing test `tests/playwright/review-mode.spec.ts:271` (`popover opened near viewport edge stays within visible text canvas bounds`) asserts popover bounds stay within `#canvas-text` bounds.
