### PR TITLE
docs: integrate handoff protocol into tabula for v0.0.3

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "tabula",
-  "version": "v0.0.2",
-  "description": "Tabula is a local-first MCP canvas and review runtime that defines and implements an object-scoped intent interface. The model centers AI invocation on selected UI objects via long press, mode-aware intent capture (voice, silent prompt, comment), explicit human approval controls (accept, edit, reject), and annotation-first review flows with commit-controlled persistence. The project emphasizes low-motion, low-redraw interaction behavior suitable for e-ink and high-latency display contexts while keeping API surfaces and runtime interfaces reproducible.",
+  "version": "v0.0.3",
+  "description": "Tabula is a local-first MCP canvas and review runtime that defines and implements an object-scoped intent interface. The model centers AI invocation on selected UI objects via long press, mode-aware intent capture (voice, silent prompt, comment), explicit human approval controls (accept, edit, reject), and annotation-first review flows with commit-controlled persistence. This publication also includes integrated handoff protocol specifications, schemas, and conformance examples in the same repository to keep interaction and transport contracts citable together. The project emphasizes low-motion, low-redraw interaction behavior suitable for e-ink and high-latency display contexts while keeping API surfaces and runtime interfaces reproducible.",
   "license": "MIT",
   "upload_type": "software",
   "creators": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
   - family-names: Albert
     given-names: Christopher
 license: MIT
-version: v0.0.2
+version: v0.0.3
 date-released: 2026-02-21
 repository-code: https://github.com/krystophny/tabula
 url: https://github.com/krystophny/tabula
@@ -14,7 +14,7 @@ abstract: >-
   Tabula is a local-first MCP canvas and review runtime that defines an
   object-scoped intent interface with local invocation, mode-aware intent
   capture, explicit Accept/Edit/Reject controls, and commit-based review
-  workflows.
+  workflows, with integrated handoff protocol specs and schemas in-repo.
 keywords:
   - object-scoped intent interface
   - human-in-the-loop

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ License: MIT (`LICENSE`)
 - **UI paradigm**: [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)
 - **Review state and commit flow**: [`docs/review-mode-workflow.md`](docs/review-mode-workflow.md)
 - **HTTP/MCP interface inventory**: [`docs/interfaces.md`](docs/interfaces.md)
+- **Integrated handoff protocol spec**: [`docs/handoff-protocol/README.md`](docs/handoff-protocol/README.md)
 - **System architecture**: [`docs/architecture.md`](docs/architecture.md)
-- **Next release notes (v0.0.2)**: [`docs/release-v0.0.2.md`](docs/release-v0.0.2.md)
+- **Next release notes (v0.0.3)**: [`docs/release-v0.0.3.md`](docs/release-v0.0.3.md)
+- **Published release (v0.0.2)**: [`docs/release-v0.0.2.md`](docs/release-v0.0.2.md)
 - **Published baseline (v0.0.1)**: [`docs/release-v0.0.1.md`](docs/release-v0.0.1.md)
 
 ## Install
@@ -58,6 +60,7 @@ tabula canvas
 See:
 - [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)
 - [`docs/review-mode-workflow.md`](docs/review-mode-workflow.md)
+- [`docs/interfaces.md`](docs/interfaces.md)
 
 ## Integration Example (Optional)
 

--- a/docs/handoff-protocol/README.md
+++ b/docs/handoff-protocol/README.md
@@ -1,0 +1,35 @@
+# Integrated Handoff Protocol Spec
+
+This directory carries the handoff protocol specification and conformance assets as part of the Tabula publication set.
+
+Primary goals:
+- keep the object-scoped UI paradigm as the top-level product framing
+- keep transport/protocol contracts versioned and citable in the same public repository
+- avoid split publication timing across multiple repos for core interoperability specs
+
+Read in this order:
+1. `spec/overview.md`
+2. `spec/lifecycle.md`
+3. `spec/message-actions-v1.md`
+4. `spec/security.md`
+5. `security/threat-model.md`
+
+Schemas:
+- `schemas/envelope-v1.json`
+- `schemas/kind-file-v1.json`
+- `schemas/kind-mail-headers-v1.json`
+- `schemas/message-action-capabilities-v1.json`
+- `schemas/message-action-request-v1.json`
+- `schemas/message-action-response-v1.json`
+- `schemas/error-v1.json`
+
+Conformance examples:
+- `conformance/examples/*`
+- `conformance/negative/*`
+- `conformance/runner-spec.md`
+
+Upstream snapshot note:
+- `README.upstream.md` preserves the imported upstream overview text.
+
+License:
+- This integrated spec is distributed under repository MIT license (`LICENSE`).

