### PR TITLE
fix: Companion Mode: runtime state machine and websocket protocol (fixes #136)

### DIFF
--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -59,6 +59,12 @@ func handleParticipantStart(a *App, conn *chatWSConn, chatSessionID string) {
 
 	_ = a.store.AddParticipantEvent(sess.ID, 0, "session_started", "{}")
 	_ = conn.writeJSON(participantMessage{Type: "participant_started", SessionID: sess.ID})
+	a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+		State:                companionRuntimeStateListening,
+		Reason:               "participant_started",
+		ProjectKey:           projectKey,
+		ParticipantSessionID: sess.ID,
+	})
 	log.Printf("participant session started: %s", sess.ID)
 }
 
@@ -75,6 +81,15 @@ func handleParticipantBinaryChunk(a *App, conn *chatWSConn, data []byte) {
 		zeroizeBytes(conn.participantBuf)
 		conn.participantBuf = nil
 		conn.participantMu.Unlock()
+		if session, err := a.store.GetParticipantSession(sessionID); err == nil {
+			a.broadcastCompanionRuntimeState(session.ProjectKey, companionRuntimeSnapshot{
+				State:                companionRuntimeStateError,
+				Reason:               "participant_chunk_too_large",
+				Error:                "participant chunk exceeds max size",
+				ProjectKey:           session.ProjectKey,
+				ParticipantSessionID: sessionID,
+			})
+		}
 		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "participant chunk exceeds max size"})
 		return
 	}
@@ -90,7 +105,22 @@ func handleParticipantBinaryChunk(a *App, conn *chatWSConn, data []byte) {
 func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf []byte) {
 	defer zeroizeBytes(buf)
 
+	participantSession, sessionErr := a.store.GetParticipantSession(sessionID)
+	projectKey := ""
+	if sessionErr == nil {
+		projectKey = participantSession.ProjectKey
+	}
+
 	if a.sttURL == "" {
+		if projectKey != "" {
+			a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+				State:                companionRuntimeStateError,
+				Reason:               "stt_not_configured",
+				Error:                "STT sidecar is not configured",
+				ProjectKey:           projectKey,
+				ParticipantSessionID: sessionID,
+			})
+		}
 		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "STT sidecar is not configured"})
 		return
 	}
@@ -101,6 +131,15 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 	normalizedMimeType, normalizedData, normalizeErr := stt.NormalizeForWhisper(mimeType, buf)
 	if normalizeErr != nil {
 		log.Printf("participant normalize error: %v", normalizeErr)
+		if projectKey != "" {
+			a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+				State:                companionRuntimeStateError,
+				Reason:               "participant_normalize_failed",
+				Error:                fmt.Sprintf("audio normalization failed: %v", normalizeErr),
+				ProjectKey:           projectKey,
+				ParticipantSessionID: sessionID,
+			})
+		}
 		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("audio normalization failed: %v", normalizeErr))
 		return
 	}
@@ -112,6 +151,15 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 			return
 		}
 		log.Printf("participant transcribe error: %v", err)
+		if projectKey != "" {
+			a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+				State:                companionRuntimeStateError,
+				Reason:               "participant_transcribe_failed",
+				Error:                fmt.Sprintf("transcription failed: %v", err),
+				ProjectKey:           projectKey,
+				ParticipantSessionID: sessionID,
+			})
+		}
 		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("transcription failed: %v", err))
 		return
 	}
@@ -137,11 +185,45 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 			return
 		}
 		log.Printf("participant store segment error: %v", err)
+		if projectKey != "" {
+			a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+				State:                companionRuntimeStateError,
+				Reason:               "participant_store_failed",
+				Error:                fmt.Sprintf("failed to store transcript segment: %v", err),
+				ProjectKey:           projectKey,
+				ParticipantSessionID: sessionID,
+			})
+		}
 		writeParticipantErrorIfActive(conn, sessionID, fmt.Sprintf("failed to store transcript segment: %v", err))
 		return
 	}
 
 	_ = a.store.AddParticipantEvent(sessionID, seg.ID, "segment_committed", fmt.Sprintf(`{"text":%q}`, text))
