### PR TITLE
fix(ui): replace green play indicator with black stop square

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -4207,7 +4207,7 @@ function bindUi() {
       || zenIndicator.classList.contains('is-listening')
     );
     const pointHitsIndicatorChip = (x, y) => {
-      const chips = zenIndicator.querySelectorAll('.zen-record-dot, .zen-play-icon');
+      const chips = zenIndicator.querySelectorAll('.zen-record-dot, .zen-stop-square');
       for (const chip of chips) {
         if (!(chip instanceof HTMLElement)) continue;
         const style = window.getComputedStyle(chip);

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -41,7 +41,7 @@
 
       <div id="zen-indicator" class="zen-indicator" style="display:none">
         <span class="zen-record-dot"></span>
-        <span class="zen-play-icon"></span>
+        <span class="zen-stop-square"></span>
       </div>
 
       <textarea id="zen-input" class="zen-input" style="display:none" rows="1" placeholder=""></textarea>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -602,7 +602,7 @@ body.keyboard-open .zen-indicator.is-listening {
 }
 
 .zen-indicator.is-recording { --cue-frame-color: #d92d20; }
-.zen-indicator.is-working  { --cue-frame-color: #22a846; }
+.zen-indicator.is-working  { --cue-frame-color: #111111; }
 .zen-indicator.is-listening { --cue-frame-color: #2563eb; }
 
 .zen-indicator.is-recording::before,
@@ -619,7 +619,7 @@ body.keyboard-open .zen-indicator.is-listening {
 }
 
 .zen-indicator .zen-record-dot,
-.zen-indicator .zen-play-icon {
+.zen-indicator .zen-stop-square {
   display: none;
   position: absolute;
   top: max(18px, var(--zen-safe-area-top));
@@ -655,20 +655,17 @@ body.keyboard-open .zen-indicator.is-listening {
   animation: zen-listen-pulse 1s ease-out infinite;
 }
 
-.zen-indicator.is-working .zen-play-icon {
+.zen-indicator.is-working .zen-stop-square {
   display: inline-flex;
-  background: transparent;
-  border: none;
-  width: 0;
-  height: 0;
-  border-left: calc(var(--cue-chip-size) * 1.0) solid #22a846;
-  border-top: calc(var(--cue-chip-size) * 0.6) solid transparent;
-  border-bottom: calc(var(--cue-chip-size) * 0.6) solid transparent;
+  width: calc(var(--cue-chip-size) * 0.75);
+  height: calc(var(--cue-chip-size) * 0.75);
+  border-radius: 1px;
+  background: #111111;
 }
 
 @media (max-width: 767px) {
   .zen-indicator .zen-record-dot,
-  .zen-indicator .zen-play-icon {
+  .zen-indicator .zen-stop-square {
     --cue-chip-size: 16px;
     top: max(14px, var(--zen-safe-area-top));
     right: max(14px, var(--zen-safe-area-right));
@@ -682,15 +679,8 @@ body.keyboard-open .zen-indicator.is-listening {
     --cue-frame-color: #111111;
   }
   .zen-indicator .zen-record-dot,
-  .zen-indicator .zen-play-icon {
+  .zen-indicator .zen-stop-square {
     background: #111111;
-    border-color: #111111;
-  }
-  .zen-indicator.is-working .zen-play-icon {
-    background: transparent;
-    border-left-color: #111111;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
   }
   .zen-indicator.is-listening .zen-record-dot {
     box-shadow: 0 0 0 0 rgba(17, 17, 17, 0.65);

--- a/internal/web/static/zen.js
+++ b/internal/web/static/zen.js
@@ -150,7 +150,7 @@ export function showIndicatorMode(mode, x, y) {
   el.style.maxHeight = '';
   el.style.transform = '';
   el.style.translate = '';
-  // Recording dot appears at tap point; play icon stays in top-right (CSS default).
+  // Recording dot appears at tap point; stop square stays in top-right (CSS default).
   const dot = el.querySelector('.zen-record-dot');
   if (dot) {
     if (nextMode === 'recording' && Number.isFinite(x) && Number.isFinite(y)) {

--- a/tests/playwright/artifact-context.spec.ts
+++ b/tests/playwright/artifact-context.spec.ts
@@ -126,7 +126,7 @@ test.describe('zen canvas layout', () => {
 
     const box = await canvasText.boundingBox();
     if (!box) throw new Error('canvas-text not visible');
-    await page.mouse.click(box.x + 20, box.y + 20, { button: 'right' });
+    await page.mouse.click(box.x + 50, box.y + 50, { button: 'right' });
     await page.waitForTimeout(200);
 
     // In zen mode, right-click opens text input

--- a/tests/playwright/chat-harness.html
+++ b/tests/playwright/chat-harness.html
@@ -25,7 +25,7 @@
 
       <div id="zen-indicator" class="zen-indicator" style="display:none">
         <span class="zen-record-dot"></span>
-        <span class="zen-play-icon"></span>
+        <span class="zen-stop-square"></span>
       </div>
 
       <textarea id="zen-input" class="zen-input" style="display:none" rows="1" placeholder=""></textarea>

--- a/tests/playwright/chat-voice-send.spec.ts
+++ b/tests/playwright/chat-voice-send.spec.ts
@@ -254,10 +254,10 @@ test('touch stop indicator routes through shared cancel endpoint', async ({ page
   await page.waitForTimeout(100);
   await expect(page.locator('#chat-history .chat-message.chat-assistant.is-pending')).toHaveCount(1);
 
-  const playIcon = page.locator('.zen-play-icon');
-  await expect(playIcon).toBeVisible();
+  const stopSquare = page.locator('.zen-stop-square');
+  await expect(stopSquare).toBeVisible();
 
-  await tapElement(page, '.zen-play-icon');
+  await tapElement(page, '.zen-stop-square');
   await waitForApiCancel(page);
 
   const log = await getLog(page);
@@ -284,7 +284,7 @@ test('touch stop retries cancel when first cancel reports zero but work remains'
 
   await injectChatEvent(page, { type: 'turn_started', turn_id: 'stop-retry-turn' });
   await page.waitForTimeout(100);
-  await tapElement(page, '.zen-play-icon');
+  await tapElement(page, '.zen-stop-square');
 
   await expect.poll(async () => {
     const log = await getLog(page);
@@ -302,7 +302,7 @@ test('touch stop while sending transcript aborts pending message submit', async 
   await waitForSTTAction(page, 'stop');
   await expect(page.locator('#zen-status')).toContainText('sending');
 
-  await tapElement(page, '.zen-play-icon');
+  await tapElement(page, '.zen-stop-square');
   await waitForApiCancel(page);
   await page.waitForTimeout(1400);
 
@@ -468,8 +468,8 @@ test('Control long-press starts at mouse location and sends artifact line contex
   const canvasText = page.locator('#canvas-text');
   const box = await canvasText.boundingBox();
   if (!box) throw new Error('canvas-text not visible');
-  const x = Math.floor(box.x + 40);
-  const y = Math.floor(box.y + 20);
+  const x = Math.floor(box.x + 50);
+  const y = Math.floor(box.y + 50);
 
   await page.mouse.move(x, y);
   await page.keyboard.down('Control');
@@ -593,14 +593,14 @@ test('recording indicator shows symbol', async ({ page }) => {
   const indicator = page.locator('#zen-indicator');
   await expect(indicator).toBeVisible();
   await expect(page.locator('.zen-record-dot')).toBeVisible();
-  await expect(page.locator('.zen-play-icon')).toBeHidden();
+  await expect(page.locator('.zen-stop-square')).toBeHidden();
 
   // Stop recording and transition to working/play indicator
   await page.mouse.click(400, 400);
   await waitForSTTAction(page, 'stop');
   await page.waitForTimeout(200);
   await expect(indicator).toBeVisible();
-  await expect(page.locator('.zen-play-icon')).toBeVisible();
+  await expect(page.locator('.zen-stop-square')).toBeVisible();
   await expect(page.locator('.zen-record-dot')).toBeHidden();
 });
 

--- a/tests/playwright/zen-canvas.spec.ts
+++ b/tests/playwright/zen-canvas.spec.ts
@@ -176,7 +176,7 @@ test.describe('zen canvas - tabula rasa', () => {
     const indicator = page.locator('#zen-indicator');
     await expect(indicator).toBeVisible();
     await expect(page.locator('.zen-record-dot')).toBeVisible();
-    await expect(page.locator('.zen-play-icon')).toBeHidden();
+    await expect(page.locator('.zen-stop-square')).toBeHidden();
 
     // Wait for recorder to start
     await waitForLogEntry(page, 'recorder', 'start');
@@ -185,7 +185,7 @@ test.describe('zen canvas - tabula rasa', () => {
     await page.mouse.click(400, 400);
     await waitForLogEntry(page, 'stt', 'stop');
     await expect(indicator).toBeVisible();
-    await expect(page.locator('.zen-play-icon')).toBeVisible();
+    await expect(page.locator('.zen-stop-square')).toBeVisible();
     await expect(page.locator('.zen-record-dot')).toBeHidden();
   });
 
@@ -439,7 +439,7 @@ test.describe('zen canvas - TTS voice output', () => {
     // Stop indicator visible, overlay hidden
     const indicator = page.locator('#zen-indicator');
     await expect(indicator).toBeVisible();
-    await expect(page.locator('.zen-play-icon')).toBeVisible();
+    await expect(page.locator('.zen-stop-square')).toBeVisible();
 
     const overlay = page.locator('#zen-overlay');
     await expect(overlay).toBeHidden();
@@ -463,7 +463,7 @@ test.describe('zen canvas - TTS voice output', () => {
     // Indicator stays visible while work is active
     const indicator = page.locator('#zen-indicator');
     await expect(indicator).toBeVisible();
-    await expect(page.locator('.zen-play-icon')).toBeVisible();
+    await expect(page.locator('.zen-stop-square')).toBeVisible();
   });
 
   test('voice response triggers TTS, no overlay', async ({ page }) => {

--- a/tests/playwright/zen-harness.html
+++ b/tests/playwright/zen-harness.html
@@ -29,7 +29,7 @@
 
       <div id="zen-indicator" class="zen-indicator" style="display:none">
         <span class="zen-record-dot"></span>
-        <span class="zen-play-icon"></span>
+        <span class="zen-stop-square"></span>
       </div>
 
       <textarea id="zen-input" class="zen-input" style="display:none" rows="1" placeholder=""></textarea>


### PR DESCRIPTION
## Summary
- Replace green border (`#22a846`) and play triangle with black border (`#111111`) and stop square for working/processing indicator state
- Rename `.zen-play-icon` to `.zen-stop-square` across all source and test files
- Fix two pre-existing test failures where `edge-left-tap` button (30px wide, z-index 430) overlapped canvas click coordinates, causing right-click and Ctrl long-press tests to miss canvas text

## Test plan
- [x] `go test ./...` passes
- [x] `npx playwright test` — 101/101 passed (previously 99/101)