### PR TITLE
fix: Companion Mode: assistant response execution from transcript (fixes #130)

### DIFF
--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -131,6 +131,7 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 	}
 
 	_ = a.store.AddParticipantEvent(sessionID, seg.ID, "segment_committed", fmt.Sprintf(`{"text":%q}`, text))
+	a.maybeTriggerCompanionResponse(sessionID, seg)
 
 	_ = conn.writeJSON(participantMessage{
 		Type:      "participant_segment_text",
@@ -141,6 +142,89 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 		EndTS:     seg.EndTS,
 		LatencyMS: latencyMS,
 	})
+}
+
+func (a *App) maybeTriggerCompanionResponse(participantSessionID string, seg store.ParticipantSegment) {
+	if a == nil || a.store == nil || seg.ID == 0 {
+		return
+	}
+	session, err := a.store.GetParticipantSession(participantSessionID)
+	if err != nil {
+		log.Printf("participant trigger session lookup error: %v", err)
+		return
+	}
+	project, err := a.store.GetProjectByProjectKey(session.ProjectKey)
+	if err != nil {
+		log.Printf("participant trigger project lookup error: %v", err)
+		return
+	}
+	cfg := a.loadCompanionConfig(project)
+	if !cfg.CompanionEnabled || !cfg.DirectedSpeechGateEnabled {
+		return
+	}
+	segments, err := a.store.ListParticipantSegments(participantSessionID, 0, 0)
+	if err != nil {
+		log.Printf("participant trigger segment lookup error: %v", err)
+		return
+	}
+	events, err := a.store.ListParticipantEvents(participantSessionID)
+	if err != nil {
+		log.Printf("participant trigger event lookup error: %v", err)
+		return
+	}
+	if participantSegmentAlreadyTriggered(events, seg.ID) {
+		return
+	}
+	gate := evaluateCompanionDirectedSpeechGate(cfg, &session, segments, events)
+	if gate.Decision != companionGateDecisionDirect || gate.SegmentID != seg.ID {
+		return
+	}
+	text := strings.TrimSpace(seg.Text)
+	if text == "" {
+		return
+	}
+	chatSession, err := a.store.GetOrCreateChatSession(session.ProjectKey)
+	if err != nil {
+		log.Printf("participant trigger chat session error: %v", err)
+		return
+	}
+	storedUser, err := a.store.AddChatMessage(chatSession.ID, "user", text, text, "text")
+	if err != nil {
+		log.Printf("participant trigger chat message error: %v", err)
+		return
+	}
+	outputMode := turnOutputModeVoice
+	if a.silentModeEnabled() {
+		outputMode = turnOutputModeSilent
+	}
+	queuedTurns := a.enqueueAssistantTurn(chatSession.ID, outputMode)
+	_ = a.store.AddParticipantEvent(
+		participantSessionID,
+		seg.ID,
+		"assistant_triggered",
+		fmt.Sprintf(`{"chat_session_id":%q,"chat_message_id":%d,"queued_turns":%d}`, chatSession.ID, storedUser.ID, queuedTurns),
+	)
+	a.broadcastChatEvent(chatSession.ID, map[string]interface{}{
+		"type":                   "message_accepted",
+		"role":                   "user",
+		"content":                text,
+		"id":                     storedUser.ID,
+		"source":                 "participant_transcript",
+		"participant_session_id": participantSessionID,
+		"participant_segment_id": seg.ID,
+	})
+}
+
+func participantSegmentAlreadyTriggered(events []store.ParticipantEvent, segmentID int64) bool {
+	for _, event := range events {
+		if event.SegmentID != segmentID {
+			continue
+		}
+		if event.EventType == "assistant_triggered" {
+			return true
+		}
+	}
+	return false
 }
 
 func releaseParticipantSession(a *App, conn *chatWSConn) (string, bool) {

--- a/internal/web/companion_response_trigger_test.go
+++ b/internal/web/companion_response_trigger_test.go
@@ -1,0 +1,401 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/krystophny/tabura/internal/appserver"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func newCompanionAppServerClient(t *testing.T, assistantMessage string) *appserver.Client {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("decode message: %v", err)
+			}
+			switch strings.TrimSpace(msg["method"].(string)) {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id":     msg["id"],
+					"result": map[string]interface{}{"userAgent": "test-client"},
+				})
+			case "initialized":
+			case "thread/start":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"thread": map[string]interface{}{"id": "thread-companion"},
+					},
+				})
+			case "turn/start":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-companion"},
+					},
+				})
+				_ = conn.WriteJSON(map[string]interface{}{
+					"method": "item/completed",
+					"params": map[string]interface{}{
+						"item": map[string]interface{}{
+							"type": "agentMessage",
+							"text": assistantMessage,
+						},
+					},
+				})
+				_ = conn.WriteJSON(map[string]interface{}{
+					"method": "turn/completed",
+					"params": map[string]interface{}{
+						"turn": map[string]interface{}{
+							"id":     "turn-companion",
+							"status": "completed",
+						},
+					},
+				})
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, err := appserver.NewClient(wsURL)
+	if err != nil {
+		t.Fatalf("new appserver client: %v", err)
+	}
+	return client
+}
+
+func waitForAssistantMessage(t *testing.T, app *App, sessionID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := latestAssistantMessage(t, app, sessionID); got == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for assistant message %q", want)
+}
+
+func TestCompanionResponseTriggerExecutesAssistantTurn(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "Companion reply.")
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Tabura, tell me something helpful.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Tabura, tell me something helpful."}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	waitForAssistantMessage(t, app, chatSession.ID, "Companion reply.")
+
+	messages, err := app.store.ListChatMessages(chatSession.ID, 10)
+	if err != nil {
+		t.Fatalf("list chat messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("chat message count = %d, want 2", len(messages))
+	}
+	if strings.TrimSpace(messages[0].Role) != "user" {
+		t.Fatalf("first message role = %q, want user", messages[0].Role)
+	}
+	if strings.TrimSpace(messages[0].ContentPlain) != "Tabura, tell me something helpful." {
+		t.Fatalf("first message text = %q", messages[0].ContentPlain)
+	}
+	if strings.TrimSpace(messages[1].Role) != "assistant" {
+		t.Fatalf("second message role = %q, want assistant", messages[1].Role)
+	}
+
+	events, err := app.store.ListParticipantEvents(participantSession.ID)
+	if err != nil {
+		t.Fatalf("list participant events: %v", err)
+	}
+	foundTrigger := false
+	for _, event := range events {
+		if event.SegmentID == seg.ID && event.EventType == "assistant_triggered" {
+			foundTrigger = true
+			break
+		}
+	}
+	if !foundTrigger {
+		t.Fatal("expected assistant_triggered participant event")
+	}
+}
+
+func TestCompanionResponseTriggerSkipsWhenCompanionDisabled(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "unexpected reply")
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = false
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Tabura, tell me something helpful.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Tabura, tell me something helpful."}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	messages, err := app.store.ListChatMessages(chatSession.ID, 10)
+	if err != nil {
+		t.Fatalf("list chat messages: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("chat message count = %d, want 0", len(messages))
+	}
+}
+
+func TestCompanionResponseTriggerSkipsFalseTriggerTranscript(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "unexpected reply")
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Please summarize the meeting.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Please summarize the meeting."}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	messages, err := app.store.ListChatMessages(chatSession.ID, 10)
+	if err != nil {
+		t.Fatalf("list chat messages: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("chat message count = %d, want 0", len(messages))
+	}
+	events, err := app.store.ListParticipantEvents(participantSession.ID)
+	if err != nil {
+		t.Fatalf("list participant events: %v", err)
+	}
+	for _, event := range events {
+		if event.SegmentID == seg.ID && event.EventType == "assistant_triggered" {
+			t.Fatal("did not expect assistant_triggered participant event")
+		}
+	}
+}
+
+func TestCompanionResponseTriggerUsesSilentModeOutputQueue(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "Silent companion reply.")
+	if err := app.setSilentModeEnabled(true); err != nil {
+		t.Fatalf("set silent mode: %v", err)
+	}
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Tabura, tell me something helpful.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Tabura, tell me something helpful."}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	waitForAssistantMessage(t, app, chatSession.ID, "Silent companion reply.")
+	if queued := app.queuedChatTurnCount(chatSession.ID); queued != 0 {
+		t.Fatalf("queued chat turns = %d, want 0", queued)
+	}
+}
+
+func TestCompanionResponseTriggerDoesNotDuplicateSegment(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "Companion reply.")
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Text:        "Tabura, tell me something helpful.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Tabura, tell me something helpful."}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	waitForAssistantMessage(t, app, chatSession.ID, "Companion reply.")
+
+	messages, err := app.store.ListChatMessages(chatSession.ID, 10)
+	if err != nil {
+		t.Fatalf("list chat messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("chat message count = %d, want 2", len(messages))
+	}
+}


