### PR TITLE
Fix silent mode canvas second-render fallback

### DIFF
--- a/internal/stt/transcribe.go
+++ b/internal/stt/transcribe.go
@@ -15,6 +15,13 @@ import (
 // MaxAudioBytes is the upper limit for a single STT audio payload.
 const MaxAudioBytes = 10 * 1024 * 1024
 
+var (
+	// ErrNoTranscriptOutput means the STT backend produced no usable text.
+	ErrNoTranscriptOutput = errors.New("voxtype produced no transcript output")
+	// ErrLikelyHallucination means Whisper returned a known silent-audio phantom.
+	ErrLikelyHallucination = errors.New("rejected likely hallucination on silent audio")
+)
+
 // TranscribeWithVoxType converts audio to WAV via ffmpeg, then transcribes
 // it with the voxtype CLI. It returns the transcript text or an error.
 func TranscribeWithVoxType(mimeType string, data []byte) (string, error) {
@@ -75,12 +82,18 @@ func TranscribeWithVoxType(mimeType string, data []byte) (string, error) {
 		text = ParseVoxTypeTranscript(string(errBytes))
 	}
 	if text == "" {
-		return "", errors.New("voxtype produced no transcript output")
+		return "", ErrNoTranscriptOutput
 	}
 	if IsWhisperHallucination(text) {
-		return "", errors.New("rejected likely hallucination on silent audio")
+		return "", ErrLikelyHallucination
 	}
 	return text, nil
+}
+
+// IsRetryableNoSpeechError reports whether err means "no usable speech yet"
+// and the caller should keep listening instead of failing hard.
+func IsRetryableNoSpeechError(err error) bool {
+	return errors.Is(err, ErrNoTranscriptOutput) || errors.Is(err, ErrLikelyHallucination)
 }
 
 // ParseVoxTypeTranscript extracts the transcript line from voxtype output,

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -1264,13 +1264,21 @@ func (a *App) finalizeAssistantResponse(
 		}
 	} else {
 		canvasCtx := a.resolveCanvasContext(projectKey)
-		if canvasCtx == nil || !canvasCtx.HasArtifact {
-			content := strings.TrimSpace(text)
-			if content != "" && canvasSessionID != "" {
-				autoCanvas = a.writeCanvasFileBlock(projectKey, canvasSessionID, fileBlock{
-					Path:    "",
-					Content: content,
-				})
+		content := strings.TrimSpace(text)
+		if content != "" && canvasSessionID != "" {
+			block := fileBlock{
+				Path:    "",
+				Content: content,
+			}
+			if canOverwriteSilentAutoCanvasArtifact(canvasCtx) {
+				block.Path = canvasCtx.ArtifactTitle
+			}
+			autoCanvas = a.writeCanvasFileBlock(projectKey, canvasSessionID, block)
+			if !autoCanvas && strings.TrimSpace(block.Path) != "" {
+				// If the current artifact path is stale or outside the active project
+				// root, fall back to a fresh scratch artifact for this response.
+				block.Path = ""
+				autoCanvas = a.writeCanvasFileBlock(projectKey, canvasSessionID, block)
 			}
 		}
 	}

--- a/internal/web/chat_canvas.go
+++ b/internal/web/chat_canvas.go
@@ -23,6 +23,7 @@ var canvasFileMarkerRe = regexp.MustCompile(`\[file:[^\]]*\]`)
 var canvasFileDirectiveOpenRe = regexp.MustCompile(`(?m)^\s*:::file\{[^}]*\}\s*$`)
 var canvasFileDirectiveCloseRe = regexp.MustCompile(`(?m)^\s*:::\s*$`)
 var canvasTempFileStemRe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+var canvasScratchTitlePrefix = filepath.ToSlash(filepath.Join(".tabura", "artifacts", "tmp")) + "/"
 
 var attrRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
 
@@ -82,6 +83,29 @@ func defaultCanvasTempFilePath(seed string) string {
 	}
 	name := fmt.Sprintf("%s-%d.md", stem, time.Now().UnixNano())
 	return filepath.ToSlash(filepath.Join(".tabura", "artifacts", "tmp", name))
+}
+
+func isCanvasScratchArtifactTitle(title string) bool {
+	t := filepath.ToSlash(strings.TrimSpace(title))
+	if t == "" {
+		return false
+	}
+	t = strings.TrimPrefix(t, "./")
+	if strings.HasPrefix(t, canvasScratchTitlePrefix) {
+		return true
+	}
+	return strings.Contains(t, "/"+canvasScratchTitlePrefix)
+}
+
+func canOverwriteSilentAutoCanvasArtifact(ctx *canvasContext) bool {
+	if ctx == nil || !ctx.HasArtifact {
+		return false
+	}
+	kind := strings.TrimSpace(ctx.ArtifactKind)
+	if kind != "text" && kind != "text_artifact" {
+		return false
+	}
+	return isCanvasScratchArtifactTitle(ctx.ArtifactTitle)
 }
 
 func resolveCanvasFilePath(cwd, requested string) (absolutePath, canvasTitle string, err error) {

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -1,9 +1,15 @@
 package web
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/krystophny/tabura/internal/store"
@@ -435,6 +441,45 @@ func TestResolveCanvasFilePath_DefaultsToTempArtifactPath(t *testing.T) {
 	}
 }
 
+func TestIsCanvasScratchArtifactTitle(t *testing.T) {
+	if !isCanvasScratchArtifactTitle(".tabura/artifacts/tmp/reply.md") {
+		t.Fatal("expected relative tmp artifact title to be detected")
+	}
+	if !isCanvasScratchArtifactTitle("/home/u/proj/.tabura/artifacts/tmp/reply.md") {
+		t.Fatal("expected absolute tmp artifact title to be detected")
+	}
+	if isCanvasScratchArtifactTitle(".tabura/artifacts/pr/pr-12.diff") {
+		t.Fatal("did not expect PR artifact title to be detected as scratch")
+	}
+	if isCanvasScratchArtifactTitle("README.md") {
+		t.Fatal("did not expect workspace file title to be detected as scratch")
+	}
+}
+
+func TestCanOverwriteSilentAutoCanvasArtifact(t *testing.T) {
+	if !canOverwriteSilentAutoCanvasArtifact(&canvasContext{
+		HasArtifact:   true,
+		ArtifactTitle: ".tabura/artifacts/tmp/reply.md",
+		ArtifactKind:  "text_artifact",
+	}) {
+		t.Fatal("expected text tmp artifact to be overwriteable")
+	}
+	if canOverwriteSilentAutoCanvasArtifact(&canvasContext{
+		HasArtifact:   true,
+		ArtifactTitle: "notes.md",
+		ArtifactKind:  "text_artifact",
+	}) {
+		t.Fatal("did not expect workspace text file artifact to be overwriteable")
+	}
+	if canOverwriteSilentAutoCanvasArtifact(&canvasContext{
+		HasArtifact:   true,
+		ArtifactTitle: ".tabura/artifacts/tmp/reply.md",
+		ArtifactKind:  "image_artifact",
+	}) {
+		t.Fatal("did not expect non-text artifact to be overwriteable")
+	}
+}
+
 func TestResolveArtifactFilePath_AbsoluteExists(t *testing.T) {
 	tmp := t.TempDir()
 	f := filepath.Join(tmp, "main.go")
@@ -492,5 +537,269 @@ func TestResolveArtifactFilePath_Directory(t *testing.T) {
 	got := resolveArtifactFilePath(tmp, "subdir.d")
 	if got != "" {
 		t.Fatalf("expected empty for directory, got %q", got)
+	}
+}
+
+type canvasMCPMock struct {
+	mu               sync.Mutex
+	artifactTitle    string
+	artifactKind     string
+	artifactText     string
+	lastShownTitle   string
+	lastShownContent string
+	artifactShow     int32
+}
+
+func (m *canvasMCPMock) setupServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || strings.TrimSpace(r.URL.Path) != "/mcp" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		params, _ := payload["params"].(map[string]interface{})
+		name := strings.TrimSpace(fmt.Sprint(params["name"]))
+		args, _ := params["arguments"].(map[string]interface{})
+
+		var structured map[string]interface{}
+		switch name {
+		case "canvas_status":
+			m.mu.Lock()
+			active := map[string]interface{}{
+				"title": m.artifactTitle,
+				"kind":  m.artifactKind,
+				"text":  m.artifactText,
+			}
+			m.mu.Unlock()
+			structured = map[string]interface{}{"active_artifact": active}
+		case "canvas_artifact_show":
+			atomic.AddInt32(&m.artifactShow, 1)
+			title := strings.TrimSpace(fmt.Sprint(args["title"]))
+			kind := strings.TrimSpace(fmt.Sprint(args["kind"]))
+			content := fmt.Sprint(args["markdown_or_text"])
+			m.mu.Lock()
+			m.artifactTitle = title
+			if kind != "" {
+				m.artifactKind = kind
+			}
+			m.artifactText = content
+			m.lastShownTitle = title
+			m.lastShownContent = content
+			m.mu.Unlock()
+			structured = map[string]interface{}{"ok": true}
+		default:
+			http.Error(w, "unknown tool", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      payload["id"],
+			"result": map[string]interface{}{
+				"structuredContent": structured,
+				"isError":           false,
+			},
+		})
+	}))
+}
+
+func TestFinalizeAssistantResponse_SilentOverwritesScratchArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: ".tabura/artifacts/tmp/reply.md",
+		artifactKind:  "text_artifact",
+		artifactText:  "old content",
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.mu.Lock()
+	app.tunnelPorts[app.canvasSessionIDForProject(project)] = port
+	app.mu.Unlock()
+	ctx := app.resolveCanvasContext(project.ProjectKey)
+	if ctx == nil {
+		t.Fatal("expected canvas context")
+	}
+	if !canOverwriteSilentAutoCanvasArtifact(ctx) {
+		t.Fatalf("expected scratch artifact to be overwritable, got %+v", *ctx)
+	}
+
+	var persistedID int64
+	var persistedText string
+	_ = app.finalizeAssistantResponse(
+		session.ID,
+		project.ProjectKey,
+		"second response",
+		&persistedID,
+		&persistedText,
+		"",
+		"",
+		"",
+		turnOutputModeSilent,
+	)
+
+	if got := atomic.LoadInt32(&mock.artifactShow); got == 0 {
+		t.Fatal("expected silent response to push canvas_artifact_show for scratch artifact")
+	}
+	if strings.TrimSpace(mock.lastShownTitle) != ".tabura/artifacts/tmp/reply.md" {
+		t.Fatalf("expected overwrite same scratch artifact title, got %q", mock.lastShownTitle)
+	}
+	if strings.TrimSpace(mock.lastShownContent) != "second response" {
+		t.Fatalf("expected updated canvas content, got %q", mock.lastShownContent)
+	}
+	scratchPath := filepath.Join(project.RootPath, filepath.FromSlash(".tabura/artifacts/tmp/reply.md"))
+	b, err := os.ReadFile(scratchPath)
+	if err != nil {
+		t.Fatalf("expected scratch file written: %v", err)
+	}
+	if strings.TrimSpace(string(b)) != "second response" {
+		t.Fatalf("expected scratch file content updated, got %q", string(b))
+	}
+}
+
+func TestFinalizeAssistantResponse_SilentFallsBackToScratchForWorkspaceArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	workspaceFile := filepath.Join(project.RootPath, "docs", "notes.md")
+	if err := os.MkdirAll(filepath.Dir(workspaceFile), 0o755); err != nil {
+		t.Fatalf("mkdir workspace file dir: %v", err)
+	}
+	if err := os.WriteFile(workspaceFile, []byte("user-owned"), 0o644); err != nil {
+		t.Fatalf("seed workspace file: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: "docs/notes.md",
+		artifactKind:  "text_artifact",
+		artifactText:  "user-owned",
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.mu.Lock()
+	app.tunnelPorts[app.canvasSessionIDForProject(project)] = port
+	app.mu.Unlock()
+
+	var persistedID int64
+	var persistedText string
+	_ = app.finalizeAssistantResponse(
+		session.ID,
+		project.ProjectKey,
+		"assistant follow-up",
+		&persistedID,
+		&persistedText,
+		"",
+		"",
+		"",
+		turnOutputModeSilent,
+	)
+
+	if got := atomic.LoadInt32(&mock.artifactShow); got != 1 {
+		t.Fatalf("expected one canvas_artifact_show for workspace artifact fallback, got %d", got)
+	}
+	if strings.TrimSpace(mock.lastShownTitle) == "docs/notes.md" {
+		t.Fatalf("expected fallback scratch artifact title, got %q", mock.lastShownTitle)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(mock.lastShownTitle), ".tabura/artifacts/tmp/") {
+		t.Fatalf("expected scratch artifact title, got %q", mock.lastShownTitle)
+	}
+	if strings.TrimSpace(mock.lastShownContent) != "assistant follow-up" {
+		t.Fatalf("expected fallback scratch artifact content, got %q", mock.lastShownContent)
+	}
+	b, err := os.ReadFile(workspaceFile)
+	if err != nil {
+		t.Fatalf("read workspace file: %v", err)
+	}
+	if strings.TrimSpace(string(b)) != "user-owned" {
+		t.Fatalf("workspace file should remain untouched, got %q", string(b))
+	}
+	scratchPath := filepath.Join(project.RootPath, filepath.FromSlash(strings.TrimSpace(mock.lastShownTitle)))
+	scratchBytes, err := os.ReadFile(scratchPath)
+	if err != nil {
+		t.Fatalf("read scratch artifact file: %v", err)
+	}
+	if strings.TrimSpace(string(scratchBytes)) != "assistant follow-up" {
+		t.Fatalf("expected scratch artifact file content updated, got %q", string(scratchBytes))
+	}
+}
+
+func TestFinalizeAssistantResponse_SilentFallsBackWhenOverwritePathEscapesProject(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: "/tmp/other-project/.tabura/artifacts/tmp/reply.md",
+		artifactKind:  "text_artifact",
+		artifactText:  "old",
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.mu.Lock()
+	app.tunnelPorts[app.canvasSessionIDForProject(project)] = port
+	app.mu.Unlock()
+
+	var persistedID int64
+	var persistedText string
+	_ = app.finalizeAssistantResponse(
+		session.ID,
+		project.ProjectKey,
+		"fresh response",
+		&persistedID,
+		&persistedText,
+		"",
+		"",
+		"",
+		turnOutputModeSilent,
+	)
+
+	if got := atomic.LoadInt32(&mock.artifactShow); got != 1 {
+		t.Fatalf("expected one successful fallback canvas_artifact_show call, got %d", got)
+	}
+	if strings.TrimSpace(mock.lastShownTitle) == "/tmp/other-project/.tabura/artifacts/tmp/reply.md" {
+		t.Fatalf("expected fallback to new local scratch artifact, got %q", mock.lastShownTitle)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(mock.lastShownTitle), ".tabura/artifacts/tmp/") {
+		t.Fatalf("expected local scratch artifact title, got %q", mock.lastShownTitle)
+	}
+	if strings.TrimSpace(mock.lastShownContent) != "fresh response" {
+		t.Fatalf("expected fallback scratch artifact content, got %q", mock.lastShownContent)
 	}
 }

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -51,10 +51,7 @@ func (a *App) ensureHubProject() (store.Project, error) {
 		return existing, nil
 	}
 
-	rootPath := strings.TrimSpace(a.localProjectDir)
-	if rootPath == "" {
-		rootPath = filepath.Join(a.dataDir, "projects", "hub")
-	}
+	rootPath := filepath.Join(a.dataDir, "projects", "hub")
 	absRoot, err := filepath.Abs(rootPath)
 	if err != nil {
 		return store.Project{}, err
@@ -80,6 +77,12 @@ func (a *App) ensureHubProject() (store.Project, error) {
 				_ = a.store.UpdateProjectChatModel(existing.ID, modelprofile.AliasSpark)
 				_ = a.store.UpdateProjectChatModelReasoningEffort(existing.ID, modelprofile.ReasoningLow)
 				return existing, nil
+			}
+			existingByPath, lookupByPathErr := a.store.GetProjectByRootPath(absRoot)
+			if lookupByPathErr == nil && isHubProject(existingByPath) {
+				_ = a.store.UpdateProjectChatModel(existingByPath.ID, modelprofile.AliasSpark)
+				_ = a.store.UpdateProjectChatModelReasoningEffort(existingByPath.ID, modelprofile.ReasoningLow)
+				return existingByPath, nil
 			}
 		}
 		return store.Project{}, err

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -651,3 +651,36 @@ func TestHubProjectProfileUsesSparkLow(t *testing.T) {
 		t.Fatalf("hub turn reasoning = %q, want %q", got, modelprofile.ReasoningLow)
 	}
 }
