### PR TITLE
fix: [V3] Helpy STT integration in Tabula (fixes #29)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,8 +1,10 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"embed"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +34,10 @@ const (
 	DaemonPort            = 9420
 	LocalSessionID        = "local"
 	defaultProducerMCPURL = "http://127.0.0.1:8090/mcp"
+	defaultHelpySTTURL    = "http://127.0.0.1:8090"
+	helpySTTPath          = "/api/v0/voice/stt"
+	maxMailSTTRetries     = 2
+	maxMailSTTAudioBytes  = 10 * 1024 * 1024
 )
 
 //go:embed static/* static/vendor/*
@@ -153,6 +159,7 @@ func (a *App) Router() http.Handler {
 	r.Post("/api/mail/mark-read", a.handleMailMarkRead)
 	r.Post("/api/mail/action", a.handleMailAction)
 	r.Post("/api/mail/draft-reply", a.handleMailDraftReply)
+	r.Post("/api/mail/stt", a.handleMailSTT)
 
 	// ws
 	r.Get("/ws/terminal/{session_id}", a.handleTerminalWS)
@@ -795,6 +802,108 @@ func (a *App) handleMailDraftReply(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type helpySTTResult struct {
+	Text                string  `json:"text"`
+	Language            string  `json:"language"`
+	LanguageProbability float64 `json:"language_probability"`
+}
+
+type helpySTTSuccessEnvelope struct {
+	Status string         `json:"status"`
+	Result helpySTTResult `json:"result"`
+}
+
+type helpySTTErrorEnvelope struct {
+	Status    string `json:"status"`
+	Error     string `json:"error"`
+	Code      string `json:"code"`
+	Retryable bool   `json:"retryable"`
+}
+
+type helpySTTUpstreamError struct {
+	HTTPStatus int
+	Code       string
+	Retryable  bool
+	Message    string
+}
+
+func (e *helpySTTUpstreamError) Error() string {
+	if strings.TrimSpace(e.Code) != "" {
+		return fmt.Sprintf("stt request failed (%s): %s", e.Code, strings.TrimSpace(e.Message))
+	}
+	return fmt.Sprintf("stt request failed: %s", strings.TrimSpace(e.Message))
+}
+
+func (a *App) handleMailSTT(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req struct {
+		ProducerMCPURL string `json:"producer_mcp_url"`
+		HelpyBaseURL   string `json:"helpy_base_url"`
+		MimeType       string `json:"mime_type"`
+		AudioBase64    string `json:"audio_base64"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	decodedAudio := strings.TrimSpace(req.AudioBase64)
+	if decodedAudio == "" {
+		http.Error(w, "audio_base64 is required", http.StatusBadRequest)
+		return
+	}
+	audioData, err := base64.StdEncoding.DecodeString(decodedAudio)
+	if err != nil {
+		http.Error(w, "audio_base64 must be valid base64", http.StatusBadRequest)
+		return
+	}
+	if len(audioData) == 0 {
+		http.Error(w, "audio payload is empty", http.StatusBadRequest)
+		return
+	}
+	if len(audioData) > maxMailSTTAudioBytes {
+		http.Error(w, "audio payload exceeds max size", http.StatusBadRequest)
+		return
+	}
+
+	mimeType := normalizeSTTMimeType(req.MimeType)
+	if !isAllowedSTTMimeType(mimeType) {
+		http.Error(w, "mime_type must be audio/* or application/octet-stream", http.StatusBadRequest)
+		return
+	}
+
+	helpyBaseURL, err := resolveHelpySTTBaseURL(req.HelpyBaseURL, req.ProducerMCPURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result, attempts, err := callHelpySTTWithRetry(r.Context(), helpyBaseURL, mimeType, audioData)
+	if err != nil {
+		var upstreamErr *helpySTTUpstreamError
+		if errors.As(err, &upstreamErr) {
+			status := upstreamErr.HTTPStatus
+			if status < 400 || status > 599 {
+				status = http.StatusBadGateway
+			}
+			http.Error(w, upstreamErr.Error(), status)
+			return
+		}
+		http.Error(w, fmt.Sprintf("stt request failed: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"text":                 strings.TrimSpace(result.Text),
+		"language":             strings.TrimSpace(result.Language),
+		"language_probability": result.LanguageProbability,
+		"source":               "helpy_stt",
+		"attempts":             attempts,
+	})
+}
+
 func tryProducerDraftReply(mcpURL, provider, messageID, subject, sender, selectionText string) (string, bool) {
 	resp, err := mcpToolsCallURL(mcpURL, "draft_reply", map[string]interface{}{
 		"provider":       provider,
@@ -901,6 +1010,179 @@ func mcpToolsCallURL(mcpURL, name string, arguments map[string]interface{}) (map
 		return nil, errors.New("MCP call failed: missing structuredContent")
 	}
 	return sc, nil
+}
+
+func normalizeSTTMimeType(raw string) string {
+	candidate := strings.TrimSpace(raw)
+	if candidate == "" {
+		return "audio/webm"
+	}
+	if i := strings.Index(candidate, ";"); i >= 0 {
+		candidate = strings.TrimSpace(candidate[:i])
+	}
+	if candidate == "" {
+		return "audio/webm"
+	}
+	return strings.ToLower(candidate)
+}
+
+func isAllowedSTTMimeType(mimeType string) bool {
+	if mimeType == "application/octet-stream" {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "audio/")
+}
+
+func resolveHelpySTTBaseURL(overrideBaseURL, producerMCPURL string) (string, error) {
+	candidate := strings.TrimSpace(overrideBaseURL)
+	if candidate == "" {
+		candidate = strings.TrimSpace(os.Getenv("TABULA_HELPY_STT_BASE_URL"))
+	}
+	if candidate == "" {
+		normalizedMCPURL, err := normalizeProducerMCPURL(producerMCPURL)
+		if err == nil {
+			if parsedMCPURL, parseErr := url.Parse(normalizedMCPURL); parseErr == nil {
+				candidate = (&url.URL{
+					Scheme: parsedMCPURL.Scheme,
+					Host:   parsedMCPURL.Host,
+				}).String()
+			}
+		}
+	}
+	if candidate == "" {
+		candidate = defaultHelpySTTURL
+	}
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return "", fmt.Errorf("invalid helpy_base_url")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("helpy_base_url must use http or https")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("helpy_base_url must include host")
+	}
+	if !isLoopbackHost(host) {
+		return "", fmt.Errorf("helpy_base_url host must be loopback")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("helpy_base_url must not include query or fragment")
+	}
+	trimmedPath := strings.TrimSpace(parsed.Path)
+	if trimmedPath != "" && trimmedPath != "/" {
+		return "", fmt.Errorf("helpy_base_url must not include path")
+	}
+	parsed.Path = ""
+	return parsed.String(), nil
+}
+
+func callHelpySTTWithRetry(ctx context.Context, helpyBaseURL, mimeType string, audioData []byte) (helpySTTResult, int, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxMailSTTRetries; attempt++ {
+		result, err := callHelpySTTOnce(ctx, helpyBaseURL, mimeType, audioData)
+		if err == nil {
+			return result, attempt, nil
+		}
+		lastErr = err
+		var upstreamErr *helpySTTUpstreamError
+		if errors.As(err, &upstreamErr) {
+			if !upstreamErr.Retryable || attempt >= maxMailSTTRetries {
+				return helpySTTResult{}, attempt, err
+			}
+		} else if attempt >= maxMailSTTRetries {
+			return helpySTTResult{}, attempt, err
+		}
+		select {
+		case <-ctx.Done():
+			return helpySTTResult{}, attempt, ctx.Err()
+		case <-time.After(120 * time.Millisecond):
+		}
+	}
+	return helpySTTResult{}, maxMailSTTRetries, lastErr
+}
+
+func callHelpySTTOnce(ctx context.Context, helpyBaseURL, mimeType string, audioData []byte) (helpySTTResult, error) {
+	body := bytes.NewReader(audioData)
+	endpoint := strings.TrimRight(helpyBaseURL, "/") + helpySTTPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, body)
+	if err != nil {
+		return helpySTTResult{}, err
+	}
+	req.Header.Set("Content-Type", mimeType)
+
+	resp, err := (&http.Client{Timeout: 25 * time.Second}).Do(req)
+	if err != nil {
+		return helpySTTResult{}, &helpySTTUpstreamError{
+			HTTPStatus: http.StatusBadGateway,
+			Code:       "stt.upstream_unreachable",
+			Retryable:  true,
+			Message:    err.Error(),
+		}
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return helpySTTResult{}, &helpySTTUpstreamError{
+			HTTPStatus: http.StatusBadGateway,
+			Code:       "stt.upstream_read_failed",
+			Retryable:  true,
+			Message:    err.Error(),
+		}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		parsedErr := helpySTTUpstreamError{
+			HTTPStatus: resp.StatusCode,
+			Retryable:  resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500,
+			Message:    strings.TrimSpace(string(rawBody)),
+		}
+		var envelope helpySTTErrorEnvelope
+		if err := json.Unmarshal(rawBody, &envelope); err == nil {
+			if strings.TrimSpace(envelope.Code) != "" {
+				parsedErr.Code = strings.TrimSpace(envelope.Code)
+			}
+			if strings.TrimSpace(envelope.Error) != "" {
+				parsedErr.Message = strings.TrimSpace(envelope.Error)
+			}
+			if envelope.Retryable {
+				parsedErr.Retryable = true
+			}
+		}
+		if parsedErr.Message == "" {
+			parsedErr.Message = http.StatusText(resp.StatusCode)
+		}
+		return helpySTTResult{}, &parsedErr
+	}
+
+	var success helpySTTSuccessEnvelope
+	if err := json.Unmarshal(rawBody, &success); err != nil {
+		return helpySTTResult{}, &helpySTTUpstreamError{
+			HTTPStatus: http.StatusBadGateway,
+			Code:       "stt.invalid_response",
+			Retryable:  true,
+			Message:    "invalid JSON in STT response",
+		}
+	}
+	if !strings.EqualFold(strings.TrimSpace(success.Status), "ok") {
+		return helpySTTResult{}, &helpySTTUpstreamError{
+			HTTPStatus: http.StatusBadGateway,
+			Code:       "stt.invalid_status",
+			Retryable:  true,
+			Message:    fmt.Sprintf("unexpected status %q", strings.TrimSpace(success.Status)),
+		}
+	}
+	success.Result.Text = strings.TrimSpace(success.Result.Text)
+	if success.Result.Text == "" {
+		return helpySTTResult{}, &helpySTTUpstreamError{
+			HTTPStatus: http.StatusBadGateway,
+			Code:       "stt.empty_transcript",
+			Retryable:  false,
+			Message:    "upstream STT returned empty transcript",
+		}
+	}
+	return success.Result, nil
 }
 
 func normalizeProducerMCPURL(raw string) (string, error) {

--- a/internal/web/server_mail_actions_test.go
+++ b/internal/web/server_mail_actions_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -438,6 +439,106 @@ func TestMailDraftReplyFallsBackWhenToolUnavailable(t *testing.T) {
 	}
 	if draft, _ := payload["draft_text"].(string); strings.TrimSpace(draft) == "" {
 		t.Fatalf("expected non-empty fallback draft_text")
+	}
+}
+
+func TestMailSTTProxyRetriesAndReturnsTranscript(t *testing.T) {
+	attempts := 0
+	helpy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if r.URL.Path != "/api/v0/voice/stt" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "audio/webm" {
+			t.Fatalf("expected content-type audio/webm, got %q", got)
+		}
+		if attempts == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":    "error",
+				"error":     "backend unavailable",
+				"code":      "stt.backend_failed",
+				"retryable": true,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"result": map[string]any{
+				"text":                 "reply by tomorrow",
+				"language":             "en",
+				"language_probability": 0.91,
+			},
+		})
+	}))
+	defer helpy.Close()
+
+	audioPayload := base64.StdEncoding.EncodeToString([]byte("audio-bytes"))
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/mail/stt", map[string]any{
+		"helpy_base_url": helpy.URL,
+		"mime_type":      "audio/webm",
+		"audio_base64":   audioPayload,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["text"]; got != "reply by tomorrow" {
+		t.Fatalf("expected transcript text, got %#v", got)
+	}
+	if got := payload["source"]; got != "helpy_stt" {
+		t.Fatalf("expected source=helpy_stt, got %#v", got)
+	}
+	if got := payload["attempts"]; got != float64(2) {
+		t.Fatalf("expected attempts=2, got %#v", got)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected two upstream attempts, got %d", attempts)
+	}
+}
+
+func TestMailSTTRejectsMalformedAudio(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/mail/stt", map[string]any{
+		"mime_type":    "audio/webm",
+		"audio_base64": "$$$not-base64$$$",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "valid base64") {
+		t.Fatalf("expected explicit base64 error, got %s", rr.Body.String())
+	}
+}
+
+func TestMailSTTUsesConfiguredBaseURLAndSurfacesValidation(t *testing.T) {
+	helpy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":    "error",
+			"error":     "empty audio data",
+			"code":      "stt.empty_audio",
+			"retryable": false,
+		})
+	}))
+	defer helpy.Close()
+	t.Setenv("TABULA_HELPY_STT_BASE_URL", helpy.URL)
+
+	audioPayload := base64.StdEncoding.EncodeToString([]byte("x"))
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/mail/stt", map[string]any{
+		"mime_type":    "audio/webm",
+		"audio_base64": audioPayload,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "stt.empty_audio") {
+		t.Fatalf("expected upstream code in error message, got %s", rr.Body.String())
 	}
 }
 

--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -625,6 +625,10 @@ function clearSelectionInteractionHandlers() {
 function clearMailInteractionHandlers() {
   const e = getEls();
   flushPendingUndoAction();
+  if (activeMailContext) {
+    const recording = getMailRecordingState(activeMailContext);
+    stopMailRecordingMedia(recording);
+  }
   if (e.text._mailClickHandler) {
     e.text.removeEventListener('click', e.text._mailClickHandler);
     e.text._mailClickHandler = null;
@@ -924,6 +928,65 @@ async function callDraftReply(context, message) {
   return payload;
 }
 
+function base64FromBytes(bytes) {
+  if (!bytes || !bytes.length) return '';
+  const chunkSize = 0x8000;
+  let out = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    out += String.fromCharCode(...chunk);
+  }
+  return btoa(out);
+}
+
+async function callMailSTT(context, audioBlob) {
+  if (!audioBlob || typeof audioBlob.arrayBuffer !== 'function') {
+    throw new Error('missing recorded audio payload');
+  }
+  const audioBytes = new Uint8Array(await audioBlob.arrayBuffer());
+  if (!audioBytes.length) {
+    throw new Error('recorded audio payload is empty');
+  }
+  const req = {
+    producer_mcp_url: context.producerMcpUrl,
+    mime_type: audioBlob.type || 'application/octet-stream',
+    audio_base64: base64FromBytes(audioBytes),
+  };
+  const customBaseURL = String(window.__TABULA_HELPY_STT_BASE_URL || '').trim();
+  if (customBaseURL) {
+    req.helpy_base_url = customBaseURL;
+  }
+  const resp = await fetch('/api/mail/stt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  let payload = {};
+  const raw = await resp.text();
+  if (raw) {
+    try {
+      payload = JSON.parse(raw);
+    } catch (_) {
+      if (!resp.ok) {
+        throw new Error(raw);
+      }
+    }
+  }
+  if (!resp.ok) {
+    throw new Error(typeof payload === 'object' && payload !== null && payload.error
+      ? payload.error
+      : raw || 'speech transcription failed');
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('speech transcription returned invalid response');
+  }
+  const transcript = String(payload.text || '').trim();
+  if (!transcript) {
+    throw new Error('speech transcription returned empty text');
+  }
+  return payload;
+}
+
 function findMailHeader(context, messageID) {
   for (const h of context.headers || []) {
     if (h.id === messageID) return h;
@@ -945,6 +1008,14 @@ function createDefaultMailRecordingState() {
     origin: '',
     holdPointerId: null,
     lastStopReason: '',
+    captureToken: 0,
+    mediaRecorder: null,
+    mediaStream: null,
+    chunks: [],
+    mimeType: 'audio/webm',
+    transcribing: false,
+    stopRequested: false,
+    error: '',
     transitions: ['mode:hold', 'state:idle'],
   };
 }
@@ -1044,6 +1115,9 @@ function pushMailRecordingTransition(recording, token) {
 }
 
 function recordingTriggerLabel(recording) {
+  if (recording.transcribing) {
+    return 'Transcribing...';
+  }
   if (recording.mode === MAIL_RECORDING_MODE.TOGGLE) {
     return recording.state === MAIL_RECORDING_STATE.RECORDING ? 'Stop Recording' : 'Start Recording';
   }
@@ -1058,7 +1132,11 @@ function setMailRecordingDomState(context) {
   if (!e.text) return;
   const recording = getMailRecordingState(context);
   const isActive = recording.state === MAIL_RECORDING_STATE.RECORDING;
-  const indicator = isActive
+  const indicator = recording.error
+    ? recording.error
+    : recording.transcribing
+      ? 'Transcribing...'
+      : isActive
     ? `Recording (${recording.mode} mode)`
     : `Ready (${recording.mode} mode)`;
   e.text.dataset.mailRecordingState = recording.state || MAIL_RECORDING_STATE.IDLE;
@@ -1085,21 +1163,213 @@ function setMailRecordingDomState(context) {
   e.text.querySelectorAll('button[data-mail-record-action="trigger"]').forEach((button) => {
     button.textContent = recordingTriggerLabel(recording);
     button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    button.disabled = recording.transcribing;
   });
   e.text.querySelectorAll('button[data-mail-record-action="stop"]').forEach((button) => {
-    button.disabled = !isActive;
+    button.disabled = !isActive || recording.transcribing;
     button.hidden = !isActive;
   });
+}
+
+function stopMailRecordingMedia(recording) {
+  if (recording?.mediaRecorder) {
+    try {
+      if (recording.mediaRecorder.state !== 'inactive') {
+        recording.mediaRecorder.stop();
+      }
+    } catch (_) {
+      // no-op: recorder might already be stopping/stopped
+    }
+  }
+  const stream = recording?.mediaStream;
+  if (stream && typeof stream.getTracks === 'function') {
+    stream.getTracks().forEach((track) => {
+      if (track && typeof track.stop === 'function') {
+        track.stop();
+      }
+    });
+  }
+  if (!recording) return;
+  recording.mediaRecorder = null;
+  recording.mediaStream = null;
+  recording.chunks = [];
+  recording.stopRequested = false;
+}
+
+async function startMailRecordingMediaCapture(context, token) {
+  const recording = getMailRecordingState(context);
+  if (!pendingDraftPromptCapture) {
+    return;
+  }
+  if (!window.MediaRecorder || !navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+    throw new Error('Microphone capture is unavailable in this browser.');
+  }
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  if (recording.captureToken !== token || recording.state !== MAIL_RECORDING_STATE.RECORDING) {
+    if (stream && typeof stream.getTracks === 'function') {
+      stream.getTracks().forEach((track) => {
+        if (track && typeof track.stop === 'function') {
+          track.stop();
+        }
+      });
+    }
+    return;
+  }
+  let recorder = null;
+  try {
+    const preferredType = 'audio/webm;codecs=opus';
+    if (typeof window.MediaRecorder.isTypeSupported === 'function' && window.MediaRecorder.isTypeSupported(preferredType)) {
+      recorder = new window.MediaRecorder(stream, { mimeType: preferredType });
+    } else {
+      recorder = new window.MediaRecorder(stream);
+    }
+  } catch (_) {
+    recorder = new window.MediaRecorder(stream);
+  }
+  recording.mediaStream = stream;
+  recording.mediaRecorder = recorder;
+  recording.chunks = [];
+  recording.mimeType = recorder.mimeType || 'audio/webm';
+  recorder.addEventListener('dataavailable', (ev) => {
+    if (ev?.data && ev.data.size > 0) {
+      recording.chunks.push(ev.data);
+    }
+  });
+  recorder.start();
+  if (recording.stopRequested) {
+    try {
+      recorder.stop();
+    } catch (_) {
+      stopMailRecordingMedia(recording);
+    }
+  }
+}
+
+async function stopMailRecordingMediaAndCollectBlob(context, token) {
+  const recording = getMailRecordingState(context);
+  if (recording.captureToken !== token) {
+    return null;
+  }
+  const recorder = recording.mediaRecorder;
+  if (!recorder) {
+    return null;
+  }
+  const toBlob = () => {
+    const parts = Array.isArray(recording.chunks) ? recording.chunks.slice() : [];
+    stopMailRecordingMedia(recording);
+    if (!parts.length) {
+      return null;
+    }
+    return new Blob(parts, { type: recording.mimeType || recorder.mimeType || 'audio/webm' });
+  };
+  if (recorder.state === 'inactive') {
+    return toBlob();
+  }
+  return new Promise((resolve, reject) => {
+    const onStop = () => {
+      recorder.removeEventListener('error', onError);
+      resolve(toBlob());
+    };
+    const onError = () => {
+      recorder.removeEventListener('stop', onStop);
+      stopMailRecordingMedia(recording);
+      reject(new Error('recording failed'));
+    };
+    recorder.addEventListener('stop', onStop, { once: true });
+    recorder.addEventListener('error', onError, { once: true });
+    try {
+      recorder.stop();
+    } catch (err) {
+      recorder.removeEventListener('stop', onStop);
+      recorder.removeEventListener('error', onError);
+      stopMailRecordingMedia(recording);
+      reject(err);
+    }
+  });
+}
+
+async function transcribePendingDraftPrompt(context, token) {
+  const recording = getMailRecordingState(context);
+  if (!pendingDraftPromptCapture) {
+    stopMailRecordingMedia(recording);
+    return;
+  }
+  const pending = pendingDraftPromptCapture;
+  const isSamePending = () => pendingDraftPromptCapture === pending;
+  recording.transcribing = true;
+  recording.error = '';
+  setMailRecordingDomState(context);
+  if (isSamePending()) {
+    setMailAssistStatus(pending.context, pending.row, pending.inDetail, 'Transcribing voice input...', 'info');
+  }
+  try {
+    const audioBlob = await stopMailRecordingMediaAndCollectBlob(context, token);
+    if (!audioBlob || audioBlob.size <= 0) {
+      throw new Error('No audio captured. Hold to record and try again.');
+    }
+    const stt = await callMailSTT(context, audioBlob);
+    const transcript = String(stt?.text || '').trim();
+    if (!transcript) {
+      throw new Error('Speech recognizer returned empty text.');
+    }
+    resolvePendingDraftPromptCapture(transcript, 'Transcribed from voice input.', pending);
+  } catch (err) {
+    if (!isSamePending()) {
+      return;
+    }
+    const message = String(err?.message || err || 'speech transcription failed');
+    recording.error = `Transcription failed: ${message}`;
+    setMailAssistStatus(
+      pending.context,
+      pending.row,
+      pending.inDetail,
+      `Transcription failed: ${message}. Retry recording or type a prompt.`,
+      'warning',
+    );
+  } finally {
+    recording.transcribing = false;
+    setMailRecordingDomState(context);
+  }
 }
 
 function startMailRecording(context, origin) {
   const recording = getMailRecordingState(context);
   if (recording.state === MAIL_RECORDING_STATE.RECORDING) return false;
+  const token = Number(recording.captureToken || 0) + 1;
+  recording.captureToken = token;
+  recording.stopRequested = false;
   recording.state = MAIL_RECORDING_STATE.RECORDING;
   recording.origin = String(origin || '').trim();
   recording.lastStopReason = '';
+  recording.error = '';
   pushMailRecordingTransition(recording, 'state:recording');
   setMailRecordingDomState(context);
+  if (pendingDraftPromptCapture) {
+    void startMailRecordingMediaCapture(context, token).catch((err) => {
+      if (recording.captureToken !== token) {
+        return;
+      }
+      const pending = pendingDraftPromptCapture;
+      recording.state = MAIL_RECORDING_STATE.IDLE;
+      recording.origin = '';
+      recording.stopRequested = false;
+      recording.lastStopReason = 'capture_error';
+      recording.error = `Recording failed: ${String(err?.message || err || 'capture failed')}`;
+      pushMailRecordingTransition(recording, 'stop:capture_error');
+      pushMailRecordingTransition(recording, 'state:idle');
+      stopMailRecordingMedia(recording);
+      setMailRecordingDomState(context);
+      if (pending) {
+        setMailAssistStatus(
+          pending.context,
+          pending.row,
+          pending.inDetail,
+          `${recording.error}. Retry recording or type a prompt.`,
+          'warning',
+        );
+      }
+    });
+  }
   return true;
 }
 
@@ -1109,10 +1379,16 @@ function stopMailRecording(context, reason) {
   recording.state = MAIL_RECORDING_STATE.IDLE;
   recording.origin = '';
   recording.holdPointerId = null;
+  recording.stopRequested = true;
   recording.lastStopReason = String(reason || 'stop').trim() || 'stop';
   pushMailRecordingTransition(recording, `stop:${recording.lastStopReason}`);
   pushMailRecordingTransition(recording, 'state:idle');
   setMailRecordingDomState(context);
+  if (pendingDraftPromptCapture) {
+    void transcribePendingDraftPrompt(context, recording.captureToken);
+  } else {
+    stopMailRecordingMedia(recording);
+  }
   return true;
 }
 
@@ -1258,12 +1534,46 @@ function cancelPendingDraftPromptCapture(message) {
   return true;
 }
 
-function submitPendingDraftPromptCapture() {
-  if (!pendingDraftPromptCapture) return false;
-  const pending = pendingDraftPromptCapture;
+function getDraftPromptControls() {
   const panel = document.querySelector('[data-mail-draft-panel]');
   const promptInput = panel ? panel.querySelector('[data-mail-draft-prompt]') : null;
   const generateBtn = panel ? panel.querySelector('button[data-mail-action="draft-generate"]') : null;
+  return { panel, promptInput, generateBtn };
+}
+
+function resolvePendingDraftPromptCapture(promptText, sourceLabel, expectedPending = null) {
+  if (!pendingDraftPromptCapture) return false;
+  if (expectedPending && pendingDraftPromptCapture !== expectedPending) return false;
+  const pending = pendingDraftPromptCapture;
+  const normalized = String(promptText || '').trim();
+  if (!normalized) {
+    setMailAssistStatus(pending.context, pending.row, pending.inDetail, 'Speech transcript was empty. Retry recording or type a prompt.', 'warning');
+    return false;
+  }
+  const { promptInput, generateBtn } = getDraftPromptControls();
+  if (promptInput) {
+    promptInput.value = normalized;
+    promptInput.disabled = true;
+  }
+  if (generateBtn) {
+    generateBtn.disabled = true;
+  }
+  pendingDraftPromptCapture = null;
+  pending.resolve(normalized);
+  setMailAssistStatus(
+    pending.context,
+    pending.row,
+    pending.inDetail,
+    sourceLabel || 'Prompt captured. Generating draft...',
+    'info',
+  );
+  return true;
+}
+
+function submitPendingDraftPromptCapture() {
+  if (!pendingDraftPromptCapture) return false;
+  const pending = pendingDraftPromptCapture;
+  const { promptInput, generateBtn } = getDraftPromptControls();
   const promptText = String(promptInput?.value || '').trim();
   if (!promptText) {
     setMailAssistStatus(pending.context, pending.row, pending.inDetail, 'Enter a prompt before generating.', 'warning');
@@ -1278,9 +1588,7 @@ function submitPendingDraftPromptCapture() {
   if (generateBtn) {
     generateBtn.disabled = true;
   }
-  pendingDraftPromptCapture = null;
-  pending.resolve(promptText);
-  return true;
+  return resolvePendingDraftPromptCapture(promptText, 'Prompt captured. Generating draft...');
 }
 
 function waitForDraftPromptCapture(context, row, inDetail, messageID, actionId) {
@@ -1292,7 +1600,7 @@ function waitForDraftPromptCapture(context, row, inDetail, messageID, actionId) 
     promptDisabled: false,
     generateDisabled: false,
   });
-  setMailAssistStatus(context, row, inDetail, 'Add a prompt, then choose Generate.', 'info');
+  setMailAssistStatus(context, row, inDetail, 'Add a prompt or record voice input, then generate.', 'info');
   return new Promise((resolve, reject) => {
     pendingDraftPromptCapture = {
       resolve,

--- a/tests/playwright/mail-actions.spec.ts
+++ b/tests/playwright/mail-actions.spec.ts
@@ -61,6 +61,84 @@ async function mockCapabilities(page: Page, provider = 'gmail') {
   });
 }
 
+async function mockMicrophoneCapture(page: Page, chunkText = 'voice sample') {
+  await page.evaluate((payload) => {
+    const fakeStream = {
+      getTracks() {
+        return [{ stop() {} }];
+      },
+    };
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        async getUserMedia() {
+          return fakeStream;
+        },
+      },
+    });
+
+    class FakeMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+
+      constructor(stream, options = {}) {
+        this.stream = stream;
+        this.state = 'inactive';
+        this.mimeType = options.mimeType || 'audio/webm';
+        this._listeners = new Map();
+      }
+
+      addEventListener(type, cb) {
+        if (!this._listeners.has(type)) {
+          this._listeners.set(type, []);
+        }
+        this._listeners.get(type).push(cb);
+      }
+
+      removeEventListener(type, cb) {
+        const list = this._listeners.get(type);
+        if (!list) return;
+        this._listeners.set(type, list.filter((fn) => fn !== cb));
+      }
+
+      _emit(type, ev) {
+        const list = this._listeners.get(type) || [];
+        for (const fn of list) {
+          fn(ev);
+        }
+      }
+
+      start() {
+        this.state = 'recording';
+      }
+
+      stop() {
+        if (this.state === 'inactive') return;
+        this.state = 'inactive';
+        queueMicrotask(() => {
+          const blob = new Blob([payload], { type: this.mimeType });
+          const dataEvent = { data: blob };
+          this._emit('dataavailable', dataEvent);
+          if (typeof this.ondataavailable === 'function') {
+            this.ondataavailable(dataEvent);
+          }
+          this._emit('stop', {});
+          if (typeof this.onstop === 'function') {
+            this.onstop({});
+          }
+        });
+      }
+    }
+
+    Object.defineProperty(window, 'MediaRecorder', {
+      configurable: true,
+      writable: true,
+      value: FakeMediaRecorder,
+    });
+  }, chunkText);
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/tests/playwright/harness.html');
 });
@@ -681,6 +759,105 @@ test('keyboardless flow can complete full recording cycle via global button', as
   await trigger.click();
   await expect(canvasText).toHaveAttribute('data-mail-recording-state', 'idle');
   await expect(page.locator('[data-mail-record-indicator]')).toContainText('Ready (toggle mode)');
+});
+
+test('recording stop sends STT transcript into draft reply pipeline', async ({ page }) => {
+  const sttCalls: Array<Record<string, unknown>> = [];
+  const draftCalls: Array<Record<string, unknown>> = [];
+  const transcript = 'Please confirm delivery by Friday.';
+
+  await mockCapabilities(page);
+  await mockMicrophoneCapture(page, 'voice-bytes');
+
+  await page.route('**/api/mail/stt', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    sttCalls.push(body);
+    await route.fulfill({
+      json: {
+        text: transcript,
+        language: 'en',
+        language_probability: 0.98,
+        source: 'helpy_stt',
+        attempts: 1,
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    draftCalls.push(body);
+    await route.fulfill({
+      json: {
+        source: 'llm',
+        draft_text: `Voice draft for ${body.message_id}`,
+      },
+    });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm23', date: '2026-02-20T13:00:00Z', sender: 'voice@example.com', subject: 'Voice path' },
+  ]);
+
+  await page.click('tr[data-message-id="m23"] button[data-mail-action="draft-reply"]');
+  await expect.poll(async () => page.locator('#canvas-text').getAttribute('data-mail-assist-state')).toBe('capturing');
+
+  await page.click('button[data-mail-record-mode="toggle"]');
+  const trigger = page.locator('button[data-mail-record-action="trigger"]');
+  await trigger.click();
+  await expect(page.locator('#canvas-text')).toHaveAttribute('data-mail-recording-state', 'recording');
+  await trigger.click();
+  await expect(page.locator('#canvas-text')).toHaveAttribute('data-mail-recording-state', 'idle');
+
+  await expect.poll(() => sttCalls.length).toBe(1);
+  await expect.poll(() => draftCalls.length).toBe(1);
+  expect(String(sttCalls[0]?.audio_base64 || '')).not.toBe('');
+  expect(draftCalls[0]?.selection_text).toBe(transcript);
+  await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-text]')).toHaveValue(/Voice draft for m23/);
+  await expect(page.locator('tr[data-message-id="m23"] [data-mail-row-status]')).toContainText('Draft ready');
+});
+
+test('recording STT failure remains recoverable via manual prompt retry', async ({ page }) => {
+  let draftCalls = 0;
+
+  await mockCapabilities(page);
+  await mockMicrophoneCapture(page, 'voice-bytes');
+
+  await page.route('**/api/mail/stt', async (route) => {
+    await route.fulfill({
+      status: 502,
+      body: 'upstream unavailable',
+    });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    draftCalls += 1;
+    const body = JSON.parse(route.request().postData() || '{}');
+    await route.fulfill({
+      json: {
+        source: 'llm',
+        draft_text: `Manual fallback for ${body.message_id}`,
+      },
+    });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm24', date: '2026-02-20T13:30:00Z', sender: 'retry@example.com', subject: 'Retry path' },
+  ]);
+
+  await page.click('tr[data-message-id="m24"] button[data-mail-action="draft-reply"]');
+  await page.click('button[data-mail-record-mode="toggle"]');
+  const trigger = page.locator('button[data-mail-record-action="trigger"]');
+  await trigger.click();
+  await trigger.click();
+
+  await expect(page.locator('tr[data-message-id="m24"] [data-mail-row-status]')).toContainText('Transcription failed');
+  expect(draftCalls).toBe(0);
+
+  await page.fill('[data-mail-draft-panel] [data-mail-draft-prompt]', 'Manual retry prompt.');
+  await page.click('[data-mail-draft-panel] button[data-mail-action="draft-generate"]');
+
+  await expect.poll(() => draftCalls).toBe(1);
+  await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-text]')).toHaveValue(/Manual fallback for m24/);
 });
 
 test('unregistered assist action_id returns deterministic error without network call', async ({ page }) => {


### PR DESCRIPTION
## Summary
- added `POST /api/mail/stt` in Tabula web to proxy Helpy STT (`/api/v0/voice/stt`) with strict payload validation and loopback-only base URL normalization
- implemented deterministic retry behavior for transient STT failures and surfaced upstream validation codes/messages
- wired mail recording stop -> STT -> Draft Reply prompt pipeline in `canvas.js`
- added tests for STT retry/config/validation and Playwright coverage for success + recoverable failure flows

## Verification
- Requirement: transcript returns to Draft Reply pipeline when recording stops
  - Evidence: `npm run test:e2e -- tests/playwright/mail-actions.spec.ts -g 'recording stop sends STT transcript into draft reply pipeline|recording STT failure remains recoverable via manual prompt retry'`
  - Output excerpt:
    - `✓ recording stop sends STT transcript into draft reply pipeline`
    - assertion checks `draft-reply` receives `selection_text` from STT transcript.

- Requirement: Helpy STT unavailable shows recoverable error and allows retry
  - Evidence: same Playwright command above
  - Output excerpt:
    - `✓ recording STT failure remains recoverable via manual prompt retry`
    - test validates UI shows `Transcription failed` and manual prompt retry still generates draft.

- Requirement: malformed audio surfaces explicit validation error
  - Evidence: `go test ./internal/web -run 'Mail(STT|Action|Read|MarkRead|DraftReply)'`
  - Output excerpt: `ok   github.com/krystophny/tabula/internal/web`
  - Covered by `TestMailSTTRejectsMalformedAudio`.

- Requirement: configurable Helpy base URL + deterministic retry behavior
  - Evidence: same Go test command above
  - Output excerpt: `ok   github.com/krystophny/tabula/internal/web`
  - Covered by `TestMailSTTUsesConfiguredBaseURLAndSurfacesValidation` and `TestMailSTTProxyRetriesAndReturnsTranscript` (asserts `attempts=2`).
