### PR TITLE
docs: sharpen UI paradigm docs and v0.0.2 release metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "tabula",
-  "version": "v0.0.1",
-  "description": "Tabula is a local-first MCP canvas and review runtime for object-scoped AI workflows.",
+  "version": "v0.0.2",
+  "description": "Tabula is a local-first MCP canvas and review runtime that defines and implements an object-scoped intent interface. The model centers AI invocation on selected UI objects via long press, mode-aware intent capture (voice, silent prompt, comment), explicit human approval controls (accept, edit, reject), and annotation-first review flows with commit-controlled persistence. The project emphasizes low-motion, low-redraw interaction behavior suitable for e-ink and high-latency display contexts while keeping API surfaces and runtime interfaces reproducible.",
   "license": "MIT",
   "upload_type": "software",
   "creators": [
@@ -10,6 +10,10 @@
     }
   ],
   "keywords": [
+    "object-scoped intent interface",
+    "human-in-the-loop",
+    "document-centric ai",
+    "multimodal interaction",
     "mcp",
     "canvas",
     "review",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,14 +6,20 @@ authors:
   - family-names: Albert
     given-names: Christopher
 license: MIT
-version: v0.0.1
+version: v0.0.2
 date-released: 2026-02-21
 repository-code: https://github.com/krystophny/tabula
 url: https://github.com/krystophny/tabula
 abstract: >-
-  Tabula is a local-first MCP canvas and review runtime focused on object-scoped
-  intent capture, annotation, and explicit user-controlled commit flows.
+  Tabula is a local-first MCP canvas and review runtime that defines an
+  object-scoped intent interface with local invocation, mode-aware intent
+  capture, explicit Accept/Edit/Reject controls, and commit-based review
+  workflows.
 keywords:
+  - object-scoped intent interface
+  - human-in-the-loop
+  - document-centric ai
+  - multimodal interaction
   - mcp
   - canvas
   - review

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # tabula
 
-Tabula is a local-first MCP canvas and review runtime.
+Tabula is a local-first MCP canvas and review runtime built around an object-scoped intent interface.
 
-It provides:
-- MCP server tools for canvas sessions and marks
-- Browser canvas UI with review workflows
-- Web runtime with auth, terminal, and canvas relays
-- Handoff import path for producer/consumer integrations
+Core paradigm:
+- Invoke AI on the object itself, not in a persistent global chat panel.
+- Capture intent in context (voice, prompt, or comment mode).
+- Keep all generated output as explicit proposals under user control.
+- Commit changes through review workflows instead of hidden auto-apply.
 
 License: MIT (`LICENSE`)
 
 ## Start Here
 
-- Spec index: `docs/spec-index.md`
-- Interaction model: `docs/object-scoped-intent-ui.md`
-- Review workflow: `docs/review-mode-workflow.md`
-- Interfaces: `docs/interfaces.md`
-- Architecture: `docs/architecture.md`
-- Release freeze notes: `docs/release-v0.0.1.md`
+- **Spec hub**: [`docs/spec-index.md`](docs/spec-index.md)
+- **UI paradigm**: [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)
+- **Review state and commit flow**: [`docs/review-mode-workflow.md`](docs/review-mode-workflow.md)
+- **HTTP/MCP interface inventory**: [`docs/interfaces.md`](docs/interfaces.md)
+- **System architecture**: [`docs/architecture.md`](docs/architecture.md)
+- **Next release notes (v0.0.2)**: [`docs/release-v0.0.2.md`](docs/release-v0.0.2.md)
+- **Published baseline (v0.0.1)**: [`docs/release-v0.0.1.md`](docs/release-v0.0.1.md)
 
 ## Install
 
@@ -47,7 +48,18 @@ tabula canvas
 - Canvas websocket: `ws://127.0.0.1:9420/ws/canvas`
 - Local browser session id: `local`
 
-## Quick Handoff Import Example
+## Novel UI Focus (What To Evaluate First)
+
+1. Object-scoped invocation behavior (`long press` and local prompt/capture paths).
+2. Explicit proposal lifecycle (`Accept`, `Edit`, `Reject`) with no hidden mutation.
+3. Annotation-first review semantics with commit-controlled persistence.
+4. Low-refresh and e-ink-friendly interaction constraints.
+
+See:
+- [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)
+- [`docs/review-mode-workflow.md`](docs/review-mode-workflow.md)
+
+## Integration Example (Optional)
 
 ```bash
 PRODUCER=http://127.0.0.1:8090/mcp

--- a/docs/release-v0.0.2.md
+++ b/docs/release-v0.0.2.md
@@ -1,0 +1,31 @@
+# Release v0.0.2
+
+## Scope
+
+`v0.0.2` is a documentation and metadata refinement release focused on clarity and publication quality.
+
+## Highlights
+
+- Reframed project messaging around the object-scoped intent UI paradigm.
+- Improved documentation navigation and cross-links.
+- Strengthened archival metadata descriptions for release indexing.
+- Kept implementation behavior unchanged while clarifying interface references.
+
+## Primary Reading Order
+
+1. `docs/object-scoped-intent-ui.md`
+2. `docs/review-mode-workflow.md`
+3. `docs/interfaces.md`
+4. `docs/architecture.md`
+
+## Interface Stability Notes
+
+- No runtime API removals in this release.
+- Existing MCP tool names and web endpoints remain documented and unchanged.
+
+## Traceability
+
+For publication metadata, associate this release with:
+- release label: `v0.0.2`
+- repository: `https://github.com/krystophny/tabula`
+- exact source revision: tag target commit hash

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -1,14 +1,20 @@
 # Tabula Spec Index
 
-Canonical documentation for `v0.0.1`.
+Canonical documentation.
 
 ## Product and Behavior Specs
 
-- Interaction model: `object-scoped-intent-ui.md`
-- Review workflow and commit model: `review-mode-workflow.md`
-- Public interface references: `interfaces.md`
-- Architecture: `architecture.md`
-- Version freeze and release notes: `release-v0.0.1.md`
+Read in this order:
+
+1. `object-scoped-intent-ui.md`
+2. `review-mode-workflow.md`
+3. `interfaces.md`
+4. `architecture.md`
+
+Release notes:
+
+- Upcoming: `release-v0.0.2.md`
+- Published baseline: `release-v0.0.1.md`
 
 ## Source Code Anchors
 
@@ -35,6 +41,6 @@ Canonical documentation for `v0.0.1`.
 
 ## Scope Boundaries
 
-- Tabula is the canvas consumer and interaction runtime.
-- Producer-side source access (mail/files/calendar/etc.) is external.
-- Handoff transport contracts are defined in `handoff-protocol`.
+- Tabula defines the interaction/runtime layer for object-scoped intent workflows.
+- Producer-side source access (mail/files/calendar/etc.) is external and pluggable.
+- Handoff transport contracts are integration details defined in `handoff-protocol`.


### PR DESCRIPTION
## Summary\n- improve docs navigation and cross-links from README/spec index\n- emphasize the object-scoped intent UI paradigm as the primary project framing\n- expand archival metadata fields for v0.0.2 (.zenodo.json and CITATION.cff)\n- add release notes doc for v0.0.2\n\n## Verification\n- go test ./...\n- npm run test:reports