### PR TITLE
fix: single active run per project and Hub monitor (fixes #133)

### DIFF
--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -221,13 +221,14 @@ func (a *App) handleChatSessionActivity(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
-	activeTurns := a.activeChatTurnCount(sessionID)
-	queuedTurns := a.queuedChatTurnCount(sessionID)
+	state := a.projectRunStateForSession(sessionID)
 	writeJSON(w, map[string]interface{}{
-		"ok":           true,
-		"active_turns": activeTurns,
-		"queued_turns": queuedTurns,
-		"is_working":   activeTurns > 0 || queuedTurns > 0,
+		"ok":             true,
+		"active_turns":   state.ActiveTurns,
+		"queued_turns":   state.QueuedTurns,
+		"is_working":     state.IsWorking,
+		"status":         state.Status,
+		"active_turn_id": state.ActiveTurnID,
 	})
 }
 

--- a/internal/web/chat_cancel_test.go
+++ b/internal/web/chat_cancel_test.go
@@ -424,11 +424,23 @@ func TestHandleChatSessionActivityReportsActiveTurns(t *testing.T) {
 		t.Fatalf("create chat session: %v", err)
 	}
 
-	app.registerActiveChatTurn(session.ID, "run-1", func() {})
+	firstCanceled := make(chan struct{}, 1)
+	app.registerActiveChatTurn(session.ID, "run-1", func() {
+		select {
+		case firstCanceled <- struct{}{}:
+		default:
+		}
+	})
 	app.registerActiveChatTurn(session.ID, "run-2", func() {})
 	app.turns.mu.Lock()
 	app.turns.queue[session.ID] = 3
 	app.turns.mu.Unlock()
+
+	select {
+	case <-firstCanceled:
+	default:
+		t.Fatal("expected replaced active turn to be canceled")
+	}
 
 	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/chat/sessions/"+session.ID+"/activity", map[string]any{})
 	if rr.Code != http.StatusOK {
@@ -439,11 +451,17 @@ func TestHandleChatSessionActivityReportsActiveTurns(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if got := intFromAny(payload["active_turns"], -1); got != 2 {
-		t.Fatalf("expected active_turns=2, got %v", payload["active_turns"])
+	if got := intFromAny(payload["active_turns"], -1); got != 1 {
+		t.Fatalf("expected active_turns=1, got %v", payload["active_turns"])
 	}
 	if got := intFromAny(payload["queued_turns"], -1); got != 3 {
 		t.Fatalf("expected queued_turns=3, got %v", payload["queued_turns"])
+	}
+	if got := strFromAny(payload["active_turn_id"]); got != "run-2" {
+		t.Fatalf("expected active_turn_id=run-2, got %q", got)
+	}
+	if got := strFromAny(payload["status"]); got != "running" {
+		t.Fatalf("expected status=running, got %q", got)
 	}
 }
 

--- a/internal/web/chat_queue.go
+++ b/internal/web/chat_queue.go
@@ -13,16 +13,21 @@ import (
 
 type chatTurnTracker struct {
 	mu         sync.Mutex
-	cancel     map[string]map[string]context.CancelFunc
+	active     map[string]activeChatTurn
 	queue      map[string]int
 	outputMode map[string][]string
 	localOnly  map[string][]bool
 	worker     map[string]bool
 }
 
+type activeChatTurn struct {
+	runID  string
+	cancel context.CancelFunc
+}
+
 func newChatTurnTracker() *chatTurnTracker {
 	return &chatTurnTracker{
-		cancel:     map[string]map[string]context.CancelFunc{},
+		active:     map[string]activeChatTurn{},
 		queue:      map[string]int{},
 		outputMode: map[string][]string{},
 		localOnly:  map[string][]bool{},
@@ -32,53 +37,52 @@ func newChatTurnTracker() *chatTurnTracker {
 
 func (t *chatTurnTracker) register(sessionID, runID string, cancelFn context.CancelFunc) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.cancel[sessionID] == nil {
-		t.cancel[sessionID] = map[string]context.CancelFunc{}
+	previous, hadPrevious := t.active[sessionID]
+	t.active[sessionID] = activeChatTurn{
+		runID:  runID,
+		cancel: cancelFn,
 	}
-	t.cancel[sessionID][runID] = cancelFn
+	t.mu.Unlock()
+	if hadPrevious && previous.runID != runID && previous.cancel != nil {
+		previous.cancel()
+	}
 }
 
 func (t *chatTurnTracker) unregister(sessionID, runID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	runs := t.cancel[sessionID]
-	if runs == nil {
+	current, ok := t.active[sessionID]
+	if !ok {
 		return
 	}
-	delete(runs, runID)
-	if len(runs) == 0 {
-		delete(t.cancel, sessionID)
+	if current.runID == runID {
+		delete(t.active, sessionID)
 	}
 }
 
 func (t *chatTurnTracker) cancelActive(sessionID string) int {
 	t.mu.Lock()
-	runs := t.cancel[sessionID]
-	if len(runs) == 0 {
+	current, ok := t.active[sessionID]
+	if !ok {
 		t.mu.Unlock()
 		return 0
 	}
-	cancels := make([]context.CancelFunc, 0, len(runs))
-	for _, fn := range runs {
-		cancels = append(cancels, fn)
-	}
-	delete(t.cancel, sessionID)
+	delete(t.active, sessionID)
 	t.mu.Unlock()
-	for _, fn := range cancels {
-		fn()
+	if current.cancel != nil {
+		current.cancel()
 	}
-	return len(cancels)
+	return 1
 }
 
 func (t *chatTurnTracker) cancelAll() {
 	t.mu.Lock()
-	all := t.cancel
-	t.cancel = map[string]map[string]context.CancelFunc{}
+	all := t.active
+	t.active = map[string]activeChatTurn{}
 	t.mu.Unlock()
-	for _, runs := range all {
-		for _, fn := range runs {
-			fn()
+	for _, run := range all {
+		if run.cancel != nil {
+			run.cancel()
 		}
 	}
 }
@@ -89,13 +93,23 @@ func (t *chatTurnTracker) clearQueued(sessionID string) int {
 	queued := t.queue[sessionID]
 	delete(t.queue, sessionID)
 	delete(t.outputMode, sessionID)
+	delete(t.localOnly, sessionID)
 	return queued
 }
 
 func (t *chatTurnTracker) activeCount(sessionID string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return len(t.cancel[sessionID])
+	if _, ok := t.active[sessionID]; ok {
+		return 1
+	}
+	return 0
+}
+
+func (t *chatTurnTracker) activeRunID(sessionID string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.active[sessionID].runID
 }
 
 func (t *chatTurnTracker) queuedCount(sessionID string) int {
@@ -173,6 +187,33 @@ func (t *chatTurnTracker) markIdleIfEmpty(sessionID string) bool {
 type dequeuedTurn struct {
 	outputMode string
 	localOnly  bool
+}
+
+type projectRunState struct {
+	ActiveTurns  int    `json:"active_turns"`
+	QueuedTurns  int    `json:"queued_turns"`
+	IsWorking    bool   `json:"is_working"`
+	Status       string `json:"status"`
+	ActiveTurnID string `json:"active_turn_id,omitempty"`
+}
+
+func newProjectRunState(activeTurns, queuedTurns int, activeTurnID string) projectRunState {
+	state := projectRunState{
+		ActiveTurns: activeTurns,
+		QueuedTurns: queuedTurns,
+		IsWorking:   activeTurns > 0 || queuedTurns > 0,
+		Status:      "idle",
+	}
+	if activeTurns > 0 {
+		state.Status = "running"
+	}
+	if activeTurns == 0 && queuedTurns > 0 {
+		state.Status = "queued"
+	}
+	if activeTurns > 0 {
+		state.ActiveTurnID = strings.TrimSpace(activeTurnID)
+	}
+	return state
 }
 
 func (a *App) registerActiveChatTurn(sessionID, runID string, cancel context.CancelFunc) {
@@ -293,8 +334,18 @@ func (a *App) activeChatTurnCount(sessionID string) int {
 	return a.turns.activeCount(sessionID)
 }
 
+func (a *App) activeChatTurnID(sessionID string) string {
+	return a.turns.activeRunID(sessionID)
+}
+
 func (a *App) queuedChatTurnCount(sessionID string) int {
 	return a.turns.queuedCount(sessionID)
+}
+
+func (a *App) projectRunStateForSession(sessionID string) projectRunState {
+	activeTurns := a.activeChatTurnCount(sessionID)
+	queuedTurns := a.queuedChatTurnCount(sessionID)
+	return newProjectRunState(activeTurns, queuedTurns, a.activeChatTurnID(sessionID))
 }
 
 func (a *App) enqueueAssistantTurn(sessionID, outputMode string, opts ...bool) int {

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -31,18 +31,19 @@ type projectCreateRequest struct {
 }
 
 type projectAPIModel struct {
-	ID                       string `json:"id"`
-	Name                     string `json:"name"`
-	Kind                     string `json:"kind"`
-	RootPath                 string `json:"root_path"`
-	ProjectKey               string `json:"project_key"`
-	MCPURL                   string `json:"mcp_url,omitempty"`
-	IsDefault                bool   `json:"is_default"`
-	ChatSessionID            string `json:"chat_session_id"`
-	ChatMode                 string `json:"chat_mode"`
-	ChatModel                string `json:"chat_model"`
-	ChatModelReasoningEffort string `json:"chat_model_reasoning_effort"`
-	CanvasSessionID          string `json:"canvas_session_id"`
+	ID                       string          `json:"id"`
+	Name                     string          `json:"name"`
+	Kind                     string          `json:"kind"`
+	RootPath                 string          `json:"root_path"`
+	ProjectKey               string          `json:"project_key"`
+	MCPURL                   string          `json:"mcp_url,omitempty"`
+	IsDefault                bool            `json:"is_default"`
+	ChatSessionID            string          `json:"chat_session_id"`
+	ChatMode                 string          `json:"chat_mode"`
+	ChatModel                string          `json:"chat_model"`
+	ChatModelReasoningEffort string          `json:"chat_model_reasoning_effort"`
+	CanvasSessionID          string          `json:"canvas_session_id"`
+	RunState                 projectRunState `json:"run_state"`
 }
 
 type projectChatModelRequest struct {
@@ -86,6 +87,15 @@ type projectWelcomeResponse struct {
 	Scope     string                  `json:"scope"`
 	Title     string                  `json:"title"`
 	Sections  []projectWelcomeSection `json:"sections"`
+}
+
+type projectActivityItem struct {
+	ProjectID     string          `json:"project_id"`
+	ProjectKey    string          `json:"project_key"`
+	Name          string          `json:"name"`
+	Kind          string          `json:"kind"`
+	ChatSessionID string          `json:"chat_session_id"`
+	RunState      projectRunState `json:"run_state"`
 }
 
 func normalizeProjectKindInput(kind, path string) string {
@@ -320,6 +330,22 @@ func (a *App) buildProjectAPIModel(project store.Project) (projectAPIModel, erro
 		ChatModel:                alias,
 		ChatModelReasoningEffort: effort,
 		CanvasSessionID:          a.canvasSessionIDForProject(project),
+		RunState:                 a.projectRunStateForSession(session.ID),
+	}, nil
+}
+
+func (a *App) buildProjectActivityItem(project store.Project) (projectActivityItem, error) {
+	session, err := a.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		return projectActivityItem{}, err
+	}
+	return projectActivityItem{
+		ProjectID:     project.ID,
+		ProjectKey:    project.ProjectKey,
+		Name:          project.Name,
+		Kind:          project.Kind,
+		ChatSessionID: session.ID,
+		RunState:      a.projectRunStateForSession(session.ID),
 	}, nil
 }
 
@@ -351,6 +377,30 @@ func (a *App) handleProjectsList(w http.ResponseWriter, r *http.Request) {
 		"default_project_id": defaultProject.ID,
 		"active_project_id":  activeProject.ID,
 		"projects":           items,
+	})
+}
+
+func (a *App) handleProjectsActivity(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	projects, _, err := a.listProjectsWithDefault()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	items := make([]projectActivityItem, 0, len(projects))
+	for _, project := range projects {
+		item, err := a.buildProjectActivityItem(project)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		items = append(items, item)
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":       true,
+		"projects": items,
 	})
 }
 
@@ -913,15 +963,26 @@ func (a *App) buildHubWelcomeSections(projects []store.Project, activeProjectID 
 		if isHubProject(project) {
 			continue
 		}
+		item, err := a.buildProjectAPIModel(project)
+		if err != nil {
+			continue
+		}
 		subtitle := strings.TrimSpace(project.RootPath)
 		if project.ID == activeProjectID {
 			subtitle = "current active project"
+		}
+		description := "Open project canvas"
+		switch item.RunState.Status {
+		case "running":
+			description = fmt.Sprintf("%d active run, %d queued", item.RunState.ActiveTurns, item.RunState.QueuedTurns)
+		case "queued":
+			description = fmt.Sprintf("%d queued run", item.RunState.QueuedTurns)
 		}
 		projectCards = append(projectCards, projectWelcomeCard{
 			ID:          "project-" + project.ID,
 			Title:       strings.TrimSpace(project.Name),
 			Subtitle:    subtitle,
-			Description: "Open project canvas",
+			Description: description,
 			Action: projectWelcomeAction{
 				Type:      "switch_project",
 				ProjectID: project.ID,

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -22,6 +22,27 @@ type projectsListResponse struct {
 		ChatModel       string `json:"chat_model"`
 		ReasoningEffort string `json:"chat_model_reasoning_effort"`
 		CanvasSessionID string `json:"canvas_session_id"`
+		RunState        struct {
+			ActiveTurns  int    `json:"active_turns"`
+			QueuedTurns  int    `json:"queued_turns"`
+			IsWorking    bool   `json:"is_working"`
+			Status       string `json:"status"`
+			ActiveTurnID string `json:"active_turn_id"`
+		} `json:"run_state"`
+	} `json:"projects"`
+}
+
+type projectsActivityResponse struct {
+	OK       bool `json:"ok"`
+	Projects []struct {
+		ProjectID     string `json:"project_id"`
+		ChatSessionID string `json:"chat_session_id"`
+		RunState      struct {
+			ActiveTurns int    `json:"active_turns"`
+			QueuedTurns int    `json:"queued_turns"`
+			IsWorking   bool   `json:"is_working"`
+			Status      string `json:"status"`
+		} `json:"run_state"`
 	} `json:"projects"`
 }
 
@@ -69,6 +90,9 @@ func TestProjectsListIncludesActiveAndSessions(t *testing.T) {
 	}
 	if first.ChatModel == "" {
 		t.Fatalf("expected project chat model")
+	}
+	if first.RunState.Status == "" {
+		t.Fatalf("expected project run state status")
 	}
 }
 
@@ -271,6 +295,99 @@ func TestHubProjectCreatedWithFixedSparkModel(t *testing.T) {
 	if !foundHub {
 		t.Fatalf("expected hub project in projects list")
 	}
+}
+
+func TestProjectsListIncludesRunState(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	app.registerActiveChatTurn(session.ID, "run-projects", func() {})
+	app.turns.mu.Lock()
+	app.turns.queue[session.ID] = 2
+	app.turns.mu.Unlock()
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects", map[string]any{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var payload projectsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, item := range payload.Projects {
+		if item.ID != project.ID {
+			continue
+		}
+		if item.RunState.ActiveTurns != 1 {
+			t.Fatalf("active_turns = %d, want 1", item.RunState.ActiveTurns)
+		}
+		if item.RunState.QueuedTurns != 2 {
+			t.Fatalf("queued_turns = %d, want 2", item.RunState.QueuedTurns)
+		}
+		if !item.RunState.IsWorking {
+			t.Fatalf("expected project to be working")
+		}
+		if item.RunState.Status != "running" {
+			t.Fatalf("status = %q, want running", item.RunState.Status)
+		}
+		if item.RunState.ActiveTurnID != "run-projects" {
+			t.Fatalf("active_turn_id = %q, want run-projects", item.RunState.ActiveTurnID)
+		}
+		return
+	}
+	t.Fatalf("expected project %q in list response", project.ID)
+}
+
+func TestProjectsActivityListsPerProjectRunState(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	app.turns.mu.Lock()
+	app.turns.queue[session.ID] = 3
+	app.turns.mu.Unlock()
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/activity", map[string]any{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected activity 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var payload projectsActivityResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode activity response: %v", err)
+	}
+	for _, item := range payload.Projects {
+		if item.ProjectID != project.ID {
+			continue
+		}
+		if item.ChatSessionID != session.ID {
+			t.Fatalf("chat_session_id = %q, want %q", item.ChatSessionID, session.ID)
+		}
+		if item.RunState.ActiveTurns != 0 {
+			t.Fatalf("active_turns = %d, want 0", item.RunState.ActiveTurns)
+		}
+		if item.RunState.QueuedTurns != 3 {
+			t.Fatalf("queued_turns = %d, want 3", item.RunState.QueuedTurns)
+		}
+		if !item.RunState.IsWorking {
+			t.Fatalf("expected project to be working")
+		}
+		if item.RunState.Status != "queued" {
+			t.Fatalf("status = %q, want queued", item.RunState.Status)
+		}
+		return
+	}
+	t.Fatalf("expected project %q in activity response", project.ID)
 }
 
 func TestHubProjectRejectsModelUpdates(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -346,6 +346,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/extensions", a.handleExtensions)
 	r.Post("/api/extensions/commands/{command_id}", a.handleExtensionCommandExecute)
 	r.Get("/api/projects", a.handleProjectsList)
+	r.Get("/api/projects/activity", a.handleProjectsActivity)
 	r.Post("/api/projects", a.handleProjectCreate)
 	r.Post("/api/projects/{project_id}/activate", a.handleProjectActivate)
 	r.Post("/api/projects/{project_id}/chat-model", a.handleProjectChatModelUpdate)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -209,6 +209,7 @@ let devReloadInFlight = false;
 let devReloadRequested = false;
 let assistantActivityTimer = null;
 let assistantActivityInFlight = false;
+let projectRunStatesInFlight = false;
 let assistantSilentCancelInFlight = false;
 let chatWsLastMessageAt = 0;
 let suppressClickUntil = 0;
@@ -3746,6 +3747,7 @@ async function fetchProjects() {
     ...project,
     id: String(project?.id || ''),
     chat_model_reasoning_effort: String(project?.chat_model_reasoning_effort || '').trim().toLowerCase(),
+    run_state: normalizeProjectRunState(project?.run_state),
   })).filter((project) => project.id);
   state.defaultProjectId = String(payload?.default_project_id || '').trim();
   state.serverActiveProjectId = String(payload?.active_project_id || '').trim();
@@ -3753,11 +3755,39 @@ async function fetchProjects() {
   renderEdgeTopModelButtons();
 }
 
+function normalizeProjectRunState(runState) {
+  const activeTurns = Math.max(0, Number(runState?.active_turns || 0) || 0);
+  const queuedTurns = Math.max(0, Number(runState?.queued_turns || 0) || 0);
+  let status = String(runState?.status || '').trim().toLowerCase();
+  if (status !== 'running' && status !== 'queued' && status !== 'idle') {
+    status = activeTurns > 0 ? 'running' : (queuedTurns > 0 ? 'queued' : 'idle');
+  }
+  return {
+    active_turns: activeTurns,
+    queued_turns: queuedTurns,
+    is_working: Boolean(runState?.is_working) || activeTurns > 0 || queuedTurns > 0,
+    status,
+    active_turn_id: String(runState?.active_turn_id || '').trim(),
+  };
+}
+
+function projectRunStateSummary(project) {
+  const runState = normalizeProjectRunState(project?.run_state);
+  if (runState.status === 'running') {
+    return `${runState.active_turns} active, ${runState.queued_turns} queued`;
+  }
+  if (runState.status === 'queued') {
+    return `${runState.queued_turns} queued`;
+  }
+  return 'idle';
+}
+
 function upsertProject(project) {
   if (!project || !project.id) return;
   if (project.chat_model_reasoning_effort !== undefined) {
     project.chat_model_reasoning_effort = String(project.chat_model_reasoning_effort || '').trim().toLowerCase();
   }
+  project.run_state = normalizeProjectRunState(project.run_state);
   const index = state.projects.findIndex((item) => item.id === project.id);
   if (index >= 0) {
     state.projects[index] = project;
@@ -3790,6 +3820,7 @@ function renderEdgeTopProjects() {
   if (!(host instanceof HTMLElement)) return;
   host.innerHTML = '';
   for (const project of state.projects) {
+    const runState = normalizeProjectRunState(project.run_state);
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'edge-project-btn';
@@ -3799,8 +3830,21 @@ function renderEdgeTopProjects() {
     if (project.id === state.activeProjectId) {
       button.classList.add('is-active');
     }
+    if (runState.is_working) {
+      button.classList.add('is-working');
+    }
+    if (runState.status === 'running') {
+      button.classList.add('is-running');
+    }
+    if (runState.status === 'queued') {
+      button.classList.add('is-queued');
+    }
+    button.dataset.runState = runState.status;
     button.textContent = String(project.name || project.id || 'Project');
-    button.title = String(project.root_path || '');
+    const summary = projectRunStateSummary(project);
+    const rootPath = String(project.root_path || '').trim();
+    button.title = rootPath ? `${summary} | ${rootPath}` : summary;
+    button.setAttribute('aria-label', `${String(project.name || project.id || 'Project')}: ${summary}`);
     button.addEventListener('click', () => {
       if (isHubProject(project)) {
         void switchToHub();
@@ -4048,6 +4092,14 @@ async function refreshAssistantActivity() {
     if (!Number.isFinite(queuedTurns) || queuedTurns < 0) return;
     state.assistantRemoteActiveCount = activeTurns;
     state.assistantRemoteQueuedCount = queuedTurns;
+    const project = activeProject();
+    if (project?.id) {
+      upsertProject({
+        ...project,
+        run_state: payload,
+      });
+      renderEdgeTopProjects();
+    }
     const recentlyStarted = (Date.now() - state.assistantLastStartedAt) < ACTIVE_TURN_ACTIVITY_CLEAR_GRACE_MS;
     if (activeTurns <= 0
       && queuedTurns <= 0
@@ -4071,6 +4123,30 @@ async function refreshAssistantActivity() {
   }
 }
 
+async function refreshProjectRunStates() {
+  if (!isHubActive() || projectRunStatesInFlight) return;
+  projectRunStatesInFlight = true;
+  try {
+    const resp = await fetch(apiURL('projects/activity'), { cache: 'no-store' });
+    if (!resp.ok) return;
+    const payload = await resp.json();
+    const items = Array.isArray(payload?.projects) ? payload.projects : [];
+    for (const item of items) {
+      const projectID = String(item?.project_id || '').trim();
+      if (!projectID) continue;
+      const existing = state.projects.find((project) => project.id === projectID);
+      if (!existing) continue;
+      upsertProject({
+        ...existing,
+        run_state: item?.run_state,
+      });
+    }
+    renderEdgeTopProjects();
+  } finally {
+    projectRunStatesInFlight = false;
+  }
+}
+
 function startAssistantActivityWatcher() {
   if (assistantActivityTimer !== null) return;
   const tick = () => {
@@ -4085,6 +4161,9 @@ function startAssistantActivityWatcher() {
       }
     }
     void refreshAssistantActivity();
+    if (isHubActive()) {
+      void refreshProjectRunStates();
+    }
   };
   assistantActivityTimer = window.setInterval(tick, ASSISTANT_ACTIVITY_POLL_MS);
   tick();

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -1219,6 +1219,27 @@ body.panel-motion-enabled {
   color: #f9fafb;
 }
 
+.edge-project-btn.is-working {
+  border-color: #b45309;
+  background: #fef3c7;
+}
+
+.edge-project-btn.is-working::after {
+  content: "•";
+  margin-left: 0.35rem;
+  color: #b45309;
+}
+
+.edge-project-btn.is-active.is-working {
+  border-color: #92400e;
+  background: #92400e;
+  color: #fffbeb;
+}
+
+.edge-project-btn.is-active.is-working::after {
+  color: #fbbf24;
+}
+
 .liability-modal {
   position: fixed;
   inset: 0;

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -361,6 +361,7 @@
         chat_mode: 'chat',
         chat_model: 'spark',
         chat_model_reasoning_effort: 'low',
+        run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       },
       {
         id: 'hub',
@@ -373,12 +374,27 @@
         chat_mode: 'chat',
         chat_model: 'spark',
         chat_model_reasoning_effort: 'low',
+        run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       },
     ];
     let activeProjectId = 'test';
+    let harnessProjectRunStates = {
+      test: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+      hub: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+    };
+    window.__setProjectRunStates = (states) => {
+      const next = states && typeof states === 'object' ? states : {};
+      harnessProjectRunStates = {
+        ...harnessProjectRunStates,
+        ...next,
+      };
+    };
     const cloneProject = (id) => {
       const project = harnessProjects.find((item) => item.id === id) || harnessProjects[0];
-      return { ...project };
+      return {
+        ...project,
+        run_state: { ...(harnessProjectRunStates[project.id] || project.run_state || {}) },
+      };
     };
 
     // Mock fetch for /api/setup etc.
@@ -469,8 +485,19 @@
           payload: { project_id: projectId, model, reasoning_effort: effort },
         });
         return new Response(JSON.stringify({
-          project: { ...harnessProjects[index] },
+          project: cloneProject(projectId),
         }), { status: 200 });
+      }
+      if (u.includes('/api/projects/activity')) {
+        const projects = harnessProjects.map((project) => ({
+          project_id: project.id,
+          project_key: project.project_key,
+          name: project.name,
+          kind: project.kind,
+          chat_session_id: project.chat_session_id,
+          run_state: { ...(harnessProjectRunStates[project.id] || project.run_state || {}) },
+        }));
+        return new Response(JSON.stringify({ ok: true, projects }), { status: 200 });
       }
       if (u.includes('/api/projects/') && u.includes('/files')) {
         const pathPart = u.split('/api/projects/')[1] || '';
@@ -569,7 +596,7 @@
         }), { status: 200 });
       }
       if (u.includes('/api/projects')) {
-        const projects = harnessProjects.map((project) => ({ ...project }));
+        const projects = harnessProjects.map((project) => cloneProject(project.id));
         return new Response(JSON.stringify({
           projects,
           default_project_id: 'test',

--- a/tests/playwright/hub-mode.spec.ts
+++ b/tests/playwright/hub-mode.spec.ts
@@ -90,6 +90,20 @@ test('switching from hub back to project keeps normal project switching', async 
   }, { timeout: 5_000 }).toBe(true);
 });
 
+test('hub monitors project run state without activating the project', async ({ page }) => {
+  const projectButton = page.locator('#edge-top-projects .edge-project-btn:not(.edge-hub-btn)');
+
+  await page.evaluate(() => {
+    (window as any).__setProjectRunStates({
+      test: { active_turns: 1, queued_turns: 2, is_working: true, status: 'running', active_turn_id: 'turn-1' },
+    });
+  });
+
+  await expect.poll(async () => projectButton.getAttribute('title'), { timeout: 5_000 }).toContain('1 active, 2 queued');
+  await expect(projectButton).toHaveClass(/is-working/);
+  await expect(projectButton).not.toHaveClass(/is-active/);
+});
+
 test('system switch_model action updates project model state', async ({ page }) => {
   await page.evaluate(() => {
     document.getElementById('edge-top')?.classList.add('edge-pinned');


### PR DESCRIPTION
## Summary
- enforce single active assistant-turn ownership per project chat session
- expose normalized project run state in `/api/projects` and `/api/projects/activity`
- surface Hub run monitoring in the project strip and cover it with Go and Playwright tests

## Verification
- No project can host two active runs at once: `go test ./internal/web -run "Test(ProjectsListIncludesActiveAndSessions|HubProjectCreatedWithFixedSparkModel|ProjectsListIncludesRunState|ProjectsActivityListsPerProjectRunState|HandleChatSessionActivityReportsActiveTurns)" -count=1` -> `ok github.com/krystophny/tabura/internal/web 0.029s`. `TestHandleChatSessionActivityReportsActiveTurns` now replaces `run-1` with `run-2` and asserts `active_turns=1`, `active_turn_id=run-2`, and `status=running`.
- Hub can monitor many runs without becoming a worker host: `./scripts/playwright.sh tests/playwright/hub-mode.spec.ts` -> `✓  4 [chromium] › tests/playwright/hub-mode.spec.ts:93:5 › hub monitors project run state without activating the project (2.1s)` and `7 passed (5.7s)`.
- Run state is queryable in core APIs/UI: `go test ./internal/web -run "Test(ProjectsListIncludesActiveAndSessions|HubProjectCreatedWithFixedSparkModel|ProjectsListIncludesRunState|ProjectsActivityListsPerProjectRunState|HandleChatSessionActivityReportsActiveTurns)" -count=1` -> `ok github.com/krystophny/tabura/internal/web 0.029s`. `TestProjectsListIncludesRunState` asserts `/api/projects` returns `run_state`; `TestProjectsActivityListsPerProjectRunState` asserts `/api/projects/activity` returns per-project queued/running state for Hub monitoring.
