### PR TITLE
fix: feat: conversation mode, hotword detection, hub mode (fixes #72)

### DIFF
--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -28,6 +28,7 @@ Available actions:
 - {"action":"switch_model","alias":"codex|gpt|spark","effort":"low|medium|high|extra_high"}
 - {"action":"toggle_silent"}
 - {"action":"toggle_conversation"}
+- {"action":"delegate","model":"codex|gpt|spark","task":"..."}
 - {"action":"cancel_work"}
 - {"action":"show_status"}
 

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -74,6 +76,57 @@ func setupMockIntentLLMServer(t *testing.T, status int, content string) *httptes
 	}))
 }
 
+func setupMockDelegateStartServer(t *testing.T, jobID string, seen *int, observed *map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		params, _ := payload["params"].(map[string]interface{})
+		if strings.TrimSpace(strFromAny(params["name"])) != "delegate_to_model" {
+			http.Error(w, "unexpected tool", http.StatusBadRequest)
+			return
+		}
+		args, _ := params["arguments"].(map[string]interface{})
+		if args == nil {
+			http.Error(w, "missing arguments", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(strFromAny(args["prompt"])) == "" {
+			http.Error(w, "missing prompt", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(strFromAny(args["cwd"])) == "" {
+			http.Error(w, "missing cwd", http.StatusBadRequest)
+			return
+		}
+		if seen != nil {
+			*seen += 1
+		}
+		if observed != nil {
+			copied := map[string]interface{}{}
+			for key, value := range args {
+				copied[key] = value
+			}
+			*observed = copied
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": map[string]interface{}{
+				"structuredContent": map[string]interface{}{
+					"job_id": jobID,
+				},
+			},
+		})
+	}))
+}
+
 func latestAssistantMessage(t *testing.T, app *App, sessionID string) string {
 	t.Helper()
 	updatedMessages, err := app.store.ListChatMessages(sessionID, 100)
@@ -108,6 +161,7 @@ func TestParseSystemAction(t *testing.T) {
 		{name: "toggle conversation", raw: `{"action":"toggle_conversation"}`, wantAction: "toggle_conversation"},
 		{name: "cancel work", raw: `{"action":"cancel_work"}`, wantAction: "cancel_work"},
 		{name: "show status", raw: `{"action":"show_status"}`, wantAction: "show_status"},
+		{name: "delegate", raw: `{"action":"delegate","model":"codex","task":"audit tests"}`, wantAction: "delegate"},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -123,6 +177,121 @@ func TestParseSystemAction(t *testing.T) {
 				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
 			}
 		})
+	}
+}
+
+func TestClassifyIntentLocallyAcceptsDelegateAction(t *testing.T) {
+	classifier := setupMockIntentClassifierServer(t, http.StatusOK, map[string]interface{}{
+		"intent":     "delegate",
+		"confidence": 0.92,
+		"entities": map[string]interface{}{
+			"model": "gpt",
+			"task":  "review this repository",
+		},
+	})
+	defer classifier.Close()
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.intentClassifierURL = classifier.URL
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	action, confidence, err := app.classifyIntentLocally(context.Background(), "delegate repo review")
+	if err != nil {
+		t.Fatalf("classify intent locally: %v", err)
+	}
+	if action == nil {
+		t.Fatalf("expected delegate action")
+	}
+	if action.Action != "delegate" {
+		t.Fatalf("action = %q, want delegate", action.Action)
+	}
+	if confidence != 0.92 {
+		t.Fatalf("confidence = %v, want 0.92", confidence)
+	}
+	if got := strings.TrimSpace(strFromAny(action.Params["model"])); got != "gpt" {
+		t.Fatalf("delegate model = %q, want gpt", got)
+	}
+	if got := strings.TrimSpace(strFromAny(action.Params["task"])); got != "review this repository" {
+		t.Fatalf("delegate task = %q, want review this repository", got)
+	}
+}
+
+func TestExecuteSystemActionDelegateStartsJob(t *testing.T) {
+	app := newAuthedTestApp(t)
+	defaultProject, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("hub session: %v", err)
+	}
+
+	delegateCalls := 0
+	var observed map[string]interface{}
+	server := setupMockDelegateStartServer(t, "job-123", &delegateCalls, &observed)
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse mock url: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse mock port: %v", err)
+	}
+	app.mu.Lock()
+	app.tunnelPorts[app.canvasSessionIDForProject(defaultProject)] = port
+	app.mu.Unlock()
+
+	msg, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
+		Action: "delegate",
+		Params: map[string]interface{}{
+			"model": "gpt",
+			"task":  "review the current repository state",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute delegate: %v", err)
+	}
+	if !strings.Contains(msg, "job-123") {
+		t.Fatalf("delegate message = %q, want job id", msg)
+	}
+	if payload == nil {
+		t.Fatalf("expected delegate payload")
+	}
+	if got := strings.TrimSpace(strFromAny(payload["type"])); got != "delegate" {
+		t.Fatalf("payload type = %q, want delegate", got)
+	}
+	if got := strings.TrimSpace(strFromAny(payload["job_id"])); got != "job-123" {
+		t.Fatalf("payload job_id = %q, want job-123", got)
+	}
+	if got := strings.TrimSpace(strFromAny(payload["model"])); got != "gpt" {
+		t.Fatalf("payload model = %q, want gpt", got)
+	}
+	if got := strings.TrimSpace(strFromAny(payload["project_id"])); got != defaultProject.ID {
+		t.Fatalf("payload project_id = %q, want %q", got, defaultProject.ID)
+	}
+	if delegateCalls != 1 {
+		t.Fatalf("delegate tool calls = %d, want 1", delegateCalls)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["model"])); got != "gpt" {
+		t.Fatalf("delegate model arg = %q, want gpt", got)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["prompt"])); got != "review the current repository state" {
+		t.Fatalf("delegate prompt arg = %q, want expected task", got)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["cwd"])); got != strings.TrimSpace(defaultProject.RootPath) {
+		t.Fatalf("delegate cwd arg = %q, want %q", got, defaultProject.RootPath)
 	}
 }
 

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -103,11 +103,32 @@ func systemActionStringParam(params map[string]interface{}, key string) string {
 
 func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "switch_project", "switch_model", "toggle_silent", "toggle_conversation", "cancel_work", "show_status":
+	case "switch_project", "switch_model", "toggle_silent", "toggle_conversation", "cancel_work", "show_status", "delegate":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
 	}
