### PR TITLE
fix: Companion Mode: room memory and entity timeline (fixes #132)

### DIFF
--- a/internal/roomstate/derive.go
+++ b/internal/roomstate/derive.go
@@ -1,0 +1,375 @@
+package roomstate
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type Result struct {
+	SummaryText   string
+	Entities      []string
+	TopicTimeline []any
+	UpdatedAt     int64
+}
+
+type timelineItem struct {
+	At        int64
+	Type      string
+	EventType string
+	Speaker   string
+	Topic     string
+	Detail    string
+	SegmentID int64
+}
+
+var (
+	entityPattern          = regexp.MustCompile(`\b(?:[A-Z][a-z0-9]+|[A-Z]{2,})(?:\s+(?:[A-Z][a-z0-9]+|[A-Z]{2,}))*\b`)
+	spacePattern           = regexp.MustCompile(`\s+`)
+	punctuationTrimPattern = regexp.MustCompile(`^[^A-Za-z0-9]+|[^A-Za-z0-9]+$`)
+)
+
+var ignoredEntities = map[string]struct{}{
+	"a":         {},
+	"an":        {},
+	"and":       {},
+	"assistant": {},
+	"hello":     {},
+	"i":         {},
+	"meeting":   {},
+	"please":    {},
+	"session":   {},
+	"speaker":   {},
+	"tabura":    {},
+	"task":      {},
+	"thanks":    {},
+	"the":       {},
+	"we":        {},
+}
+
+func Derive(segments []store.ParticipantSegment, events []store.ParticipantEvent) Result {
+	entitySet := map[string]struct{}{}
+	timeline := make([]timelineItem, 0, len(segments)+len(events))
+	updatedAt := int64(0)
+
+	for _, seg := range segments {
+		if ts := maxInt64(seg.CommittedAt, maxInt64(seg.EndTS, seg.StartTS)); ts > updatedAt {
+			updatedAt = ts
+		}
+		text := normalizeSpace(seg.Text)
+		speaker := cleanEntityName(seg.Speaker)
+		if speaker != "" {
+			entitySet[speaker] = struct{}{}
+		}
+		if text == "" {
+			continue
+		}
+		addEntities(entitySet, speaker)
+		addEntities(entitySet, extractEntities(text)...)
+		topic := summarizeTextTopic(text)
+		if topic == "" {
+			continue
+		}
+		timeline = append(timeline, timelineItem{
+			At:        maxInt64(seg.StartTS, seg.CommittedAt),
+			Type:      "segment",
+			Speaker:   speaker,
+			Topic:     topic,
+			Detail:    text,
+			SegmentID: seg.ID,
+		})
+	}
+
+	for _, event := range events {
+		if event.CreatedAt > updatedAt {
+			updatedAt = event.CreatedAt
+		}
+		addEntities(entitySet, extractEntitiesFromPayload(event.PayloadJSON)...)
+		item := timelineFromEvent(event)
+		if item.Topic == "" && item.Detail == "" {
+			continue
+		}
+		timeline = append(timeline, item)
+	}
+
+	sort.SliceStable(timeline, func(i, j int) bool {
+		if timeline[i].At == timeline[j].At {
+			if timeline[i].SegmentID == timeline[j].SegmentID {
+				return timeline[i].EventType < timeline[j].EventType
+			}
+			return timeline[i].SegmentID < timeline[j].SegmentID
+		}
+		return timeline[i].At < timeline[j].At
+	})
+	timeline = dedupeTimeline(timeline)
+
+	entities := make([]string, 0, len(entitySet))
+	for entity := range entitySet {
+		entities = append(entities, entity)
+	}
+	sort.Strings(entities)
+
+	resultTimeline := make([]any, 0, len(timeline))
+	for _, item := range timeline {
+		entry := map[string]any{
+			"at":    item.At,
+			"type":  item.Type,
+			"topic": item.Topic,
+		}
+		if item.EventType != "" {
+			entry["event_type"] = item.EventType
+		}
+		if item.Speaker != "" {
+			entry["speaker"] = item.Speaker
+		}
+		if item.Detail != "" {
+			entry["detail"] = item.Detail
+		}
+		if item.SegmentID != 0 {
+			entry["segment_id"] = item.SegmentID
+		}
+		resultTimeline = append(resultTimeline, entry)
+	}
+
+	return Result{
+		SummaryText:   buildSummary(entities, timeline),
+		Entities:      entities,
+		TopicTimeline: resultTimeline,
+		UpdatedAt:     updatedAt,
+	}
+}
+
+func buildSummary(entities []string, timeline []timelineItem) string {
+	topics := latestDistinctTopics(timeline, 3)
+	parts := make([]string, 0, 2)
+	if len(topics) > 0 {
+		parts = append(parts, fmt.Sprintf("Timeline: %s.", strings.Join(topics, "; ")))
+	}
+	if len(entities) > 0 {
+		parts = append(parts, fmt.Sprintf("Entities: %s.", strings.Join(firstN(entities, 4), ", ")))
+	}
+	return strings.Join(parts, " ")
+}
+
+func latestDistinctTopics(timeline []timelineItem, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, n)
+	for i := len(timeline) - 1; i >= 0 && len(out) < n; i-- {
+		topic := normalizeSpace(timeline[i].Topic)
+		if topic == "" {
+			continue
+		}
+		key := strings.ToLower(topic)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, topic)
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+func firstN(values []string, n int) []string {
+	if n <= 0 || len(values) == 0 {
+		return nil
+	}
+	if len(values) <= n {
+		return values
+	}
+	return values[:n]
+}
+
+func dedupeTimeline(items []timelineItem) []timelineItem {
+	if len(items) == 0 {
+		return items
+	}
+	out := make([]timelineItem, 0, len(items))
+	var prev timelineItem
+	for i, item := range items {
+		if i == 0 || !sameTimelineItem(prev, item) {
+			out = append(out, item)
+			prev = item
+		}
+	}
+	return out
+}
+
+func sameTimelineItem(a, b timelineItem) bool {
+	return a.At == b.At &&
+		a.Type == b.Type &&
+		a.EventType == b.EventType &&
+		a.Speaker == b.Speaker &&
+		a.Topic == b.Topic &&
+		a.Detail == b.Detail &&
+		a.SegmentID == b.SegmentID
+}
+
+func timelineFromEvent(event store.ParticipantEvent) timelineItem {
+	payload := parsePayload(event.PayloadJSON)
+	topic := ""
+	detail := ""
+	switch strings.TrimSpace(event.EventType) {
+	case "segment_committed":
+		topic = ""
+	case "session_started":
+		topic = "Session started"
+		detail = payloadString(payload, "reason")
+	case "session_stopped":
+		topic = "Session stopped"
+		detail = payloadString(payload, "reason")
+	case "assistant_triggered":
+		topic = "Assistant response triggered"
+	case "assistant_turn_completed":
+		topic = "Assistant response completed"
+	case "assistant_turn_cancelled":
+		topic = "Assistant response cancelled"
+	case "assistant_turn_failed":
+		topic = "Assistant response failed"
+	case "assistant_interrupted":
+		topic = "Assistant response interrupted"
+	default:
+		topic = payloadString(payload, "topic")
+		if topic == "" {
+			topic = summarizeTextTopic(payloadString(payload, "text"))
+		}
+	}
+	return timelineItem{
+		At:        event.CreatedAt,
+		Type:      "event",
+		EventType: strings.TrimSpace(event.EventType),
+		Topic:     normalizeSpace(topic),
+		Detail:    normalizeSpace(detail),
+		SegmentID: event.SegmentID,
+	}
+}
+
+func extractEntitiesFromPayload(raw string) []string {
+	payload := parsePayload(raw)
+	if payload == nil {
+		return nil
+	}
+	out := []string{}
+	collectPayloadEntities(&out, "", payload)
+	return out
+}
+
+func collectPayloadEntities(out *[]string, key string, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		for childKey, childValue := range v {
+			collectPayloadEntities(out, childKey, childValue)
+		}
+	case []any:
+		for _, childValue := range v {
+			collectPayloadEntities(out, key, childValue)
+		}
+	case string:
+		clean := normalizeSpace(v)
+		if clean == "" {
+			return
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "entity", "entities", "name", "participant", "participants", "person", "people", "project", "speaker", "subject", "team":
+			*out = append(*out, cleanEntityName(clean))
+		case "text", "topic", "title":
+			*out = append(*out, extractEntities(clean)...)
+		}
+	}
+}
+
+func parsePayload(raw string) map[string]any {
+	clean := strings.TrimSpace(raw)
+	if clean == "" || clean == "{}" {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(clean), &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func payloadString(payload map[string]any, key string) string {
+	if payload == nil {
+		return ""
+	}
+	value := normalizeSpace(fmt.Sprint(payload[key]))
+	if value == "<nil>" {
+		return ""
+	}
+	return value
+}
+
+func addEntities(set map[string]struct{}, entities ...string) {
+	for _, entity := range entities {
+		clean := cleanEntityName(entity)
+		if clean == "" {
+			continue
+		}
+		set[clean] = struct{}{}
+	}
+}
+
+func extractEntities(text string) []string {
+	matches := entityPattern.FindAllString(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		clean := cleanEntityName(match)
+		if clean != "" {
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+func cleanEntityName(raw string) string {
+	clean := punctuationTrimPattern.ReplaceAllString(normalizeSpace(raw), "")
+	if clean == "" {
+		return ""
+	}
+	if _, ignored := ignoredEntities[strings.ToLower(clean)]; ignored {
+		return ""
+	}
+	return clean
+}
+
+func summarizeTextTopic(text string) string {
+	clean := normalizeSpace(text)
+	if clean == "" {
+		return ""
+	}
+	clean = strings.TrimPrefix(clean, "Tabura, ")
+	clean = strings.TrimPrefix(clean, "tabura, ")
+	clean = strings.TrimPrefix(clean, "Assistant, ")
+	clean = strings.TrimPrefix(clean, "assistant, ")
+	clean = strings.TrimRight(clean, ".!?")
+	words := strings.Fields(clean)
+	if len(words) > 10 {
+		words = words[:10]
+	}
+	return strings.Join(words, " ")
+}
+
+func normalizeSpace(raw string) string {
+	return strings.TrimSpace(spacePattern.ReplaceAllString(raw, " "))
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/roomstate/derive_test.go
+++ b/internal/roomstate/derive_test.go
@@ -1,0 +1,82 @@
+package roomstate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestDeriveCarriesEntitiesAndReconstructsTimeline(t *testing.T) {
+	segments := []store.ParticipantSegment{
+		{
+			ID:          1,
+			SessionID:   "psess-1",
+			StartTS:     100,
+			EndTS:       101,
+			Speaker:     "Alice",
+			Text:        "Review the Acme Cloud budget and API rollout.",
+			CommittedAt: 102,
+			Status:      "final",
+		},
+		{
+			ID:          2,
+			SessionID:   "psess-1",
+			StartTS:     130,
+			EndTS:       131,
+			Speaker:     "Bob",
+			Text:        "Bob will send Contoso follow-up notes after the meeting.",
+			CommittedAt: 132,
+			Status:      "final",
+		},
+	}
+	events := []store.ParticipantEvent{
+		{SessionID: "psess-1", EventType: "session_started", PayloadJSON: `{"reason":"manual"}`, CreatedAt: 99},
+		{SessionID: "psess-1", SegmentID: 2, EventType: "assistant_triggered", PayloadJSON: `{"chat_session_id":"chat-1"}`, CreatedAt: 140},
+		{SessionID: "psess-1", SegmentID: 2, EventType: "assistant_turn_completed", PayloadJSON: `{"chat_session_id":"chat-1"}`, CreatedAt: 150},
+		{SessionID: "psess-1", EventType: "session_stopped", PayloadJSON: `{"reason":"manual"}`, CreatedAt: 160},
+	}
+
+	result := Derive(segments, events)
+
+	for _, want := range []string{"Alice", "Bob", "Acme Cloud", "Contoso"} {
+		if !contains(result.Entities, want) {
+			t.Fatalf("entities = %#v, want %q", result.Entities, want)
+		}
+	}
+	if result.UpdatedAt != 160 {
+		t.Fatalf("updated_at = %d, want 160", result.UpdatedAt)
+	}
+	if len(result.TopicTimeline) != 6 {
+		t.Fatalf("topic_timeline = %d, want 6", len(result.TopicTimeline))
+	}
+	first, ok := result.TopicTimeline[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first timeline item type = %T, want map[string]any", result.TopicTimeline[0])
+	}
+	if got := strings.TrimSpace(first["topic"].(string)); got != "Session started" {
+		t.Fatalf("first topic = %q, want Session started", got)
+	}
+	last, ok := result.TopicTimeline[len(result.TopicTimeline)-1].(map[string]any)
+	if !ok {
+		t.Fatalf("last timeline item type = %T, want map[string]any", result.TopicTimeline[len(result.TopicTimeline)-1])
+	}
+	if got := strings.TrimSpace(last["topic"].(string)); got != "Session stopped" {
+		t.Fatalf("last topic = %q, want Session stopped", got)
+	}
+	if !strings.Contains(result.SummaryText, "Assistant response completed") {
+		t.Fatalf("summary_text = %q, want assistant completion topic", result.SummaryText)
+	}
+	if !strings.Contains(result.SummaryText, "Acme Cloud") {
+		t.Fatalf("summary_text = %q, want entity carry-forward", result.SummaryText)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/projects_companion_artifacts.go
+++ b/internal/web/projects_companion_artifacts.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/krystophny/tabura/internal/roomstate"
 	"github.com/krystophny/tabura/internal/store"
 )
 
@@ -144,6 +145,120 @@ func parseCompanionTopicTimeline(raw string) []any {
 	return out
 }
 
+func mergeCompanionEntities(primary, secondary []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(primary)+len(secondary))
+	for _, entity := range append(primary, secondary...) {
+		clean := strings.TrimSpace(entity)
+		if clean == "" {
+			continue
+		}
+		key := strings.ToLower(clean)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, clean)
+	}
+	return out
+}
+
+func normalizeTimelineKey(item any) string {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return strings.TrimSpace(fmt.Sprint(item))
+	}
+	return string(data)
+}
+
+func mergeCompanionTopicTimeline(primary, secondary []any) []any {
+	seen := map[string]struct{}{}
+	out := make([]any, 0, len(primary)+len(secondary))
+	for _, item := range append(primary, secondary...) {
+		key := normalizeTimelineKey(item)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func formatCompanionTopicTimelineItem(item any) string {
+	if typed, ok := item.(map[string]any); ok {
+		topic := strings.TrimSpace(fmt.Sprint(typed["topic"]))
+		speaker := strings.TrimSpace(fmt.Sprint(typed["speaker"]))
+		detail := strings.TrimSpace(fmt.Sprint(typed["detail"]))
+		if topic == "<nil>" {
+			topic = ""
+		}
+		if speaker == "<nil>" {
+			speaker = ""
+		}
+		if detail == "<nil>" {
+			detail = ""
+		}
+		switch {
+		case speaker != "" && detail != "" && detail != topic:
+			return fmt.Sprintf("%s: %s (%s)", speaker, topic, detail)
+		case speaker != "" && topic != "":
+			return fmt.Sprintf("%s: %s", speaker, topic)
+		case topic != "" && detail != "" && detail != topic:
+			return fmt.Sprintf("%s (%s)", topic, detail)
+		case topic != "":
+			return topic
+		case detail != "":
+			return detail
+		}
+	}
+	return strings.TrimSpace(fmt.Sprint(item))
+}
+
+type companionRoomMemory struct {
+	SummaryText   string
+	UpdatedAt     int64
+	Entities      []string
+	TopicTimeline []any
+}
+
+func (a *App) loadCompanionRoomMemory(sessionID string) (companionRoomMemory, error) {
+	segments, err := a.store.ListParticipantSegments(sessionID, 0, 0)
+	if err != nil {
+		return companionRoomMemory{}, err
+	}
+	events, err := a.store.ListParticipantEvents(sessionID)
+	if err != nil {
+		return companionRoomMemory{}, err
+	}
+	derived := roomstate.Derive(segments, events)
+	memory := companionRoomMemory{
+		SummaryText:   derived.SummaryText,
+		UpdatedAt:     derived.UpdatedAt,
+		Entities:      derived.Entities,
+		TopicTimeline: derived.TopicTimeline,
+	}
+	state, err := a.store.GetParticipantRoomState(sessionID)
+	if err != nil {
+		if isNoRows(err) {
+			return memory, nil
+		}
+		return companionRoomMemory{}, err
+	}
+	if strings.TrimSpace(state.SummaryText) != "" {
+		memory.SummaryText = state.SummaryText
+	}
+	if state.UpdatedAt > memory.UpdatedAt {
+		memory.UpdatedAt = state.UpdatedAt
+	}
+	memory.Entities = mergeCompanionEntities(parseCompanionEntities(state.EntitiesJSON), memory.Entities)
+	memory.TopicTimeline = mergeCompanionTopicTimeline(parseCompanionTopicTimeline(state.TopicTimelineJSON), memory.TopicTimeline)
+	return memory, nil
+}
+
 func respondCompanionArtifact(w http.ResponseWriter, format string, payload any, markdownText, plainText string) {
 	switch strings.ToLower(strings.TrimSpace(format)) {
 	case "", "json":
@@ -272,7 +387,7 @@ func renderCompanionReferencesMarkdown(session *store.ParticipantSession, entiti
 		return b.String()
 	}
 	for _, topic := range topics {
-		fmt.Fprintf(&b, "- %s\n", strings.TrimSpace(fmt.Sprint(topic)))
+		fmt.Fprintf(&b, "- %s\n", formatCompanionTopicTimelineItem(topic))
 	}
 	return b.String()
 }
@@ -297,7 +412,7 @@ func renderCompanionReferencesText(session *store.ParticipantSession, entities [
 		return b.String()
 	}
 	for _, topic := range topics {
-		fmt.Fprintf(&b, "- %s\n", strings.TrimSpace(fmt.Sprint(topic)))
+		fmt.Fprintf(&b, "- %s\n", formatCompanionTopicTimelineItem(topic))
 	}
 	return b.String()
 }
@@ -348,15 +463,13 @@ func (a *App) handleProjectCompanionSummary(w http.ResponseWriter, r *http.Reque
 	summaryText := ""
 	updatedAt := int64(0)
 	if session != nil {
-		state, err := a.store.GetParticipantRoomState(session.ID)
-		if err != nil && !isNoRows(err) {
+		memory, err := a.loadCompanionRoomMemory(session.ID)
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if err == nil {
-			summaryText = state.SummaryText
-			updatedAt = state.UpdatedAt
-		}
+		summaryText = memory.SummaryText
+		updatedAt = memory.UpdatedAt
 	}
 	payload := companionSummaryResponse{
 		OK:          true,
@@ -381,15 +494,13 @@ func (a *App) handleProjectCompanionReferences(w http.ResponseWriter, r *http.Re
 	entities := []string{}
 	topics := []any{}
 	if session != nil {
-		state, err := a.store.GetParticipantRoomState(session.ID)
-		if err != nil && !isNoRows(err) {
+		memory, err := a.loadCompanionRoomMemory(session.ID)
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if err == nil {
-			entities = parseCompanionEntities(state.EntitiesJSON)
-			topics = parseCompanionTopicTimeline(state.TopicTimelineJSON)
-		}
+		entities = memory.Entities
+		topics = memory.TopicTimeline
 	}
 	payload := companionReferencesResponse{
 		OK:            true,

--- a/internal/web/projects_companion_artifacts_test.go
+++ b/internal/web/projects_companion_artifacts_test.go
@@ -150,3 +150,178 @@ func TestProjectCompanionSummaryAndReferencesAPIAndExports(t *testing.T) {
 		t.Fatalf("references markdown missing captured metadata: %q", rr.Body.String())
 	}
 }
+
+func TestProjectCompanionRoomMemoryDerivesFromTranscriptAndEvents(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, session := seedProjectCompanionSession(t, app)
+
+	if err := app.store.AddParticipantEvent(session.ID, 0, "session_started", `{"reason":"manual"}`); err != nil {
+		t.Fatalf("AddParticipantEvent session_started: %v", err)
+	}
+	seg1, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   session.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Speaker:     "Alice",
+		Text:        "Review the Acme Cloud budget before Friday.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("AddParticipantSegment seg1: %v", err)
+	}
+	seg2, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   session.ID,
+		StartTS:     120,
+		EndTS:       121,
+		Speaker:     "Bob",
+		Text:        "Bob will send Contoso follow-up notes after the meeting.",
+		CommittedAt: 122,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("AddParticipantSegment seg2: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(session.ID, seg1.ID, "segment_committed", `{"text":"Review the Acme Cloud budget before Friday."}`); err != nil {
+		t.Fatalf("AddParticipantEvent segment_committed seg1: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(session.ID, seg2.ID, "segment_committed", `{"text":"Bob will send Contoso follow-up notes after the meeting."}`); err != nil {
+		t.Fatalf("AddParticipantEvent segment_committed seg2: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(session.ID, seg2.ID, "assistant_triggered", `{"chat_session_id":"chat-1"}`); err != nil {
+		t.Fatalf("AddParticipantEvent assistant_triggered: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(session.ID, seg2.ID, "assistant_turn_completed", `{"chat_session_id":"chat-1"}`); err != nil {
+		t.Fatalf("AddParticipantEvent assistant_turn_completed: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/summary", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET derived summary status = %d, want 200", rr.Code)
+	}
+	var summary companionSummaryResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("decode derived summary payload: %v", err)
+	}
+	if summary.Session == nil || summary.Session.ID != session.ID {
+		t.Fatalf("summary session = %#v, want %q", summary.Session, session.ID)
+	}
+	if !strings.Contains(summary.SummaryText, "Assistant response completed") {
+		t.Fatalf("summary_text = %q, want assistant completion topic", summary.SummaryText)
+	}
+	if !strings.Contains(summary.SummaryText, "Acme Cloud") {
+		t.Fatalf("summary_text = %q, want derived entity", summary.SummaryText)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/references", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET derived references status = %d, want 200", rr.Code)
+	}
+	var refs companionReferencesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &refs); err != nil {
+		t.Fatalf("decode derived references payload: %v", err)
+	}
+	for _, want := range []string{"Alice", "Bob", "Acme Cloud", "Contoso"} {
+		if !containsString(refs.Entities, want) {
+			t.Fatalf("entities = %#v, want %q", refs.Entities, want)
+		}
+	}
+	if len(refs.TopicTimeline) != 5 {
+		t.Fatalf("topic_timeline = %d, want 5", len(refs.TopicTimeline))
+	}
+	if !topicTimelineContains(refs.TopicTimeline, "Session started") {
+		t.Fatalf("topic_timeline = %#v, want Session started entry", refs.TopicTimeline)
+	}
+	last, ok := refs.TopicTimeline[len(refs.TopicTimeline)-1].(map[string]any)
+	if !ok {
+		t.Fatalf("last topic timeline entry type = %T, want map[string]any", refs.TopicTimeline[len(refs.TopicTimeline)-1])
+	}
+	if got := strings.TrimSpace(last["topic"].(string)); got != "Assistant response completed" {
+		t.Fatalf("last topic = %q, want Assistant response completed", got)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/references?format=md", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET derived references markdown status = %d, want 200", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "Alice: Review the Acme Cloud budget before Friday") {
+		t.Fatalf("references markdown missing derived segment timeline: %q", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Assistant response completed") {
+		t.Fatalf("references markdown missing derived assistant event: %q", rr.Body.String())
+	}
+}
+
+func TestProjectCompanionRoomMemoryIsProjectScoped(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, session := seedProjectCompanionSession(t, app)
+
+	otherProject, err := app.store.CreateProject("Meeting Temp", "meeting-temp", t.TempDir(), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject other: %v", err)
+	}
+	otherSession, err := app.store.AddParticipantSession(otherProject.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession other: %v", err)
+	}
+
+	if _, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   session.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Speaker:     "Alice",
+		Text:        "Discuss the Acme Cloud budget.",
+		CommittedAt: 102,
+		Status:      "final",
+	}); err != nil {
+		t.Fatalf("AddParticipantSegment primary: %v", err)
+	}
+	if _, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   otherSession.ID,
+		StartTS:     200,
+		EndTS:       201,
+		Speaker:     "Mallory",
+		Text:        "Discuss the Zeus acquisition.",
+		CommittedAt: 202,
+		Status:      "final",
+	}); err != nil {
+		t.Fatalf("AddParticipantSegment other: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/references", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET scoped references status = %d, want 200", rr.Code)
+	}
+	var refs companionReferencesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &refs); err != nil {
+		t.Fatalf("decode scoped references payload: %v", err)
+	}
+	if !containsString(refs.Entities, "Acme Cloud") {
+		t.Fatalf("entities = %#v, want Acme Cloud", refs.Entities)
+	}
+	if containsString(refs.Entities, "Zeus") || containsString(refs.Entities, "Mallory") {
+		t.Fatalf("entities leaked across projects: %#v", refs.Entities)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func topicTimelineContains(items []any, want string) bool {
+	for _, item := range items {
+		typed, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(typed["topic"].(string)) == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add `internal/roomstate` to derive companion entities, summaries, and topic timelines from participant transcript segments plus structured session events
- use the derived room memory in the companion summary and references endpoints, while merging any persisted room-state metadata
- render structured timeline entries cleanly in markdown/text companion artifacts

## Verification
- Entity carry-forward and timeline reconstruction: `go test ./internal/roomstate ./internal/web -run 'TestDeriveCarriesEntitiesAndReconstructsTimeline|TestProjectCompanionSummaryAndReferencesAPIAndExports|TestProjectCompanionRoomMemoryDerivesFromTranscriptAndEvents|TestProjectCompanionRoomMemoryIsProjectScoped'`
  - output: `ok   github.com/krystophny/tabura/internal/roomstate 0.002s` and `ok   github.com/krystophny/tabura/internal/web 0.025s`
  - tests: `TestDeriveCarriesEntitiesAndReconstructsTimeline` and `TestProjectCompanionRoomMemoryDerivesFromTranscriptAndEvents`
- Memory is derived from transcript text plus structured session events only: same command
  - evidence: `TestProjectCompanionRoomMemoryDerivesFromTranscriptAndEvents` does not call `UpsertParticipantRoomState`; it verifies derived `/api/projects/<id>/summary` content contains `Assistant response completed` and the `/api/projects/<id>/references?format=md` artifact contains `Alice: Review the Acme Cloud budget before Friday`
- Project scoping for future temporary meeting/task projects: same command
  - evidence: `TestProjectCompanionRoomMemoryIsProjectScoped` verifies one project's derived entities include `Acme Cloud` and exclude another project's `Zeus`/`Mallory` transcript data; this is the same project-key session boundary temporary projects will use
- Persisted artifacts remain text/metadata only: same command
  - evidence: `TestProjectCompanionSummaryAndReferencesAPIAndExports` still asserts the transcript/summary/references payloads do not contain `audio`
