### PR TITLE
fix: feat(voice): openWakeWord hotword detection with custom Tabura m (fixes #67)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -269,7 +269,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"script-src 'self'; "+
+				"script-src 'self' 'wasm-unsafe-eval'; "+
 				"style-src 'self' 'unsafe-inline'; "+
 				"img-src 'self' data:; "+
 				"connect-src 'self' ws: wss:; "+
@@ -597,7 +597,7 @@ func (a *App) handleFilesProxy(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("Content-Security-Policy",
 		"default-src 'self'; "+
-			"script-src 'self'; "+
+			"script-src 'self' 'wasm-unsafe-eval'; "+
 			"style-src 'self' 'unsafe-inline'; "+
 			"img-src 'self' data:; "+
 			"connect-src 'self' ws: wss:; "+

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -17,6 +17,14 @@ import {
   cancelConversationListen,
   isConversationListenActive,
 } from './conversation.js';
+import {
+  initHotword,
+  startHotwordMonitor,
+  stopHotwordMonitor,
+  isHotwordActive,
+  onHotwordDetected,
+  setHotwordThreshold,
+} from './hotword.js';
 
 const state = {
   sessionId: 'local',
@@ -49,6 +57,8 @@ const state = {
   conversationMode: false,
   conversationListenActive: false,
   conversationListenTimer: null,
+  hotwordEnabled: false,
+  hotwordActive: false,
   voiceAwaitingTurn: false,
   voiceTurns: new Set(),
   indicatorSuppressedByCanvasUpdate: false,
@@ -334,6 +344,10 @@ let ttsSentenceChunker = null;
 let ttsEnabled = false;
 let ttsLastSpeakText = '';
 let ttsSpeakLang = 'en';
+let hotwordSyncInFlight = false;
+let hotwordResyncQueued = false;
+let hotwordInitAttempted = false;
+let hotwordUnsubscribe = null;
 
 function readTTSSilentPreference() {
   try {
@@ -355,6 +369,85 @@ function canSpeakTTS() {
   return Boolean(ttsEnabled) && !Boolean(state.ttsSilent);
 }
 
+function canStartHotwordMonitor() {
+  if (!state.hotwordEnabled) return false;
+  if (!state.conversationMode) return false;
+  if (!canSpeakTTS()) return false;
+  if (isRecording()) return false;
+  if (state.chatVoiceCapture) return false;
+  if (state.voiceAwaitingTurn) return false;
+  if (isAssistantWorking()) return false;
+  if (isTTSSpeaking()) return false;
+  if (isConversationListenActive()) return false;
+  return true;
+}
+
+async function syncHotwordMonitor() {
+  if (!state.hotwordEnabled || !canStartHotwordMonitor()) {
+    if (isHotwordActive()) {
+      stopHotwordMonitor();
+    }
+    state.hotwordActive = false;
+    return;
+  }
+  if (isHotwordActive()) {
+    state.hotwordActive = true;
+    return;
+  }
+  try {
+    const stream = await acquireMicStream();
+    await startHotwordMonitor(stream);
+  } catch (_) {}
+  state.hotwordActive = isHotwordActive();
+}
+
+function requestHotwordSync() {
+  if (hotwordSyncInFlight) {
+    hotwordResyncQueued = true;
+    return;
+  }
+  hotwordSyncInFlight = true;
+  void syncHotwordMonitor().finally(() => {
+    hotwordSyncInFlight = false;
+    if (hotwordResyncQueued) {
+      hotwordResyncQueued = false;
+      requestHotwordSync();
+    }
+  });
+}
+
+function configureHotwordLifecycle() {
+  if (typeof hotwordUnsubscribe === 'function') return;
+  hotwordUnsubscribe = onHotwordDetected(() => {
+    if (!canStartHotwordMonitor()) return;
+    stopHotwordMonitor();
+    state.hotwordActive = false;
+    onTTSPlaybackComplete();
+    updateAssistantActivityIndicator();
+    requestHotwordSync();
+  });
+}
+
+async function initHotwordLifecycle() {
+  if (hotwordInitAttempted) return state.hotwordEnabled;
+  hotwordInitAttempted = true;
+  try {
+    const enabled = await initHotword();
+    state.hotwordEnabled = Boolean(enabled);
+    if (state.hotwordEnabled) {
+      setHotwordThreshold(0.5);
+      configureHotwordLifecycle();
+    } else {
+      console.warn('Hotword unavailable; continuing without wake-word activation.');
+    }
+  } catch (err) {
+    state.hotwordEnabled = false;
+    console.warn('Hotword initialization error:', err);
+  }
+  requestHotwordSync();
+  return state.hotwordEnabled;
+}
+
 function applyConversationStateSnapshot(snapshot = null) {
   const nextMode = snapshot && typeof snapshot === 'object'
     ? Boolean(snapshot.conversationMode)
@@ -368,6 +461,7 @@ function applyConversationStateSnapshot(snapshot = null) {
   state.conversationMode = nextMode;
   state.conversationListenActive = nextListenActive;
   state.conversationListenTimer = nextListenTimer;
+  requestHotwordSync();
 }
 
 function isMobileSilent() {
@@ -468,6 +562,7 @@ function setTTSSilentMode(silent, { persist = true } = {}) {
     document.body.classList.remove('silent-mode');
   }
   renderEdgeTopModelButtons();
+  requestHotwordSync();
 }
 
 function toggleTTSSilentMode() {
@@ -500,6 +595,7 @@ function stopTTSPlayback() {
     state.ttsPlaying = false;
     updateAssistantActivityIndicator();
   }
+  requestHotwordSync();
 }
 
 configureConversation({
@@ -1529,6 +1625,7 @@ function updateAssistantActivityIndicator() {
     state.assistantUnknownTurns = 0;
     state.assistantActiveTurns.clear();
   }
+  state.hotwordActive = isHotwordActive();
   const pos = getLastInputPosition();
   const px = Number.isFinite(pos?.x) && pos.x > 0 ? pos.x : Math.floor(window.innerWidth / 2);
   const py = Number.isFinite(pos?.y) && pos.y > 0 ? pos.y : Math.floor(window.innerHeight / 2);
@@ -1538,6 +1635,7 @@ function updateAssistantActivityIndicator() {
   } else {
     hideIndicator();
   }
+  requestHotwordSync();
 }
 
 function paneIdForCanvasKind(kind) {
@@ -4073,6 +4171,7 @@ async function init() {
     ttsEnabled = false;
   }
   setTTSSilentMode(readTTSSilentPreference(), { persist: false });
+  await initHotwordLifecycle();
 
   await fetchProjects();
   const initialProjectID = resolveInitialProjectID();

--- a/internal/web/static/hotword.js
+++ b/internal/web/static/hotword.js
@@ -1,0 +1,431 @@
+const HOTWORD_VENDOR_BASE = '/static/vendor/openwakeword';
+const HOTWORD_MODEL_FILES = {
+  mel: `${HOTWORD_VENDOR_BASE}/melspectrogram.onnx`,
+  embedding: `${HOTWORD_VENDOR_BASE}/embedding_model.onnx`,
+  keyword: `${HOTWORD_VENDOR_BASE}/hey_tabura.onnx`,
+};
+const HOTWORD_DEFAULT_THRESHOLD = 0.5;
+const HOTWORD_DETECTION_COOLDOWN_MS = 1500;
+const HOTWORD_TARGET_SAMPLE_RATE = 16000;
+const HOTWORD_FRAME_MS = 80;
+const HOTWORD_TARGET_FRAME_SAMPLES = Math.floor((HOTWORD_TARGET_SAMPLE_RATE * HOTWORD_FRAME_MS) / 1000);
+
+const listeners = new Set();
+
+const state = {
+  initialized: false,
+  available: false,
+  active: false,
+  threshold: HOTWORD_DEFAULT_THRESHOLD,
+  mode: 'none',
+  mock: null,
+  model: null,
+  audioCtx: null,
+  sourceNode: null,
+  processorNode: null,
+  sinkNode: null,
+  targetSampleBuffer: new Float32Array(0),
+  pendingFrames: [],
+  processingFrames: false,
+  lastDetectionAt: 0,
+};
+
+function clampNumber(value, min, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, n));
+}
+
+function resolveMock() {
+  const candidate = window.__taburaHotwordMock;
+  if (!candidate || typeof candidate !== 'object') return null;
+  if (typeof candidate.init !== 'function') return null;
+  if (typeof candidate.start !== 'function') return null;
+  if (typeof candidate.stop !== 'function') return null;
+  return candidate;
+}
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-hotword-src="${src}"]`);
+    if (existing) {
+      if (existing.dataset.loaded === 'true') {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error(`failed to load ${src}`)), { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.dataset.hotwordSrc = src;
+    script.addEventListener('load', () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    }, { once: true });
+    script.addEventListener('error', () => reject(new Error(`failed to load ${src}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+async function ensureOrtRuntime() {
+  if (window.ort) return window.ort;
+  await loadScript(`${HOTWORD_VENDOR_BASE}/ort.min.js`);
+  if (!window.ort) {
+    throw new Error('onnx runtime not available after script load');
+  }
+  return window.ort;
+}
+
+function extractTensor(output) {
+  if (!output) return null;
+  if (output.data && output.dims) return output;
+  if (output instanceof Float32Array) return { data: output, dims: [1, output.length] };
+  if (Array.isArray(output)) {
+    const arr = Float32Array.from(output.map((value) => Number(value) || 0));
+    return { data: arr, dims: [1, arr.length] };
+  }
+  return null;
+}
+
+function tensorScore(output) {
+  const tensor = extractTensor(output);
+  if (!tensor || !tensor.data || tensor.data.length === 0) return 0;
+  let maxValue = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < tensor.data.length; i += 1) {
+    const value = Number(tensor.data[i]);
+    if (Number.isFinite(value) && value > maxValue) {
+      maxValue = value;
+    }
+  }
+  if (!Number.isFinite(maxValue)) return 0;
+  if (maxValue >= 0 && maxValue <= 1) return maxValue;
+  const logistic = 1 / (1 + Math.exp(-maxValue));
+  if (!Number.isFinite(logistic)) return 0;
+  return clampNumber(logistic, 0, 1);
+}
+
+function concatFloat32(a, b) {
+  if (!(a instanceof Float32Array) || a.length === 0) return b;
+  if (!(b instanceof Float32Array) || b.length === 0) return a;
+  const out = new Float32Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+function resampleToTargetRate(samples, sourceRate) {
+  if (!(samples instanceof Float32Array) || samples.length === 0) {
+    return new Float32Array(0);
+  }
+  const srcRate = Number(sourceRate);
+  if (!Number.isFinite(srcRate) || srcRate <= 0 || srcRate === HOTWORD_TARGET_SAMPLE_RATE) {
+    return samples;
+  }
+
+  const ratio = srcRate / HOTWORD_TARGET_SAMPLE_RATE;
+  const outLength = Math.max(1, Math.floor(samples.length / ratio));
+  const out = new Float32Array(outLength);
+
+  for (let i = 0; i < outLength; i += 1) {
+    const srcPos = i * ratio;
+    const left = Math.floor(srcPos);
+    const right = Math.min(samples.length - 1, left + 1);
+    const weight = srcPos - left;
+    const leftVal = samples[left] || 0;
+    const rightVal = samples[right] || 0;
+    out[i] = (leftVal * (1 - weight)) + (rightVal * weight);
+  }
+
+  return out;
+}
+
+function emitHotwordDetected() {
+  const now = Date.now();
+  if ((now - state.lastDetectionAt) < HOTWORD_DETECTION_COOLDOWN_MS) {
+    return;
+  }
+  state.lastDetectionAt = now;
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (_) {}
+  });
+}
+
+async function runPipelineOnnx(frame) {
+  if (!state.model || !state.model.ort) return 0;
+  const { ort, melSession, embeddingSession, keywordSession } = state.model;
+  if (!keywordSession) return 0;
+
+  const runStage = async (session, inputTensor) => {
+    const inputName = Array.isArray(session.inputNames) && session.inputNames.length > 0
+      ? session.inputNames[0]
+      : 'input';
+    const feed = { [inputName]: inputTensor };
+    const outputs = await session.run(feed);
+    if (!outputs || typeof outputs !== 'object') {
+      return null;
+    }
+    const outputName = Array.isArray(session.outputNames) && session.outputNames.length > 0
+      ? session.outputNames[0]
+      : Object.keys(outputs)[0];
+    return outputs[outputName] || null;
+  };
+
+  try {
+    let tensor = new ort.Tensor('float32', frame, [1, frame.length]);
+    if (melSession) {
+      const melOut = await runStage(melSession, tensor);
+      if (!melOut) return 0;
+      tensor = melOut;
+    }
+    if (embeddingSession) {
+      const embedOut = await runStage(embeddingSession, tensor);
+      if (!embedOut) return 0;
+      tensor = embedOut;
+    }
+    const keywordOut = await runStage(keywordSession, tensor);
+    return tensorScore(keywordOut);
+  } catch (_) {
+    return 0;
+  }
+}
+
+async function processFrameQueue() {
+  if (state.processingFrames) return;
+  state.processingFrames = true;
+  try {
+    while (state.active && state.pendingFrames.length > 0) {
+      const frame = state.pendingFrames.shift();
+      if (!(frame instanceof Float32Array) || frame.length === 0) continue;
+      const score = await runPipelineOnnx(frame);
+      if (score >= state.threshold) {
+        emitHotwordDetected();
+      }
+    }
+  } finally {
+    state.processingFrames = false;
+  }
+}
+
+function onAudioProcess(event) {
+  if (!state.active) return;
+  const inputBuffer = event?.inputBuffer;
+  if (!inputBuffer || typeof inputBuffer.getChannelData !== 'function') return;
+  const channel = inputBuffer.getChannelData(0);
+  if (!(channel instanceof Float32Array) || channel.length === 0) return;
+
+  const resampled = resampleToTargetRate(channel, inputBuffer.sampleRate);
+  if (resampled.length === 0) return;
+
+  state.targetSampleBuffer = concatFloat32(state.targetSampleBuffer, resampled);
+
+  while (state.targetSampleBuffer.length >= HOTWORD_TARGET_FRAME_SAMPLES) {
+    const frame = state.targetSampleBuffer.slice(0, HOTWORD_TARGET_FRAME_SAMPLES);
+    state.targetSampleBuffer = state.targetSampleBuffer.slice(HOTWORD_TARGET_FRAME_SAMPLES);
+    state.pendingFrames.push(frame);
+  }
+
+  void processFrameQueue();
+}
+
+function stopOnnxNodes() {
+  if (state.processorNode) {
+    state.processorNode.onaudioprocess = null;
+    try { state.processorNode.disconnect(); } catch (_) {}
+    state.processorNode = null;
+  }
+  if (state.sourceNode) {
+    try { state.sourceNode.disconnect(); } catch (_) {}
+    state.sourceNode = null;
+  }
+  if (state.sinkNode) {
+    try { state.sinkNode.disconnect(); } catch (_) {}
+    state.sinkNode = null;
+  }
+  if (state.audioCtx) {
+    try { state.audioCtx.close(); } catch (_) {}
+    state.audioCtx = null;
+  }
+  state.targetSampleBuffer = new Float32Array(0);
+  state.pendingFrames = [];
+  state.processingFrames = false;
+}
+
+async function startOnnxMonitor(stream) {
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextCtor) return false;
+
+  const audioCtx = new AudioContextCtor();
+  const sourceNode = audioCtx.createMediaStreamSource(stream);
+  if (typeof audioCtx.createScriptProcessor !== 'function') {
+    throw new Error('ScriptProcessor is not supported in this browser');
+  }
+
+  const processorNode = audioCtx.createScriptProcessor(4096, 1, 1);
+  const sinkNode = typeof audioCtx.createGain === 'function' ? audioCtx.createGain() : null;
+  if (sinkNode) {
+    sinkNode.gain.value = 0;
+  }
+
+  processorNode.onaudioprocess = onAudioProcess;
+  sourceNode.connect(processorNode);
+  if (sinkNode) {
+    processorNode.connect(sinkNode);
+    sinkNode.connect(audioCtx.destination);
+  } else {
+    processorNode.connect(audioCtx.destination);
+  }
+
+  if (audioCtx.state === 'suspended' && typeof audioCtx.resume === 'function') {
+    await audioCtx.resume().catch(() => {});
+  }
+
+  state.audioCtx = audioCtx;
+  state.sourceNode = sourceNode;
+  state.processorNode = processorNode;
+  state.sinkNode = sinkNode;
+  return true;
+}
+
+async function initOnnxModel() {
+  const ort = await ensureOrtRuntime();
+  if (ort?.env?.wasm) {
+    ort.env.wasm.wasmPaths = `${HOTWORD_VENDOR_BASE}/`;
+  }
+
+  const sessionOptions = {
+    executionProviders: ['wasm'],
+    graphOptimizationLevel: 'all',
+  };
+
+  const melSession = await ort.InferenceSession.create(HOTWORD_MODEL_FILES.mel, sessionOptions);
+  const embeddingSession = await ort.InferenceSession.create(HOTWORD_MODEL_FILES.embedding, sessionOptions);
+  const keywordSession = await ort.InferenceSession.create(HOTWORD_MODEL_FILES.keyword, sessionOptions);
+
+  state.model = {
+    ort,
+    melSession,
+    embeddingSession,
+    keywordSession,
+  };
+}
+
+export async function initHotword() {
+  if (state.initialized) return state.available;
+
+  state.initialized = true;
+  state.threshold = HOTWORD_DEFAULT_THRESHOLD;
+
+  const mock = resolveMock();
+  if (mock) {
+    state.mock = mock;
+    state.mode = 'mock';
+    try {
+      const ok = await Promise.resolve(mock.init());
+      state.available = Boolean(ok);
+      if (!state.available) {
+        state.mode = 'none';
+        state.mock = null;
+      }
+      return state.available;
+    } catch (_) {
+      state.available = false;
+      state.mode = 'none';
+      state.mock = null;
+      return false;
+    }
+  }
+
+  try {
+    await initOnnxModel();
+    state.mode = 'onnx';
+    state.available = true;
+    return true;
+  } catch (err) {
+    state.available = false;
+    state.mode = 'none';
+    state.model = null;
+    console.warn('Hotword initialization failed:', err);
+    return false;
+  }
+}
+
+export async function startHotwordMonitor(micStream) {
+  if (!state.initialized) {
+    await initHotword();
+  }
+  if (!state.available || !micStream) {
+    return false;
+  }
+  if (state.active) {
+    return true;
+  }
+
+  if (state.mode === 'mock' && state.mock) {
+    try {
+      state.mock.start(micStream, () => emitHotwordDetected());
+      state.active = true;
+      return true;
+    } catch (_) {
+      state.active = false;
+      return false;
+    }
+  }
+
+  if (state.mode !== 'onnx') {
+    return false;
+  }
+
+  try {
+    const started = await startOnnxMonitor(micStream);
+    state.active = Boolean(started);
+    return state.active;
+  } catch (err) {
+    stopOnnxNodes();
+    state.active = false;
+    console.warn('Hotword monitor start failed:', err);
+    return false;
+  }
+}
+
+export function stopHotwordMonitor() {
+  if (!state.active) return;
+  if (state.mode === 'mock' && state.mock) {
+    try {
+      state.mock.stop();
+    } catch (_) {}
+  }
+  if (state.mode === 'onnx') {
+    stopOnnxNodes();
+  }
+  state.active = false;
+}
+
+export function isHotwordActive() {
+  return state.active;
+}
+
+export function onHotwordDetected(callback) {
+  if (typeof callback !== 'function') {
+    return () => {};
+  }
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function setHotwordThreshold(value) {
+  state.threshold = clampNumber(value, 0, 1);
+  if (state.mode === 'mock' && state.mock && typeof state.mock.setThreshold === 'function') {
+    try {
+      state.mock.setThreshold(state.threshold);
+    } catch (_) {}
+  }
+  return state.threshold;
+}

--- a/scripts/hotword-config.yaml
+++ b/scripts/hotword-config.yaml
@@ -1,0 +1,7 @@
+target_phrase:
+  - "hey tabura"
+n_samples: 2000
+n_samples_val: 500
+augmentation_rounds: 3
+output_dir: "./models/hotword"
+model_name: "hey_tabura"

--- a/scripts/train-hotword.sh
+++ b/scripts/train-hotword.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TRAINER_DIR="${TABURA_HOTWORD_TRAINER_DIR:-$ROOT_DIR/tools/openwakeword-trainer}"
+CONFIG_PATH="${TABURA_HOTWORD_CONFIG:-$ROOT_DIR/scripts/hotword-config.yaml}"
+OUTPUT_DIR="${TABURA_HOTWORD_OUTPUT_DIR:-$ROOT_DIR/models/hotword}"
+SAMPLES_DIR="${TABURA_HOTWORD_SAMPLES_DIR:-$ROOT_DIR/data/hotword-samples}"
+PYTHON_BIN="${PYTHON:-python3}"
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "hotword config not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+if [[ ! -d "$TRAINER_DIR/.git" ]]; then
+  mkdir -p "$(dirname "$TRAINER_DIR")"
+  git clone --depth=1 https://github.com/lgpearson1771/openwakeword-trainer "$TRAINER_DIR"
+fi
+
+VENV_DIR="$TRAINER_DIR/.venv"
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+"$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel >/dev/null
+"$VENV_DIR/bin/python" -m pip install -e "$TRAINER_DIR" >/dev/null
+
+TRAIN_CMD=()
+if [[ -f "$TRAINER_DIR/train.py" ]]; then
+  TRAIN_CMD=("$VENV_DIR/bin/python" "$TRAINER_DIR/train.py")
+elif [[ -f "$TRAINER_DIR/scripts/train.py" ]]; then
+  TRAIN_CMD=("$VENV_DIR/bin/python" "$TRAINER_DIR/scripts/train.py")
+elif [[ -f "$TRAINER_DIR/openwakeword_trainer/train.py" ]]; then
+  TRAIN_CMD=("$VENV_DIR/bin/python" -m openwakeword_trainer.train)
+else
+  echo "unable to locate trainer entrypoint inside $TRAINER_DIR" >&2
+  exit 1
+fi
+
+EXTRA_ARGS=()
+if [[ -d "$SAMPLES_DIR" ]]; then
+  EXTRA_ARGS+=(--real-samples-dir "$SAMPLES_DIR")
+fi
+
+"${TRAIN_CMD[@]}" --config "$CONFIG_PATH" "${EXTRA_ARGS[@]}" "$@"
+
+MODEL_PATH="$OUTPUT_DIR/hey_tabura.onnx"
+if [[ ! -f "$MODEL_PATH" ]]; then
+  echo "training finished but expected model missing: $MODEL_PATH" >&2
+  exit 1
+fi
+
+echo "trained model: $MODEL_PATH"

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type HarnessLogEntry = {
+  type: string;
+  action?: string;
+  text?: string;
+  [key: string]: unknown;
+};
+
+async function getLog(page: Page): Promise<HarnessLogEntry[]> {
+  return page.evaluate(() => (window as any).__harnessLog.slice());
+}
+
+async function clearLog(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__harnessLog.splice(0);
+  });
+}
+
+async function waitReady(page: Page, query = '') {
+  await page.goto(`/tests/playwright/zen-harness.html${query}`);
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    return s.chatWs && s.chatWs.readyState === (window as any).WebSocket.OPEN;
+  }, null, { timeout: 5_000 });
+  await page.waitForTimeout(200);
+  await page.evaluate(() => {
+    window.localStorage.removeItem('tabura.conversationMode');
+  });
+}
+
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((eventPayload) => {
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    if (chatWs?.injectEvent) {
+      chatWs.injectEvent(eventPayload);
+    }
+  }, payload);
+}
+
+async function triggerVoiceAssistantTTS(page: Page, turnID: string, text = 'Hello there.') {
+  await page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    const s = app.getState();
+    s.lastInputOrigin = 'voice';
+    s.voiceAwaitingTurn = true;
+  });
+  await injectChatEvent(page, { type: 'turn_started', turn_id: turnID });
+  await injectChatEvent(page, { type: 'assistant_message', turn_id: turnID, message: text });
+  await injectChatEvent(page, { type: 'assistant_output', role: 'assistant', turn_id: turnID, message: text });
+}
+
+async function setConversationListenWindowMs(page: Page, ms: number) {
+  await page.evaluate((value) => {
+    (window as any).__taburaConversationListenMs = value;
+  }, ms);
+}
+
+async function waitForEdgeButtons(page: Page) {
+  await expect.poll(async () => page.evaluate(() => {
+    const conv = document.querySelector('#edge-top-models .edge-conv-btn');
+    const silent = document.querySelector('#edge-top-models .edge-silent-btn');
+    return Boolean(conv && silent);
+  })).toBe(true);
+}
+
+async function setConversationMode(page: Page, enabled: boolean) {
+  await waitForEdgeButtons(page);
+  await page.evaluate((target) => {
+    const button = document.querySelector('#edge-top-models .edge-conv-btn');
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('conversation button not found');
+    }
+    const current = button.getAttribute('aria-pressed') === 'true';
+    if (current !== target) {
+      button.click();
+    }
+  }, enabled);
+  await expect.poll(async () => page.evaluate(() => {
+    const button = document.querySelector('#edge-top-models .edge-conv-btn');
+    return button instanceof HTMLButtonElement ? button.getAttribute('aria-pressed') : 'false';
+  })).toBe(enabled ? 'true' : 'false');
+}
+
+async function triggerHotword(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__triggerHotwordDetection();
+  });
+}
+
+async function waitForHotwordStart(page: Page) {
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'hotword' && entry.action === 'start');
+  }, { timeout: 4_000 }).toBe(true);
+}
+
+test('hotword detection opens conversation listening window', async ({ page }) => {
+  await waitReady(page);
+  await setConversationListenWindowMs(page, 1_200);
+  await setConversationMode(page, true);
+  await waitForHotwordStart(page);
+  await clearLog(page);
+
+  await triggerHotword(page);
+
+  await expect.poll(async () => page.evaluate(() => {
+    const indicator = document.getElementById('zen-indicator');
+    return Boolean(indicator?.classList.contains('is-listening'));
+  })).toBe(true);
+});
+
+test('hotword plus speech starts recording', async ({ page }) => {
+  await waitReady(page);
+  await setConversationListenWindowMs(page, 2_500);
+  await page.evaluate(() => {
+    (window as any).__setVadDbFrames([
+      ...Array.from({ length: 8 }, () => -80),
+      ...Array.from({ length: 10 }, () => -12),
+      ...Array.from({ length: 8 }, () => -80),
+    ]);
+  });
+  await setConversationMode(page, true);
+  await waitForHotwordStart(page);
+  await clearLog(page);
+
+  await triggerHotword(page);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }, { timeout: 5_000 }).toBe(true);
+});
+
+test('hotword is paused during recording', async ({ page }) => {
+  await waitReady(page);
+  await setConversationListenWindowMs(page, 3_000);
+  await page.evaluate(() => {
+    (window as any).__setVadDbFrames([
+      ...Array.from({ length: 8 }, () => -80),
+      ...Array.from({ length: 10 }, () => -12),
+      ...Array.from({ length: 20 }, () => -12),
+    ]);
+  });
+  await setConversationMode(page, true);
+  await waitForHotwordStart(page);
+  await clearLog(page);
+
+  await triggerHotword(page);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect.poll(async () => page.evaluate(() => (window as any).__isHotwordActive())).toBe(false);
+  const log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'hotword' && entry.action === 'stop')).toBe(true);
+});
+
+test('hotword is paused while TTS playback is active', async ({ page }) => {
+  await waitReady(page);
+  await setConversationListenWindowMs(page, 2_500);
+  await setConversationMode(page, true);
+  await waitForHotwordStart(page);
+  await page.evaluate(() => {
+    (window as any).__setTTSPlaybackDelayMs(500);
+  });
+  await clearLog(page);
+
+  await triggerVoiceAssistantTTS(page, 'hotword-tts-1', 'Testing hotword pause during playback.');
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'tts');
+  }).toBe(true);
+  await expect.poll(async () => page.evaluate(() => (window as any).__isHotwordActive())).toBe(false);
+
+  const log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'hotword' && entry.action === 'stop')).toBe(true);
+});
+
+test('conversation mode off keeps hotword disabled', async ({ page }) => {
+  await waitReady(page);
+  await setConversationListenWindowMs(page, 1_200);
+  await setConversationMode(page, false);
+  await clearLog(page);
+
+  await triggerHotword(page);
+  await page.waitForTimeout(250);
+
+  const isListening = await page.evaluate(() => {
+    const indicator = document.getElementById('zen-indicator');
+    return Boolean(indicator?.classList.contains('is-listening'));
+  });
+  expect(isListening).toBe(false);
+  const isHotwordActive = await page.evaluate(() => (window as any).__isHotwordActive());
+  expect(isHotwordActive).toBe(false);
+});
+
+test('hotword init failure degrades gracefully with no crash', async ({ page }) => {
+  await waitReady(page, '?hotword=fail');
+  await setConversationListenWindowMs(page, 1_200);
+  await setConversationMode(page, true);
+  await clearLog(page);
+
+  await triggerHotword(page);
+  await page.waitForTimeout(250);
+
+  const log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'hotword' && entry.action === 'start')).toBe(false);
+  expect(log.some((entry) => entry.type === 'unhandled_rejection')).toBe(false);
+
+  await triggerVoiceAssistantTTS(page, 'hotword-degrade-1');
+  await expect.poll(async () => page.evaluate(() => {
+    const indicator = document.getElementById('zen-indicator');
+    return Boolean(indicator?.classList.contains('is-listening'));
+  })).toBe(true);
+});

