### PR TITLE
fix: feat: cross-platform distribution, installer, auto-update (fixes #79)

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -334,7 +334,7 @@ func selectReleaseAsset(assets []githubAsset, version, goos, goarch string) (git
 		if !strings.HasPrefix(name, "tabura_") {
 			continue
 		}
-		if !strings.Contains(name, goos) || !strings.Contains(name, goarch) {
+		if !assetNameHasToken(name, goos) || !assetNameHasToken(name, goarch) {
 			continue
 		}
 		if goos == "windows" && strings.HasSuffix(name, ".zip") {
@@ -345,6 +345,22 @@ func selectReleaseAsset(assets []githubAsset, version, goos, goarch string) (git
 		}
 	}
 	return githubAsset{}, fmt.Errorf("no release asset found for %s/%s", goos, goarch)
+}
+
+func assetNameHasToken(name, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	if want == "" {
+		return false
+	}
+	tokens := strings.FieldsFunc(strings.ToLower(name), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	})
+	for _, token := range tokens {
+		if token == want {
+			return true
+		}
+	}
+	return false
 }
 
 func selectChecksumAsset(assets []githubAsset) (githubAsset, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -241,6 +241,34 @@ func TestRunRejectsChecksumMismatchAndKeepsOriginalExecutable(t *testing.T) {
 	}
 }
 
+func TestSelectReleaseAssetFallbackDoesNotPartialMatchArch(t *testing.T) {
+	t.Parallel()
+
+	_, err := selectReleaseAsset([]githubAsset{
+		{Name: "tabura_latest_linux_arm64.tar.gz"},
+	}, "1.2.4", "linux", "arm")
+	if err == nil {
+		t.Fatalf("expected no matching asset for linux/arm when only arm64 exists")
+	}
+	if !strings.Contains(err.Error(), "no release asset found") {
+		t.Fatalf("error = %q, want no release asset found", err)
+	}
+}
+
+func TestSelectReleaseAssetFallbackMatchesTokenizedArch(t *testing.T) {
+	t.Parallel()
+
+	asset, err := selectReleaseAsset([]githubAsset{
+		{Name: "tabura_latest_linux_arm.tar.gz"},
+	}, "1.2.4", "linux", "arm")
+	if err != nil {
+		t.Fatalf("selectReleaseAsset() error = %v", err)
+	}
+	if asset.Name != "tabura_latest_linux_arm.tar.gz" {
+		t.Fatalf("asset name = %q, want tabura_latest_linux_arm.tar.gz", asset.Name)
+	}
+}
+
 func mustTarGzBinary(t *testing.T, name string, data []byte) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Fix `tabura update` fallback asset matching to require token-level OS/arch matches instead of substring matches.
- Prevents `linux/arm` updates from incorrectly selecting `arm64` artifacts.
- Add regression tests for fallback asset matching behavior.

## Verification
### Requirement-by-requirement evidence
- Requirement from #79: self-update must use the correct cross-platform release artifact.
  - Evidence: `TestSelectReleaseAssetFallbackDoesNotPartialMatchArch` fails if `linux/arm` accepts an `arm64` artifact.
  - Evidence: `TestSelectReleaseAssetFallbackMatchesTokenizedArch` verifies valid tokenized fallback names still resolve.

### Test fails on main
```bash
$ git worktree add --detach /tmp/tabula-main-issue79 origin/main
$ cp internal/update/update_test.go /tmp/tabula-main-issue79/internal/update/update_test.go
$ (cd /tmp/tabula-main-issue79 && go test ./internal/update -run TestSelectReleaseAssetFallbackDoesNotPartialMatchArch -count=1)
--- FAIL: TestSelectReleaseAssetFallbackDoesNotPartialMatchArch (0.00s)
    update_test.go:251: expected no matching asset for linux/arm when only arm64 exists
FAIL
FAIL    github.com/krystophny/tabura/internal/update    0.002s
```

### Test passes after fix
```bash
$ go test ./internal/update -run 'TestSelectReleaseAssetFallbackDoesNotPartialMatchArch|TestSelectReleaseAssetFallbackMatchesTokenizedArch' -count=1
ok      github.com/krystophny/tabura/internal/update    0.002s
```

### Additional package check
```bash
$ go test ./internal/update -count=1
ok      github.com/krystophny/tabura/internal/update    0.005s
```
