### PR TITLE
fix: Meeting notes mode: core pipeline (Pass A local + Pass B Whisper (fixes #105)

### DIFF
--- a/internal/store/store_participant.go
+++ b/internal/store/store_participant.go
@@ -47,6 +47,8 @@ type ParticipantRoomState struct {
 	UpdatedAt         int64  `json:"updated_at"`
 }
 
+var ErrParticipantSessionEnded = errors.New("participant session is ended")
+
 func (s *Store) AddParticipantSession(projectKey, configJSON string) (ParticipantSession, error) {
 	key := strings.TrimSpace(projectKey)
 	if key == "" {
@@ -122,6 +124,16 @@ func (s *Store) AddParticipantSegment(seg ParticipantSegment) (ParticipantSegmen
 	sessionID := strings.TrimSpace(seg.SessionID)
 	if sessionID == "" {
 		return ParticipantSegment{}, errors.New("session id is required")
+	}
+	var endedAt int64
+	if err := s.db.QueryRow(
+		`SELECT ended_at FROM participant_sessions WHERE id = ?`,
+		sessionID,
+	).Scan(&endedAt); err != nil {
+		return ParticipantSegment{}, err
+	}
+	if endedAt != 0 {
+		return ParticipantSegment{}, ErrParticipantSessionEnded
 	}
 	now := time.Now().Unix()
 	if seg.CommittedAt == 0 {

--- a/internal/store/store_participant_test.go
+++ b/internal/store/store_participant_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -136,6 +137,28 @@ func TestParticipantSegmentCRUD(t *testing.T) {
 	}
 	if results[0].Text != "hello meeting" {
 		t.Fatalf("search text = %q", results[0].Text)
+	}
+}
+
+func TestParticipantSegmentRejectsEndedSession(t *testing.T) {
+	s := newTestStore(t)
+
+	sess, err := s.AddParticipantSession("proj-ended", "{}")
+	if err != nil {
+		t.Fatalf("add session: %v", err)
+	}
+	if err := s.EndParticipantSession(sess.ID); err != nil {
+		t.Fatalf("end session: %v", err)
+	}
+
+	_, err = s.AddParticipantSegment(ParticipantSegment{
+		SessionID: sess.ID,
+		StartTS:   100,
+		EndTS:     110,
+		Text:      "late transcript",
+	})
+	if !errors.Is(err, ErrParticipantSessionEnded) {
+		t.Fatalf("AddParticipantSegment() error = %v, want %v", err, ErrParticipantSessionEnded)
 	}
 }
 

--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -100,6 +101,7 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 	normalizedMimeType, normalizedData, normalizeErr := stt.NormalizeForWhisper(mimeType, buf)
 	if normalizeErr != nil {
 		log.Printf("participant normalize error: %v", normalizeErr)
+		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("audio normalization failed: %v", normalizeErr))
 		return
 	}
 
@@ -110,6 +112,7 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 			return
 		}
 		log.Printf("participant transcribe error: %v", err)
+		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("transcription failed: %v", err))
 		return
 	}
 	text = strings.TrimSpace(text)
@@ -130,7 +133,11 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 		Status:      "final",
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrParticipantSessionEnded) {
+			return
+		}
 		log.Printf("participant store segment error: %v", err)
+		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("failed to store transcript segment: %v", err))
 		return
 	}
 
@@ -145,6 +152,20 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 		StartTS:   seg.StartTS,
 		EndTS:     seg.EndTS,
 		LatencyMS: latencyMS,
+	})
+}
+
+func writeParticipantErrorIfActive(conn *chatWSConn, sessionID, errMsg string) {
+	conn.participantMu.Lock()
+	active := conn.participantActive && conn.participantSessionID == sessionID
+	conn.participantMu.Unlock()
+	if !active {
+		return
+	}
+	_ = conn.writeJSON(participantMessage{
+		Type:      "participant_error",
+		SessionID: sessionID,
+		Error:     errMsg,
 	})
 }
 

--- a/internal/web/chat_participant_test.go
+++ b/internal/web/chat_participant_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/store"
 )
 
@@ -24,6 +26,81 @@ func enableCompanionForTestProject(t *testing.T, app *App, projectKey string) {
 	cfg.CompanionEnabled = true
 	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
 		t.Fatalf("save companion config: %v", err)
+	}
+}
+
+func newParticipantTestWSConn(t *testing.T) (*chatWSConn, *websocket.Conn, func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	serverConn := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConn <- ws
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial test websocket: %v", err)
+	}
+
+	var ws *websocket.Conn
+	select {
+	case ws = <-serverConn:
+	case <-time.After(2 * time.Second):
+		_ = clientConn.Close()
+		srv.Close()
+		t.Fatal("timed out waiting for server websocket")
+	}
+
+	cleanup := func() {
+		_ = ws.Close()
+		_ = clientConn.Close()
+		srv.Close()
+	}
+	return newChatWSConn(ws), clientConn, cleanup
+}
+
+func readParticipantMessage(t *testing.T, clientConn *websocket.Conn, timeout time.Duration) participantMessage {
+	t.Helper()
+	if err := clientConn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	defer func() {
+		_ = clientConn.SetReadDeadline(time.Time{})
+	}()
+
+	_, data, err := clientConn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	var msg participantMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal participant message: %v", err)
+	}
+	return msg
+}
+
+func assertNoParticipantMessage(t *testing.T, clientConn *websocket.Conn, timeout time.Duration) {
+	t.Helper()
+	if err := clientConn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	defer func() {
+		_ = clientConn.SetReadDeadline(time.Time{})
+	}()
+
+	_, _, err := clientConn.ReadMessage()
+	if err == nil {
+		t.Fatal("unexpected participant message")
+	}
+	netErr, ok := err.(net.Error)
+	if !ok || !netErr.Timeout() {
+		t.Fatalf("ReadMessage error = %v, want timeout", err)
 	}
 }
 
