### PR TITLE
fix: feat(build): goreleaser cross-platform binary builds and GitHub (fixes #73)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+version: 2
+project_name: tabura
+
+builds:
+  - id: tabura
+    main: ./cmd/tabura
+    binary: tabura
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .ShortCommit }}
+
+archives:
+  - id: tabura
+    ids:
+      - tabura
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "tabura_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+      - scripts/piper_tts_server.py
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: krystophny
+    name: tabura
+  draft: false
+  prerelease: auto
+
+changelog:
+  use: github-native

--- a/cmd/tabura/main.go
+++ b/cmd/tabura/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -22,6 +23,13 @@ import (
 	"github.com/krystophny/tabura/internal/serve"
 	"github.com/krystophny/tabura/internal/store"
 	"github.com/krystophny/tabura/internal/web"
+)
+
+const defaultBinaryVersion = "0.1.4"
+
+var (
+	version = defaultBinaryVersion
+	commit  = "dev"
 )
 
 func main() {
@@ -44,6 +52,8 @@ func run(args []string) int {
 		return cmdMCPServer(args[1:])
 	case "set-password":
 		return cmdSetPassword(args[1:])
+	case "version":
+		return cmdVersion()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		printHelp()
@@ -53,7 +63,7 @@ func run(args []string) int {
 
 func printHelp() {
 	fmt.Println("tabura <command> [flags]")
-	fmt.Println("commands: schema bootstrap server mcp-server set-password")
+	fmt.Println("commands: schema bootstrap server mcp-server set-password version")
 }
 
 func cmdSchema() int {
@@ -299,4 +309,24 @@ func cmdSetPassword(args []string) int {
 	}
 	fmt.Println("Password set.")
 	return 0
+}
+
+func cmdVersion() int {
+	fmt.Println(formatVersionLine(version, commit, runtime.GOOS, runtime.GOARCH))
+	return 0
+}
+
+func formatVersionLine(rawVersion, rawCommit, goos, goarch string) string {
+	release := strings.TrimSpace(rawVersion)
+	if release == "" {
+		release = "0.0.0"
+	}
+	if !strings.HasPrefix(strings.ToLower(release), "v") {
+		release = "v" + release
+	}
+	shortCommit := strings.TrimSpace(rawCommit)
+	if shortCommit == "" {
+		shortCommit = "unknown"
+	}
+	return fmt.Sprintf("tabura %s (%s) %s/%s", release, shortCommit, goos, goarch)
 }

--- a/cmd/tabura/main_test.go
+++ b/cmd/tabura/main_test.go
@@ -18,3 +18,19 @@ func TestParseServerConfigRejectsPublicMCPWithoutUnsafeFlag(t *testing.T) {
 		t.Fatalf("parseServerConfig(public mcp) status = %d, want 2", status)
 	}
 }
+
+func TestFormatVersionLinePrefixesVersion(t *testing.T) {
+	got := formatVersionLine("0.1.4", "abc1234", "linux", "amd64")
+	want := "tabura v0.1.4 (abc1234) linux/amd64"
+	if got != want {
+		t.Fatalf("formatVersionLine() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatVersionLineKeepsPrefixedVersionAndHandlesMissingCommit(t *testing.T) {
+	got := formatVersionLine("v1.2.3", "", "windows", "arm64")
+	want := "tabura v1.2.3 (unknown) windows/arm64"
+	if got != want {
+		t.Fatalf("formatVersionLine() = %q, want %q", got, want)
+	}
+}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -24,6 +24,7 @@ sed -i "s/^date-released: .*/date-released: ${today}/" CITATION.cff
 
 # Go source (bare version without v prefix)
 sed -E -i "s/(ServerVersion[[:space:]]*=[[:space:]]*\")[^\"]*(\")/\\1${bare}\\2/" internal/mcp/server.go
+sed -E -i "s/(defaultBinaryVersion[[:space:]]*=[[:space:]]*\")[^\"]*(\")/\\1${bare}\\2/" cmd/tabura/main.go
 sed -E -i "s/(\"version\":[[:space:]]*\")[^\"]*(\")/\\1${bare}\\2/" internal/web/server.go
 sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${bare}\"/" internal/appserver/client.go
 sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${bare}\"/" internal/appserver/session.go
@@ -34,6 +35,7 @@ echo "Files updated:"
 echo "  .zenodo.json"
 echo "  CITATION.cff"
 echo "  internal/mcp/server.go"
+echo "  cmd/tabura/main.go"
 echo "  internal/web/server.go"
 echo "  internal/appserver/client.go"
 echo "  internal/appserver/session.go"


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` for cross-platform `tabura` binaries (`linux|darwin|windows` x `amd64|arm64`) with ldflags injection for `main.version` and `main.commit`.
- Add `.github/workflows/release.yml` to run GoReleaser on tag pushes matching `v*`.
- Add `tabura version` subcommand to print `version`, `commit`, and `GOOS/GOARCH`.
- Update `scripts/bump-version.sh` so version bumps also update `cmd/tabura/main.go` (`defaultBinaryVersion`).

## Verification
1. Requirement: GoReleaser configuration is valid.
```bash
$ go run github.com/goreleaser/goreleaser/v2@latest check --config .goreleaser.yaml
  • checking                                  path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

2. Requirement: `tabura version` prints version, commit, and platform.
```bash
$ go run ./cmd/tabura version
tabura v0.1.4 (dev) linux/amd64
```

3. Requirement: related Go code and tests pass after changes.
```bash
$ go test ./cmd/tabura ./internal/web
ok   github.com/krystophny/tabura/cmd/tabura        (cached)
ok   github.com/krystophny/tabura/internal/web      (cached)
```

4. Requirement: bump script keeps CLI version in sync.
- `scripts/bump-version.sh` now includes:
  - `sed -E -i "s/(defaultBinaryVersion[[:space:]]*=[[:space:]]*\")[^\"]*(\")/\\1${bare}\\2/" cmd/tabura/main.go`

## Notes
- GitHub release publication and artifact matrix upload are exercised by CI via `.github/workflows/release.yml` on `v*` tags.
