### PR TITLE
fix: docs(licensing): licensing audit, model download policy, and THI (fixes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Risk notice: see [`DISCLAIMER.md`](DISCLAIMER.md)
 - **Codex app-server integration**: [`docs/codex-app-server-pivot.md`](docs/codex-app-server-pivot.md)
 - **HTTP/MCP interface inventory**: [`docs/interfaces.md`](docs/interfaces.md)
 - **UI paradigm**: [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)
+- **Model download policy**: [`docs/model-download-policy.md`](docs/model-download-policy.md)
+- **Third-party licenses**: [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md)
 - **Current release notes (v0.1.4)**: [`docs/release-v0.1.4.md`](docs/release-v0.1.4.md)
 
 ## Install

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,42 @@
+# Third-Party Licenses
+
+This document tracks third-party components used by Tabura and whether they are
+bundled in the repository build outputs or downloaded at setup/runtime.
+
+## Bundled In Binary
+
+| Component | License | Notes |
+|---|---|---|
+| marked.js | MIT | Embedded web asset |
+| highlight.js | BSD-3-Clause | Embedded web asset |
+| PDF.js | Apache-2.0 | Embedded web asset |
+| MathJax | Apache-2.0 | Embedded web asset |
+| Liberation fonts | SIL OFL 1.1 | Embedded font assets |
+| Foxit PDF fonts | BSD | Embedded font assets |
+
+## Downloaded At Setup Time
+
+| Component | License | Delivery model |
+|---|---|---|
+| Piper TTS Python runtime | GPL | Installed into isolated Python virtualenv and exposed over local HTTP |
+| Piper voice models | Per-model (see Hugging Face model cards) | Downloaded model files |
+| ffmpeg | GPL/LGPL (package dependent) | Installed as system package |
+| voxtype | MIT | Installed as external executable |
+
+## Planned Optional Downloads
+
+| Component | License | Notes |
+|---|---|---|
+| ONNX Runtime Web | MIT | Browser-side runtime for local inference |
+| openWakeWord models | Apache-2.0 | Local wake-word inference models |
+| DistilBERT intent model | Apache-2.0 | Local intent sidecar model |
+| Qwen3 0.6B GGUF | Apache-2.0 | Optional local mid-tier intent fallback |
+| llama.cpp | MIT | Optional local LLM server runtime |
+
+## Licensing Boundary
+
+- Tabura's Go binary remains MIT-licensed.
+- GPL-governed Piper runtime is integrated as a loopback HTTP sidecar process and
+  is not linked into the Go binary.
+- Voice model licensing is handled per model card; setup scripts print a Tier-2
+  notice before download.

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -1,0 +1,58 @@
+# Model Download Policy
+
+This policy defines what Tabura downloads, from where, under which license, and
+how user consent is handled.
+
+## Consent Tiers
+
+### Tier 1: Silent
+
+Permissive components (MIT/BSD/Apache/OFL) may be bundled or auto-downloaded
+without an explicit prompt.
+
+Examples:
+- Tabura binary (MIT)
+- ONNX Runtime Web (MIT)
+- openWakeWord models (Apache-2.0)
+- DistilBERT model artifacts (Apache-2.0)
+- llama.cpp binaries (MIT)
+
+### Tier 2: Notice + Opt-Out
+
+Components with additional distribution obligations or per-model terms require a
+clear notice before installation/download. Install proceeds unless the user opts
+out.
+
+Examples:
+- Piper TTS runtime (GPL, deployed as local HTTP sidecar)
+- Piper voice models (per-model terms documented in model cards)
+- ffmpeg (GPL/LGPL, package dependent)
+- voxtype (MIT external executable)
+- Qwen3 0.6B GGUF (Apache-2.0 model download)
+
+## Current Downloaded Components
+
+| Component | Source | License | Tier |
+|---|---|---|---|
+| Piper TTS runtime | PyPI (`piper-tts`) | GPL | Tier 2 |
+| Piper voice models | Hugging Face (`rhasspy/piper-voices`) | Per-model | Tier 2 |
+| ffmpeg | System package manager | GPL/LGPL | Tier 2 |
+| voxtype | Cargo/AUR/Homebrew path | MIT | Tier 2 |
+
+## Planned Model Downloads
+
+| Component | Source | License | Tier |
+|---|---|---|---|
+| ONNX Runtime Web | npm/web artifact source | MIT | Tier 1 |
+| openWakeWord models | project/model registry | Apache-2.0 | Tier 1 |
+| DistilBERT intent model | model registry | Apache-2.0 | Tier 1 |
+| Qwen3 0.6B GGUF | Hugging Face | Apache-2.0 | Tier 2 |
+
+## Operator Rules
+
+- Never statically or dynamically link Piper runtime libraries into the Go
+  binary.
+- Keep Piper integration on loopback HTTP.
+- Display model/runtime notice text before Tier-2 downloads in setup scripts.
+- Keep [`THIRD_PARTY_LICENSES.md`](../THIRD_PARTY_LICENSES.md) updated whenever
+  dependencies or download behavior change.

--- a/internal/licensing/policy_test.go
+++ b/internal/licensing/policy_test.go
@@ -1,0 +1,117 @@
+package licensing
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestThirdPartyLicenseInventoryIncludesRequiredComponents(t *testing.T) {
+	t.Parallel()
+
+	content := readRepoFile(t, "THIRD_PARTY_LICENSES.md")
+	requireContainsAll(t, content,
+		"# Third-Party Licenses",
+		"| Piper TTS Python runtime | GPL |",
+		"| Piper voice models | Per-model",
+		"| ffmpeg | GPL/LGPL",
+		"| voxtype | MIT |",
+		"not linked into the Go binary",
+	)
+}
+
+func TestModelDownloadPolicyDefinesTierRulesAndCurrentDownloads(t *testing.T) {
+	t.Parallel()
+
+	content := readRepoFile(t, "docs", "model-download-policy.md")
+	requireContainsAll(t, content,
+		"# Model Download Policy",
+		"### Tier 1: Silent",
+		"### Tier 2: Notice + Opt-Out",
+		"| Piper TTS runtime | PyPI (`piper-tts`) | GPL | Tier 2 |",
+		"| Piper voice models | Hugging Face (`rhasspy/piper-voices`) | Per-model | Tier 2 |",
+		"Never statically or dynamically link Piper runtime libraries into the Go",
+		"Display model/runtime notice text before Tier-2 downloads in setup scripts.",
+	)
+}
+
+func TestPiperSetupScriptContainsTier2NoticeAndOptOutFlow(t *testing.T) {
+	t.Parallel()
+
+	content := readRepoFile(t, "scripts", "setup-tabura-piper-tts.sh")
+	requireContainsAll(t, content,
+		"=== Piper TTS Tier-2 Notice ===",
+		"Runtime license: GPL",
+		"confirm_default_yes",
+		"TABURA_ASSUME_YES",
+		"Continue with Piper TTS setup?",
+		"Skipping model download:",
+	)
+}
+
+func TestNoKnownGPLSidecarDependenciesAreLinkedIntoGoBinary(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "list", "-deps", "-f", "{{if .Module}}{{.Module.Path}}{{end}}", "./cmd/tabura")
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps failed: %v\n%s", err, string(out))
+	}
+
+	forbidden := []string{"piper", "ffmpeg", "voxtype", "openwakeword", "llama.cpp"}
+	for _, line := range strings.Split(string(out), "\n") {
+		module := strings.TrimSpace(line)
+		if module == "" {
+			continue
+		}
+		lowered := strings.ToLower(module)
+		for _, token := range forbidden {
+			if strings.Contains(lowered, token) {
+				t.Fatalf("forbidden sidecar dependency token %q found in module path %q", token, module)
+			}
+		}
+	}
+}
+
+func readRepoFile(t *testing.T, pathParts ...string) string {
+	t.Helper()
+
+	path := filepath.Join(append([]string{repoRoot(t)}, pathParts...)...)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root not found from current working directory")
+		}
+		dir = parent
+	}
+}
+
+func requireContainsAll(t *testing.T, content string, required ...string) {
+	t.Helper()
+
+	for _, marker := range required {
+		if !strings.Contains(content, marker) {
+			t.Fatalf("missing required marker %q", marker)
+		}
+	}
+}