+	if projectKey != "" {
+		a.broadcastCompanionTranscriptEvent(projectKey, map[string]interface{}{
+			"type":                   companionEventTranscriptPartial,
+			"participant_session_id": sessionID,
+			"participant_segment_id": seg.ID,
+			"text":                   text,
+			"status":                 "partial",
+			"latency_ms":             latencyMS,
+		})
+		a.broadcastCompanionTranscriptEvent(projectKey, map[string]interface{}{
+			"type":                   companionEventTranscriptFinal,
+			"participant_session_id": sessionID,
+			"participant_segment_id": seg.ID,
+			"text":                   text,
+			"status":                 seg.Status,
+			"latency_ms":             latencyMS,
+		})
+		a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+			State:                companionRuntimeStateListening,
+			Reason:               "transcript_finalized",
+			ProjectKey:           projectKey,
+			ParticipantSessionID: sessionID,
+			ParticipantSegmentID: seg.ID,
+		})
+	}
 	a.maybeTriggerCompanionResponse(sessionID, seg)
 
 	_ = conn.writeJSON(participantMessage{
@@ -215,6 +297,13 @@ func (a *App) maybeTriggerCompanionResponse(participantSessionID string, seg sto
 	default:
 		return
 	}
+	a.broadcastCompanionRuntimeState(session.ProjectKey, companionRuntimeSnapshot{
+		State:                companionRuntimeStateThinking,
+		Reason:               policy.Reason,
+		ProjectKey:           session.ProjectKey,
+		ParticipantSessionID: participantSessionID,
+		ParticipantSegmentID: seg.ID,
+	})
 	text := strings.TrimSpace(seg.Text)
 	if text == "" {
 		return
@@ -285,8 +374,19 @@ func releaseParticipantSession(a *App, conn *chatWSConn) (string, bool) {
 
 	zeroizeBytes(remainingBuf)
 
+	projectKey := ""
+	if session, err := a.store.GetParticipantSession(sessionID); err == nil {
+		projectKey = session.ProjectKey
+	}
 	_ = a.store.EndParticipantSession(sessionID)
 	_ = a.store.AddParticipantEvent(sessionID, 0, "session_stopped", "{}")
+	if projectKey != "" {
+		cfg := defaultCompanionConfig()
+		if project, err := a.store.GetProjectByProjectKey(projectKey); err == nil {
+			cfg = a.loadCompanionConfig(project)
+		}
+		a.settleCompanionRuntimeState(projectKey, cfg, "participant_stopped")
+	}
 	return sessionID, true
 }
 

--- a/internal/web/chat_tts.go
+++ b/internal/web/chat_tts.go
@@ -18,19 +18,54 @@ const (
 )
 
 func (a *App) handleTTSSpeak(sessionID string, conn *chatWSConn, seq int64, text, lang string) {
+	projectKey := ""
+	if session, err := a.store.GetChatSession(sessionID); err == nil {
+		projectKey = session.ProjectKey
+		if strings.TrimSpace(projectKey) != "" {
+			a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+				State:      companionRuntimeStateTalking,
+				Reason:     "tts_started",
+				ProjectKey: projectKey,
+				OutputMode: turnOutputModeVoice,
+			})
+		}
+	}
 	wavData, clientErr := a.synthesizeTTSAudio(sessionID, seq, text, lang)
 	ready := conn.completeTTSSeq(seq, wavData, clientErr)
 	for _, result := range ready {
 		if result.err != "" {
 			log.Printf("tts emit error: session=%s seq=%d err=%s", sessionID, result.seq, result.err)
+			if projectKey != "" {
+				a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+					State:      companionRuntimeStateError,
+					Reason:     "tts_failed",
+					Error:      result.err,
+					ProjectKey: projectKey,
+					OutputMode: turnOutputModeVoice,
+				})
+			}
 			_ = conn.writeJSON(map[string]string{"type": "tts_error", "error": result.err})
 			continue
 		}
 		if err := conn.writeBinary(result.audio); err != nil {
 			log.Printf("tts websocket write error: session=%s seq=%d bytes=%d err=%v", sessionID, result.seq, len(result.audio), err)
+			if projectKey != "" {
+				a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+					State:      companionRuntimeStateError,
+					Reason:     "tts_delivery_failed",
+					Error:      err.Error(),
+					ProjectKey: projectKey,
+					OutputMode: turnOutputModeVoice,
+				})
+			}
 			continue
 		}
 		log.Printf("tts delivered: session=%s seq=%d bytes=%d", sessionID, result.seq, len(result.audio))
+		if projectKey != "" {
+			if project, err := a.store.GetProjectByProjectKey(projectKey); err == nil {
+				a.settleCompanionRuntimeState(projectKey, a.loadCompanionConfig(project), "tts_completed")
+			}
+		}
 	}
 }
 

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -155,6 +155,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 			if strings.TrimSpace(ev.TurnID) != "" {
 				latestTurnID = ev.TurnID
 			}
+			a.markCompanionThinking(sessionID, session.ProjectKey, latestTurnID, outputMode, "assistant_turn_started")
 		case "assistant_message":
 			latestMessage = ev.Message
 			latestTurnID = ev.TurnID