@@ -560,6 +637,124 @@ func TestParticipantBinaryChunkTranscribesWAVSegmentImmediately(t *testing.T) {
 	if conn.participantBuf != nil {
 		t.Fatal("participantBuf should be cleared after immediate chunk transcription")
 	}
+}
+
+func TestParticipantBinaryChunkTranscribeFailureSendsParticipantError(t *testing.T) {
+	app := newAuthedTestApp(t)
+	t.Setenv("PATH", t.TempDir())
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forced sidecar failure", http.StatusBadGateway)
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, chatSession.ID)
+	started := readParticipantMessage(t, clientConn, 2*time.Second)
+	if started.Type != "participant_started" {
+		t.Fatalf("start message type = %q, want participant_started", started.Type)
+	}
+
+	handleParticipantBinaryChunk(app, conn, buildParticipantSpeechWAV(240, 16000))
+
+	msg := readParticipantMessage(t, clientConn, 2*time.Second)
+	if msg.Type != "participant_error" {
+		t.Fatalf("message type = %q, want participant_error", msg.Type)
+	}
+	if !strings.Contains(msg.Error, "transcription failed") {
+		t.Fatalf("participant error = %q, want transcription failure", msg.Error)
+	}
+
+	segments, err := app.store.ListParticipantSegments(started.SessionID, 0, 0)
+	if err != nil {
+		t.Fatalf("ListParticipantSegments: %v", err)
+	}
+	if len(segments) != 0 {
+		t.Fatalf("segments count = %d, want 0 after failed transcription", len(segments))
+	}
+}
+
+func TestParticipantStopDropsLateTranscriptCommit(t *testing.T) {
+	app := newAuthedTestApp(t)
+	t.Setenv("PATH", t.TempDir())
+
+	requestStarted := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestStarted <- struct{}{}:
+		default:
+		}
+		<-releaseResponse
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"late participant transcript"}`))
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, chatSession.ID)
+	started := readParticipantMessage(t, clientConn, 2*time.Second)
+	if started.Type != "participant_started" {
+		t.Fatalf("start message type = %q, want participant_started", started.Type)
+	}
+
+	handleParticipantBinaryChunk(app, conn, buildParticipantSpeechWAV(240, 16000))
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for participant STT request")
+	}
+
+	handleParticipantStop(app, conn)
+	stopped := readParticipantMessage(t, clientConn, 2*time.Second)
+	if stopped.Type != "participant_stopped" {
+		t.Fatalf("stop message type = %q, want participant_stopped", stopped.Type)
+	}
+
+	close(releaseResponse)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		segments, err := app.store.ListParticipantSegments(started.SessionID, 0, 0)
+		if err != nil {
+			t.Fatalf("ListParticipantSegments: %v", err)
+		}
+		if len(segments) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("segments count = %d, want 0 after stop", len(segments))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assertNoParticipantMessage(t, clientConn, 250*time.Millisecond)
 }
 
 func TestParticipantStartUsesChatSessionProjectKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject late participant transcript commits after session stop
- emit `participant_error` for active-session normalization, transcription, and store failures
- add regression coverage for stop-after-chunk and failed sidecar paths

## Verification
- Requirement: start -> chunked audio -> transcript segments -> stop stays single-pass and does not commit late transcripts after stop.
  Evidence command: `go test ./internal/store ./internal/web -list 'TestParticipant|TestPrivacyParticipant'`
  Evidence excerpt: `TestParticipantBinaryChunkTranscribesWAVSegmentImmediately`, `TestParticipantSegmentRejectsEndedSession`, `TestParticipantStopDropsLateTranscriptCommit`
  Execution command: `go test ./internal/store ./internal/web -run 'TestParticipant|TestPrivacyParticipant' 2>&1 | tee /tmp/tabura-issue-105-test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/store 0.038s`, `ok   github.com/krystophny/tabura/internal/web 0.421s`
- Requirement: server emits `participant_error` when a participant chunk fails to transcribe.
  Evidence command: `go test ./internal/store ./internal/web -list 'TestParticipant|TestPrivacyParticipant'`
  Evidence excerpt: `TestParticipantBinaryChunkTranscribeFailureSendsParticipantError`
  Execution command: `go test ./internal/store ./internal/web -run 'TestParticipant|TestPrivacyParticipant' 2>&1 | tee /tmp/tabura-issue-105-test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.421s`
- Requirement: persist only transcript text and metadata; no audio persistence is introduced.
  Evidence command: `go test ./internal/store ./internal/web -list 'TestParticipant|TestPrivacyParticipant'`
  Evidence excerpt: `TestPrivacyParticipantConfigNeverStoresAudioPersistence`, `TestPrivacyParticipantMessageNoAudioFields`, `TestPrivacyParticipantBufferCleanupOnStop`
  Execution command: `go test ./internal/store ./internal/web -run 'TestParticipant|TestPrivacyParticipant' 2>&1 | tee /tmp/tabura-issue-105-test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/store 0.038s`, `ok   github.com/krystophny/tabura/internal/web 0.421s`