+}
+
+func normalizeDelegateModel(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "codex":
+		return "codex"
+	case "gpt", "spark":
+		return strings.ToLower(strings.TrimSpace(raw))
+	default:
+		return ""
+	}
+}
+
+func systemActionDelegateTask(params map[string]interface{}) string {
+	for _, key := range []string{"task", "prompt", "text"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
 }
 
 func mergeSystemActionParams(target map[string]interface{}, source map[string]interface{}) {
@@ -325,6 +346,59 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			return "", nil, err
 		}
 		return status, nil, nil
+	case "delegate":
+		targetProject, err := a.hubPrimaryProject()
+		if err != nil {
+			return "", nil, err
+		}
+		model := normalizeDelegateModel(
+			firstNonEmptyPrompt(
+				systemActionStringParam(action.Params, "model"),
+				systemActionStringParam(action.Params, "alias"),
+			),
+		)
+		if model == "" {
+			return "", nil, errors.New("delegate model must be codex, gpt, or spark")
+		}
+		task := systemActionDelegateTask(action.Params)
+		if task == "" {
+			return "", nil, errors.New("delegate task is required")
+		}
+		cwd := strings.TrimSpace(targetProject.RootPath)
+		if cwd == "" {
+			cwd = strings.TrimSpace(a.cwdForProjectKey(targetProject.ProjectKey))
+		}
+		if cwd == "" {
+			return "", nil, errors.New("delegate cwd is not available")
+		}
+		canvasSessionID := strings.TrimSpace(a.canvasSessionIDForProject(targetProject))
+		if canvasSessionID == "" {
+			return "", nil, errors.New("delegate canvas session is not available")
+		}
+		a.mu.Lock()
+		port, ok := a.tunnelPorts[canvasSessionID]
+		a.mu.Unlock()
+		if !ok {
+			return "", nil, fmt.Errorf("no active MCP tunnel for project %q", targetProject.Name)
+		}
+		status, err := a.mcpToolsCall(port, "delegate_to_model", map[string]interface{}{
+			"model":  model,
+			"prompt": task,
+			"cwd":    cwd,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+		jobID := strings.TrimSpace(fmt.Sprint(status["job_id"]))
+		if jobID == "" || jobID == "<nil>" {
+			return "", nil, errors.New("delegate_to_model did not return job_id")
+		}
+		return fmt.Sprintf("Delegated to %s as job %s.", model, jobID), map[string]interface{}{
+			"type":       "delegate",
+			"job_id":     jobID,
+			"model":      model,
+			"project_id": targetProject.ID,
+		}, nil
 	default:
 		return "", nil, fmt.Errorf("unsupported action: %s", action.Action)
 	}


### PR DESCRIPTION
## Summary
- Implemented `delegate` as a first-class hub/system action in backend intent normalization and execution.
- Wired hub delegate execution to MCP `delegate_to_model` with validated `model`/`task`, project-aware `cwd`, and returned `job_id` payload.
- Updated hub system prompt action catalog to include `delegate` so model output and backend capabilities match.
- Added regression tests for delegate parsing, local intent classification, and delegate execution via MCP.

## Verification
### Requirement Mapping
- Requirement: Hub mode must support LLM-routed system commands for global assistant actions.
  - Evidence: `TestParseSystemAction/delegate` and `TestExecuteSystemActionDelegateStartsJob` validate `delegate` is recognized and executed as a system action.
- Requirement: Local intent classifier path must route supported actions without falling back unnecessarily.
  - Evidence: `TestClassifyIntentLocallyAcceptsDelegateAction` verifies classifier output `intent=delegate` is accepted and surfaced with params.
- Requirement: Delegate action must trigger concrete backend work, not a no-op.
  - Evidence: `TestExecuteSystemActionDelegateStartsJob` asserts MCP `delegate_to_model` is invoked with expected args and returns `job_id`.

### Test Fails On Main
```bash
$ git worktree add --detach /tmp/tabura-main-XXXXXX origin/main
$ cp internal/web/chat_hub_test.go /tmp/tabura-main-XXXXXX/internal/web/chat_hub_test.go
$ (cd /tmp/tabura-main-XXXXXX && go test ./internal/web -run 'TestParseSystemAction|TestClassifyIntentLocallyAcceptsDelegateAction|TestExecuteSystemActionDelegateStartsJob')
--- FAIL: TestParseSystemAction (0.00s)
    --- FAIL: TestParseSystemAction/delegate (0.00s)
        chat_hub_test.go:174: expected parsed action
--- FAIL: TestClassifyIntentLocallyAcceptsDelegateAction (0.00s)
    chat_hub_test.go:208: expected delegate action
--- FAIL: TestExecuteSystemActionDelegateStartsJob (0.00s)
    chat_hub_test.go:264: execute delegate: unsupported action: delegate
FAIL
```

### Test Passes After Fix
```bash
$ go test ./internal/web -run 'TestParseSystemAction|TestClassifyIntentLocallyAcceptsDelegateAction|TestExecuteSystemActionDelegateStartsJob'
ok   github.com/krystophny/tabura/internal/web	0.014s
```
