### PR TITLE
fix: feat(intent): Qwen3 0.6B local LLM fallback for ambiguous intent (fixes #71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,11 @@ Tabura uses one monolithic runtime command for app operation:
 
 No separate `tabura-mcp.service` or `tabura-voxtype-mcp.service` sidecars are used.
 No Helpy integration/runtime is active in Tabura.
-Tabura keeps three local sidecars:
+Tabura keeps four local sidecars:
 - `tabura-codex-app-server.service` for Codex app-server
 - `tabura-piper-tts.service` for Piper TTS over loopback HTTP
 - `tabura-intent.service` for local intent classification (`/classify` on `127.0.0.1:8425`)
+- `tabura-llm.service` for Qwen3 0.6B via llama.cpp (`/v1/chat/completions` on `127.0.0.1:8426`)
 
 ## Security Boundary
 
@@ -62,17 +63,18 @@ Primary units:
 - `tabura-codex-app-server.service`
 - `tabura-piper-tts.service`
 - `tabura-intent.service` (optional but recommended)
+- `tabura-llm.service` (optional for ambiguous-intent fallback)
 
 Quick status:
 
 ```bash
-systemctl --user status tabura-web.service tabura-codex-app-server.service tabura-piper-tts.service tabura-intent.service --no-pager -n 40
+systemctl --user status tabura-web.service tabura-codex-app-server.service tabura-piper-tts.service tabura-intent.service tabura-llm.service --no-pager -n 40
 ```
 
 Restart core stack:
 
 ```bash
-systemctl --user restart tabura-codex-app-server.service tabura-piper-tts.service tabura-intent.service tabura-web.service
+systemctl --user restart tabura-codex-app-server.service tabura-piper-tts.service tabura-intent.service tabura-llm.service tabura-web.service
 ```
 
 ## Endpoints
@@ -83,6 +85,7 @@ systemctl --user restart tabura-codex-app-server.service tabura-piper-tts.servic
 - App-server: `ws://127.0.0.1:8787`
 - TTS (Piper): `http://127.0.0.1:8424`
 - Intent classifier: `http://127.0.0.1:8425/classify` (`TABURA_INTENT_CLASSIFIER_URL`, use `off` to disable)
+- Intent LLM fallback: `http://127.0.0.1:8426/v1/chat/completions` (`TABURA_INTENT_LLM_URL`, use `off` to disable)
 - Local canvas session: `local`
 
 ## Start Local Web UI In Temporary Directory

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ tabura server --project-dir . --data-dir ~/.tabura-web --web-host 0.0.0.0 --web-
 
 ## Runtime Stack (Canonical)
 
-Tabura runs as one Go runtime plus four local sidecars:
+Tabura runs as one Go runtime plus five local services:
 
 1. `tabura-web.service` (`tabura server`)
 2. `tabura-codex-app-server.service` (`codex app-server`)
 3. `tabura-piper-tts.service` (Piper `/v1/audio/speech`)
 4. `tabura-intent.service` (local intent classifier at `127.0.0.1:8425/classify`)
-5. Voice commit uses built-in VAD auto-stop (no extra voice sidecar)
+5. `tabura-llm.service` (Qwen3 0.6B fallback at `127.0.0.1:8426/v1/chat/completions`)
+6. Voice commit uses built-in VAD auto-stop (no extra voice sidecar)
 
 Why Piper remains an HTTP sidecar:
 - Piper `libpiper` linking is GPL-governed; direct linking would change distribution obligations.
@@ -100,6 +101,7 @@ Why Piper remains an HTTP sidecar:
 - Codex app-server websocket: `ws://127.0.0.1:8787`
 - Piper TTS endpoint: `http://127.0.0.1:8424/v1/audio/speech`
 - Intent classifier endpoint: `http://127.0.0.1:8425/classify` (`TABURA_INTENT_CLASSIFIER_URL`, set `off` to disable)
+- Intent LLM fallback endpoint: `http://127.0.0.1:8426/v1/chat/completions` (`TABURA_INTENT_LLM_URL`, set `off` to disable)
 - Local canvas session id: `local`
 - Spark thinking budget for Spark model (fast path): `TABURA_APP_SERVER_SPARK_REASONING_EFFORT=low` (`low`/`medium`/`high`/`extra_high`)
 

--- a/deploy/systemd/user/tabura-llm.service
+++ b/deploy/systemd/user/tabura-llm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Tabura Local Intent LLM (Qwen3 0.6B)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/code/assi/tabula
+Environment=HOME=%h
+Environment=TABURA_LLM_MODEL_DIR=%h/.local/share/tabura-llm/models
+ExecStart=%h/code/assi/tabula/scripts/setup-local-llm.sh
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=15
+
+[Install]
+WantedBy=default.target

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ Runtime stack:
 - `tabura-codex-app-server.service` runs Codex app-server
 - `tabura-piper-tts.service` runs Piper TTS API on loopback
 - `tabura-intent.service` runs local intent classification on loopback (`/classify`)
+- `tabura-llm.service` runs Qwen3 0.6B intent fallback on loopback (`/v1/chat/completions`)
 
 ## Components
 
@@ -37,6 +38,7 @@ Runtime stack:
 - Codex app-server remains a separate local service and is consumed over `ws://127.0.0.1:8787`.
 - Piper TTS remains a separate local HTTP service on `http://127.0.0.1:8424`.
 - Intent classifier remains a separate local HTTP service on `http://127.0.0.1:8425/classify`.
+- Intent LLM fallback remains a separate local HTTP service on `http://127.0.0.1:8426/v1/chat/completions`.
 - Piper is intentionally not linked into the Go binary (`libpiper`) to avoid GPL-linked distribution coupling.
 
 ## UI Layout (Zen Canvas)

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -195,32 +195,47 @@ func (a *App) runHubTurn(sessionID string, session store.ChatSession, messages [
 
 	persistedAssistantID := int64(0)
 	persistedAssistantText := ""
+	executeClassifiedAction := func(action *SystemAction) bool {
+		actionMessage, actionPayload, actionErr := a.executeSystemAction(sessionID, session, action)
+		if actionErr != nil {
+			return false
+		}
+		assistantText := strings.TrimSpace(actionMessage)
+		if assistantText == "" {
+			assistantText = "Done."
+		}
+		if actionPayload != nil {
+			a.broadcastChatEvent(sessionID, map[string]interface{}{
+				"type":   "system_action",
+				"action": actionPayload,
+			})
+		}
+		a.finalizeAssistantResponse(
+			sessionID,
+			session.ProjectKey,
+			assistantText,
+			&persistedAssistantID,
+			&persistedAssistantText,
+			"",
+			runID,
+			"",
+			outputMode,
+		)
+		return true
+	}
+
 	localAction, localConfidence, localErr := a.classifyIntentLocally(ctx, userText)
 	if localErr == nil && localAction != nil && localConfidence >= intentClassifierMinConfidence {
-		actionMessage, actionPayload, actionErr := a.executeSystemAction(sessionID, session, localAction)
-		if actionErr == nil {
-			assistantText := strings.TrimSpace(actionMessage)
-			if assistantText == "" {
-				assistantText = "Done."
-			}
-			if actionPayload != nil {
-				a.broadcastChatEvent(sessionID, map[string]interface{}{
-					"type":   "system_action",
-					"action": actionPayload,
-				})
-			}
-			a.finalizeAssistantResponse(
-				sessionID,
-				session.ProjectKey,
-				assistantText,
-				&persistedAssistantID,
-				&persistedAssistantText,
-				"",
-				runID,
-				"",
-				outputMode,
-			)
+		if executeClassifiedAction(localAction) {
 			return
+		}
+	}
+	if localErr != nil || localAction == nil || localConfidence < intentClassifierMinConfidence {
+		llmAction, llmErr := a.classifyIntentWithLLM(ctx, userText)
+		if llmErr == nil && llmAction != nil {
+			if executeClassifiedAction(llmAction) {
+				return
+			}
 		}
 	}
 

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -39,6 +39,41 @@ func setupMockIntentClassifierServer(t *testing.T, status int, response map[stri
 	}))
 }
 
+func setupMockIntentLLMServer(t *testing.T, status int, content string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		messages, ok := payload["messages"].([]interface{})
+		if !ok || len(messages) == 0 {
+			http.Error(w, "missing messages", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": content,
+					},
+				},
+			},
+		})
+	}))
+}
+
 func latestAssistantMessage(t *testing.T, app *App, sessionID string) string {
 	t.Helper()
 	updatedMessages, err := app.store.ListChatMessages(sessionID, 100)
@@ -305,12 +340,15 @@ func TestHubRunTurnFallsBackToSparkOnLowIntentConfidence(t *testing.T) {
 		"entities":   map[string]interface{}{},
 	})
 	defer classifier.Close()