+
+func TestEnsureHubProjectUsesDedicatedRootWhenLocalProjectConfigured(t *testing.T) {
+	dataDir := t.TempDir()
+	localProjectDir := t.TempDir()
+	app, err := New(dataDir, localProjectDir, "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	defaultProject, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+
+	if strings.TrimSpace(hub.ProjectKey) != HubProjectKey {
+		t.Fatalf("hub key = %q, want %q", hub.ProjectKey, HubProjectKey)
+	}
+	if filepath.Clean(hub.RootPath) == filepath.Clean(defaultProject.RootPath) {
+		t.Fatalf("hub root path collides with default project root: %q", hub.RootPath)
+	}
+
+	expectedHubRoot := filepath.Join(dataDir, "projects", "hub")
+	if filepath.Clean(hub.RootPath) != filepath.Clean(expectedHubRoot) {
+		t.Fatalf("hub root path = %q, want %q", hub.RootPath, expectedHubRoot)
+	}
+}

--- a/internal/web/chat_stt.go
+++ b/internal/web/chat_stt.go
@@ -14,6 +14,7 @@ type sttMessage struct {
 	MimeType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Error    string `json:"error,omitempty"`
+	Reason   string `json:"reason,omitempty"`
 }
 
 func handleSTTStart(conn *chatWSConn, mimeType string) {
@@ -64,19 +65,23 @@ func handleSTTStop(conn *chatWSConn) {
 	conn.sttMu.Unlock()
 
 	if len(buf) < 1024 {
-		_ = conn.writeJSON(sttMessage{Type: "stt_error", Error: "recording too short"})
+		_ = conn.writeJSON(sttMessage{Type: "stt_empty", Reason: "recording_too_short"})
 		return
 	}
 
 	text, err := stt.TranscribeWithVoxType(mimeType, buf)
 	if err != nil {
+		if stt.IsRetryableNoSpeechError(err) {
+			_ = conn.writeJSON(sttMessage{Type: "stt_empty", Reason: "no_speech_detected"})
+			return
+		}
 		log.Printf("stt transcribe error: %v", err)
 		_ = conn.writeJSON(sttMessage{Type: "stt_error", Error: fmt.Sprintf("transcription failed: %v", err)})
 		return
 	}
 	text = strings.TrimSpace(text)
 	if text == "" {
-		_ = conn.writeJSON(sttMessage{Type: "stt_error", Error: "speech recognizer returned empty text"})
+		_ = conn.writeJSON(sttMessage{Type: "stt_empty", Reason: "empty_transcript"})
 		return
 	}
 	_ = conn.writeJSON(sttMessage{Type: "stt_result", Text: text})


### PR DESCRIPTION
## Summary
- Fix silent-mode finalize logic so canvas rendering always happens when content exists
- Reuse active artifact only for safe scratch paths under .tabura/artifacts/tmp; fall back to fresh scratch otherwise
- Keep hub project on its dedicated root path during activation
- Keep voice capture alive on empty or hallucinated STT results
- Show clear error status when mic capture is unavailable
- Restore white-page click and Ctrl PTT routing when canvas viewport is hidden
- Restore PTT reliability for PDF clicks and Ctrl key

## Test plan
- [x] `go test ./...` passes
- [x] `npx playwright test` -- 101/101 passed