### PR TITLE
fix: Companion Mode: directed-speech gate from transcript context (fixes #129)

### DIFF
--- a/internal/web/companion_gate.go
+++ b/internal/web/companion_gate.go
@@ -1,0 +1,144 @@
+package web
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	companionGateDecisionDisabled     = "disabled"
+	companionGateDecisionDirect       = "direct_address"
+	companionGateDecisionNotAddressed = "not_addressed"
+	companionGateDecisionUncertain    = "uncertain"
+)
+
+type companionDirectedSpeechGate struct {
+	Enabled       bool   `json:"enabled"`
+	Decision      string `json:"decision"`
+	Reason        string `json:"reason"`
+	SessionID     string `json:"session_id,omitempty"`
+	SegmentID     int64  `json:"segment_id,omitempty"`
+	EvaluatedText string `json:"evaluated_text,omitempty"`
+	EvaluatedAt   int64  `json:"evaluated_at,omitempty"`
+	LastEventType string `json:"last_event_type,omitempty"`
+}
+
+var (
+	companionAddressLeadPattern = regexp.MustCompile(`(?i)^(?:hey|ok|okay)\s+(?:tabura|assistant)\b|^(?:tabura|assistant)\b`)
+	companionAddressCuePattern  = regexp.MustCompile(`(?i)\b(?:tabura|assistant)\b[:,!?]`)
+	companionRequestPattern     = regexp.MustCompile(`(?i)\b(?:can|could|would|will)\s+you\b|^(?:please\s+)?(?:summarize|open|show|tell|give|find|write|draft|explain|list|track|remind|create|help)\b|^(?:what|when|where|why|how)\b`)
+)
+
+func (a *App) loadCompanionDirectedSpeechGate(cfg companionConfig, session *store.ParticipantSession) companionDirectedSpeechGate {
+	if !cfg.CompanionEnabled || !cfg.DirectedSpeechGateEnabled {
+		return evaluateCompanionDirectedSpeechGate(cfg, session, nil, nil)
+	}
+	if session == nil {
+		return evaluateCompanionDirectedSpeechGate(cfg, nil, nil, nil)
+	}
+	segments, err := a.store.ListParticipantSegments(session.ID, 0, 0)
+	if err != nil {
+		return companionDirectedSpeechGate{
+			Enabled:   cfg.DirectedSpeechGateEnabled,
+			Decision:  companionGateDecisionUncertain,
+			Reason:    "segment_lookup_failed",
+			SessionID: session.ID,
+		}
+	}
+	events, err := a.store.ListParticipantEvents(session.ID)
+	if err != nil {
+		return companionDirectedSpeechGate{
+			Enabled:   cfg.DirectedSpeechGateEnabled,
+			Decision:  companionGateDecisionUncertain,
+			Reason:    "event_lookup_failed",
+			SessionID: session.ID,
+		}
+	}
+	return evaluateCompanionDirectedSpeechGate(cfg, session, segments, events)
+}
+
+func evaluateCompanionDirectedSpeechGate(cfg companionConfig, session *store.ParticipantSession, segments []store.ParticipantSegment, events []store.ParticipantEvent) companionDirectedSpeechGate {
+	gate := companionDirectedSpeechGate{
+		Enabled:  cfg.DirectedSpeechGateEnabled,
+		Decision: companionGateDecisionUncertain,
+		Reason:   "no_transcript_context",
+	}
+	if !cfg.CompanionEnabled {
+		gate.Decision = companionGateDecisionDisabled
+		gate.Reason = "companion_disabled"
+		return gate
+	}
+	if !cfg.DirectedSpeechGateEnabled {
+		gate.Decision = companionGateDecisionDisabled
+		gate.Reason = "gate_disabled"
+		return gate
+	}
+	if session == nil {
+		return gate
+	}
+	gate.SessionID = session.ID
+	if len(events) > 0 {
+		lastEvent := events[len(events)-1]
+		gate.LastEventType = lastEvent.EventType
+		gate.EvaluatedAt = lastEvent.CreatedAt
+	}
+	latest := latestMeaningfulParticipantSegment(segments)
+	if latest == nil {
+		if gate.LastEventType == "session_started" {
+			gate.Reason = "awaiting_transcript"
+		}
+		return gate
+	}
+	gate.SegmentID = latest.ID
+	gate.EvaluatedText = strings.TrimSpace(latest.Text)
+	if latest.CommittedAt > 0 {
+		gate.EvaluatedAt = latest.CommittedAt
+	}
+	if isCompanionDirectAddress(latest.Text) {
+		gate.Decision = companionGateDecisionDirect
+		gate.Reason = "assistant_name_mentioned"
+		return gate
+	}
+	if isCompanionRequestWithoutDirectAddress(latest.Text) {
+		gate.Reason = "request_without_assistant_name"
+		return gate
+	}
+	gate.Decision = companionGateDecisionNotAddressed
+	gate.Reason = "no_assistant_address_signal"
+	return gate
+}
+
+func latestMeaningfulParticipantSegment(segments []store.ParticipantSegment) *store.ParticipantSegment {
+	for i := len(segments) - 1; i >= 0; i-- {
+		if strings.TrimSpace(segments[i].Text) == "" {
+			continue
+		}
+		return &segments[i]
+	}
+	return nil
+}
+
+func isCompanionDirectAddress(raw string) bool {
+	text := normalizeCompanionGateText(raw)
+	if text == "" {
+		return false
+	}
+	if companionAddressLeadPattern.MatchString(text) || companionAddressCuePattern.MatchString(text) {
+		return true
+	}
+	return companionRequestPattern.MatchString(text) && strings.Contains(text, "tabura")
+}
+
+func isCompanionRequestWithoutDirectAddress(raw string) bool {
+	text := normalizeCompanionGateText(raw)
+	if text == "" || isCompanionDirectAddress(text) {
+		return false
+	}
+	return companionRequestPattern.MatchString(text)
+}
+
+func normalizeCompanionGateText(raw string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(raw))), " ")
+}