+	llm := setupMockIntentLLMServer(t, http.StatusServiceUnavailable, "temporary failure")
+	defer llm.Close()
 
 	app, err := New(t.TempDir(), "", "", wsURL, "", "", "", false)
 	if err != nil {
 		t.Fatalf("new app: %v", err)
 	}
 	app.intentClassifierURL = classifier.URL
+	app.intentLLMURL = llm.URL
 	t.Cleanup(func() {
 		_ = app.Shutdown(context.Background())
 	})
@@ -334,6 +372,48 @@ func TestHubRunTurnFallsBackToSparkOnLowIntentConfidence(t *testing.T) {
 
 	if got := latestAssistantMessage(t, app, session.ID); got != assistantReply {
 		t.Fatalf("assistant message = %q, want %q", got, assistantReply)
+	}
+}
+
+func TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence(t *testing.T) {
+	classifier := setupMockIntentClassifierServer(t, http.StatusOK, map[string]interface{}{
+		"intent":     "toggle_silent",
+		"confidence": 0.25,
+		"entities":   map[string]interface{}{},
+	})
+	defer classifier.Close()
+	llm := setupMockIntentLLMServer(t, http.StatusOK, "```json\n{\"action\":\"toggle_silent\"}\n```")
+	defer llm.Close()
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.intentClassifierURL = classifier.URL
+	app.intentLLMURL = llm.URL
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("hub session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 100)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	app.runHubTurn(session.ID, session, messages, turnOutputModeSilent)
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Toggled silent mode." {
+		t.Fatalf("assistant message = %q, want %q", got, "Toggled silent mode.")
 	}
 }
 

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -16,10 +16,28 @@ import (
 
 const (
 	DefaultIntentClassifierURL     = "http://127.0.0.1:8425"
+	DefaultIntentLLMURL            = "http://127.0.0.1:8426"
 	intentClassifierMinConfidence  = 0.8
 	intentClassifierRequestTimeout = 75 * time.Millisecond
 	intentClassifierResponseLimit  = 64 * 1024
+	intentLLMRequestTimeout        = 150 * time.Millisecond
+	intentLLMResponseLimit         = 128 * 1024
+	intentLLMModel                 = "qwen3-0.6b-q4_k_m"
 )
+
+const intentLLMSystemPrompt = `Classify the user intent and return JSON only.
+Allowed actions:
+- switch_project (name)
+- switch_model (alias, effort)
+- toggle_silent
+- toggle_conversation
+- cancel_work
+- show_status
+- delegate
+- chat
+
+For system actions, return {"action":"<action>", ...params}.
+For non-system conversation, return {"action":"chat"}.`
 
 type localIntentClassifierResponse struct {
 	Action     string                 `json:"action"`
@@ -32,12 +50,28 @@ type localIntentClassifierResponse struct {
 	Effort     string                 `json:"effort"`
 }
 
+type localIntentLLMChatCompletionResponse struct {
+	Choices []localIntentLLMChoice `json:"choices"`
+}
+
+type localIntentLLMChoice struct {
+	Message localIntentLLMMessage `json:"message"`
+}
+
+type localIntentLLMMessage struct {
+	Content string `json:"content"`
+}
+
 type SystemAction struct {
 	Action string                 `json:"action"`
 	Params map[string]interface{} `json:"-"`
 }
 
 func parseSystemAction(raw string) (*SystemAction, error) {
+	return parseSystemActionJSON(raw)
+}
+
+func parseSystemActionJSON(raw string) (*SystemAction, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return nil, nil
@@ -46,13 +80,16 @@ func parseSystemAction(raw string) (*SystemAction, error) {
 	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
 		return nil, nil
 	}
-	action := strings.ToLower(strings.TrimSpace(fmt.Sprint(obj["action"])))
+	action := normalizeSystemActionName(fmt.Sprint(obj["action"]))
+	if action == "" {
+		action = normalizeSystemActionName(fmt.Sprint(obj["intent"]))
+	}
 	if action == "" {
 		return nil, nil
 	}
 	params := make(map[string]interface{}, len(obj))
 	for key, value := range obj {
-		if strings.EqualFold(strings.TrimSpace(key), "action") {
+		if strings.EqualFold(strings.TrimSpace(key), "action") || strings.EqualFold(strings.TrimSpace(key), "intent") {
 			continue
 		}
 		params[key] = value
@@ -84,6 +121,28 @@ func mergeSystemActionParams(target map[string]interface{}, source map[string]in
 		}
 		target[trimmed] = value
 	}
+}
+
+func stripCodeFence(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 0 {
+		return trimmed
+	}
+	if !strings.HasPrefix(strings.TrimSpace(lines[0]), "```") {
+		return trimmed
+	}
+	end := len(lines)
+	if end > 1 && strings.HasPrefix(strings.TrimSpace(lines[end-1]), "```") {
+		end--
+	}
+	if end <= 1 {
+		return ""
+	}
+	return strings.TrimSpace(strings.Join(lines[1:end], "\n"))
 }
 
 func (a *App) classifyIntentLocally(ctx context.Context, text string) (*SystemAction, float64, error) {
@@ -141,6 +200,71 @@ func (a *App) classifyIntentLocally(ctx context.Context, text string) (*SystemAc
 		params["effort"] = strings.TrimSpace(payload.Effort)
 	}
 	return &SystemAction{Action: actionName, Params: params}, payload.Confidence, nil
+}
+
+func (a *App) classifyIntentWithLLM(ctx context.Context, text string) (*SystemAction, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(a.intentLLMURL), "/")
+	if baseURL == "" {
+		return nil, nil
+	}
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return nil, nil
+	}
+
+	requestBody, _ := json.Marshal(map[string]interface{}{
+		"model":       intentLLMModel,
+		"temperature": 0,
+		"max_tokens":  128,
+		"messages": []map[string]string{
+			{"role": "system", "content": intentLLMSystemPrompt},
+			{"role": "user", "content": trimmedText},
+		},
+	})
+	requestCtx, cancel := context.WithTimeout(ctx, intentLLMRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		requestCtx,
+		http.MethodPost,
+		baseURL+"/v1/chat/completions",
+		bytes.NewReader(requestBody),
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, intentLLMResponseLimit))
+		return nil, fmt.Errorf("intent llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload localIntentLLMChatCompletionResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, intentLLMResponseLimit)).Decode(&payload); err != nil {
+		return nil, err
+	}
+	if len(payload.Choices) == 0 {
+		return nil, nil
+	}
+	content := strings.TrimSpace(payload.Choices[0].Message.Content)
+	if content == "" {
+		return nil, nil
+	}
+	action, parseErr := parseSystemActionJSON(stripCodeFence(content))
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if action == nil {
+		return nil, nil
+	}
+	if normalizeSystemActionName(action.Action) == "" {
+		return nil, nil
+	}
+	return action, nil
 }
 
 func (a *App) executeSystemAction(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -52,6 +52,7 @@ type App struct {
 	appServerModel                string
 	appServerSparkReasoningEffort string
 	intentClassifierURL           string
+	intentLLMURL                  string
 	ttsURL                        string
 	devRuntime                    bool
 
@@ -124,6 +125,13 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	if resolvedIntentClassifierURL == "" {
 		resolvedIntentClassifierURL = DefaultIntentClassifierURL
 	}
+	resolvedIntentLLMURL := strings.TrimSpace(os.Getenv("TABURA_INTENT_LLM_URL"))
+	if strings.EqualFold(resolvedIntentLLMURL, "off") {
+		resolvedIntentLLMURL = ""
+	}
+	if resolvedIntentLLMURL == "" {
+		resolvedIntentLLMURL = DefaultIntentLLMURL
+	}
 	if err := s.SetAppState(appStateDefaultChatModelKey, modelprofile.AliasSpark); err != nil {
 		_ = s.Close()
 		return nil, err
@@ -136,6 +144,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		appServerModel:                resolvedModel,
 		appServerSparkReasoningEffort: resolvedSparkReasoningEffort,
 		intentClassifierURL:           resolvedIntentClassifierURL,
+		intentLLMURL:                  resolvedIntentLLMURL,
 		ttsURL:                        resolvedTTSURL,
 		devRuntime:                    devRuntime,
 		store:                         s,
@@ -390,6 +399,7 @@ func (a *App) handleRuntime(w http.ResponseWriter, r *http.Request) {
 		"app_server_model":            a.appServerModel,
 		"app_server_reasoning_effort": sparkReasoningEffort,
 		"intent_classifier_url":       a.intentClassifierURL,
+		"intent_llm_url":              a.intentLLMURL,
 		"available_models":            modelprofile.SupportedModels(),
 		"available_reasoning_efforts": modelprofile.AvailableReasoningEffortsByAlias(),
 		"tts_enabled":                 a.ttsURL != "",

--- a/scripts/install-tabura-user-units.sh
+++ b/scripts/install-tabura-user-units.sh
@@ -22,6 +22,8 @@ required_units=(
   tabura-dev-watch.service
 )
 optional_units=(
+  tabura-intent.service
+  tabura-llm.service
   tabura-ptyd.service
 )
 

--- a/scripts/setup-local-llm.sh
+++ b/scripts/setup-local-llm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_DIR="${TABURA_LLM_MODEL_DIR:-$HOME/.local/share/tabura-llm/models}"
+MODEL_FILE="${TABURA_LLM_MODEL_FILE:-Qwen3-0.6B-Q4_K_M.gguf}"
+MODEL_URL="${TABURA_LLM_MODEL_URL:-https://huggingface.co/lmstudio-community/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf?download=true}"
+SERVER_BIN="${LLAMA_SERVER_BIN:-llama-server}"
+HOST="${TABURA_LLM_HOST:-127.0.0.1}"
+PORT="${TABURA_LLM_PORT:-8426}"
+THREADS="${TABURA_LLM_THREADS:-4}"
+CTX_SIZE="${TABURA_LLM_CTX:-2048}"
+NGL="${TABURA_LLM_NGL:-99}"
+
+if ! command -v "$SERVER_BIN" >/dev/null 2>&1; then
+  echo "llama.cpp server binary not found: $SERVER_BIN" >&2
+  echo "Install llama.cpp and ensure llama-server is on PATH (or set LLAMA_SERVER_BIN)." >&2
+  exit 1
+fi
+
+mkdir -p "$MODEL_DIR"
+MODEL_PATH="$MODEL_DIR/$MODEL_FILE"
+if [ ! -s "$MODEL_PATH" ]; then
+  echo "Downloading $MODEL_FILE to $MODEL_PATH"
+  curl -fL --retry 3 --retry-delay 2 -o "$MODEL_PATH.tmp" "$MODEL_URL"
+  mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+fi
+
+echo "Starting local intent LLM at http://$HOST:$PORT"
+exec "$SERVER_BIN" \
+  -m "$MODEL_PATH" \
+  --host "$HOST" \
+  --port "$PORT" \
+  -c "$CTX_SIZE" \
+  --threads "$THREADS" \
+  -ngl "$NGL"


### PR DESCRIPTION
## Summary
- add a Qwen3/llama.cpp intent fallback (`TABURA_INTENT_LLM_URL`, default `http://127.0.0.1:8426`) after low-confidence DistilBERT results and before Spark fallback
- add local LLM setup/runtime assets: `scripts/setup-local-llm.sh` and `deploy/systemd/user/tabura-llm.service`
- document the new sidecar and endpoint in runtime docs (`CLAUDE.md`, `README.md`, `docs/architecture.md`)
- add hub intent tests for both Qwen fallback success and Spark fallback when Qwen is unavailable

## Verification
- Requirement: DistilBERT -> Qwen3 -> Spark intent cascade.
  - Evidence: `internal/web/chat_hub.go` now attempts `classifyIntentWithLLM` when local confidence is below `intentClassifierMinConfidence`.
  - Test: `TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence`.
- Requirement: Qwen unavailable must fall through to Spark.
  - Test: `TestHubRunTurnFallsBackToSparkOnLowIntentConfidence` uses an LLM mock with `503`, and Spark response is used.
- Requirement: structured JSON output parsing from Qwen response.
  - Test: `TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence` returns fenced JSON (```json ... ```) and verifies action execution.
- Requirement: setup/service assets for local Qwen runtime.
  - Evidence: `scripts/setup-local-llm.sh` downloads `Qwen3-0.6B-Q4_K_M.gguf` and starts `llama-server`; `deploy/systemd/user/tabura-llm.service` runs it as a user unit.
- Requirement: update CLAUDE runtime docs.
  - Evidence: `CLAUDE.md` now lists `tabura-llm.service`, status/restart commands, and `TABURA_INTENT_LLM_URL` endpoint.

### Commands (captured)
- `go test ./internal/web 2>&1 | tee /tmp/test.log`
  - Excerpt: `ok   github.com/krystophny/tabura/internal/web	0.903s`
- `go test ./internal/web -run 'TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence|TestHubRunTurnFallsBackToSparkOnLowIntentConfidence' -v 2>&1 | tee /tmp/test-intent.log`
  - Excerpt:
    - `--- PASS: TestHubRunTurnFallsBackToSparkOnLowIntentConfidence`
    - `--- PASS: TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence`
