### PR TITLE
fix: Companion Mode: consent, privacy, and visible-state safeguards (fixes #138)

### DIFF
--- a/docs/meeting-notes-privacy.md
+++ b/docs/meeting-notes-privacy.md
@@ -6,6 +6,12 @@ This document formalizes the audio privacy guarantees for Tabura's speech-to-tex
 
 **Key invariant: audio exists only in RAM during processing and is never persisted to disk or database.**
 
+## Companion Consent Boundary
+
+- Companion Mode is explicit opt-in. Capture must not start until `companion_enabled=true`.
+- Disabling Companion Mode is an exit action: any active participant capture session must stop immediately.
+- Companion capture defaults to microphone-only input. Alternate capture sources are not accepted through the config surface.
+
 ## Audio Lifecycle
 
 1. **Capture**: browser MediaRecorder captures audio chunks.

--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -41,6 +41,10 @@ func handleParticipantStart(a *App, conn *chatWSConn, chatSessionID string) {
 	if projectKey == "" {
 		projectKey = "default"
 	}
+	if !cfg.CompanionEnabled {
+		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "companion mode is disabled"})
+		return
+	}
 	cfgJSON, _ := json.Marshal(cfg)
 	sess, err := a.store.AddParticipantSession(projectKey, string(cfgJSON))
 	if err != nil {

--- a/internal/web/chat_participant_test.go
+++ b/internal/web/chat_participant_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/krystophny/tabura/internal/store"
 )
 
