### PR TITLE
fix: [V4] Auto-intent inference for spoken Draft Reply (fixes #30)

### DIFF
--- a/internal/web/draft_intent.go
+++ b/internal/web/draft_intent.go
@@ -1,0 +1,128 @@
+package web
+
+import "strings"
+
+type draftReplyIntent string
+
+const (
+	draftReplyIntentDictation draftReplyIntent = "dictation"
+	draftReplyIntentPrompt    draftReplyIntent = "prompt"
+)
+
+type draftReplyIntentDecision struct {
+	Intent          draftReplyIntent
+	Reason          string
+	FallbackApplied bool
+	FallbackPolicy  draftReplyIntent
+}
+
+var draftIntentPromptPhrases = []string{
+	"draft a reply",
+	"write a reply",
+	"write back",
+	"reply with",
+	"reply saying",
+	"respond with",
+	"make it",
+	"keep it",
+	"use a",
+	"mention",
+	"include",
+	"ask for",
+	"tell them",
+	"tone",
+	"concise",
+	"formal",
+	"friendly",
+}
+
+var draftIntentDictationPhrases = []string{
+	"\n\n",
+	"\nbest,\n",
+	"\nthanks,\n",
+	"\nregards,\n",
+	"\nsincerely,\n",
+}
+
+var draftIntentDictationPrefixes = []string{
+	"hi ",
+	"hello ",
+	"dear ",
+	"hey ",
+}
+
+func classifyDraftReplyIntent(transcript string) draftReplyIntentDecision {
+	trimmed := strings.TrimSpace(transcript)
+	if trimmed == "" {
+		return ambiguousDraftReplyIntentDecision("empty_transcript")
+	}
+	normalized := strings.ToLower(trimmed)
+	promptScore := countDraftIntentPhraseHits(normalized, draftIntentPromptPhrases)
+	dictationScore := countDraftIntentPhraseHits(normalized, draftIntentDictationPhrases)
+	if hasDraftIntentPrefix(normalized, draftIntentDictationPrefixes) {
+		dictationScore += 2
+	}
+	if strings.Count(trimmed, "\n") >= 2 {
+		dictationScore++
+	}
+	if strings.HasSuffix(normalized, "best") || strings.HasSuffix(normalized, "thanks") || strings.HasSuffix(normalized, "regards") {
+		dictationScore++
+	}
+
+	switch {
+	case promptScore == 0 && dictationScore >= 2:
+		return draftReplyIntentDecision{
+			Intent:         draftReplyIntentDictation,
+			Reason:         "dictation_signals",
+			FallbackPolicy: draftReplyIntentPrompt,
+		}
+	case dictationScore == 0 && promptScore >= 1:
+		return draftReplyIntentDecision{
+			Intent:         draftReplyIntentPrompt,
+			Reason:         "instruction_signals",
+			FallbackPolicy: draftReplyIntentPrompt,
+		}
+	case dictationScore >= promptScore+2 && dictationScore >= 3:
+		return draftReplyIntentDecision{
+			Intent:         draftReplyIntentDictation,
+			Reason:         "dictation_dominant",
+			FallbackPolicy: draftReplyIntentPrompt,
+		}
+	case promptScore >= dictationScore+1 && promptScore >= 2:
+		return draftReplyIntentDecision{
+			Intent:         draftReplyIntentPrompt,
+			Reason:         "instruction_dominant",
+			FallbackPolicy: draftReplyIntentPrompt,
+		}
+	default:
+		return ambiguousDraftReplyIntentDecision("ambiguous_signals")
+	}
+}
+
+func ambiguousDraftReplyIntentDecision(reason string) draftReplyIntentDecision {
+	return draftReplyIntentDecision{
+		Intent:          draftReplyIntentPrompt,
+		Reason:          reason,
+		FallbackApplied: true,
+		FallbackPolicy:  draftReplyIntentPrompt,
+	}
+}
+
+func hasDraftIntentPrefix(text string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(text, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func countDraftIntentPhraseHits(text string, phrases []string) int {
+	score := 0
+	for _, phrase := range phrases {
+		if strings.Contains(text, phrase) {
+			score++
+		}
+	}
+	return score
+}

--- a/internal/web/draft_intent_test.go
+++ b/internal/web/draft_intent_test.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestClassifyDraftReplyIntent(t *testing.T) {
+	cases := []struct {
+		name            string
+		transcript      string
+		wantIntent      draftReplyIntent
+		wantFallback    bool
+		wantReason      string
+		wantFallbackPol draftReplyIntent
+	}{
+		{
+			name:            "dictation style transcript is routed to dictation branch",
+			transcript:      "Hi Bob,\n\nThanks for the update. I can send the draft tomorrow.\n\nBest,\nAlice",
+			wantIntent:      draftReplyIntentDictation,
+			wantFallback:    false,
+			wantReason:      "dictation_signals",
+			wantFallbackPol: draftReplyIntentPrompt,
+		},
+		{
+			name:            "instruction transcript is routed to prompt branch",
+			transcript:      "Draft a reply saying we can ship next week and keep it concise.",
+			wantIntent:      draftReplyIntentPrompt,
+			wantFallback:    false,
+			wantReason:      "instruction_signals",
+			wantFallbackPol: draftReplyIntentPrompt,
+		},
+		{
+			name:            "ambiguous transcript uses deterministic prompt fallback",
+			transcript:      "Tomorrow works.",
+			wantIntent:      draftReplyIntentPrompt,
+			wantFallback:    true,
+			wantReason:      "ambiguous_signals",
+			wantFallbackPol: draftReplyIntentPrompt,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyDraftReplyIntent(tc.transcript)
+			if got.Intent != tc.wantIntent {
+				t.Fatalf("expected intent=%q, got %q", tc.wantIntent, got.Intent)
+			}
+			if got.FallbackApplied != tc.wantFallback {
+				t.Fatalf("expected fallback_applied=%t, got %t", tc.wantFallback, got.FallbackApplied)
+			}
+			if got.Reason != tc.wantReason {
+				t.Fatalf("expected reason=%q, got %q", tc.wantReason, got.Reason)
+			}
+			if got.FallbackPolicy != tc.wantFallbackPol {
+				t.Fatalf("expected fallback_policy=%q, got %q", tc.wantFallbackPol, got.FallbackPolicy)
+			}
+		})
+	}
+}
+
+func TestMailDraftIntentRoute(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/mail/draft-intent", map[string]any{
+		"transcript": "Draft a reply saying thank you and keep it short.",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["intent"]; got != string(draftReplyIntentPrompt) {
+		t.Fatalf("expected intent=prompt, got %#v", got)
+	}
+	if got := payload["fallback_applied"]; got != false {
+		t.Fatalf("expected fallback_applied=false, got %#v", got)
+	}
+	if got := payload["fallback_policy"]; got != string(draftReplyIntentPrompt) {
+		t.Fatalf("expected fallback_policy=prompt, got %#v", got)
+	}
+}
+
+func TestMailDraftIntentRequiresTranscript(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/mail/draft-intent", map[string]any{
+		"transcript": "   ",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -159,6 +159,7 @@ func (a *App) Router() http.Handler {
 	r.Post("/api/mail/mark-read", a.handleMailMarkRead)
 	r.Post("/api/mail/action", a.handleMailAction)
 	r.Post("/api/mail/draft-reply", a.handleMailDraftReply)
+	r.Post("/api/mail/draft-intent", a.handleMailDraftIntent)
 	r.Post("/api/mail/stt", a.handleMailSTT)
 
 	// ws
@@ -799,6 +800,31 @@ func (a *App) handleMailDraftReply(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]interface{}{
 		"draft_text": draft,
 		"source":     "fallback",
+	})
+}
+
+func (a *App) handleMailDraftIntent(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req struct {
+		Transcript string `json:"transcript"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	transcript := strings.TrimSpace(req.Transcript)
+	if transcript == "" {
+		http.Error(w, "transcript is required", http.StatusBadRequest)
+		return
+	}
+	intent := classifyDraftReplyIntent(transcript)
+	writeJSON(w, map[string]interface{}{
+		"intent":           intent.Intent,
+		"reason":           intent.Reason,
+		"fallback_applied": intent.FallbackApplied,
+		"fallback_policy":  intent.FallbackPolicy,
 	})
 }
 

--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -138,6 +138,11 @@ const MAIL_RECORDING_ORIGIN = Object.freeze({
   HOLD_KEYBOARD: 'hold_keyboard',
   TOGGLE_BUTTON: 'toggle_button',
 });
+const MAIL_DRAFT_INTENT = Object.freeze({
+  PROMPT: 'prompt',
+  DICTATION: 'dictation',
+});
+const MAIL_DRAFT_INTENT_FALLBACK_POLICY = MAIL_DRAFT_INTENT.PROMPT;
 const mailAssistActionRegistry = new Map();
 const DRAFT_PROMPT_CANCELLED_CODE = 'draft_prompt_cancelled';
 let pendingDraftPromptCapture = null;
@@ -987,6 +992,38 @@ async function callMailSTT(context, audioBlob) {
   return payload;
 }
 
+async function callMailDraftIntent(context, transcript) {
+  const resp = await fetch('/api/mail/draft-intent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      provider: context.provider,
+      transcript: String(transcript || ''),
+      producer_mcp_url: context.producerMcpUrl,
+    }),
+  });
+  let payload = {};
+  const raw = await resp.text();
+  if (raw) {
+    try {
+      payload = JSON.parse(raw);
+    } catch (_) {
+      if (!resp.ok) {
+        throw new Error(raw);
+      }
+    }
+  }
+  if (!resp.ok) {
+    throw new Error(typeof payload === 'object' && payload !== null && payload.error
+      ? payload.error
+      : raw || 'draft intent inference failed');
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('draft intent inference returned invalid response');
+  }
+  return payload;
+}
+
 function findMailHeader(context, messageID) {
   for (const h of context.headers || []) {
     if (h.id === messageID) return h;
@@ -1312,7 +1349,43 @@ async function transcribePendingDraftPrompt(context, token) {
     if (!transcript) {
       throw new Error('Speech recognizer returned empty text.');
     }
-    resolvePendingDraftPromptCapture(transcript, 'Transcribed from voice input.', pending);
+    let captureResult = {
+      text: transcript,
+      intent: MAIL_DRAFT_INTENT_FALLBACK_POLICY,
+      fallbackApplied: false,
+      fallbackPolicy: MAIL_DRAFT_INTENT_FALLBACK_POLICY,
+      reason: 'intent_inference_unavailable',
+    };
+    let sourceLabel = 'Transcribed from voice input. Generating draft...';
+    try {
+      const inferred = await callMailDraftIntent(context, transcript);
+      const inferredIntent = String(inferred?.intent || '').trim().toLowerCase();
+      const intent = inferredIntent === MAIL_DRAFT_INTENT.DICTATION
+        ? MAIL_DRAFT_INTENT.DICTATION
+        : MAIL_DRAFT_INTENT.PROMPT;
+      const fallbackApplied = Boolean(inferred?.fallback_applied);
+      const fallbackPolicy = String(inferred?.fallback_policy || MAIL_DRAFT_INTENT_FALLBACK_POLICY).trim().toLowerCase() || MAIL_DRAFT_INTENT_FALLBACK_POLICY;
+      const reason = String(inferred?.reason || '').trim() || 'intent_inferred';
+      captureResult = {
+        text: transcript,
+        intent,
+        fallbackApplied,
+        fallbackPolicy,
+        reason,
+      };
+      if (intent === MAIL_DRAFT_INTENT.DICTATION) {
+        sourceLabel = 'Detected dictation. Using transcript as editable draft.';
+      } else if (fallbackApplied) {
+        sourceLabel = 'Intent ambiguous. Using prompt fallback policy to generate draft.';
+      } else {
+        sourceLabel = 'Detected prompt intent. Generating draft...';
+      }
+    } catch (_) {
+      captureResult.fallbackApplied = true;
+      captureResult.reason = 'intent_inference_failed';
+      sourceLabel = 'Intent inference unavailable. Using prompt fallback policy to generate draft.';
+    }
+    resolvePendingDraftPromptCapture(captureResult, sourceLabel, pending);
   } catch (err) {
     if (!isSamePending()) {
       return;
@@ -1541,11 +1614,28 @@ function getDraftPromptControls() {
   return { panel, promptInput, generateBtn };
 }
 
-function resolvePendingDraftPromptCapture(promptText, sourceLabel, expectedPending = null) {
+function normalizeDraftPromptCaptureResult(capture) {
+  const raw = typeof capture === 'string' ? { text: capture } : (capture || {});
+  const text = String(raw.text || '').trim();
+  const intent = String(raw.intent || '').trim().toLowerCase() === MAIL_DRAFT_INTENT.DICTATION
+    ? MAIL_DRAFT_INTENT.DICTATION
+    : MAIL_DRAFT_INTENT.PROMPT;
+  const fallbackPolicy = String(raw.fallbackPolicy || MAIL_DRAFT_INTENT_FALLBACK_POLICY).trim().toLowerCase() || MAIL_DRAFT_INTENT_FALLBACK_POLICY;
+  return {
+    text,
+    intent,
+    fallbackApplied: Boolean(raw.fallbackApplied),
+    fallbackPolicy,
+    reason: String(raw.reason || '').trim() || 'manual_prompt',
+  };
+}
+
+function resolvePendingDraftPromptCapture(capture, sourceLabel, expectedPending = null) {
   if (!pendingDraftPromptCapture) return false;
   if (expectedPending && pendingDraftPromptCapture !== expectedPending) return false;
   const pending = pendingDraftPromptCapture;
-  const normalized = String(promptText || '').trim();
+  const normalizedCapture = normalizeDraftPromptCaptureResult(capture);
+  const normalized = normalizedCapture.text;
   if (!normalized) {
     setMailAssistStatus(pending.context, pending.row, pending.inDetail, 'Speech transcript was empty. Retry recording or type a prompt.', 'warning');
     return false;
@@ -1559,7 +1649,7 @@ function resolvePendingDraftPromptCapture(promptText, sourceLabel, expectedPendi
     generateBtn.disabled = true;
   }
   pendingDraftPromptCapture = null;
-  pending.resolve(normalized);
+  pending.resolve(normalizedCapture);
   setMailAssistStatus(
     pending.context,
     pending.row,
@@ -1588,7 +1678,13 @@ function submitPendingDraftPromptCapture() {
   if (generateBtn) {
     generateBtn.disabled = true;
   }
-  return resolvePendingDraftPromptCapture(promptText, 'Prompt captured. Generating draft...');
+  return resolvePendingDraftPromptCapture({
+    text: promptText,
+    intent: MAIL_DRAFT_INTENT.PROMPT,
+    fallbackApplied: false,
+    fallbackPolicy: MAIL_DRAFT_INTENT_FALLBACK_POLICY,
+    reason: 'manual_prompt',
+  }, 'Prompt captured. Generating draft...');
 }
 
 function waitForDraftPromptCapture(context, row, inDetail, messageID, actionId) {
@@ -1696,21 +1792,29 @@ function registerDefaultMailAssistActions() {
     },
     async prepare({ context, row, inDetail, messageID, actionId, selectionText }) {
       const header = findMailHeader(context, messageID);
-      const promptText = await waitForDraftPromptCapture(context, row, inDetail, messageID, actionId);
+      const capture = await waitForDraftPromptCapture(context, row, inDetail, messageID, actionId);
+      const promptText = String(capture?.text || selectionText || '').trim();
       return {
         context,
         message: {
           id: messageID,
           sender: header?.sender || '',
           subject: header?.subject || '',
-          selectionText: promptText || selectionText || '',
+          selectionText: promptText,
           promptText,
+          inputIntent: String(capture?.intent || MAIL_DRAFT_INTENT.PROMPT).trim().toLowerCase(),
+          intentFallbackApplied: Boolean(capture?.fallbackApplied),
+          intentFallbackPolicy: String(capture?.fallbackPolicy || MAIL_DRAFT_INTENT_FALLBACK_POLICY).trim().toLowerCase() || MAIL_DRAFT_INTENT_FALLBACK_POLICY,
+          intentReason: String(capture?.reason || '').trim(),
         },
       };
     },
     onGenerating({ prepared }) {
       const promptText = prepared?.message?.promptText || '';
-      openDraftPanel('', 'Generating...', {
+      const sourceLabel = prepared?.message?.inputIntent === MAIL_DRAFT_INTENT.DICTATION
+        ? 'Applying dictation transcript...'
+        : 'Generating...';
+      openDraftPanel('', sourceLabel, {
         showPrompt: true,
         promptText,
         promptDisabled: true,
@@ -1718,12 +1822,25 @@ function registerDefaultMailAssistActions() {
       });
     },
     execute(prepared) {
+      if (prepared?.message?.inputIntent === MAIL_DRAFT_INTENT.DICTATION) {
+        return Promise.resolve({
+          source: 'dictation',
+          draft_text: String(prepared?.message?.promptText || ''),
+          intent: MAIL_DRAFT_INTENT.DICTATION,
+        });
+      }
       return callDraftReply(prepared.context, prepared.message);
     },
     onReady(payload, prepared, invocation) {
       const draftText = String(payload?.draft_text || '').trim();
       const source = String(payload?.source || 'llm').trim();
-      openDraftPanel(draftText, source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)', {
+      let sourceLabel = source === 'llm' ? 'Generated by LLM (unsent)' : 'Fallback draft (unsent)';
+      if (source === 'dictation') {
+        sourceLabel = 'Captured dictation draft (editable, unsent)';
+      } else if (prepared?.message?.intentFallbackApplied && prepared?.message?.intentFallbackPolicy === MAIL_DRAFT_INTENT_FALLBACK_POLICY) {
+        sourceLabel = 'Generated by LLM after ambiguous intent fallback (unsent)';
+      }
+      openDraftPanel(draftText, sourceLabel, {
         showPrompt: true,
         promptText: prepared?.message?.promptText || '',
         promptDisabled: false,

--- a/tests/playwright/mail-actions.spec.ts
+++ b/tests/playwright/mail-actions.spec.ts
@@ -763,6 +763,7 @@ test('keyboardless flow can complete full recording cycle via global button', as
 
 test('recording stop sends STT transcript into draft reply pipeline', async ({ page }) => {
   const sttCalls: Array<Record<string, unknown>> = [];
+  const intentCalls: Array<Record<string, unknown>> = [];
   const draftCalls: Array<Record<string, unknown>> = [];
   const transcript = 'Please confirm delivery by Friday.';
 
@@ -779,6 +780,19 @@ test('recording stop sends STT transcript into draft reply pipeline', async ({ p
         language_probability: 0.98,
         source: 'helpy_stt',
         attempts: 1,
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-intent', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    intentCalls.push(body);
+    await route.fulfill({
+      json: {
+        intent: 'prompt',
+        reason: 'instruction_signals',
+        fallback_applied: false,
+        fallback_policy: 'prompt',
       },
     });
   });
@@ -809,11 +823,119 @@ test('recording stop sends STT transcript into draft reply pipeline', async ({ p
   await expect(page.locator('#canvas-text')).toHaveAttribute('data-mail-recording-state', 'idle');
 
   await expect.poll(() => sttCalls.length).toBe(1);
+  await expect.poll(() => intentCalls.length).toBe(1);
   await expect.poll(() => draftCalls.length).toBe(1);
   expect(String(sttCalls[0]?.audio_base64 || '')).not.toBe('');
+  expect(intentCalls[0]?.transcript).toBe(transcript);
   expect(draftCalls[0]?.selection_text).toBe(transcript);
   await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-text]')).toHaveValue(/Voice draft for m23/);
   await expect(page.locator('tr[data-message-id="m23"] [data-mail-row-status]')).toContainText('Draft ready');
+});
+
+test('voice dictation intent uses transcript as editable draft without generator call', async ({ page }) => {
+  let draftCalls = 0;
+  const transcript = 'Hi Bob,\n\nThanks for the update. I can send details tomorrow.\n\nBest,\nAlice';
+
+  await mockCapabilities(page);
+  await mockMicrophoneCapture(page, 'voice-bytes');
+
+  await page.route('**/api/mail/stt', async (route) => {
+    await route.fulfill({
+      json: {
+        text: transcript,
+        language: 'en',
+        language_probability: 0.95,
+        source: 'helpy_stt',
+        attempts: 1,
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-intent', async (route) => {
+    await route.fulfill({
+      json: {
+        intent: 'dictation',
+        reason: 'dictation_signals',
+        fallback_applied: false,
+        fallback_policy: 'prompt',
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    draftCalls += 1;
+    await route.fulfill({ json: { source: 'llm', draft_text: 'unexpected generator call' } });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm25', date: '2026-02-20T14:00:00Z', sender: 'dictation@example.com', subject: 'Dictation path' },
+  ]);
+
+  await page.click('tr[data-message-id="m25"] button[data-mail-action="draft-reply"]');
+  await page.click('button[data-mail-record-mode="toggle"]');
+  const trigger = page.locator('button[data-mail-record-action="trigger"]');
+  await trigger.click();
+  await trigger.click();
+
+  await expect.poll(() => draftCalls).toBe(0);
+  await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-text]')).toHaveValue(transcript);
+  await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-source]')).toContainText('Captured dictation draft');
+});
+
+test('ambiguous voice intent uses deterministic prompt fallback policy', async ({ page }) => {
+  const draftCalls: Array<Record<string, unknown>> = [];
+  const transcript = 'Tomorrow should work.';
+
+  await mockCapabilities(page);
+  await mockMicrophoneCapture(page, 'voice-bytes');
+
+  await page.route('**/api/mail/stt', async (route) => {
+    await route.fulfill({
+      json: {
+        text: transcript,
+        language: 'en',
+        language_probability: 0.6,
+        source: 'helpy_stt',
+        attempts: 1,
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-intent', async (route) => {
+    await route.fulfill({
+      json: {
+        intent: 'prompt',
+        reason: 'ambiguous_signals',
+        fallback_applied: true,
+        fallback_policy: 'prompt',
+      },
+    });
+  });
+
+  await page.route('**/api/mail/draft-reply', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    draftCalls.push(body);
+    await route.fulfill({
+      json: {
+        source: 'llm',
+        draft_text: `Fallback generated for ${body.message_id}`,
+      },
+    });
+  });
+
+  await renderMail(page, 'gmail', [
+    { id: 'm26', date: '2026-02-20T14:30:00Z', sender: 'fallback@example.com', subject: 'Fallback path' },
+  ]);
+
+  await page.click('tr[data-message-id="m26"] button[data-mail-action="draft-reply"]');
+  await page.click('button[data-mail-record-mode="toggle"]');
+  const trigger = page.locator('button[data-mail-record-action="trigger"]');
+  await trigger.click();
+  await trigger.click();
+
+  await expect.poll(() => draftCalls.length).toBe(1);
+  expect(draftCalls[0]?.selection_text).toBe(transcript);
+  await expect(page.locator('[data-mail-draft-panel] [data-mail-draft-source]')).toContainText('ambiguous intent fallback');
 });
 
 test('recording STT failure remains recoverable via manual prompt retry', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add `/api/mail/draft-intent` with deterministic intent inference (`dictation` vs `prompt`) and explicit fallback metadata
- route voice draft capture through intent inference in `internal/web/static/canvas.js`
- bypass generator for dictation (use transcript directly as editable draft), keep prompt branch on `/api/mail/draft-reply`
- surface ambiguous fallback in draft source label
- add unit/API tests for classifier + Playwright coverage for prompt, dictation, and ambiguous voice flows

## Verification
- Requirement: dictation-like transcript uses dictated content as draft body.
  - Evidence: Playwright `voice dictation intent uses transcript as editable draft without generator call` passed and asserts `draftCalls === 0` plus draft textarea equals transcript.
- Requirement: prompt-like transcript routes to generator.
  - Evidence: Playwright `recording stop sends STT transcript into draft reply pipeline` passed and asserts `/api/mail/draft-intent` receives transcript and `/api/mail/draft-reply` receives `selection_text`.
- Requirement: ambiguous transcript applies deterministic fallback policy and makes it visible.
  - Evidence: Playwright `ambiguous voice intent uses deterministic prompt fallback policy` passed and asserts prompt-branch call plus source label contains `ambiguous intent fallback`.
- Requirement: classifier routing has unit/API coverage.
  - Evidence: `go test ./internal/web -run 'DraftIntent'` passed (`ok   github.com/krystophny/tabula/internal/web`).

Commands run:
```bash
(go test ./internal/web -run 'DraftIntent' && npx playwright test tests/playwright/mail-actions.spec.ts -g 'recording stop sends STT transcript into draft reply pipeline|voice dictation intent uses transcript as editable draft without generator call|ambiguous voice intent uses deterministic prompt fallback policy|recording STT failure remains recoverable via manual prompt retry') 2>&1 | tee /tmp/test.log
```

Output excerpt:
```text
ok   github.com/krystophny/tabula/internal/web	0.005s
✓ recording stop sends STT transcript into draft reply pipeline
✓ voice dictation intent uses transcript as editable draft without generator call
✓ ambiguous voice intent uses deterministic prompt fallback policy
✓ recording STT failure remains recoverable via manual prompt retry
4 passed (2.5s)
```
