### PR TITLE
fix: [Tracker] Generic review + action-assist + PTT rollout order (fixes #32)

### DIFF
--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -2891,7 +2891,7 @@ function setupTextSelection(eventId) {
     if (!(target instanceof Element)) return;
     if (!e.text.contains(target)) return;
     if (target.closest('[data-review-popover]')) return;
-    if (target.closest('button,input,textarea,select,a,[contenteditable="true"]')) return;
+    if (target.closest('button,input,textarea,select,[contenteditable="true"]')) return;
     ev.preventDefault();
     openReviewCommentPopover(eventId, {
       source: 'point',

--- a/tests/playwright/review-mode.spec.ts
+++ b/tests/playwright/review-mode.spec.ts
@@ -182,6 +182,26 @@ test('right-click inline comment popover submits a comment_point draft mark', as
   expect(Number((markSet.target as any).start_offset)).toBeGreaterThanOrEqual(0);
 });
 
+test('right-click on markdown link text still opens review comment popover', async ({ page }) => {
+  await renderArtifact(
+    page,
+    plainTextEvent('evt-comment-link', '# Notes\nReview [linked phrase](https://example.com/item) in-place'),
+  );
+  await page.locator('#canvas-text a').first().click({ button: 'right' });
+
+  const popover = page.locator('[data-review-popover="true"]');
+  await expect(popover).toBeVisible();
+  await popover.locator('input').fill('Annotate link text directly.');
+  await popover.locator('button[type="submit"]').click();
+  await expect(popover).toHaveCount(0);
+
+  const markSet = await waitForLastMessageOfKind(page, 'mark_set');
+  expect(markSet.artifact_id).toBe('evt-comment-link');
+  expect(markSet.intent).toBe('draft');
+  expect(markSet.type).toBe('comment_point');
+  expect(markSet.comment).toBe('Annotate link text directly.');
+});
+
 test('highlight selection popover submits with Enter key as a highlight draft mark', async ({ page }) => {
   await renderArtifact(page, plainTextEvent('evt-highlight-1', '# Notes\nHighlight this sentence now'));
   await selectTextFromSelector(page, '#canvas-text');


### PR DESCRIPTION
## Summary
- enable right-click review comments on markdown link text by allowing `<a>` targets in the text-artifact context-menu path
- add a Playwright regression test proving link text can open the review popover and emit a `comment_point` draft mark

## Verification
Requirement: Track A generic review/comment behavior applies to all `text_artifact` content.
- Evidence: `tests/playwright/review-mode.spec.ts` includes `right-click on markdown link text still opens review comment popover`, which right-clicks an actual markdown link and asserts popover visibility plus emitted `mark_set.type === "comment_point"`.

### Test fails on main
```bash
$ git show origin/main:internal/web/static/canvas.js > internal/web/static/canvas.js
$ npm run test:e2e -- tests/playwright/review-mode.spec.ts -g "right-click on markdown link text still opens review comment popover"
✘  tests/playwright/review-mode.spec.ts:185:5 › right-click on markdown link text still opens review comment popover
Error: expect(locator).toBeVisible() failed
Locator: locator('[data-review-popover="true"]')
Error: element(s) not found
1 failed
```

### Test passes after fix
```bash
$ npm run test:e2e -- tests/playwright/review-mode.spec.ts -g "right-click on markdown link text still opens review comment popover"
✓  tests/playwright/review-mode.spec.ts:185:5 › right-click on markdown link text still opens review comment popover
1 passed
```