--- a/docs/handoff-protocol/README.upstream.md
+++ b/docs/handoff-protocol/README.upstream.md
@@ -1,0 +1,16 @@
+# handoff-protocol
+
+Versioned, producer-neutral handoff protocol for transferring typed payloads (for example files and mail headers) between MCP services without routing payload bytes through model context.
+
+## v1 Scope
+
+- Generic lifecycle: `handoff.create`, `handoff.peek`, `handoff.consume`, `handoff.revoke`, `handoff.status`
+- Kind contracts: `file`, `mail_headers`
+- Message action profile: capability and action payloads for `open`, `archive`, `delete`, `defer`
+- One-time or bounded-consume handoffs with TTL
+- Integrity metadata for file handoffs
+
+## Profiles
+
+- Handoff envelope and kinds: `spec/overview.md` + `schemas/*kind*.json`
+- Message actions profile: `spec/message-actions-v1.md`

--- a/docs/handoff-protocol/conformance/examples/file-envelope.json
+++ b/docs/handoff-protocol/conformance/examples/file-envelope.json
@@ -1,0 +1,24 @@
+{
+  "spec_version": "handoff.v1",
+  "handoff_id": "abc123",
+  "kind": "file",
+  "created_at": "2026-02-20T00:00:00Z",
+  "meta": {
+    "filename": "report.txt",
+    "mime_type": "text/plain",
+    "size_bytes": 5,
+    "sha256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+  },
+  "payload": {
+    "encoding": "base64",
+    "content_base64": "aGVsbG8="
+  },
+  "policy": {
+    "expires_at": "2026-02-20T00:10:00Z",
+    "max_consumes": 1,
+    "consumed_count": 0,
+    "remaining_consumes": 1,
+    "single_use": true,
+    "revoked": false
+  }
+}

--- a/docs/handoff-protocol/conformance/examples/mail-headers-envelope.json
+++ b/docs/handoff-protocol/conformance/examples/mail-headers-envelope.json
@@ -1,0 +1,27 @@
+{
+  "spec_version": "handoff.v1",
+  "handoff_id": "def456",
+  "kind": "mail_headers",
+  "created_at": "2026-02-20T00:00:00Z",
+  "meta": {
+    "provider": "gmail",
+    "folder": "INBOX",
+    "count": 2
+  },
+  "payload": {
+    "headers": [
+      {
+        "id": "m1",
+        "date": "2026-02-20T00:00:00Z",
+        "sender": "a@example.com",
+        "subject": "One"
+      },
+      {
+        "id": "m2",
+        "date": "2026-02-19T00:00:00Z",
+        "sender": "b@example.com",
+        "subject": "Two"
+      }
+    ]
+  }
+}

--- a/docs/handoff-protocol/conformance/examples/message-action-capabilities-gmail.json
+++ b/docs/handoff-protocol/conformance/examples/message-action-capabilities-gmail.json
@@ -1,0 +1,7 @@
+{
+  "provider": "gmail",
+  "supports_open": true,
+  "supports_archive": true,
+  "supports_delete_to_trash": true,
+  "supports_native_defer": true
+}

--- a/docs/handoff-protocol/conformance/examples/message-action-capabilities-imap.json
+++ b/docs/handoff-protocol/conformance/examples/message-action-capabilities-imap.json
@@ -1,0 +1,7 @@
+{
+  "provider": "imap",
+  "supports_open": true,
+  "supports_archive": true,
+  "supports_delete_to_trash": true,
+  "supports_native_defer": false
+}

--- a/docs/handoff-protocol/conformance/examples/message-action-defer-request.json
+++ b/docs/handoff-protocol/conformance/examples/message-action-defer-request.json
@@ -1,0 +1,6 @@
+{
+  "provider": "gmail",
+  "action": "defer",
+  "message_id": "m123",
+  "until_at": "2026-02-27T09:00:00Z"
+}

--- a/docs/handoff-protocol/conformance/examples/message-action-defer-response-gmail-native.json
+++ b/docs/handoff-protocol/conformance/examples/message-action-defer-response-gmail-native.json
@@ -1,0 +1,8 @@
+{
+  "provider": "gmail",
+  "action": "defer",
+  "message_id": "m123",
+  "status": "ok",
+  "effective_provider_mode": "native",
+  "deferred_until_at": "2026-02-27T09:00:00Z"
+}

--- a/docs/handoff-protocol/conformance/examples/message-action-defer-response-imap-stub.json
+++ b/docs/handoff-protocol/conformance/examples/message-action-defer-response-imap-stub.json
@@ -1,0 +1,8 @@
+{
+  "provider": "imap",
+  "action": "defer",
+  "message_id": "m999",
+  "status": "stub_not_supported",
+  "effective_provider_mode": "stub",
+  "stub_reason": "DEFER_NOT_SUPPORTED_FOR_PROVIDER"
+}

--- a/docs/handoff-protocol/conformance/negative/message-action-defer-request-missing-until-at.json
+++ b/docs/handoff-protocol/conformance/negative/message-action-defer-request-missing-until-at.json
@@ -1,0 +1,5 @@
+{
+  "provider": "gmail",
+  "action": "defer",
+  "message_id": "m123"
+}

--- a/docs/handoff-protocol/conformance/negative/message-action-defer-response-stub-invalid-reason.json
+++ b/docs/handoff-protocol/conformance/negative/message-action-defer-response-stub-invalid-reason.json
@@ -1,0 +1,8 @@
+{
+  "provider": "imap",
+  "action": "defer",
+  "message_id": "m999",
+  "status": "stub_not_supported",
+  "effective_provider_mode": "stub",
+  "stub_reason": "NOT_AVAILABLE"
+}

--- a/docs/handoff-protocol/conformance/negative/missing-kind.json
+++ b/docs/handoff-protocol/conformance/negative/missing-kind.json
@@ -1,0 +1,7 @@
+{
+  "spec_version": "handoff.v1",
+  "handoff_id": "oops",
+  "created_at": "2026-02-20T00:00:00Z",
+  "meta": {},
+  "payload": {}
+}

--- a/docs/handoff-protocol/conformance/runner-spec.md
+++ b/docs/handoff-protocol/conformance/runner-spec.md
@@ -1,0 +1,18 @@
+# Conformance Runner Notes
+
+A runner should validate:
+
+1. Envelope schema validation for positive examples.
+2. Kind-specific schema validation for positive examples.
+3. Negative examples must fail schema validation.
+4. Producer behavior checks:
+   - `consume` decrements/advances counters.
+   - expired/revoked handoffs are rejected.
+
+For message action profile v1, validate additionally:
+
+1. Capability fixtures against `schemas/message-action-capabilities-v1.json`.
+2. Request fixtures against `schemas/message-action-request-v1.json`.
+3. Response fixtures against `schemas/message-action-response-v1.json`.
+4. Negative defer request fixture (missing `until_at`) must fail validation.
+5. Negative defer stub response fixture (invalid `stub_reason`) must fail validation.

--- a/docs/handoff-protocol/schemas/envelope-v1.json
+++ b/docs/handoff-protocol/schemas/envelope-v1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/envelope-v1.json",
+  "title": "Handoff Envelope v1",
+  "type": "object",
+  "required": ["spec_version", "handoff_id", "kind", "created_at", "meta", "payload"],
+  "properties": {
+    "spec_version": { "type": "string", "const": "handoff.v1" },
+    "handoff_id": { "type": "string", "minLength": 1 },
+    "kind": { "type": "string", "enum": ["file", "mail_headers"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "meta": { "type": "object" },
+    "payload": { "type": "object" },
+    "policy": {
+      "type": "object",
+      "properties": {
+        "expires_at": { "type": "string", "format": "date-time" },
+        "max_consumes": { "type": "integer", "minimum": 1 },
+        "consumed_count": { "type": "integer", "minimum": 0 },
+        "remaining_consumes": { "type": "integer", "minimum": 0 },
+        "single_use": { "type": "boolean" },
+        "revoked": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/handoff-protocol/schemas/error-v1.json
+++ b/docs/handoff-protocol/schemas/error-v1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/error-v1.json",
+  "title": "Handoff Error v1",
+  "type": "object",
+  "required": ["code", "message"],
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": [
+        "HANDOFF_NOT_FOUND",
+        "HANDOFF_EXPIRED",
+        "HANDOFF_REVOKED",
+        "HANDOFF_POLICY_VIOLATION",
+        "HANDOFF_INTEGRITY_MISMATCH",
+        "HANDOFF_UNSUPPORTED_KIND"
+      ]
+    },
+    "message": { "type": "string" },
+    "details": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/docs/handoff-protocol/schemas/kind-file-v1.json
+++ b/docs/handoff-protocol/schemas/kind-file-v1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/kind-file-v1.json",
+  "title": "Handoff File Kind v1",
+  "type": "object",
+  "required": ["meta", "payload"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["filename", "mime_type", "size_bytes", "sha256"],
+      "properties": {
+        "filename": { "type": "string", "minLength": 1 },
+        "mime_type": { "type": "string", "minLength": 1 },
+        "size_bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "additionalProperties": true
+    },
+    "payload": {
+      "type": "object",
+      "required": ["content_base64"],
+      "properties": {
+        "encoding": { "type": "string" },
+        "content_base64": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/handoff-protocol/schemas/kind-mail-headers-v1.json
+++ b/docs/handoff-protocol/schemas/kind-mail-headers-v1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/kind-mail-headers-v1.json",
+  "title": "Handoff Mail Headers Kind v1",
+  "type": "object",
+  "required": ["meta", "payload"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["count"],
+      "properties": {
+        "provider": { "type": "string" },
+        "folder": { "type": "string" },
+        "count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "payload": {
+      "type": "object",
+      "required": ["headers"],
+      "properties": {
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "date", "sender", "subject"],
+            "properties": {
+              "id": { "type": "string" },
+              "date": { "type": "string", "format": "date-time" },
+              "sender": { "type": "string" },
+              "subject": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/handoff-protocol/schemas/message-action-capabilities-v1.json
+++ b/docs/handoff-protocol/schemas/message-action-capabilities-v1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/message-action-capabilities-v1.json",
+  "title": "Message Action Capabilities v1",
+  "type": "object",
+  "required": [
+    "supports_open",
+    "supports_archive",
+    "supports_delete_to_trash",
+    "supports_native_defer"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "supports_open": {
+      "type": "boolean"
+    },
+    "supports_archive": {
+      "type": "boolean"
+    },
+    "supports_delete_to_trash": {
+      "type": "boolean"
+    },
+    "supports_native_defer": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/handoff-protocol/schemas/message-action-request-v1.json
+++ b/docs/handoff-protocol/schemas/message-action-request-v1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/message-action-request-v1.json",
+  "title": "Message Action Request v1",
+  "type": "object",
+  "required": [
+    "action",
+    "message_id"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "open",
+        "archive",
+        "delete",
+        "defer"
+      ]
+    },
+    "message_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "until_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "defer"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "until_at"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/docs/handoff-protocol/schemas/message-action-response-v1.json
+++ b/docs/handoff-protocol/schemas/message-action-response-v1.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/message-action-response-v1.json",
+  "title": "Message Action Response v1",
+  "type": "object",
+  "required": [
+    "action",
+    "message_id",
+    "status",
+    "effective_provider_mode"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "open",
+        "archive",
+        "delete",
+        "defer"
+      ]
+    },
+    "message_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "stub_not_supported",
+        "error"
+      ]
+    },
+    "effective_provider_mode": {
+      "type": "string",
+      "enum": [
+        "native",
+        "stub"
+      ]
+    },
+    "deferred_until_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "stub_reason": {
+      "type": "string",
+      "enum": [
+        "DEFER_NOT_SUPPORTED_FOR_PROVIDER"
+      ]
+    },
+    "error_code": {
+      "type": "string",
+      "minLength": 1
+    },
+    "error_message": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "stub_not_supported"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "action": {
+            "const": "defer"
+          },
+          "effective_provider_mode": {
+            "const": "stub"
+          }
+        },
+        "required": [
+          "stub_reason"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "error_code",
+          "error_message"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "defer"
+          },
+          "status": {
+            "const": "ok"
+          }
+        },
+        "required": [
+          "action",
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "deferred_until_at"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/docs/handoff-protocol/security/threat-model.md
+++ b/docs/handoff-protocol/security/threat-model.md
@@ -1,0 +1,15 @@
+# Threat Model (v1)
+
+## Threats
+
+- Replay of handoff IDs
+- Unauthorized consume by wrong consumer
+- Tampered payload in transit/storage
+- Overlong lifetime leading to stale credential abuse
+
+## Mitigations
+
+- Single-use default and strict consume counters
+- Authn/authz on producer MCP endpoint
+- Integrity checks (`sha256`, `size_bytes`) for file payloads
+- Short TTL defaults and explicit revocation support

--- a/docs/handoff-protocol/spec/lifecycle.md
+++ b/docs/handoff-protocol/spec/lifecycle.md
@@ -1,0 +1,65 @@
+# Lifecycle
+
+## handoff.create
+
+Input:
+- `kind`: `file` | `mail_headers`
+- `selector`: kind-specific source selection
+- `policy` (optional): `ttl_seconds`, `expires_at`, `max_consumes`
+
+Output:
+- `spec_version`, `handoff_id`, `kind`, `meta`, `created_at`, `policy_summary`
+
+## handoff.peek
+
+Input:
+- `handoff_id`
+
+Output:
+- Same as create metadata, no payload.
+
+## handoff.consume
+
+Input:
+- `handoff_id`
+
+Output:
+- `spec_version`, `handoff_id`, `kind`, `created_at`, `meta`, `payload`, `policy`
+
+## handoff.revoke
+
+Input:
+- `handoff_id`
+
+Output:
+- Revocation acknowledgement + policy summary.
+
+## handoff.status
+
+Input:
+- `handoff_id`
+
+Output:
+- Metadata + policy counters + revocation state.
+
+## Message Actions (profile)
+
+This protocol family also defines payload contracts for deterministic message actions.
+These are transport-agnostic and can be carried by MCP tools or HTTP APIs.
+
+Core request shape:
+- `action`: `open` | `archive` | `delete` | `defer`
+- `message_id`
+- `until_at` (required when `action=defer`)
+
+Core response shape:
+- `action`
+- `message_id`
+- `status`: `ok` | `stub_not_supported` | `error`
+- `effective_provider_mode`: `native` | `stub`
+
+For IMAP defer v1, standardized stub behavior is:
+- `action=defer`
+- `status=stub_not_supported`
+- `effective_provider_mode=stub`
+- `stub_reason=DEFER_NOT_SUPPORTED_FOR_PROVIDER`

--- a/docs/handoff-protocol/spec/message-actions-v1.md
+++ b/docs/handoff-protocol/spec/message-actions-v1.md
@@ -1,0 +1,54 @@
+# Message Actions Profile v1
+
+This profile defines deterministic action payloads for UI-triggered message triage.
+It is intentionally non-LLM and transport-agnostic.
+
+## Capability payload
+
+Required boolean fields:
+
+- `supports_open`
+- `supports_archive`
+- `supports_delete_to_trash`
+- `supports_native_defer`
+
+## Action request payload
+
+Required:
+
+- `action`: `open` | `archive` | `delete` | `defer`
+- `message_id`
+
+Conditional required:
+
+- `until_at` when `action=defer`, RFC3339.
+
+## Action response payload
+
+Required:
+
+- `action`
+- `message_id`
+- `status`: `ok` | `stub_not_supported` | `error`
+- `effective_provider_mode`: `native` | `stub`
+
+Recommended:
+
+- `provider`
+- `deferred_until_at` for successful defer
+- `error_code`, `error_message` for status `error`
+- `stub_reason` for status `stub_not_supported`
+
+## Provider semantics
+
+### Gmail defer
+
+- Use provider-native defer/snooze.
+- Return `effective_provider_mode=native`.
+
+### IMAP defer (v1)
+
+- Return structured stub response.
+- Do not mutate inbox state in v1.
+- Return `effective_provider_mode=stub` and `status=stub_not_supported`.
+- Return `stub_reason=DEFER_NOT_SUPPORTED_FOR_PROVIDER`.

--- a/docs/handoff-protocol/spec/overview.md
+++ b/docs/handoff-protocol/spec/overview.md
@@ -1,0 +1,46 @@
+# Handoff Protocol v1 Overview
+
+## Goals
+
+- Decouple producer/consumer from shared filesystem assumptions.
+- Keep payload bytes out of LLM prompt/tool argument context.
+- Provide a typed and versioned envelope for interoperability.
+- Provide deterministic, non-LLM action payload contracts for message triage UX.
+
+## Roles
+
+- Producer: creates and serves handoff payloads.
+- Consumer: imports payload and renders/uses it.
+
+## Required producer tools
+
+- `handoff.create`
+- `handoff.peek`
+- `handoff.consume`
+- `handoff.revoke`
+- `handoff.status`
+
+## Message action profile (v1)
+
+This repo also defines v1 payload contracts for deterministic message actions:
+
+- capabilities: `supports_open`, `supports_archive`, `supports_delete_to_trash`, `supports_native_defer`
+- actions: `open`, `archive`, `delete`, `defer`
+- defer request: requires `until_at` (RFC3339)
+- defer response: includes `status` and `effective_provider_mode` (`native` | `stub`)
+
+## Required envelope fields
+
+- `spec_version` (example: `handoff.v1`)
+- `handoff_id`
+- `kind`
+- `created_at` (RFC3339)
+- `meta` (kind metadata)
+- `payload` (kind payload)
+
+## Policy model
+
+- TTL (`expires_at` or `ttl_seconds` at create-time)
+- Consume limit (`max_consumes`)
+- Counters (`consumed_count`, `remaining_consumes`)
+- Optional revocation (`revoked`)

--- a/docs/handoff-protocol/spec/security.md
+++ b/docs/handoff-protocol/spec/security.md
@@ -1,0 +1,21 @@
+# Security Model
+
+## Defaults
+
+- `max_consumes = 1`
+- TTL should be short (recommended: 10 minutes)
+- Producer returns typed payloads only to authenticated consumers
+
+## Guidance
+
+- Use TLS for producer endpoints.
+- Bind tokens or credentials to consumer identity when possible.
+- Audit create/peek/consume/revoke operations.
+- For `file` handoffs, validate `sha256` and `size_bytes` on consume.
+- For message actions, validate action-specific required fields (`until_at` for `defer`) before provider calls.
+- Audit deterministic action invocations (`open`, `archive`, `delete`, `defer`) with provider mode (`native` or `stub`).
+
+## Out of scope for v1
+
+- Brokered object storage fallback
+- End-to-end encrypted multi-hop payload wrapping

--- a/docs/release-v0.0.3.md
+++ b/docs/release-v0.0.3.md
@@ -1,0 +1,32 @@
+# Release v0.0.3
+
+## Scope
+
+`v0.0.3` consolidates protocol publication into Tabula while keeping the object-scoped UI paradigm as the primary project framing.
+
+## Highlights
+
+- Integrated handoff protocol specs, schemas, security notes, and conformance fixtures into this repository under `docs/handoff-protocol/`.
+- Improved documentation navigation and cross-links from README/spec index.
+- Kept paradigm-first framing in top-level docs while preserving protocol details as a first-class reference set.
+- Expanded archival metadata text to describe unified interaction + protocol publication scope.
+
+## Primary Reading Order
+
+1. `docs/object-scoped-intent-ui.md`
+2. `docs/review-mode-workflow.md`
+3. `docs/interfaces.md`
+4. `docs/architecture.md`
+5. `docs/handoff-protocol/README.md`
+
+## Interface Stability Notes
+
+- No runtime API removals in this release.
+- Existing MCP tool names and web endpoints remain documented and unchanged.
+
+## Traceability
+
+For publication metadata, associate this release with:
+- release label: `v0.0.3`
+- repository: `https://github.com/krystophny/tabula`
+- exact source revision: tag target commit hash

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -11,9 +11,14 @@ Read in this order:
 3. `interfaces.md`
 4. `architecture.md`
 
+Integrated protocol reference:
+
+- `handoff-protocol/README.md`
+
 Release notes:
 
-- Upcoming: `release-v0.0.2.md`
+- Upcoming: `release-v0.0.3.md`
+- Published release: `release-v0.0.2.md`
 - Published baseline: `release-v0.0.1.md`
 
 ## Source Code Anchors
@@ -43,4 +48,4 @@ Release notes:
 
 - Tabula defines the interaction/runtime layer for object-scoped intent workflows.
 - Producer-side source access (mail/files/calendar/etc.) is external and pluggable.
-- Handoff transport contracts are integration details defined in `handoff-protocol`.
+- Handoff transport contracts are documented in this repo under `docs/handoff-protocol/`.


### PR DESCRIPTION
## Summary
- import handoff protocol specs, schemas, security notes, and conformance fixtures into docs/handoff-protocol/
- keep object-scoped intent UI as top-level framing while making protocol docs first-class and co-published
- update README/spec index links and add v0.0.3 release notes
- bump archival metadata versions to v0.0.3

## Verification
- go test ./...
- npm run test:reports