--- a/tests/playwright/zen-harness.html
+++ b/tests/playwright/zen-harness.html
@@ -108,6 +108,53 @@
     window.__setCancelResponses([]);
     window.__setActivityResponse({ active_turns: 0, queued_turns: 0, delegate_active: 0 });
     window.__setMessagePostDelay(0);
+    const harnessParams = new URL(window.location.href).searchParams;
+    let hotwordInitEnabled = harnessParams.get('hotword') !== 'fail';
+    let ttsPlaybackDelayMs = 10;
+    window.__setHotwordInitEnabled = (enabled) => {
+      hotwordInitEnabled = Boolean(enabled);
+    };
+    window.__setTTSPlaybackDelayMs = (ms) => {
+      const n = Number(ms);
+      ttsPlaybackDelayMs = Number.isFinite(n) && n >= 0 ? Math.floor(n) : 10;
+    };
+    window.__setTTSPlaybackDelayMs(10);
+    window.__taburaHotwordMock = {
+      active: false,
+      onDetect: null,
+      threshold: 0.5,
+      init() {
+        window.__harnessLog.push({ type: 'hotword', action: 'init', enabled: hotwordInitEnabled });
+        return hotwordInitEnabled;
+      },
+      start(_stream, onDetect) {
+        this.active = true;
+        this.onDetect = typeof onDetect === 'function' ? onDetect : null;
+        window.__harnessLog.push({ type: 'hotword', action: 'start' });
+      },
+      stop() {
+        if (this.active) {
+          window.__harnessLog.push({ type: 'hotword', action: 'stop' });
+        }
+        this.active = false;
+        this.onDetect = null;
+      },
+      setThreshold(value) {
+        this.threshold = Number(value);
+        window.__harnessLog.push({ type: 'hotword', action: 'threshold', value: this.threshold });
+      },
+      trigger() {
+        if (!this.active || typeof this.onDetect !== 'function') return;
+        window.__harnessLog.push({ type: 'hotword', action: 'detect' });
+        this.onDetect();
+      },
+    };
+    window.__triggerHotwordDetection = () => {
+      if (window.__taburaHotwordMock) {
+        window.__taburaHotwordMock.trigger();
+      }
+    };
+    window.__isHotwordActive = () => Boolean(window.__taburaHotwordMock?.active);
 
     const harnessProjects = [
       {
@@ -406,7 +453,7 @@
           onended: null,
           connect() {},
           start() {
-            setTimeout(() => { if (node.onended) node.onended(); }, 10);
+            setTimeout(() => { if (node.onended) node.onended(); }, ttsPlaybackDelayMs);
           },
           stop() {},
         };


### PR DESCRIPTION
## Summary
- Added browser hotword module at `internal/web/static/hotword.js` with the required lifecycle API (`initHotword`, `startHotwordMonitor`, `stopHotwordMonitor`, `isHotwordActive`, `onHotwordDetected`, `setHotwordThreshold`), including ONNX-runtime loading and graceful fallback.
- Integrated hotword lifecycle into `internal/web/static/app.js` so it runs only in idle conversation mode, triggers listening on wake-word detection, and pauses during recording/TTS/assistant activity.
- Added hotword training assets: `scripts/hotword-config.yaml` and `scripts/train-hotword.sh`.
- Updated CSP in `internal/web/server.go` to allow WASM ONNX execution via `'wasm-unsafe-eval'`.
- Added focused Playwright coverage in `tests/playwright/hotword.spec.ts` and harness hotword mocks in `tests/playwright/zen-harness.html`.

## Verification
1. Requirement: Add hotword module exports and lifecycle API.
Command: `rg -n "export async function initHotword|export async function startHotwordMonitor|export function stopHotwordMonitor|export function isHotwordActive|export function onHotwordDetected|export function setHotwordThreshold" internal/web/static/hotword.js`
Output excerpt:
- `318:export async function initHotword() {`
- `358:export async function startHotwordMonitor(micStream) {`
- `396:export function stopHotwordMonitor() {`
- `409:export function isHotwordActive() {`
- `413:export function onHotwordDetected(callback) {`
- `423:export function setHotwordThreshold(value) {`

2. Requirement: Hotword state-machine behavior (detect -> listening; detect+speech -> recording; pauses during recording/TTS; disabled when conversation off; graceful degradation).
Command: `npx playwright test tests/playwright/hotword.spec.ts`
Output excerpt:
- `✓ tests/playwright/hotword.spec.ts:101:5 › hotword detection opens conversation listening window`
- `✓ tests/playwright/hotword.spec.ts:116:5 › hotword plus speech starts recording`
- `✓ tests/playwright/hotword.spec.ts:138:5 › hotword is paused during recording`
- `✓ tests/playwright/hotword.spec.ts:164:5 › hotword is paused while TTS playback is active`
- `✓ tests/playwright/hotword.spec.ts:186:5 › conversation mode off keeps hotword disabled`
- `✓ tests/playwright/hotword.spec.ts:204:5 › hotword init failure degrades gracefully with no crash`

3. Requirement: Allow ONNX WASM execution via CSP.
Command: `rg -n "script-src 'self' 'wasm-unsafe-eval'" internal/web/server.go`
Output excerpt:
- `272: "script-src 'self' 'wasm-unsafe-eval'; "`
- `600: "script-src 'self' 'wasm-unsafe-eval'; "`

4. Requirement: Add hotword training pipeline assets.
Command: `ls -l scripts/hotword-config.yaml scripts/train-hotword.sh`
Output excerpt:
- `scripts/hotword-config.yaml`
- `scripts/train-hotword.sh` (executable)

5. Regression/compile check for web package.
Command: `go test ./internal/web/...`
Output excerpt:
- `ok github.com/krystophny/tabura/internal/web 0.882s`

Log file: `/tmp/test.log`