+func enableCompanionForTestProject(t *testing.T, app *App, projectKey string) {
+	t.Helper()
+	project, err := app.store.GetProjectByProjectKey(strings.TrimSpace(projectKey))
+	if err != nil {
+		t.Fatalf("GetProjectByProjectKey(%q): %v", projectKey, err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+}
+
 func TestParticipantConfigGetRequiresAuth(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -53,8 +66,8 @@ func TestParticipantConfigDefaultValues(t *testing.T) {
 	if cfg.MaxSegmentDurationMS <= 0 {
 		t.Fatalf("max_segment_duration_ms = %d", cfg.MaxSegmentDurationMS)
 	}
-	if !cfg.CompanionEnabled {
-		t.Fatal("companion_enabled = false, want true")
+	if cfg.CompanionEnabled {
+		t.Fatal("companion_enabled = true, want false")
 	}
 }
 
@@ -481,11 +494,20 @@ func TestParticipantBinaryChunkTranscribesWAVSegmentImmediately(t *testing.T) {
 	}))
 	defer sttSrv.Close()
 	app.sttURL = sttSrv.URL
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	handleParticipantStart(app, conn, "project-chat")
+	handleParticipantStart(app, conn, chatSession.ID)
 
 	conn.participantMu.Lock()
 	sessionID := conn.participantSessionID
@@ -550,6 +572,7 @@ func TestParticipantStartUsesChatSessionProjectKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession: %v", err)
 	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
@@ -580,6 +603,7 @@ func TestParticipantReleaseSessionEndsPersistedSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession: %v", err)
 	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
@@ -623,10 +647,19 @@ func TestParticipantReleaseSessionEndsPersistedSession(t *testing.T) {
 
 func TestParticipantWSStartStop(t *testing.T) {
 	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	handleParticipantStart(app, conn, "test-session")
+	handleParticipantStart(app, conn, session.ID)
 
 	conn.participantMu.Lock()
 	active := conn.participantActive
@@ -657,11 +690,20 @@ func TestParticipantWSStartStop(t *testing.T) {
 
 func TestParticipantDoubleStartReturnsError(t *testing.T) {
 	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	handleParticipantStart(app, conn, "test-session")
-	handleParticipantStart(app, conn, "test-session")
+	handleParticipantStart(app, conn, session.ID)
+	handleParticipantStart(app, conn, session.ID)
 
 	conn.participantMu.Lock()
 	defer conn.participantMu.Unlock()
@@ -681,6 +723,88 @@ func TestParticipantStopWithoutStartReturnsError(t *testing.T) {
 	defer conn.participantMu.Unlock()
 	if conn.participantActive {
 		t.Fatal("should not be active after stop-without-start")
+	}
+}
+
+func TestParticipantStartRequiresCompanionEnabled(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	conn, cleanup := newTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, "test-session")
+
+	conn.participantMu.Lock()
+	active := conn.participantActive
+	sessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if active {
+		t.Fatal("participantActive = true, want false when companion is disabled")
+	}
+	if sessionID != "" {
+		t.Fatalf("participantSessionID = %q, want empty", sessionID)
+	}
+	sessions, err := app.store.ListParticipantSessions(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("ListParticipantSessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("participant sessions = %d, want 0", len(sessions))
+	}
+}
+
+func TestParticipantConfigPutDisableStopsActiveSession(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	conn, cleanup := newTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	handleParticipantStart(app, conn, session.ID)
+
+	conn.participantMu.Lock()
+	participantSessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if participantSessionID == "" {
+		t.Fatal("expected participant session id")
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/participant/config", map[string]any{
+		"companion_enabled": false,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200", rr.Code)
+	}
+
+	conn.participantMu.Lock()
+	active := conn.participantActive
+	currentSessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if active {
+		t.Fatal("participantActive = true, want false after disabling companion")
+	}
+	if currentSessionID != "" {
+		t.Fatalf("participantSessionID = %q, want empty after disabling companion", currentSessionID)
+	}
+
+	persisted, err := app.store.GetParticipantSession(participantSessionID)
+	if err != nil {
+		t.Fatalf("GetParticipantSession: %v", err)
+	}
+	if persisted.EndedAt == 0 {
+		t.Fatal("participant session should be ended after disabling companion")
 	}
 }
 

--- a/internal/web/companion_gate_test.go
+++ b/internal/web/companion_gate_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestEvaluateCompanionDirectedSpeechGate(t *testing.T) {
 	cfg := defaultCompanionConfig()
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	session := &store.ParticipantSession{ID: "psess-test", StartedAt: 100}
 	events := []store.ParticipantEvent{{EventType: "segment_committed", CreatedAt: 130}}

--- a/internal/web/companion_response_trigger_test.go
+++ b/internal/web/companion_response_trigger_test.go
@@ -107,6 +107,7 @@ func TestCompanionResponseTriggerExecutesAssistantTurn(t *testing.T) {
 		t.Fatalf("ensure default project: %v", err)
 	}
 	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)
@@ -240,6 +241,7 @@ func TestCompanionResponseTriggerSkipsFalseTriggerTranscript(t *testing.T) {
 		t.Fatalf("ensure default project: %v", err)
 	}
 	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)
@@ -305,6 +307,7 @@ func TestCompanionResponseTriggerUsesSilentModeOutputQueue(t *testing.T) {
 		t.Fatalf("ensure default project: %v", err)
 	}
 	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)
@@ -355,6 +358,7 @@ func TestCompanionResponseTriggerDoesNotDuplicateSegment(t *testing.T) {
 		t.Fatalf("ensure default project: %v", err)
 	}
 	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)

--- a/internal/web/projects_companion.go
+++ b/internal/web/projects_companion.go
@@ -62,7 +62,7 @@ type companionStateResponse struct {
 
 func defaultCompanionConfig() companionConfig {
 	return companionConfig{
-		CompanionEnabled:          true,
+		CompanionEnabled:          false,
 		DirectedSpeechGateEnabled: false,
 		Language:                  "en",
 		MaxSegmentDurationMS:      30000,
@@ -222,10 +222,14 @@ func (a *App) handleParticipantConfigPut(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	cfg := applyCompanionConfigPatch(a.loadCompanionConfig(project), patch)
+	current := a.loadCompanionConfig(project)
+	cfg := applyCompanionConfigPatch(current, patch)
 	if err := a.saveCompanionConfig(project.ID, cfg); err != nil {
 		http.Error(w, "failed to save config", http.StatusInternalServerError)
 		return
+	}
+	if current.CompanionEnabled && !cfg.CompanionEnabled {
+		a.disableCompanionCapture(project.ProjectKey)
 	}
 	writeJSON(w, cfg)
 }
@@ -264,10 +268,14 @@ func (a *App) handleProjectCompanionConfigPut(w http.ResponseWriter, r *http.Req
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	cfg := applyCompanionConfigPatch(a.loadCompanionConfig(project), patch)
+	current := a.loadCompanionConfig(project)
+	cfg := applyCompanionConfigPatch(current, patch)
 	if err := a.saveCompanionConfig(project.ID, cfg); err != nil {
 		http.Error(w, "failed to save config", http.StatusInternalServerError)
 		return
+	}
+	if current.CompanionEnabled && !cfg.CompanionEnabled {
+		a.disableCompanionCapture(project.ProjectKey)
 	}
 	writeJSON(w, cfg)
 }
@@ -312,7 +320,7 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 		gateSession = latestSession
 	}
 	state := companionRuntimeStateIdle
-	if activeSessions > 0 {
+	if cfg.CompanionEnabled && activeSessions > 0 {
 		state = companionRuntimeStateListening
 	}
 	gate := a.loadCompanionDirectedSpeechGate(cfg, gateSession)
@@ -331,4 +339,42 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 		DirectedSpeechGate: gate,
 		Config:             cfg,
 	})
+}
+
+func (a *App) disableCompanionCapture(projectKey string) {
+	cleanProjectKey := strings.TrimSpace(projectKey)
+	if cleanProjectKey == "" {
+		return
+	}
+	a.hub.forEachChatConn(func(conn *chatWSConn) {
+		conn.participantMu.Lock()
+		sessionID := strings.TrimSpace(conn.participantSessionID)
+		active := conn.participantActive
+		conn.participantMu.Unlock()
+		if !active || sessionID == "" {
+			return
+		}
+		session, err := a.store.GetParticipantSession(sessionID)
+		if err != nil || session.ProjectKey != cleanProjectKey {
+			return
+		}
+		stoppedSessionID, ok := releaseParticipantSession(a, conn)
+		if !ok {
+			return
+		}
+		_ = conn.writeJSON(participantMessage{Type: "participant_stopped", SessionID: stoppedSessionID})
+		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "companion mode is disabled"})
+	})
+
+	sessions, err := a.store.ListParticipantSessions(cleanProjectKey)
+	if err != nil {
+		return
+	}
+	for _, session := range sessions {
+		if session.EndedAt != 0 {
+			continue
+		}
+		_ = a.store.EndParticipantSession(session.ID)
+		_ = a.store.AddParticipantEvent(session.ID, 0, "session_stopped", `{"reason":"companion_disabled"}`)
+	}
 }

--- a/internal/web/projects_companion_test.go
+++ b/internal/web/projects_companion_test.go
@@ -80,13 +80,16 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 	handleParticipantStart(app, conn, session.ID)
-	defer handleParticipantStop(app, conn)
 
 	conn.participantMu.Lock()
 	activeSessionID := conn.participantSessionID
+	active := conn.participantActive
 	conn.participantMu.Unlock()
-	if activeSessionID == "" {
-		t.Fatal("expected active participant session id")
+	if active {
+		t.Fatal("participantActive = true, want false when companion is disabled")
+	}
+	if activeSessionID != "" {
+		t.Fatalf("active participant session id = %q, want empty", activeSessionID)
 	}
 
 	rrState := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/companion/state", nil)
@@ -103,20 +106,14 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	if state.ProjectKey != project.ProjectKey {
 		t.Fatalf("project_key = %q, want %q", state.ProjectKey, project.ProjectKey)
 	}
-	if state.State != companionRuntimeStateListening {
-		t.Fatalf("state = %q, want %q", state.State, companionRuntimeStateListening)
+	if state.State != companionRuntimeStateIdle {
+		t.Fatalf("state = %q, want %q", state.State, companionRuntimeStateIdle)
 	}
-	if state.ActiveSessions != 1 {
-		t.Fatalf("active_sessions = %d, want 1", state.ActiveSessions)
+	if state.ActiveSessions != 0 {
+		t.Fatalf("active_sessions = %d, want 0", state.ActiveSessions)
 	}
-	if state.ActiveSessionID != activeSessionID {
-		t.Fatalf("active_session_id = %q, want %q", state.ActiveSessionID, activeSessionID)
-	}
-	if state.LatestSession == nil {
-		t.Fatal("expected latest_session")
-	}
-	if state.LatestSession.ProjectKey != project.ProjectKey {
-		t.Fatalf("latest_session.project_key = %q, want %q", state.LatestSession.ProjectKey, project.ProjectKey)
+	if state.ActiveSessionID != "" {
+		t.Fatalf("active_session_id = %q, want empty", state.ActiveSessionID)
 	}
 	if state.Config.IdleSurface != "black" {
 		t.Fatalf("state config idle_surface = %q, want black", state.Config.IdleSurface)
@@ -135,6 +132,56 @@ func TestProjectCompanionConfigPutAndState(t *testing.T) {
 	}
 }
 
+func TestProjectCompanionStateReportsListeningWhenEnabled(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	conn, cleanup := newTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, session.ID)
+	defer handleParticipantStop(app, conn)
+
+	conn.participantMu.Lock()
+	activeSessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if activeSessionID == "" {
+		t.Fatal("expected active participant session id")
+	}
+
+	rrState := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/companion/state", nil)
+	if rrState.Code != http.StatusOK {
+		t.Fatalf("GET state status = %d, want 200", rrState.Code)
+	}
+	var state companionStateResponse
+	if err := json.Unmarshal(rrState.Body.Bytes(), &state); err != nil {
+		t.Fatalf("decode companion state: %v", err)
+	}
+	if state.State != companionRuntimeStateListening {
+		t.Fatalf("state = %q, want %q", state.State, companionRuntimeStateListening)
+	}
+	if state.ActiveSessions != 1 {
+		t.Fatalf("active_sessions = %d, want 1", state.ActiveSessions)
+	}
+	if state.ActiveSessionID != activeSessionID {
+		t.Fatalf("active_session_id = %q, want %q", state.ActiveSessionID, activeSessionID)
+	}
+	if state.LatestSession == nil {
+		t.Fatal("expected latest_session")
+	}
+}
+
 func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 	app := newAuthedTestApp(t)
 	project, err := app.ensureDefaultProjectRecord()
@@ -142,6 +189,7 @@ func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 		t.Fatalf("ensureDefaultProjectRecord: %v", err)
 	}
 	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
 	cfg.DirectedSpeechGateEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -382,6 +382,16 @@
       test: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       hub: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
     };
+    window.__participantConfig = {
+      companion_enabled: false,
+      language: 'en',
+      max_segment_duration_ms: 30000,
+      session_ram_cap_mb: 64,
+      stt_model: 'whisper-1',
+      idle_surface: 'robot',
+      audio_persistence: 'none',
+      capture_source: 'microphone',
+    };
     window.__setProjectRunStates = (states) => {
       const next = states && typeof states === 'object' ? states : {};
       harnessProjectRunStates = {
@@ -626,23 +636,23 @@
       if (u.includes('/api/participant/config') && opts?.method === 'PUT') {
         let body = {};
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
-        const cfg = {
-          language: String(body.language || 'en'),
-          max_segment_duration_ms: Number(body.max_segment_duration_ms || 30000),
-          session_ram_cap_mb: Number(body.session_ram_cap_mb || 64),
-          stt_model: String(body.stt_model || 'whisper-1'),
+        window.__participantConfig = {
+          ...window.__participantConfig,
+          companion_enabled: Object.prototype.hasOwnProperty.call(body, 'companion_enabled')
+            ? Boolean(body.companion_enabled)
+            : Boolean(window.__participantConfig.companion_enabled),
+          language: String(body.language || window.__participantConfig.language || 'en'),
+          max_segment_duration_ms: Number(body.max_segment_duration_ms || window.__participantConfig.max_segment_duration_ms || 30000),
+          session_ram_cap_mb: Number(body.session_ram_cap_mb || window.__participantConfig.session_ram_cap_mb || 64),
+          stt_model: String(body.stt_model || window.__participantConfig.stt_model || 'whisper-1'),
+          idle_surface: String(body.idle_surface || window.__participantConfig.idle_surface || 'robot'),
           audio_persistence: 'none',
+          capture_source: 'microphone',
         };
-        return new Response(JSON.stringify(cfg), { status: 200 });
+        return new Response(JSON.stringify(window.__participantConfig), { status: 200 });
       }
       if (u.includes('/api/participant/config')) {
-        return new Response(JSON.stringify({
-          language: 'en',
-          max_segment_duration_ms: 30000,
-          session_ram_cap_mb: 64,
-          stt_model: 'whisper-1',
-          audio_persistence: 'none',
-        }), { status: 200 });
+        return new Response(JSON.stringify(window.__participantConfig), { status: 200 });
       }
       if (u.includes('/api/participant/status')) {
         return new Response(JSON.stringify({ ok: true, active_sessions: 0 }), { status: 200 });
@@ -801,8 +811,17 @@
           } else if (msg.type === 'stt_cancel') {
             window.__harnessLog.push({ type: 'stt', action: 'cancel' });
           } else if (msg.type === 'participant_start') {
-            window.__harnessLog.push({ type: 'participant', action: 'start' });
             const ws = this;
+            if (!window.__participantConfig?.companion_enabled) {
+              window.__harnessLog.push({ type: 'participant', action: 'blocked' });
+              setTimeout(() => {
+                if (ws.onmessage) {
+                  ws.onmessage({ data: JSON.stringify({ type: 'participant_error', error: 'companion mode is disabled' }) });
+                }
+              }, 5);
+              return;
+            }
+            window.__harnessLog.push({ type: 'participant', action: 'start' });
             setTimeout(() => {
               if (ws.onmessage) {
                 ws.onmessage({ data: JSON.stringify({ type: 'participant_started', session_id: 'psess-harness-001' }) });

--- a/tests/playwright/participant-capture.spec.ts
+++ b/tests/playwright/participant-capture.spec.ts
@@ -14,6 +14,16 @@ async function clearLog(page: Page) {
   await page.evaluate(() => { (window as any).__harnessLog.splice(0); });
 }
 
+async function setParticipantConfig(page: Page, patch: Record<string, unknown>) {
+  await page.evaluate(async (nextPatch) => {
+    await fetch('/api/participant/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(nextPatch),
+    });
+  }, patch);
+}
+
 async function waitForLogEntry(page: Page, type: string, action: string) {
   await expect.poll(async () => {
     const log = await getLog(page);
@@ -38,6 +48,7 @@ test.beforeEach(async ({ page }) => {
 
 test('participant WS start sends participant_start and receives participant_started', async ({ page }) => {
   await clearLog(page);
+  await setParticipantConfig(page, { companion_enabled: true });
 
   await page.evaluate(() => {
     const sessions = (window as any).__mockWsSessions || [];
@@ -54,6 +65,7 @@ test('participant WS start sends participant_start and receives participant_star
 
 test('participant WS stop sends participant_stop and receives participant_stopped', async ({ page }) => {
   await clearLog(page);
+  await setParticipantConfig(page, { companion_enabled: true });
 
   await page.evaluate(() => {
     const sessions = (window as any).__mockWsSessions || [];
@@ -113,7 +125,9 @@ test('participant config API returns audio_persistence=none', async ({ page }) =
     const resp = await fetch('/api/participant/config');
     return resp.json();
   });
+  expect(config.companion_enabled).toBe(false);
   expect(config.audio_persistence).toBe('none');
+  expect(config.capture_source).toBe('microphone');
   expect(config.language).toBeTruthy();
 });
 
@@ -128,6 +142,23 @@ test('participant config PUT cannot override audio_persistence', async ({ page }
   });
   expect(config.audio_persistence).toBe('none');
   expect(config.language).toBe('de');
+  expect(config.capture_source).toBe('microphone');
+});
+
+test('participant WS start is blocked until companion mode is explicitly enabled', async ({ page }) => {
+  await clearLog(page);
+
+  await page.evaluate(() => {
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    if (chatWs) {
+      chatWs.send(JSON.stringify({ type: 'participant_start' }));
+    }
+  });
+
+  await waitForLogEntry(page, 'participant', 'blocked');
+  const log = await getLog(page);
+  expect(log.some(e => e.type === 'participant' && e.action === 'start')).toBe(false);
 });
 
 test('participant capture sends 16k wav segments and clears rolling buffer after ship', async ({ page }) => {


### PR DESCRIPTION
## Summary
Tighten Companion Mode so capture is explicit opt-in instead of implicit background behavior.

## Verification
- Explicit manual toggle into Companion Mode: `internal/web/projects_companion.go` now defaults `companion_enabled` to `false`, and `handleParticipantStart` rejects capture while disabled. Evidence: `go test ./internal/web -run "Test(Participant|ProjectCompanion|CompanionResponseTrigger|EvaluateCompanionDirectedSpeechGate)"` -> `ok   github.com/krystophny/tabura/internal/web 0.282s`; `./scripts/playwright.sh tests/playwright/participant-capture.spec.ts` -> `participant WS start is blocked until companion mode is explicitly enabled`.
- Explicit exit from Companion Mode: disabling Companion Mode now stops active participant sessions through `disableCompanionCapture`. Evidence: `TestParticipantConfigPutDisableStopsActiveSession` passed in the Go verification run above.
- Privacy invariants stay microphone-only and RAM-only: config normalization still forces `audio_persistence=none` and `capture_source=microphone`, and the consent boundary is documented in `docs/meeting-notes-privacy.md`. Evidence: `./scripts/playwright.sh tests/playwright/participant-capture.spec.ts` -> `10 passed (4.0s)`.
