### PR TITLE
fix: feat(hub): LLM-routed system commands via hub prompt (fixes #69)

### DIFF
--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -33,11 +32,6 @@ Available actions:
 - {"action":"show_status"}
 
 For conversational responses, reply with plain text.`
-
-type hubAction struct {
-	Action string
-	Raw    map[string]interface{}
-}
 
 func isHubProject(project store.Project) bool {
 	if strings.EqualFold(strings.TrimSpace(project.ProjectKey), HubProjectKey) {
@@ -112,26 +106,6 @@ func latestUserMessage(messages []store.ChatMessage) string {
 		}
 	}
 	return ""
-}
-
-func parseHubAction(raw string) (*hubAction, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil, nil
-	}
-	var obj map[string]interface{}
-	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
-		return nil, nil
-	}
-	action := strings.ToLower(strings.TrimSpace(fmt.Sprint(obj["action"])))
-	if action == "" {
-		return nil, nil
-	}
-	return &hubAction{Action: action, Raw: obj}, nil
-}
-
-func hubStringParam(raw map[string]interface{}, key string) string {
-	return strings.TrimSpace(fmt.Sprint(raw[key]))
 }
 
 func (a *App) hubPrimaryProject() (store.Project, error) {
@@ -258,9 +232,9 @@ func (a *App) runHubTurn(sessionID string, session store.ChatSession, messages [
 	if assistantText == "" {
 		assistantText = "(assistant returned no content)"
 	}
-	action, _ := parseHubAction(assistantText)
+	action, _ := parseSystemAction(assistantText)
 	if action != nil {
-		actionMessage, actionPayload, actionErr := a.executeHubAction(sessionID, session, action)
+		actionMessage, actionPayload, actionErr := a.executeSystemAction(sessionID, session, action)
 		if actionErr != nil {
 			assistantText = fmt.Sprintf("Hub action failed: %s", actionErr.Error())
 		} else {
@@ -290,62 +264,4 @@ func (a *App) runHubTurn(sessionID string, session store.ChatSession, messages [
 		resp.ThreadID,
 		outputMode,
 	)
-}
-
-func (a *App) executeHubAction(sessionID string, session store.ChatSession, action *hubAction) (string, map[string]interface{}, error) {
-	if action == nil {
-		return "", nil, errors.New("hub action is required")
-	}
-	switch action.Action {
-	case "switch_project":
-		targetName := hubStringParam(action.Raw, "name")
-		project, err := a.hubFindProjectByName(targetName)
-		if err != nil {
-			return "", nil, err
-		}
-		activated, err := a.activateProject(project.ID)
-		if err != nil {
-			return "", nil, err
-		}
-		return fmt.Sprintf("Switched to %s.", activated.Name), map[string]interface{}{
-			"type":       "switch_project",
-			"project_id": activated.ID,
-		}, nil
-	case "switch_model":
-		targetProject, err := a.hubPrimaryProject()
-		if err != nil {
-			return "", nil, err
-		}
-		updated, err := a.updateProjectChatModel(
-			targetProject.ID,
-			hubStringParam(action.Raw, "alias"),
-			hubStringParam(action.Raw, "effort"),
-		)
-		if err != nil {
-			return "", nil, err
-		}
-		return fmt.Sprintf(
-			"Model for %s set to %s (%s).",
-			updated.Name,
-			updated.ChatModel,
-			updated.ChatModelReasoningEffort,
-		), nil, nil
-	case "toggle_silent":
-		return "Toggled silent mode.", map[string]interface{}{"type": "toggle_silent"}, nil
-	case "toggle_conversation":
-		return "Toggled conversation mode.", map[string]interface{}{"type": "toggle_conversation"}, nil
-	case "cancel_work":
-		activeCanceled, queuedCanceled := a.cancelChatWork(sessionID)
-		delegateCanceled := a.cancelDelegatedJobsForProject(session.ProjectKey)
-		total := activeCanceled + queuedCanceled + delegateCanceled
-		return fmt.Sprintf("Canceled %d running task(s).", total), nil, nil
-	case "show_status":
-		status, err := a.fetchCodexStatusMessage(session.ProjectKey)
-		if err != nil {
-			return "", nil, err
-		}
-		return status, nil, nil
-	default:
-		return "", nil, fmt.Errorf("unsupported action: %s", action.Action)
-	}
 }

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -8,8 +9,8 @@ import (
 	"github.com/krystophny/tabura/internal/modelprofile"
 )
 
-func TestParseHubAction(t *testing.T) {
-	plain, err := parseHubAction("hello world")
+func TestParseSystemAction(t *testing.T) {
+	plain, err := parseSystemAction("hello world")
 	if err != nil {
 		t.Fatalf("plain parse returned error: %v", err)
 	}
@@ -17,15 +18,32 @@ func TestParseHubAction(t *testing.T) {
 		t.Fatalf("expected nil action for plain text")
 	}
 
-	action, err := parseHubAction(`{"action":"switch_project","name":"docs"}`)
-	if err != nil {
-		t.Fatalf("json parse returned error: %v", err)
+	cases := []struct {
+		name       string
+		raw        string
+		wantAction string
+	}{
+		{name: "switch project", raw: `{"action":"switch_project","name":"docs"}`, wantAction: "switch_project"},
+		{name: "switch model", raw: `{"action":"switch_model","alias":"gpt","effort":"high"}`, wantAction: "switch_model"},
+		{name: "toggle silent", raw: `{"action":"toggle_silent"}`, wantAction: "toggle_silent"},
+		{name: "toggle conversation", raw: `{"action":"toggle_conversation"}`, wantAction: "toggle_conversation"},
+		{name: "cancel work", raw: `{"action":"cancel_work"}`, wantAction: "cancel_work"},
+		{name: "show status", raw: `{"action":"show_status"}`, wantAction: "show_status"},
 	}
-	if action == nil {
-		t.Fatalf("expected parsed action")
-	}
-	if action.Action != "switch_project" {
-		t.Fatalf("action = %q, want switch_project", action.Action)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			action, parseErr := parseSystemAction(tc.raw)
+			if parseErr != nil {
+				t.Fatalf("parse action: %v", parseErr)
+			}
+			if action == nil {
+				t.Fatalf("expected parsed action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+		})
 	}
 }
 
@@ -43,10 +61,9 @@ func TestHubSwitchModelTargetsPrimaryProject(t *testing.T) {
 		t.Fatalf("hub session: %v", err)
 	}
 
-	msg, payload, err := app.executeHubAction(session.ID, session, &hubAction{
+	msg, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
 		Action: "switch_model",
-		Raw: map[string]interface{}{
-			"action": "switch_model",
+		Params: map[string]interface{}{
 			"alias":  "gpt",
 			"effort": "extra_high",
 		},
@@ -54,8 +71,11 @@ func TestHubSwitchModelTargetsPrimaryProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute switch_model: %v", err)
 	}
-	if payload != nil {
-		t.Fatalf("switch_model payload = %#v, want nil", payload)
+	if payload == nil {
+		t.Fatalf("expected switch_model payload")
+	}
+	if got := strings.TrimSpace(payload["type"].(string)); got != "switch_model" {
+		t.Fatalf("action payload type = %q, want switch_model", got)
 	}
 	if !strings.Contains(strings.ToLower(msg), "model") {
 		t.Fatalf("expected model update message, got %q", msg)
@@ -112,11 +132,10 @@ func TestHubSwitchProjectActionReturnsActivationPayload(t *testing.T) {
 		t.Fatalf("expected linked project to be created")
 	}
 
-	_, payload, err := app.executeHubAction(session.ID, session, &hubAction{
+	_, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
 		Action: "switch_project",
-		Raw: map[string]interface{}{
-			"action": "switch_project",
-			"name":   "note",
+		Params: map[string]interface{}{
+			"name": "note",
 		},
 	})
 	if err != nil {
@@ -130,6 +149,74 @@ func TestHubSwitchProjectActionReturnsActivationPayload(t *testing.T) {
 	}
 	if got := strings.TrimSpace(payload["project_id"].(string)); got != target.ID {
 		t.Fatalf("action payload project_id = %q, want %q", got, target.ID)
+	}
+}
+
+func TestExecuteSystemActionRejectsUnsupportedAction(t *testing.T) {
+	app := newAuthedTestApp(t)
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("hub session: %v", err)
+	}
+
+	_, _, err = app.executeSystemAction(session.ID, session, &SystemAction{Action: "unknown"})
+	if err == nil {
+		t.Fatalf("expected unsupported action error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "unsupported action") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHubRunTurnKeepsPlainTextAssistantOutput(t *testing.T) {
+	const assistantReply = "All systems nominal."
+	wsServer := setupMockAppServerStatusServer(t, assistantReply)
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	app, err := New(t.TempDir(), "", "", wsURL, "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("hub session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "status?", "status?", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	messages, err := app.store.ListChatMessages(session.ID, 100)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	app.runHubTurn(session.ID, session, messages, turnOutputModeSilent)
+
+	updatedMessages, err := app.store.ListChatMessages(session.ID, 100)
+	if err != nil {
+		t.Fatalf("list updated messages: %v", err)
+	}
+	lastAssistant := ""
+	for i := len(updatedMessages) - 1; i >= 0; i-- {
+		if strings.EqualFold(strings.TrimSpace(updatedMessages[i].Role), "assistant") {
+			lastAssistant = strings.TrimSpace(updatedMessages[i].ContentPlain)
+			break
+		}
+	}
+	if lastAssistant != assistantReply {
+		t.Fatalf("assistant plain text = %q, want %q", lastAssistant, assistantReply)
 	}
 }
 

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type SystemAction struct {
+	Action string                 `json:"action"`
+	Params map[string]interface{} `json:"-"`
+}
+
+func parseSystemAction(raw string) (*SystemAction, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		return nil, nil
+	}
+	action := strings.ToLower(strings.TrimSpace(fmt.Sprint(obj["action"])))
+	if action == "" {
+		return nil, nil
+	}
+	params := make(map[string]interface{}, len(obj))
+	for key, value := range obj {
+		if strings.EqualFold(strings.TrimSpace(key), "action") {
+			continue
+		}
+		params[key] = value
+	}
+	return &SystemAction{Action: action, Params: params}, nil
+}
+
+func systemActionStringParam(params map[string]interface{}, key string) string {
+	return strings.TrimSpace(fmt.Sprint(params[key]))
+}
+
+func (a *App) executeSystemAction(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	if action == nil {
+		return "", nil, errors.New("system action is required")
+	}
+	switch action.Action {
+	case "switch_project":
+		targetName := systemActionStringParam(action.Params, "name")
+		project, err := a.hubFindProjectByName(targetName)
+		if err != nil {
+			return "", nil, err
+		}
+		activated, err := a.activateProject(project.ID)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Switched to %s.", activated.Name), map[string]interface{}{
+			"type":       "switch_project",
+			"project_id": activated.ID,
+		}, nil
+	case "switch_model":
+		targetProject, err := a.hubPrimaryProject()
+		if err != nil {
+			return "", nil, err
+		}
+		updated, err := a.updateProjectChatModel(
+			targetProject.ID,
+			systemActionStringParam(action.Params, "alias"),
+			systemActionStringParam(action.Params, "effort"),
+		)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf(
+				"Model for %s set to %s (%s).",
+				updated.Name,
+				updated.ChatModel,
+				updated.ChatModelReasoningEffort,
+			), map[string]interface{}{
+				"type":       "switch_model",
+				"project_id": updated.ID,
+				"alias":      updated.ChatModel,
+				"effort":     updated.ChatModelReasoningEffort,
+			}, nil
+	case "toggle_silent":
+		return "Toggled silent mode.", map[string]interface{}{"type": "toggle_silent"}, nil
+	case "toggle_conversation":
+		return "Toggled conversation mode.", map[string]interface{}{"type": "toggle_conversation"}, nil
+	case "cancel_work":
+		activeCanceled, queuedCanceled := a.cancelChatWork(sessionID)
+		delegateCanceled := a.cancelDelegatedJobsForProject(session.ProjectKey)
+		total := activeCanceled + queuedCanceled + delegateCanceled
+		return fmt.Sprintf("Canceled %d running task(s).", total), nil, nil
+	case "show_status":
+		status, err := a.fetchCodexStatusMessage(session.ProjectKey)
+		if err != nil {
+			return "", nil, err
+		}
+		return status, nil, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported action: %s", action.Action)
+	}
+}

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -2478,6 +2478,32 @@ function handleChatEvent(payload) {
       if (projectID) {
         void switchProject(projectID);
       }
+    } else if (actionType === 'switch_model') {
+      const projectID = String(action?.project_id || '').trim();
+      const alias = normalizeProjectChatModelAlias(action?.alias);
+      const effortRaw = String(action?.effort || '').trim().toLowerCase();
+      if (projectID && alias) {
+        const existing = state.projects.find((item) => item.id === projectID);
+        if (existing) {
+          const nextEffort = normalizeProjectChatModelReasoningEffort(
+            effortRaw || existing.chat_model_reasoning_effort || '',
+            alias,
+          );
+          upsertProject({
+            ...existing,
+            chat_model: alias,
+            chat_model_reasoning_effort: nextEffort,
+          });
+          renderEdgeTopProjects();
+          renderEdgeTopModelButtons();
+          showStatus(`model set to ${alias}`);
+          return;
+        }
+      }
+      if (alias) {
+        const effort = effortRaw ? normalizeProjectChatModelReasoningEffort(effortRaw, alias) : '';
+        void switchProjectChatModel(alias, effort);
+      }
     } else if (actionType === 'toggle_silent') {
       toggleTTSSilentMode();
     } else if (actionType === 'toggle_conversation') {

--- a/tests/playwright/hub-mode.spec.ts
+++ b/tests/playwright/hub-mode.spec.ts
@@ -14,6 +14,16 @@ async function clearLog(page: Page) {
   await page.evaluate(() => { (window as any).__harnessLog.splice(0); });
 }
 
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((eventPayload) => {
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => String(ws?.url || '').includes('/ws/chat/'));
+    if (chatWs && typeof chatWs.injectEvent === 'function') {
+      chatWs.injectEvent(eventPayload);
+    }
+  }, payload);
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/tests/playwright/zen-harness.html');
   await page.waitForFunction(() => {
@@ -75,5 +85,57 @@ test('switching from hub back to project keeps normal project switching', async 
         && String(entry.payload?.project_id || '') === 'test',
     );
     return seenHub && seenProject;
+  }, { timeout: 5_000 }).toBe(true);
+});
+
+test('system switch_model action updates project model state', async ({ page }) => {
+  await injectChatEvent(page, {
+    type: 'system_action',
+    action: {
+      type: 'switch_model',
+      project_id: 'test',
+      alias: 'gpt',
+      effort: 'high',
+    },
+  });
+
+  await expect(page.locator('#edge-top-models .edge-model-btn', { hasText: 'gpt' })).toHaveClass(/is-active/);
+  await expect(page.locator('#edge-top-models .edge-reasoning-effort-select')).toHaveValue('high');
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.action === 'project_chat_model');
+  }).toBe(false);
+});
+
+test('system toggle actions update ui state', async ({ page }) => {
+  const silentButton = page.locator('#edge-top-models .edge-silent-btn');
+  const convButton = page.locator('#edge-top-models .edge-conv-btn');
+
+  await expect(silentButton).not.toHaveClass(/is-active/);
+  await expect(convButton).not.toHaveClass(/is-active/);
+
+  await injectChatEvent(page, { type: 'system_action', action: { type: 'toggle_silent' } });
+  await injectChatEvent(page, { type: 'system_action', action: { type: 'toggle_conversation' } });
+
+  await expect(silentButton).toHaveClass(/is-active/);
+  await expect(convButton).toHaveClass(/is-active/);
+});
+
+test('system switch_project action routes through project activation', async ({ page }) => {
+  await injectChatEvent(page, {
+    type: 'system_action',
+    action: {
+      type: 'switch_project',
+      project_id: 'hub',
+    },
+  });
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_activate'
+        && String(entry.payload?.project_id || '') === 'hub',
+    );
   }, { timeout: 5_000 }).toBe(true);
 });

--- a/tests/playwright/zen-harness.html
+++ b/tests/playwright/zen-harness.html
@@ -167,6 +167,36 @@
           project,
         }), { status: 200 });
       }
+      if (u.includes('/api/projects') && u.includes('/chat-model') && opts?.method === 'POST') {
+        const projectId = decodeURIComponent(u.split('/api/projects/')[1].split('/chat-model')[0] || '').trim();
+        const index = harnessProjects.findIndex((project) => project.id === projectId);
+        if (index < 0) {
+          return new Response('project not found', { status: 404 });
+        }
+        let body = {};
+        try {
+          body = JSON.parse(String(opts?.body || '{}'));
+        } catch (_) {
+          body = {};
+        }
+        const model = String(body?.model || harnessProjects[index].chat_model || 'spark').trim().toLowerCase();
+        const effort = String(body?.reasoning_effort || harnessProjects[index].chat_model_reasoning_effort || 'low').trim().toLowerCase();
+        harnessProjects[index] = {
+          ...harnessProjects[index],
+          chat_model: model || harnessProjects[index].chat_model,
+          chat_model_reasoning_effort: effort || harnessProjects[index].chat_model_reasoning_effort,
+        };
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'project_chat_model',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { project_id: projectId, model, reasoning_effort: effort },
+        });
+        return new Response(JSON.stringify({
+          project: { ...harnessProjects[index] },
+        }), { status: 200 });
+      }
       if (u.includes('/api/projects')) {
         const projects = harnessProjects.map((project) => ({ ...project }));
         return new Response(JSON.stringify({


### PR DESCRIPTION
## Summary
- add a shared system-action parser/executor in `internal/web/chat_intent.go` and route hub turns through it
- emit structured `switch_model` action payloads from backend execution
- handle `system_action.switch_model` on the frontend without redundant API calls when backend already updated state
- extend hub Playwright harness and spec coverage for system actions

## Verification
- JSON action parsing for each action type
  - Evidence: `go test ./internal/web`
  - Tests: `TestParseSystemAction` (`switch_project`, `switch_model`, `toggle_silent`, `toggle_conversation`, `cancel_work`, `show_status`)
  - Output excerpt: `ok github.com/krystophny/tabura/internal/web 0.882s`
- Fuzzy project name matching
  - Evidence: `go test ./internal/web`
  - Test: `TestHubSwitchProjectActionReturnsActivationPayload` (matches `"note"` -> project `"notes"`)
- Invalid action -> error response
  - Evidence: `go test ./internal/web`
  - Test: `TestExecuteSystemActionRejectsUnsupportedAction`
- Plain text (no action) -> assistant message pass-through
  - Evidence: `go test ./internal/web`
  - Test: `TestHubRunTurnKeepsPlainTextAssistantOutput`
- Frontend executes each action type correctly
  - Evidence: `npx playwright test tests/playwright/hub-mode.spec.ts`
  - Tests:
    - `system switch_model action updates project model state`
    - `system toggle actions update ui state`
    - `system switch_project action routes through project activation`
  - Output excerpt: `6 passed (2.7s)`
