### PR TITLE
fix: [A6] Generic Review/Annotation - Review workflow tests (fixes #23)

### DIFF
--- a/internal/canvas/adapter_test.go
+++ b/internal/canvas/adapter_test.go
@@ -143,6 +143,66 @@ func TestCanvasCommitConvertsDraftAndCleansDraftIndex(t *testing.T) {
 	}
 }
 
+func TestHandleFeedbackSelectionMarkCommitPipelineRetainsComment(t *testing.T) {
+	a := NewAdapter(t.TempDir(), nil, true)
+	const sessionID = "s-feedback-pipeline"
+	const artifactID = "artifact-review-1"
+	const markID = "draft-review-1"
+	const comment = "Persist this review note"
+
+	a.HandleFeedback(`{"kind":"text_selection","session_id":"s-feedback-pipeline","line_start":2,"line_end":2,"start_offset":7,"end_offset":18,"text":"review span"}`)
+	selectionResp := a.CanvasSelection(sessionID)
+	selection, ok := selectionResp["selection"].(Selection)
+	if !ok {
+		t.Fatalf("expected Selection payload, got %T", selectionResp["selection"])
+	}
+	if !selection.HasSelection {
+		t.Fatalf("expected selection to be set")
+	}
+	if selection.Text != "review span" {
+		t.Fatalf("expected selection text to persist, got %q", selection.Text)
+	}
+
+	a.HandleFeedback(`{"kind":"mark_set","session_id":"s-feedback-pipeline","mark_id":"draft-review-1","artifact_id":"artifact-review-1","intent":"draft","type":"highlight","target_kind":"text_range","target":{"line_start":2,"line_end":2,"start_offset":7,"end_offset":18},"comment":"Persist this review note"}`)
+
+	marks := marksFromResult(t, a.CanvasMarksList(sessionID, artifactID, "", 0))
+	if len(marks) != 1 {
+		t.Fatalf("expected one draft mark after mark_set feedback, got %d", len(marks))
+	}
+	if marks[0].MarkID != markID {
+		t.Fatalf("expected draft mark id %q, got %q", markID, marks[0].MarkID)
+	}
+	if marks[0].Intent != IntentDraft {
+		t.Fatalf("expected draft intent before commit, got %q", marks[0].Intent)
+	}
+	if marks[0].Comment != comment {
+		t.Fatalf("expected draft comment %q, got %q", comment, marks[0].Comment)
+	}
+
+	a.HandleFeedback(`{"kind":"mark_commit","session_id":"s-feedback-pipeline","artifact_id":"artifact-review-1","include_draft":true}`)
+
+	marks = marksFromResult(t, a.CanvasMarksList(sessionID, artifactID, "", 0))
+	if len(marks) != 1 {
+		t.Fatalf("expected one mark after commit, got %d", len(marks))
+	}
+	if marks[0].Intent != IntentPersistent {
+		t.Fatalf("expected committed mark intent %q, got %q", IntentPersistent, marks[0].Intent)
+	}
+	if marks[0].Comment != comment {
+		t.Fatalf("expected committed comment %q, got %q", comment, marks[0].Comment)
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	record := a.sessions[sessionID]
+	if record == nil {
+		t.Fatalf("missing session record")
+	}
+	if _, ok := record.DraftByArtifactID[artifactID]; ok {
+		t.Fatalf("expected no draft index for artifact after commit")
+	}
+}
+
 func TestCanvasSessionOpenLoadsPersistedAnnotations(t *testing.T) {
 	tmpDir := t.TempDir()
 	const sessionID = "s-reload"

--- a/tests/playwright/review-mode.spec.ts
+++ b/tests/playwright/review-mode.spec.ts
@@ -202,6 +202,32 @@ test('highlight selection popover submits with Enter key as a highlight draft ma
   expect(Number((markSet.target as any).end_offset)).toBeGreaterThan(Number((markSet.target as any).start_offset));
 });
 
+test('highlight review flow emits mark_set with comment and mark_commit for persistence', async ({ page }) => {
+  await renderArtifact(page, plainTextEvent('evt-highlight-persist', '# Notes\nPersist this highlighted sentence'));
+  await selectTextFromSelector(page, '#canvas-text');
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('input').fill('Persist this note.');
+  await popover.locator('input').press('Enter');
+  await expect(popover).toHaveCount(0);
+
+  const draftMarkSet = await waitForLastMessageOfKind(page, 'mark_set');
+  expect(draftMarkSet.artifact_id).toBe('evt-highlight-persist');
+  expect(draftMarkSet.intent).toBe('draft');
+  expect(draftMarkSet.type).toBe('highlight');
+  expect(draftMarkSet.comment).toBe('Persist this note.');
+
+  await page.evaluate(() => {
+    const btn = document.getElementById('btn-canvas-commit') as HTMLButtonElement | null;
+    btn?.click();
+  });
+
+  const commitMessage = await waitForLastMessageOfKind(page, 'mark_commit');
+  expect(commitMessage.session_id).toBe('local');
+  expect(commitMessage.include_draft).toBe(true);
+});
+
 test('popover Escape cancels and returns focus to the review canvas', async ({ page }) => {
   await renderArtifact(page, plainTextEvent('evt-comment-esc', '# Notes\nEscape key should cancel this popover'));
   await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- Added a new Playwright scenario to validate the highlight review flow emits `mark_set` with comment and then `mark_commit` for persistence signaling.
- Added a new fast unit test for the selection -> mark_set -> mark_commit pipeline to ensure comment retention and draft-index cleanup after commit.

## Verification
- Requirement: right-click comment workflow creates a review mark.
  - Command: `npx playwright test tests/playwright/review-mode.spec.ts --grep 'right-click inline comment popover submits a comment_point draft mark|highlight review flow emits mark_set with comment and mark_commit for persistence|highlight selection cancel clears draft without creating a mark'`
  - Output excerpt: `✓ 1 tests/playwright/review-mode.spec.ts:165:5 › right-click inline comment popover submits a comment_point draft mark`

- Requirement: highlight immediate comment workflow persists mark/comment behavior.
  - Command: `npx playwright test tests/playwright/review-mode.spec.ts --grep 'right-click inline comment popover submits a comment_point draft mark|highlight review flow emits mark_set with comment and mark_commit for persistence|highlight selection cancel clears draft without creating a mark'`
  - Output excerpt: `✓ 2 tests/playwright/review-mode.spec.ts:205:5 › highlight review flow emits mark_set with comment and mark_commit for persistence`
  - Supporting unit test: `internal/canvas/adapter_test.go` (`TestHandleFeedbackSelectionMarkCommitPipelineRetainsComment`)

- Requirement: cancel paths do not persist unintended marks.
  - Command: `npx playwright test tests/playwright/review-mode.spec.ts --grep 'right-click inline comment popover submits a comment_point draft mark|highlight review flow emits mark_set with comment and mark_commit for persistence|highlight selection cancel clears draft without creating a mark'`
  - Output excerpt: `✓ 3 tests/playwright/review-mode.spec.ts:259:5 › highlight selection cancel clears draft without creating a mark`

- Requirement: fast unit coverage for selection->mark pipeline.
  - Command: `go test ./internal/canvas -run 'TestHandleFeedbackSelectionMarkCommitPipelineRetainsComment|TestCanvasCommitConvertsDraftAndCleansDraftIndex'`
  - Output excerpt: `ok github.com/krystophny/tabula/internal/canvas 0.002s`

- Combined run status:
  - Output excerpt: `3 passed (1.4s)`