--- a/internal/web/companion_gate_test.go
+++ b/internal/web/companion_gate_test.go
@@ -1,0 +1,62 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestEvaluateCompanionDirectedSpeechGate(t *testing.T) {
+	cfg := defaultCompanionConfig()
+	cfg.DirectedSpeechGateEnabled = true
+	session := &store.ParticipantSession{ID: "psess-test", StartedAt: 100}
+	events := []store.ParticipantEvent{{EventType: "segment_committed", CreatedAt: 130}}
+
+	t.Run("direct address", func(t *testing.T) {
+		segments := []store.ParticipantSegment{{ID: 7, Text: "Tabura, summarize the action items.", CommittedAt: 130}}
+		gate := evaluateCompanionDirectedSpeechGate(cfg, session, segments, events)
+		if gate.Decision != companionGateDecisionDirect {
+			t.Fatalf("decision = %q, want %q", gate.Decision, companionGateDecisionDirect)
+		}
+		if gate.Reason != "assistant_name_mentioned" {
+			t.Fatalf("reason = %q, want assistant_name_mentioned", gate.Reason)
+		}
+		if gate.SegmentID != 7 {
+			t.Fatalf("segment_id = %d, want 7", gate.SegmentID)
+		}
+	})
+
+	t.Run("non address", func(t *testing.T) {
+		segments := []store.ParticipantSegment{{ID: 8, Text: "The budget is blocked until finance signs off.", CommittedAt: 130}}
+		gate := evaluateCompanionDirectedSpeechGate(cfg, session, segments, events)
+		if gate.Decision != companionGateDecisionNotAddressed {
+			t.Fatalf("decision = %q, want %q", gate.Decision, companionGateDecisionNotAddressed)
+		}
+		if gate.Reason != "no_assistant_address_signal" {
+			t.Fatalf("reason = %q, want no_assistant_address_signal", gate.Reason)
+		}
+	})
+
+	t.Run("uncertain request", func(t *testing.T) {
+		segments := []store.ParticipantSegment{{ID: 9, Text: "Can you summarize that?", CommittedAt: 130}}
+		gate := evaluateCompanionDirectedSpeechGate(cfg, session, segments, events)
+		if gate.Decision != companionGateDecisionUncertain {
+			t.Fatalf("decision = %q, want %q", gate.Decision, companionGateDecisionUncertain)
+		}
+		if gate.Reason != "request_without_assistant_name" {
+			t.Fatalf("reason = %q, want request_without_assistant_name", gate.Reason)
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		disabled := cfg
+		disabled.DirectedSpeechGateEnabled = false
+		gate := evaluateCompanionDirectedSpeechGate(disabled, session, nil, events)
+		if gate.Decision != companionGateDecisionDisabled {
+			t.Fatalf("decision = %q, want %q", gate.Decision, companionGateDecisionDisabled)
+		}
+		if gate.Reason != "gate_disabled" {
+			t.Fatalf("reason = %q, want gate_disabled", gate.Reason)
+		}
+	})
+}

--- a/internal/web/projects_companion.go
+++ b/internal/web/projects_companion.go
@@ -19,54 +19,58 @@ const (
 )
 
 type companionConfig struct {
-	CompanionEnabled     bool   `json:"companion_enabled"`
-	Language             string `json:"language"`
-	MaxSegmentDurationMS int    `json:"max_segment_duration_ms"`
-	SessionRAMCapMB      int    `json:"session_ram_cap_mb"`
-	STTModel             string `json:"stt_model"`
-	IdleSurface          string `json:"idle_surface"`
-	AudioPersistence     string `json:"audio_persistence"`
-	CaptureSource        string `json:"capture_source"`
+	CompanionEnabled          bool   `json:"companion_enabled"`
+	DirectedSpeechGateEnabled bool   `json:"directed_speech_gate_enabled"`
+	Language                  string `json:"language"`
+	MaxSegmentDurationMS      int    `json:"max_segment_duration_ms"`
+	SessionRAMCapMB           int    `json:"session_ram_cap_mb"`
+	STTModel                  string `json:"stt_model"`
+	IdleSurface               string `json:"idle_surface"`
+	AudioPersistence          string `json:"audio_persistence"`
+	CaptureSource             string `json:"capture_source"`
 }
 
 type participantConfig = companionConfig
 
 type companionConfigPatch struct {
-	CompanionEnabled     *bool   `json:"companion_enabled"`
-	Language             *string `json:"language"`
-	MaxSegmentDurationMS *int    `json:"max_segment_duration_ms"`
-	SessionRAMCapMB      *int    `json:"session_ram_cap_mb"`
-	STTModel             *string `json:"stt_model"`
-	IdleSurface          *string `json:"idle_surface"`
-	AudioPersistence     *string `json:"audio_persistence"`
-	CaptureSource        *string `json:"capture_source"`
+	CompanionEnabled          *bool   `json:"companion_enabled"`
+	DirectedSpeechGateEnabled *bool   `json:"directed_speech_gate_enabled"`
+	Language                  *string `json:"language"`
+	MaxSegmentDurationMS      *int    `json:"max_segment_duration_ms"`
+	SessionRAMCapMB           *int    `json:"session_ram_cap_mb"`
+	STTModel                  *string `json:"stt_model"`
+	IdleSurface               *string `json:"idle_surface"`
+	AudioPersistence          *string `json:"audio_persistence"`
+	CaptureSource             *string `json:"capture_source"`
 }
 
 type companionStateResponse struct {
-	OK               bool                      `json:"ok"`
-	ProjectID        string                    `json:"project_id"`
-	ProjectKey       string                    `json:"project_key"`
-	State            string                    `json:"state"`
-	CompanionEnabled bool                      `json:"companion_enabled"`
-	IdleSurface      string                    `json:"idle_surface"`
-	AudioPersistence string                    `json:"audio_persistence"`
-	CaptureSource    string                    `json:"capture_source"`
-	ActiveSessions   int                       `json:"active_sessions"`
-	ActiveSessionID  string                    `json:"active_session_id,omitempty"`
-	LatestSession    *store.ParticipantSession `json:"latest_session,omitempty"`
-	Config           companionConfig           `json:"config"`
+	OK                 bool                        `json:"ok"`
+	ProjectID          string                      `json:"project_id"`
+	ProjectKey         string                      `json:"project_key"`
+	State              string                      `json:"state"`
+	CompanionEnabled   bool                        `json:"companion_enabled"`
+	IdleSurface        string                      `json:"idle_surface"`
+	AudioPersistence   string                      `json:"audio_persistence"`
+	CaptureSource      string                      `json:"capture_source"`
+	ActiveSessions     int                         `json:"active_sessions"`
+	ActiveSessionID    string                      `json:"active_session_id,omitempty"`
+	LatestSession      *store.ParticipantSession   `json:"latest_session,omitempty"`
+	DirectedSpeechGate companionDirectedSpeechGate `json:"directed_speech_gate"`
+	Config             companionConfig             `json:"config"`
 }
 
 func defaultCompanionConfig() companionConfig {
 	return companionConfig{
-		CompanionEnabled:     true,
-		Language:             "en",
-		MaxSegmentDurationMS: 30000,
-		SessionRAMCapMB:      64,
-		STTModel:             "whisper-1",
-		IdleSurface:          companionIdleSurfaceRobot,
-		AudioPersistence:     companionAudioPersistenceNone,
-		CaptureSource:        companionCaptureSourceMic,
+		CompanionEnabled:          true,
+		DirectedSpeechGateEnabled: false,
+		Language:                  "en",
+		MaxSegmentDurationMS:      30000,
+		SessionRAMCapMB:           64,
+		STTModel:                  "whisper-1",
+		IdleSurface:               companionIdleSurfaceRobot,
+		AudioPersistence:          companionAudioPersistenceNone,
+		CaptureSource:             companionCaptureSourceMic,
 	}
 }
 
@@ -82,6 +86,7 @@ func normalizeCompanionIdleSurface(raw string) string {
 func normalizeCompanionConfig(cfg companionConfig) companionConfig {
 	normalized := defaultCompanionConfig()
 	normalized.CompanionEnabled = cfg.CompanionEnabled
+	normalized.DirectedSpeechGateEnabled = cfg.DirectedSpeechGateEnabled
 	if language := strings.TrimSpace(cfg.Language); language != "" {
 		normalized.Language = language
 	}
@@ -103,6 +108,9 @@ func normalizeCompanionConfig(cfg companionConfig) companionConfig {
 func applyCompanionConfigPatch(cfg companionConfig, patch companionConfigPatch) companionConfig {
 	if patch.CompanionEnabled != nil {
 		cfg.CompanionEnabled = *patch.CompanionEnabled
+	}
+	if patch.DirectedSpeechGateEnabled != nil {
+		cfg.DirectedSpeechGateEnabled = *patch.DirectedSpeechGateEnabled
 	}
 	if patch.Language != nil {
 		cfg.Language = strings.TrimSpace(*patch.Language)
@@ -286,6 +294,7 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 	activeSessions := 0
 	activeSessionID := ""
 	var latestSession *store.ParticipantSession
+	var gateSession *store.ParticipantSession
 	for i := range sessions {
 		if latestSession == nil {
 			latestSession = &sessions[i]
@@ -296,24 +305,30 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 		activeSessions++
 		if activeSessionID == "" {
 			activeSessionID = sessions[i].ID
+			gateSession = &sessions[i]
 		}
+	}
+	if gateSession == nil {
+		gateSession = latestSession
 	}
 	state := companionRuntimeStateIdle
 	if activeSessions > 0 {
 		state = companionRuntimeStateListening
 	}
+	gate := a.loadCompanionDirectedSpeechGate(cfg, gateSession)
 	writeJSON(w, companionStateResponse{
-		OK:               true,
-		ProjectID:        project.ID,
-		ProjectKey:       project.ProjectKey,
-		State:            state,
-		CompanionEnabled: cfg.CompanionEnabled,
-		IdleSurface:      cfg.IdleSurface,
-		AudioPersistence: cfg.AudioPersistence,
-		CaptureSource:    cfg.CaptureSource,
-		ActiveSessions:   activeSessions,
-		ActiveSessionID:  activeSessionID,
-		LatestSession:    latestSession,
-		Config:           cfg,
+		OK:                 true,
+		ProjectID:          project.ID,
+		ProjectKey:         project.ProjectKey,
+		State:              state,
+		CompanionEnabled:   cfg.CompanionEnabled,
+		IdleSurface:        cfg.IdleSurface,
+		AudioPersistence:   cfg.AudioPersistence,
+		CaptureSource:      cfg.CaptureSource,
+		ActiveSessions:     activeSessions,
+		ActiveSessionID:    activeSessionID,
+		LatestSession:      latestSession,
+		DirectedSpeechGate: gate,
+		Config:             cfg,
 	})
 }

--- a/internal/web/projects_companion_test.go
+++ b/internal/web/projects_companion_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
 )
 
 func TestProjectCompanionConfigRequiresAuth(t *testing.T) {
@@ -39,14 +41,15 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	}
 
 	rrPut := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/projects/"+project.ID+"/companion/config", map[string]any{
-		"companion_enabled":       false,
-		"language":                "de",
-		"max_segment_duration_ms": 45000,
-		"session_ram_cap_mb":      96,
-		"stt_model":               "whisper-large-v3",
-		"idle_surface":            "black",
-		"audio_persistence":       "disk",
-		"capture_source":          "desktop",
+		"companion_enabled":            false,
+		"directed_speech_gate_enabled": true,
+		"language":                     "de",
+		"max_segment_duration_ms":      45000,
+		"session_ram_cap_mb":           96,
+		"stt_model":                    "whisper-large-v3",
+		"idle_surface":                 "black",
+		"audio_persistence":            "disk",
+		"capture_source":               "desktop",
 	})
 	if rrPut.Code != http.StatusOK {
 		t.Fatalf("PUT status = %d, want 200", rrPut.Code)
@@ -57,6 +60,9 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	}
 	if cfg.CompanionEnabled {
 		t.Fatal("companion_enabled = true, want false")
+	}
+	if !cfg.DirectedSpeechGateEnabled {
+		t.Fatal("directed_speech_gate_enabled = false, want true")
 	}
 	if cfg.Language != "de" {
 		t.Fatalf("language = %q, want de", cfg.Language)
@@ -117,5 +123,76 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	}
 	if state.Config.CompanionEnabled {
 		t.Fatal("state config companion_enabled = true, want false")
+	}
+	if state.DirectedSpeechGate.Enabled != cfg.DirectedSpeechGateEnabled {
+		t.Fatalf("state directed_speech_gate.enabled = %v, want %v", state.DirectedSpeechGate.Enabled, cfg.DirectedSpeechGateEnabled)
+	}
+	if state.DirectedSpeechGate.Decision != companionGateDecisionDisabled {
+		t.Fatalf("state directed_speech_gate.decision = %q, want %q", state.DirectedSpeechGate.Decision, companionGateDecisionDisabled)
+	}
+	if state.DirectedSpeechGate.Reason != "companion_disabled" {
+		t.Fatalf("state directed_speech_gate.reason = %q, want companion_disabled", state.DirectedSpeechGate.Reason)
+	}
+}
+
+func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	sess, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(sess.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("AddParticipantEvent session_started: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   sess.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Tabura, open the companion transcript.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("AddParticipantSegment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(sess.ID, seg.ID, "segment_committed", `{"text":"Tabura, open the companion transcript."}`); err != nil {
+		t.Fatalf("AddParticipantEvent segment_committed: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/companion/state", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET state status = %d, want 200", rr.Code)
+	}
+	var state companionStateResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &state); err != nil {
+		t.Fatalf("decode companion state: %v", err)
+	}
+	if state.DirectedSpeechGate.Decision != companionGateDecisionDirect {
+		t.Fatalf("directed_speech_gate.decision = %q, want %q", state.DirectedSpeechGate.Decision, companionGateDecisionDirect)
+	}
+	if state.DirectedSpeechGate.Reason != "assistant_name_mentioned" {
+		t.Fatalf("directed_speech_gate.reason = %q, want assistant_name_mentioned", state.DirectedSpeechGate.Reason)
+	}
+	if state.DirectedSpeechGate.SessionID != sess.ID {
+		t.Fatalf("directed_speech_gate.session_id = %q, want %q", state.DirectedSpeechGate.SessionID, sess.ID)
+	}
+	if state.DirectedSpeechGate.SegmentID != seg.ID {
+		t.Fatalf("directed_speech_gate.segment_id = %d, want %d", state.DirectedSpeechGate.SegmentID, seg.ID)
+	}
+	if state.DirectedSpeechGate.LastEventType != "segment_committed" {
+		t.Fatalf("directed_speech_gate.last_event_type = %q, want segment_committed", state.DirectedSpeechGate.LastEventType)
+	}
+	if state.DirectedSpeechGate.EvaluatedText != "Tabura, open the companion transcript." {
+		t.Fatalf("directed_speech_gate.evaluated_text = %q", state.DirectedSpeechGate.EvaluatedText)
 	}
 }


### PR DESCRIPTION
## Summary
- add an optional companion directed-speech gate config and state payload
- evaluate transcript text plus participant session events for deterministic gate decisions
- cover direct-address, non-address, uncertain, and disabled paths with focused tests

## Verification
- Optional gate and useful off-mode:
  - Command: `go test ./internal/web/... 2>&1 | tee /tmp/tabura-issue-129-test.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web  1.879s`
  - Evidence: `TestProjectCompanionConfigPutAndState` verifies `directed_speech_gate_enabled` round-trips and `/api/projects/{id}/companion/state` reports `decision=disabled` with `reason=companion_disabled` when Companion Mode itself is off.
- Deterministic gate state and reason metadata:
  - Command: `go test ./internal/web/... 2>&1 | tee /tmp/tabura-issue-129-test.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web  1.879s`
  - Evidence: `TestProjectCompanionStateExposesDirectedSpeechGateMetadata` verifies `decision`, `reason`, `session_id`, `segment_id`, `last_event_type`, and `evaluated_text` in the state API.
- Direct-address, non-address, and uncertain cases:
  - Command: `go test ./internal/web/... 2>&1 | tee /tmp/tabura-issue-129-test.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web  1.879s`
  - Evidence: `TestEvaluateCompanionDirectedSpeechGate` covers `direct_address`, `not_addressed`, `uncertain`, and disabled evaluations.
- No persisted audio dependency:
  - Command: `go test ./internal/web/... 2>&1 | tee /tmp/tabura-issue-129-test.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web  1.879s`
  - Evidence: gate evaluation reads only participant transcript segments and participant events; the same package run includes privacy coverage such as `TestPrivacyParticipantConfigNeverStoresAudioPersistence`.