@@ -411,6 +412,7 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 			if strings.TrimSpace(ev.TurnID) != "" {
 				latestTurnID = ev.TurnID
 			}
+			a.markCompanionThinking(sessionID, session.ProjectKey, latestTurnID, outputMode, "assistant_turn_started")
 		case "assistant_message":
 			latestMessage = ev.Message
 			latestTurnID = ev.TurnID
@@ -586,6 +588,19 @@ func (a *App) finalizeAssistantResponse(
 	}
 	a.finishCompanionPendingTurn(sessionID, "assistant_turn_completed")
 	a.broadcastChatEvent(sessionID, payload)
+	if isVoiceOutputMode(outputMode) && strings.TrimSpace(chatPlain) != "" {
+		a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+			State:      companionRuntimeStateTalking,
+			Reason:     "assistant_output_ready",
+			ProjectKey: projectKey,
+			TurnID:     tid,
+			OutputMode: outputMode,
+		})
+	} else {
+		if project, err := a.store.GetProjectByProjectKey(projectKey); err == nil {
+			a.settleCompanionRuntimeState(projectKey, a.loadCompanionConfig(project), "assistant_turn_completed")
+		}
+	}
 	return chatMarkdown
 }
 

--- a/internal/web/companion_policy.go
+++ b/internal/web/companion_policy.go
@@ -74,6 +74,13 @@ func (t *companionPendingTurnTracker) clear(chatSessionID string) (companionPend
 	return pending, true
 }
 
