### PR TITLE
v0.0.4: add OSS legal notice and release docs

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,46 @@
+# Legal Notice and Liability Disclaimer
+
+This repository is open-source software distributed under the MIT License (`LICENSE`).
+
+## 1) Warranty and Liability
+
+To the maximum extent permitted by applicable law:
+
+- The software is provided "as is" and "as available", without warranties of any kind.
+- The authors and contributors are not liable for any damages, losses, or claims arising from use, misuse, inability to use, or data loss.
+- You are solely responsible for backup, retention, recovery, and verification of your own data.
+
+This project must not be used as the only copy or sole system of record for important files.
+
+## 2) Operational Safety Requirement
+
+If you run this software in any environment with valuable data, you should implement:
+
+- regular backups and restore testing,
+- versioning/snapshots,
+- access controls,
+- and an incident response process.
+
+## 3) Hosted or Commercial Use
+
+This repository notice is not a substitute for product terms.
+If you provide a hosted service, managed offering, or commercial support, publish separate Terms of Service / EULA and Privacy terms that define:
+
+- liability caps,
+- exclusions of indirect/consequential damages,
+- governing law and dispute forum,
+- and customer backup/data responsibilities.
+
+## 4) Governing Law and Forum (Project Policy)
+
+For non-consumer disputes directly related to this repository and to the extent legally enforceable, the project preference is:
+
+- governing law: Republic of Austria,
+- exclusive forum: competent courts in Vienna, Austria.
+
+Mandatory consumer protections and non-waivable statutory rights remain unaffected.
+
+## 5) No Legal Advice
+
+Nothing in this repository is legal advice.
+For enforceable terms in your jurisdiction, consult qualified counsel.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Core paradigm:
 - Commit changes through review workflows instead of hidden auto-apply.
 
 License: MIT (`LICENSE`)
+Risk notice: see [`DISCLAIMER.md`](DISCLAIMER.md)
 
 ## Start Here
 
@@ -18,8 +19,8 @@ License: MIT (`LICENSE`)
 - **HTTP/MCP interface inventory**: [`docs/interfaces.md`](docs/interfaces.md)
 - **Integrated handoff protocol spec**: [`docs/handoff-protocol/README.md`](docs/handoff-protocol/README.md)
 - **System architecture**: [`docs/architecture.md`](docs/architecture.md)
-- **Next release notes (v0.0.3)**: [`docs/release-v0.0.3.md`](docs/release-v0.0.3.md)
-- **Published release (v0.0.2)**: [`docs/release-v0.0.2.md`](docs/release-v0.0.2.md)
+- **Published release (v0.0.4)**: [`docs/release-v0.0.4.md`](docs/release-v0.0.4.md)
+- **Previous release (v0.0.3)**: [`docs/release-v0.0.3.md`](docs/release-v0.0.3.md)
 - **Published baseline (v0.0.1)**: [`docs/release-v0.0.1.md`](docs/release-v0.0.1.md)
 
 ## Install

--- a/docs/release-v0.0.4.md
+++ b/docs/release-v0.0.4.md
@@ -1,0 +1,29 @@
+# Release v0.0.4
+
+## Scope
+
+`v0.0.4` adds practical legal/risk guidance for open-source usage and includes review UX refinements already landed on `main`.
+
+## Highlights
+
+- Added repository-level legal/risk notice: `DISCLAIMER.md`.
+- Documented explicit backup and data-loss responsibility expectations for operators.
+- Clarified that hosted/commercial deployments should publish separate ToS/EULA terms.
+- Updated documentation release pointers in `README.md` and `docs/spec-index.md`.
+- Includes recent review-mode UX improvements:
+  - stable popover reopen/close behavior for existing annotations,
+  - pointer cursor on hover over existing annotations,
+  - point comment marker color aligned with highlight color.
+
+## Interface Stability Notes
+
+- No runtime API removals in this release.
+- Existing MCP tool names and web endpoints remain documented and unchanged.
+
+## Traceability
+
+For publication metadata, associate this release with:
+
+- release label: `v0.0.4`
+- repository: `https://github.com/krystophny/tabula`
+- exact source revision: tag target commit hash

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -17,8 +17,8 @@ Integrated protocol reference:
 
 Release notes:
 
-- Upcoming: `release-v0.0.3.md`
-- Published release: `release-v0.0.2.md`
+- Published release: `release-v0.0.4.md`
+- Previous release: `release-v0.0.3.md`
 - Published baseline: `release-v0.0.1.md`
 
 ## Source Code Anchors


### PR DESCRIPTION
## Summary
- add `DISCLAIMER.md` with practical open-source liability and data-loss notice
- link risk notice from `README.md`
- publish `docs/release-v0.0.4.md`
- update release pointers in `docs/spec-index.md`

## Why
- provide a practical repo-level text for open-source usage risk and operator responsibilities
- prepare and document the v0.0.4 release

## Notes
- this does not replace legal counsel or hosted-service ToS/EULA