--- a/scripts/setup-tabura-piper-tts.sh
+++ b/scripts/setup-tabura-piper-tts.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 #
 # Prerequisites: curl, python3 (3.10+)
 # GPU not required - Piper uses ONNX and runs ~100x realtime on CPU.
+# Licensing: Piper runtime is GPL and is intentionally consumed as a local HTTP
+# sidecar. Voice models use per-model terms; model cards are shown before
+# download.
 
 PIPER_DIR="${HOME}/.local/share/tabura-piper-tts"
 MODEL_DIR="${PIPER_DIR}/models"
@@ -19,7 +22,40 @@ declare -A MODELS=(
     ["de_DE-karlsson-low"]="de/de_DE/karlsson/low"
 )
 
+declare -A MODEL_LICENSE_NOTES=(
+    ["en_GB-alan-medium"]="Model card indicates MIT-compatible terms."
+    ["de_DE-karlsson-low"]="Per-model terms must be checked in model card."
+)
+
+confirm_default_yes() {
+    local prompt="$1"
+    if [ "${TABURA_ASSUME_YES:-0}" = "1" ]; then
+        echo "TABURA_ASSUME_YES=1 set; accepting: ${prompt}"
+        return 0
+    fi
+
+    local response
+    read -r -p "${prompt} [Y/n] " response
+    case "$response" in
+        "" | [Yy] | [Yy][Ee][Ss]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 mkdir -p "$MODEL_DIR"
+
+# --- Tier 2 licensing notice ---
+
+echo "=== Piper TTS Tier-2 Notice ==="
+echo "Runtime license: GPL (installed in isolated Python venv)."
+echo "Integration boundary: local loopback HTTP sidecar, no Go binary linking."
+echo "Voice models: per-model terms; model card URL shown before each download."
+echo ""
+
+if ! confirm_default_yes "Continue with Piper TTS setup?"; then
+    echo "Skipped Piper TTS setup by user choice."
+    exit 0
+fi
 
 # --- Step 1: Download voice models ---
 
@@ -30,6 +66,14 @@ for model in "${!MODELS[@]}"; do
 
     if [ -f "$onnx" ] && [ -f "$json" ]; then
         echo "Model already exists: $model"
+        continue
+    fi
+
+    echo "Model license notice: ${model}"
+    echo "  ${MODEL_LICENSE_NOTES[$model]}"
+    echo "  Model card: ${HF_BASE}/${subpath}/MODEL_CARD"
+    if ! confirm_default_yes "Download ${model}?"; then
+        echo "Skipping model download: ${model}"
         continue
     fi
 


### PR DESCRIPTION
## Summary
- add `THIRD_PARTY_LICENSES.md` with bundled, setup-time, and planned components plus explicit sidecar boundary notes
- add `docs/model-download-policy.md` with Tier 1/Tier 2 consent rules and current/planned download inventory
- update `scripts/setup-tabura-piper-tts.sh` to enforce Tier-2 notice flow with default-yes prompt, per-model notices, and explicit opt-out handling
- add `internal/licensing/policy_test.go` with automated checks for policy docs, installer notice flow, and dependency-link boundary constraints
- link new policy/license docs from `README.md`

## Verification
1. Requirement: `THIRD_PARTY_LICENSES.md` lists relevant components and licenses.
- Evidence artifact: `THIRD_PARTY_LICENSES.md` includes entries for Piper runtime (GPL), Piper model terms, ffmpeg (GPL/LGPL), voxtype (MIT), and sidecar boundary notes.
- Evidence test: `TestThirdPartyLicenseInventoryIncludesRequiredComponents` in `internal/licensing/policy_test.go`.

2. Requirement: model download policy documents downloads, sources, licenses, and consent tiers.
- Evidence artifact: `docs/model-download-policy.md` defines Tier 1/Tier 2 and current/planned component tables.
- Evidence test: `TestModelDownloadPolicyDefinesTierRulesAndCurrentDownloads` in `internal/licensing/policy_test.go`.

3. Requirement: installer consent flow reflects licensing tiers.
- Evidence artifact: `scripts/setup-tabura-piper-tts.sh` now prints a Tier-2 notice, prompts `Continue with Piper TTS setup? [Y/n]`, shows per-model notice/model-card URL, and supports opt-out plus non-interactive `TABURA_ASSUME_YES=1`.
- Evidence tests: `TestPiperSetupScriptContainsTier2NoticeAndOptOutFlow` and `bash -n scripts/setup-tabura-piper-tts.sh`.

4. Requirement: no GPL sidecar code is linked into the Go binary.
- Evidence test: `TestNoKnownGPLSidecarDependenciesAreLinkedIntoGoBinary` executes `go list -deps -f '{{if .Module}}{{.Module.Path}}{{end}}' ./cmd/tabura` and fails if dependency paths include known sidecar tokens (`piper`, `ffmpeg`, `voxtype`, `openwakeword`, `llama.cpp`).

### Commands and output excerpts
```bash
$ go test ./internal/licensing 2>&1 | tee /tmp/tabura-issue-78-test.log
ok   github.com/krystophny/tabura/internal/licensing  0.075s

$ rg -n "FAIL|panic|error" /tmp/tabura-issue-78-test.log
# (no matches)

$ bash -n scripts/setup-tabura-piper-tts.sh
# (no output)
```