+func (t *companionPendingTurnTracker) get(chatSessionID string) (companionPendingTurn, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	pending, ok := t.pending[strings.TrimSpace(chatSessionID)]
+	return pending, ok
+}
+
 func (a *App) loadCompanionInteractionPolicy(cfg companionConfig, session *store.ParticipantSession) companionInteractionPolicyState {
 	if !cfg.CompanionEnabled || !cfg.DirectedSpeechGateEnabled {
 		return evaluateCompanionInteractionPolicy(cfg, session, nil, nil)
@@ -267,6 +274,28 @@ func (a *App) finishCompanionPendingTurn(chatSessionID, eventType string) {
 	}
 	payload := fmt.Sprintf(`{"chat_session_id":%q}`, strings.TrimSpace(chatSessionID))
 	_ = a.store.AddParticipantEvent(pending.participantSessionID, pending.segmentID, strings.TrimSpace(eventType), payload)
+	session, err := a.store.GetParticipantSession(pending.participantSessionID)
+	if err != nil {
+		return
+	}
+	project, err := a.store.GetProjectByProjectKey(session.ProjectKey)
+	if err != nil {
+		return
+	}
+	switch strings.TrimSpace(eventType) {
+	case "assistant_turn_cancelled":
+		a.settleCompanionRuntimeState(session.ProjectKey, a.loadCompanionConfig(project), "assistant_turn_cancelled")
+	case "assistant_turn_failed":
+		a.broadcastCompanionRuntimeState(session.ProjectKey, companionRuntimeSnapshot{
+			State:                companionRuntimeStateError,
+			Reason:               "assistant_turn_failed",
+			ProjectKey:           session.ProjectKey,
+			ParticipantSessionID: pending.participantSessionID,
+			ParticipantSegmentID: pending.segmentID,
+		})
+	case "assistant_turn_completed":
+		a.settleCompanionRuntimeState(session.ProjectKey, a.loadCompanionConfig(project), "assistant_turn_completed")
+	}
 }
 
 func (a *App) interruptCompanionPendingTurn(chatSessionID, participantSessionID string, segmentID int64, activeCanceled, queuedCanceled int) {
@@ -288,4 +317,13 @@ func (a *App) interruptCompanionPendingTurn(chatSessionID, participantSessionID 
 	}
 	payload := fmt.Sprintf(`{"chat_session_id":%q,"active_canceled":%d,"queued_canceled":%d}`, strings.TrimSpace(chatSessionID), activeCanceled, queuedCanceled)
 	_ = a.store.AddParticipantEvent(participantSessionID, segmentID, "assistant_interrupted", payload)
+	session, err := a.store.GetParticipantSession(participantSessionID)
+	if err != nil {
+		return
+	}
+	project, err := a.store.GetProjectByProjectKey(session.ProjectKey)
+	if err != nil {
+		return
+	}
+	a.settleCompanionRuntimeState(session.ProjectKey, a.loadCompanionConfig(project), "assistant_interrupted")
 }

--- a/internal/web/companion_runtime.go
+++ b/internal/web/companion_runtime.go
@@ -1,0 +1,246 @@
+package web
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	companionRuntimeStateThinking = "thinking"
+	companionRuntimeStateTalking  = "talking"
+	companionRuntimeStateError    = "error"
+
+	companionEventState             = "companion_state"
+	companionEventTranscriptPartial = "companion_transcript_partial"
+	companionEventTranscriptFinal   = "companion_transcript_final"
+)
+
+type companionRuntimeSnapshot struct {
+	State                string `json:"state"`
+	Reason               string `json:"reason,omitempty"`
+	Error                string `json:"error,omitempty"`
+	ProjectKey           string `json:"project_key,omitempty"`
+	ChatSessionID        string `json:"chat_session_id,omitempty"`
+	ParticipantSessionID string `json:"participant_session_id,omitempty"`
+	ParticipantSegmentID int64  `json:"participant_segment_id,omitempty"`
+	TurnID               string `json:"turn_id,omitempty"`
+	OutputMode           string `json:"output_mode,omitempty"`
+	UpdatedAt            int64  `json:"updated_at"`
+}
+
+type companionRuntimeTracker struct {
+	mu     sync.Mutex
+	states map[string]companionRuntimeSnapshot
+}
+
+func newCompanionRuntimeTracker() *companionRuntimeTracker {
+	return &companionRuntimeTracker{
+		states: map[string]companionRuntimeSnapshot{},
+	}
+}
+
+func (t *companionRuntimeTracker) set(projectKey string, snapshot companionRuntimeSnapshot) companionRuntimeSnapshot {
+	cleanProjectKey := strings.TrimSpace(projectKey)
+	if cleanProjectKey == "" {
+		return companionRuntimeSnapshot{}
+	}
+	snapshot.ProjectKey = cleanProjectKey
+	snapshot.State = normalizeCompanionRuntimeState(snapshot.State)
+	snapshot.Reason = strings.TrimSpace(snapshot.Reason)
+	snapshot.Error = strings.TrimSpace(snapshot.Error)
+	snapshot.ChatSessionID = strings.TrimSpace(snapshot.ChatSessionID)
+	snapshot.ParticipantSessionID = strings.TrimSpace(snapshot.ParticipantSessionID)
+	snapshot.TurnID = strings.TrimSpace(snapshot.TurnID)
+	snapshot.OutputMode = normalizeTurnOutputMode(snapshot.OutputMode)
+	if snapshot.UpdatedAt == 0 {
+		snapshot.UpdatedAt = time.Now().Unix()
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.states[cleanProjectKey] = snapshot
+	return snapshot
+}
+
+func (t *companionRuntimeTracker) get(projectKey string) (companionRuntimeSnapshot, bool) {
+	cleanProjectKey := strings.TrimSpace(projectKey)
+	if cleanProjectKey == "" {
+		return companionRuntimeSnapshot{}, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	snapshot, ok := t.states[cleanProjectKey]
+	return snapshot, ok
+}
+
+func normalizeCompanionRuntimeState(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case companionRuntimeStateListening:
+		return companionRuntimeStateListening
+	case companionRuntimeStateThinking:
+		return companionRuntimeStateThinking
+	case companionRuntimeStateTalking:
+		return companionRuntimeStateTalking
+	case companionRuntimeStateError:
+		return companionRuntimeStateError
+	default:
+		return companionRuntimeStateIdle
+	}
+}
+
+func (s companionRuntimeSnapshot) payload(eventType string) map[string]interface{} {
+	payload := map[string]interface{}{
+		"type":        strings.TrimSpace(eventType),
+		"state":       s.State,
+		"project_key": s.ProjectKey,
+		"updated_at":  s.UpdatedAt,
+	}
+	if s.Reason != "" {
+		payload["reason"] = s.Reason
+	}
+	if s.Error != "" {
+		payload["error"] = s.Error
+	}
+	if s.ChatSessionID != "" {
+		payload["chat_session_id"] = s.ChatSessionID
+	}
+	if s.ParticipantSessionID != "" {
+		payload["participant_session_id"] = s.ParticipantSessionID
+	}
+	if s.ParticipantSegmentID != 0 {
+		payload["participant_segment_id"] = s.ParticipantSegmentID
+	}
+	if s.TurnID != "" {
+		payload["turn_id"] = s.TurnID
+	}
+	if s.OutputMode != "" {
+		payload["output_mode"] = s.OutputMode
+	}
+	return payload
+}
+
+func (a *App) chatSessionIDForProjectKey(projectKey string) (string, bool) {
+	if a == nil || a.store == nil {
+		return "", false
+	}
+	session, err := a.store.GetOrCreateChatSession(strings.TrimSpace(projectKey))
+	if err != nil {
+		return "", false
+	}
+	return session.ID, true
+}
+
+func (a *App) currentCompanionRuntimeState(projectKey string, cfg companionConfig) companionRuntimeSnapshot {
+	projectKey = strings.TrimSpace(projectKey)
+	if projectKey == "" {
+		return companionRuntimeSnapshot{State: companionRuntimeStateIdle}
+	}
+	if a != nil && a.companionRuntime != nil {
+		if snapshot, ok := a.companionRuntime.get(projectKey); ok {
+			return snapshot
+		}
+	}
+	return a.companionSteadyState(projectKey, cfg, "")
+}
+
+func (a *App) companionSteadyState(projectKey string, cfg companionConfig, reason string) companionRuntimeSnapshot {
+	state := companionRuntimeStateIdle
+	if cfg.CompanionEnabled {
+		if activeSessions := a.activeCompanionSessionCount(projectKey); activeSessions > 0 {
+			state = companionRuntimeStateListening
+			if strings.TrimSpace(reason) == "" {
+				reason = "participant_capture_active"
+			}
+		}
+	}
+	if strings.TrimSpace(reason) == "" {
+		if state == companionRuntimeStateIdle {
+			reason = "idle"
+		} else {
+			reason = "listening"
+		}
+	}
+	return companionRuntimeSnapshot{
+		State:      state,
+		Reason:     strings.TrimSpace(reason),
+		ProjectKey: strings.TrimSpace(projectKey),
+	}
+}
+
+func (a *App) activeCompanionSessionCount(projectKey string) int {
+	if a == nil || a.store == nil {
+		return 0
+	}
+	sessions, err := a.store.ListParticipantSessions(strings.TrimSpace(projectKey))
+	if err != nil {
+		return 0
+	}
+	activeSessions := 0
+	for _, session := range sessions {
+		if session.EndedAt == 0 {
+			activeSessions++
+		}
+	}
+	return activeSessions
+}
+
+func (a *App) setCompanionRuntimeState(projectKey string, snapshot companionRuntimeSnapshot) companionRuntimeSnapshot {
+	if a == nil || a.companionRuntime == nil {
+		return companionRuntimeSnapshot{}
+	}
+	return a.companionRuntime.set(projectKey, snapshot)
+}
+
+func (a *App) companionPendingTurnForChatSession(chatSessionID string) (companionPendingTurn, bool) {
+	if a == nil || a.companionTurns == nil {
+		return companionPendingTurn{}, false
+	}
+	return a.companionTurns.get(chatSessionID)
+}
+
+func (a *App) broadcastCompanionRuntimeState(projectKey string, snapshot companionRuntimeSnapshot) {
+	projectKey = strings.TrimSpace(projectKey)
+	if projectKey == "" {
+		return
+	}
+	sessionID, ok := a.chatSessionIDForProjectKey(projectKey)
+	if !ok {
+		return
+	}
+	snapshot.ChatSessionID = sessionID
+	snapshot = a.setCompanionRuntimeState(projectKey, snapshot)
+	a.broadcastChatEvent(sessionID, snapshot.payload(companionEventState))
+}
+
+func (a *App) settleCompanionRuntimeState(projectKey string, cfg companionConfig, reason string) {
+	a.broadcastCompanionRuntimeState(projectKey, a.companionSteadyState(projectKey, cfg, reason))
+}
+
+func (a *App) broadcastCompanionTranscriptEvent(projectKey string, payload map[string]interface{}) {
+	projectKey = strings.TrimSpace(projectKey)
+	if projectKey == "" {
+		return
+	}
+	sessionID, ok := a.chatSessionIDForProjectKey(projectKey)
+	if !ok {
+		return
+	}
+	payload["project_key"] = projectKey
+	a.broadcastChatEvent(sessionID, payload)
+}
+
+func (a *App) markCompanionThinking(sessionID, projectKey, turnID, outputMode, reason string) {
+	pending, ok := a.companionPendingTurnForChatSession(sessionID)
+	if !ok {
+		return
+	}
+	a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+		State:                companionRuntimeStateThinking,
+		Reason:               strings.TrimSpace(reason),
+		ProjectKey:           strings.TrimSpace(projectKey),
+		ParticipantSessionID: pending.participantSessionID,
+		ParticipantSegmentID: pending.segmentID,
+		TurnID:               strings.TrimSpace(turnID),
+		OutputMode:           outputMode,
+	})
+}