### PR DESCRIPTION
## Summary
- trigger companion chat turns from newly committed participant transcript segments
- reuse the existing project chat session queue so transcript-triggered responses obey the normal single-run turn flow
- record an `assistant_triggered` participant event and add focused coverage for enabled, disabled, false-trigger, silent-mode, and dedupe paths

## Verification
- Requirement: responses trigger from transcript and event context only. Evidence: `internal/web/chat_participant.go` now calls `maybeTriggerCompanionResponse` immediately after `segment_committed`, evaluates the directed-speech gate from stored participant segments and events, and only enqueues when the latest committed segment is a direct address.
- Requirement: enabled path executes a response. Evidence: `TestCompanionResponseTriggerExecutesAssistantTurn` stores a direct-address transcript segment, verifies the project chat session gets the transcript as a user message, waits for the assistant reply, and checks that an `assistant_triggered` participant event was recorded.
- Requirement: disabled and false-trigger paths stay quiet. Evidence: `TestCompanionResponseTriggerSkipsWhenCompanionDisabled` and `TestCompanionResponseTriggerSkipsFalseTriggerTranscript` both verify that no chat messages are created and no `assistant_triggered` event is written.
- Requirement: transcript-triggered work stays on the normal queue. Evidence: the trigger path uses `enqueueAssistantTurn`, and `TestCompanionResponseTriggerUsesSilentModeOutputQueue` verifies the response completes through the queued chat-turn flow.
- Requirement: no audio persistence regression. Evidence: targeted verification included `TestPrivacyParticipantConfigNeverStoresAudioPersistence`, and the trigger path only stores text chat plus participant event metadata.
- Command: `go test ./internal/web -run 'TestCompanionResponseTrigger|TestPrivacyParticipantConfigNeverStoresAudioPersistence|TestProjectCompanionStateExposesDirectedSpeechGateMetadata' 2>&1 | tee /tmp/tabura-issue-130-test.log`
- Output excerpt: `ok   github.com/krystophny/tabura/internal/web  0.123s`