--- a/internal/web/companion_runtime_test.go
+++ b/internal/web/companion_runtime_test.go
@@ -1,0 +1,263 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func waitForWSJSONMessageType(t *testing.T, clientConn *websocket.Conn, timeout time.Duration, wantType string) map[string]interface{} {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := clientConn.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		mt, data, err := clientConn.ReadMessage()
+		if err != nil {
+			netErr, ok := err.(interface{ Timeout() bool })
+			if ok && netErr.Timeout() {
+				continue
+			}
+			t.Fatalf("ReadMessage: %v", err)
+		}
+		if mt != websocket.TextMessage {
+			continue
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			continue
+		}
+		msgType, _ := payload["type"].(string)
+		if strings.TrimSpace(msgType) == wantType {
+			return payload
+		}
+	}
+	t.Fatalf("timed out waiting for websocket message type %q", wantType)
+	return nil
+}
+
+func waitForCompanionState(t *testing.T, clientConn *websocket.Conn, timeout time.Duration, wantState, wantReason string) map[string]interface{} {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		payload := waitForWSJSONMessageType(t, clientConn, time.Until(deadline), companionEventState)
+		gotState, _ := payload["state"].(string)
+		gotReason, _ := payload["reason"].(string)
+		if strings.TrimSpace(gotState) != strings.TrimSpace(wantState) {
+			continue
+		}
+		if strings.TrimSpace(wantReason) != "" && strings.TrimSpace(gotReason) != strings.TrimSpace(wantReason) {
+			continue
+		}
+		return payload
+	}
+	t.Fatalf("timed out waiting for companion state=%q reason=%q", wantState, wantReason)
+	return nil
+}
+
+func TestCompanionRuntimeProtocolEmitsListeningAndTranscriptEvents(t *testing.T) {
+	app := newAuthedTestApp(t)
+	t.Setenv("PATH", t.TempDir())
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"Companion transcript."}`))
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = false
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(chatSession.ID, conn)
+	defer app.hub.unregisterChat(chatSession.ID, conn)
+
+	handleParticipantStart(app, conn, chatSession.ID)
+
+	started := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "participant_started")
+	if strings.TrimSpace(started["session_id"].(string)) == "" {
+		t.Fatal("participant_started.session_id is empty")
+	}
+	stateStarted := waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateListening, "participant_started")
+	if got := strings.TrimSpace(stateStarted["state"].(string)); got != companionRuntimeStateListening {
+		t.Fatalf("start companion state = %q, want %q", got, companionRuntimeStateListening)
+	}
+	if got := strings.TrimSpace(stateStarted["reason"].(string)); got != "participant_started" {
+		t.Fatalf("start companion reason = %q, want participant_started", got)
+	}
+
+	handleParticipantBinaryChunk(app, conn, buildParticipantSpeechWAV(240, 16000))
+
+	partial := waitForWSJSONMessageType(t, clientConn, 2*time.Second, companionEventTranscriptPartial)
+	if got := strings.TrimSpace(partial["text"].(string)); got != "Companion transcript." {
+		t.Fatalf("partial transcript text = %q, want %q", got, "Companion transcript.")
+	}
+	if got := strings.TrimSpace(partial["status"].(string)); got != "partial" {
+		t.Fatalf("partial transcript status = %q, want partial", got)
+	}
+
+	final := waitForWSJSONMessageType(t, clientConn, 2*time.Second, companionEventTranscriptFinal)
+	if got := strings.TrimSpace(final["text"].(string)); got != "Companion transcript." {
+		t.Fatalf("final transcript text = %q, want %q", got, "Companion transcript.")
+	}
+	if got := strings.TrimSpace(final["status"].(string)); got != "final" {
+		t.Fatalf("final transcript status = %q, want final", got)
+	}
+
+	stateFinal := waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateListening, "transcript_finalized")
+	if got := strings.TrimSpace(stateFinal["state"].(string)); got != companionRuntimeStateListening {
+		t.Fatalf("final companion state = %q, want %q", got, companionRuntimeStateListening)
+	}
+	if got := strings.TrimSpace(stateFinal["reason"].(string)); got != "transcript_finalized" {
+		t.Fatalf("final companion reason = %q, want transcript_finalized", got)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/companion/state", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET companion state status = %d, want 200", rr.Code)
+	}
+	var state companionStateResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &state); err != nil {
+		t.Fatalf("decode companion state: %v", err)
+	}
+	if state.State != companionRuntimeStateListening {
+		t.Fatalf("state = %q, want %q", state.State, companionRuntimeStateListening)
+	}
+	if state.Runtime.Reason != "transcript_finalized" {
+		t.Fatalf("runtime.reason = %q, want transcript_finalized", state.Runtime.Reason)
+	}
+}
+
+func TestCompanionRuntimeProtocolTransitionsThroughTalkingAndBackToListening(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession: %v", err)
+	}
+	app.noteCompanionPendingTurn(chatSession.ID, participantSession.ID, 77)
+
+	ttsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write(buildParticipantSpeechWAV(100, 16000))
+	}))
+	defer ttsSrv.Close()
+	app.ttsURL = ttsSrv.URL
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(chatSession.ID, conn)
+	defer app.hub.unregisterChat(chatSession.ID, conn)
+
+	persistedAssistantID := int64(0)
+	persistedAssistantText := ""
+	response := app.finalizeAssistantResponse(chatSession.ID, project.ProjectKey, "Spoken companion reply.", &persistedAssistantID, &persistedAssistantText, "turn-voice", "", "", turnOutputModeVoice)
+	if strings.TrimSpace(response) == "" {
+		t.Fatal("finalizeAssistantResponse returned empty content")
+	}
+
+	stateTalking := waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateTalking, "assistant_output_ready")
+	if got := strings.TrimSpace(stateTalking["state"].(string)); got != companionRuntimeStateTalking {
+		t.Fatalf("assistant output companion state = %q, want %q", got, companionRuntimeStateTalking)
+	}
+
+	seq := conn.reserveTTSSeq()
+	app.handleTTSSpeak(chatSession.ID, conn, seq, "Spoken companion reply.", "en")
+
+	stateTalking = waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateTalking, "tts_started")
+	if got := strings.TrimSpace(stateTalking["reason"].(string)); got != "tts_started" {
+		t.Fatalf("tts start companion reason = %q, want tts_started", got)
+	}
+	stateListening := waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateListening, "tts_completed")
+	if got := strings.TrimSpace(stateListening["state"].(string)); got != companionRuntimeStateListening {
+		t.Fatalf("tts settle companion state = %q, want %q", got, companionRuntimeStateListening)
+	}
+	if got := strings.TrimSpace(stateListening["reason"].(string)); got != "tts_completed" {
+		t.Fatalf("tts settle companion reason = %q, want tts_completed", got)
+	}
+}
+
+func TestInterruptCompanionPendingTurnBroadcastsListeningState(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession: %v", err)
+	}
+	app.noteCompanionPendingTurn(chatSession.ID, participantSession.ID, 99)
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(chatSession.ID, conn)
+	defer app.hub.unregisterChat(chatSession.ID, conn)
+
+	app.interruptCompanionPendingTurn(chatSession.ID, participantSession.ID, 99, 1, 0)
+
+	stateInterrupted := waitForCompanionState(t, clientConn, 2*time.Second, companionRuntimeStateListening, "assistant_interrupted")
+	if got := strings.TrimSpace(stateInterrupted["state"].(string)); got != companionRuntimeStateListening {
+		t.Fatalf("interrupt companion state = %q, want %q", got, companionRuntimeStateListening)
+	}
+	if got := strings.TrimSpace(stateInterrupted["reason"].(string)); got != "assistant_interrupted" {
+		t.Fatalf("interrupt companion reason = %q, want assistant_interrupted", got)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/companion/state", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET companion state status = %d, want 200", rr.Code)
+	}
+	var state companionStateResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &state); err != nil {
+		t.Fatalf("decode companion state: %v", err)
+	}
+	if state.State != companionRuntimeStateListening {
+		t.Fatalf("state = %q, want %q", state.State, companionRuntimeStateListening)
+	}
+	if state.Runtime.Reason != "assistant_interrupted" {
+		t.Fatalf("runtime.reason = %q, want assistant_interrupted", state.Runtime.Reason)
+	}
+}

--- a/internal/web/projects_companion.go
+++ b/internal/web/projects_companion.go
@@ -49,6 +49,7 @@ type companionStateResponse struct {
 	ProjectID          string                          `json:"project_id"`
 	ProjectKey         string                          `json:"project_key"`
 	State              string                          `json:"state"`
+	Runtime            companionRuntimeSnapshot        `json:"runtime"`
 	CompanionEnabled   bool                            `json:"companion_enabled"`
 	IdleSurface        string                          `json:"idle_surface"`
 	AudioPersistence   string                          `json:"audio_persistence"`
@@ -320,17 +321,15 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 	if gateSession == nil {
 		gateSession = latestSession
 	}
-	state := companionRuntimeStateIdle
-	if cfg.CompanionEnabled && activeSessions > 0 {
-		state = companionRuntimeStateListening
-	}
+	runtime := a.currentCompanionRuntimeState(project.ProjectKey, cfg)
 	gate := a.loadCompanionDirectedSpeechGate(cfg, gateSession)
 	policy := a.loadCompanionInteractionPolicy(cfg, gateSession)
 	writeJSON(w, companionStateResponse{
 		OK:                 true,
 		ProjectID:          project.ID,
 		ProjectKey:         project.ProjectKey,
-		State:              state,
+		State:              runtime.State,
+		Runtime:            runtime,
 		CompanionEnabled:   cfg.CompanionEnabled,
 		IdleSurface:        cfg.IdleSurface,
 		AudioPersistence:   cfg.AudioPersistence,
@@ -380,4 +379,9 @@ func (a *App) disableCompanionCapture(projectKey string) {
 		_ = a.store.EndParticipantSession(session.ID)
 		_ = a.store.AddParticipantEvent(session.ID, 0, "session_stopped", `{"reason":"companion_disabled"}`)
 	}
+	a.broadcastCompanionRuntimeState(cleanProjectKey, companionRuntimeSnapshot{
+		State:      companionRuntimeStateIdle,
+		Reason:     "companion_disabled",
+		ProjectKey: cleanProjectKey,
+	})
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -91,16 +91,17 @@ type App struct {
 
 	upgrader websocket.Upgrader
 
-	mu              sync.Mutex
-	confirmMu       sync.Mutex
-	workerWG        sync.WaitGroup
-	hub             *wsHub
-	turns           *chatTurnTracker
-	companionTurns  *companionPendingTurnTracker
-	tunnels         *tunnelRegistry
-	chatAppSessions map[string]*appserver.Session
-	pendingDanger   map[string]*pendingDangerousAction
-	ghCommandRunner ghCommandRunner
+	mu               sync.Mutex
+	confirmMu        sync.Mutex
+	workerWG         sync.WaitGroup
+	hub              *wsHub
+	turns            *chatTurnTracker
+	companionTurns   *companionPendingTurnTracker
+	companionRuntime *companionRuntimeTracker
+	tunnels          *tunnelRegistry
+	chatAppSessions  map[string]*appserver.Session
+	pendingDanger    map[string]*pendingDangerousAction
+	ghCommandRunner  ghCommandRunner
 
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
@@ -262,6 +263,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		hub:                           newWSHub(),
 		turns:                         newChatTurnTracker(),
 		companionTurns:                newCompanionPendingTurnTracker(),
+		companionRuntime:              newCompanionRuntimeTracker(),
 		tunnels:                       newTunnelRegistry(),
 		chatAppSessions:               map[string]*appserver.Session{},
 		pendingDanger:                 map[string]*pendingDangerousAction{},


### PR DESCRIPTION
## Summary
- add a project-scoped companion runtime tracker for `idle`, `listening`, `thinking`, `talking`, and `error`
- emit websocket protocol events for companion state changes plus transcript partial/final milestones
- expose the tracked runtime in `/api/projects/{project_id}/companion/state` and cover the protocol with focused Go tests

## Verification
- States `idle|listening|thinking|talking|error`: implemented in `internal/web/companion_runtime.go`; exercised by `TestProjectCompanionStateReportsListeningWhenEnabled`, `TestCompanionRuntimeProtocolEmitsListeningAndTranscriptEvents`, and `TestCompanionRuntimeProtocolTransitionsThroughTalkingAndBackToListening`.
- Companion toggle enter/exit behavior: `handleParticipantStart`, `releaseParticipantSession`, and `disableCompanionCapture` now broadcast companion runtime transitions for start, stop, and disable paths; covered by `TestProjectCompanionConfigPutAndState` and `TestProjectCompanionStateReportsListeningWhenEnabled`.
- Partial/final transcript events: `transcribeParticipantChunk` now emits `companion_transcript_partial` and `companion_transcript_final`; verified by `TestCompanionRuntimeProtocolEmitsListeningAndTranscriptEvents`.
- Response/TTS state events: `markCompanionThinking`, `finalizeAssistantResponse`, and `handleTTSSpeak` now emit `thinking`, `talking`, and settle-back state events; verified by `TestCompanionRuntimeProtocolTransitionsThroughTalkingAndBackToListening`.
- Interruption semantics: `interruptCompanionPendingTurn` now settles runtime state and broadcasts the interruption transition; verified by `TestInterruptCompanionPendingTurnBroadcastsListeningState`, `TestCompanionResponseTriggerInterruptsPendingTurn`, and `TestEvaluateCompanionInteractionPolicyInterruptsPendingResponse`.
- Test command: `go test -count=1 ./internal/web -run 'Test(ProjectCompanion|CompanionRuntime|CompanionResponseTriggerInterruptsPendingTurn|EvaluateCompanionInteractionPolicyInterruptsPendingResponse)' 2>&1 | tee /tmp/tabura-issue-136-test.log`
- Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.060s`
