### PR TITLE
fix: Companion Mode: temporary projects for meetings and long-running (fixes #135)

### DIFF
--- a/internal/store/store_project.go
+++ b/internal/store/store_project.go
@@ -11,6 +11,10 @@ import (
 
 func normalizeProjectKind(kind string) string {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "meeting":
+		return "meeting"
+	case "task":
+		return "task"
 	case "linked":
 		return "linked"
 	case "hub":
@@ -277,4 +281,85 @@ func (s *Store) UpdateProjectChatModelReasoningEffort(id, effort string) error {
 		projectID,
 	)
 	return err
+}
+
+func (s *Store) UpdateProjectKind(id, kind string) error {
+	projectID := strings.TrimSpace(id)
+	if projectID == "" {
+		return errors.New("project id is required")
+	}
+	_, err := s.db.Exec(
+		`UPDATE projects SET kind = ?, updated_at = ? WHERE id = ?`,
+		normalizeProjectKind(kind),
+		time.Now().Unix(),
+		projectID,
+	)
+	return err
+}
+
+func (s *Store) DeleteProject(id string) error {
+	projectID := strings.TrimSpace(id)
+	if projectID == "" {
+		return errors.New("project id is required")
+	}
+	project, err := s.GetProject(projectID)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	projectKey := strings.TrimSpace(project.ProjectKey)
+	if _, err := tx.Exec(
+		`DELETE FROM participant_room_state
+		 WHERE session_id IN (SELECT id FROM participant_sessions WHERE project_key = ?)`,
+		projectKey,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM participant_events
+		 WHERE session_id IN (SELECT id FROM participant_sessions WHERE project_key = ?)`,
+		projectKey,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM participant_segments
+		 WHERE session_id IN (SELECT id FROM participant_sessions WHERE project_key = ?)`,
+		projectKey,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM participant_sessions WHERE project_key = ?`, projectKey); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM chat_messages
+		 WHERE session_id IN (SELECT id FROM chat_sessions WHERE project_key = ?)`,
+		projectKey,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM chat_events
+		 WHERE session_id IN (SELECT id FROM chat_sessions WHERE project_key = ?)`,
+		projectKey,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM chat_sessions WHERE project_key = ?`, projectKey); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM projects WHERE id = ?`, projectID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM app_state WHERE key = 'active_project_id' AND value = ?`, projectID); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -152,6 +152,7 @@ func TestStoreProjectLifecycleAndAppState(t *testing.T) {
 	s := newTestStore(t)
 	rootA := filepath.Join(t.TempDir(), "workspace-a")
 	rootB := filepath.Join(t.TempDir(), "workspace-b")
+	rootMeeting := filepath.Join(t.TempDir(), "meeting-a")
 
 	if _, err := s.CreateProject("", "key-a", rootA, "managed", "", "", false); err == nil {
 		t.Fatalf("expected empty project name validation error")
@@ -174,6 +175,14 @@ func TestStoreProjectLifecycleAndAppState(t *testing.T) {
 	}
 	if !p2.IsDefault {
 		t.Fatalf("p2 should be default")
+	}
+
+	meeting, err := s.CreateProject("Meeting Temp", "key-meeting", rootMeeting, "meeting", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject(meeting) error: %v", err)
+	}
+	if meeting.Kind != "meeting" {
+		t.Fatalf("meeting kind = %q, want meeting", meeting.Kind)
 	}
 
 	gotByKey, err := s.GetProjectByProjectKey("key-a")
@@ -241,8 +250,8 @@ func TestStoreProjectLifecycleAndAppState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListProjects() error: %v", err)
 	}
-	if len(projects) != 2 {
-		t.Fatalf("ListProjects() len = %d, want 2", len(projects))
+	if len(projects) != 3 {
+		t.Fatalf("ListProjects() len = %d, want 3", len(projects))
 	}
 	if !projects[0].IsDefault {
 		t.Fatalf("first listed project should be default")
@@ -260,6 +269,17 @@ func TestStoreProjectLifecycleAndAppState(t *testing.T) {
 	}
 	if activeID != p2.ID {
 		t.Fatalf("ActiveProjectID() = %q, want %q", activeID, p2.ID)
+	}
+
+	if err := s.UpdateProjectKind(meeting.ID, "managed"); err != nil {
+		t.Fatalf("UpdateProjectKind() error: %v", err)
+	}
+	meetingManaged, err := s.GetProject(meeting.ID)
+	if err != nil {
+		t.Fatalf("GetProject(meeting managed) error: %v", err)
+	}
+	if meetingManaged.Kind != "managed" {
+		t.Fatalf("meeting managed kind = %q, want managed", meetingManaged.Kind)
 	}
 }
 
@@ -452,6 +472,12 @@ func TestStoreSchemaAndHelperNormalizers(t *testing.T) {
 	if got := normalizeProjectKind(" LINKED "); got != "linked" {
 		t.Fatalf("normalizeProjectKind(linked) = %q, want linked", got)
 	}
+	if got := normalizeProjectKind(" Meeting "); got != "meeting" {
+		t.Fatalf("normalizeProjectKind(meeting) = %q, want meeting", got)
+	}
+	if got := normalizeProjectKind(" TASK "); got != "task" {
+		t.Fatalf("normalizeProjectKind(task) = %q, want task", got)
+	}
 	if got := normalizeProjectKind("weird"); got != "managed" {
 		t.Fatalf("normalizeProjectKind(default) = %q, want managed", got)
 	}
@@ -490,5 +516,66 @@ func TestStoreSchemaAndHelperNormalizers(t *testing.T) {
 	}
 	if got := boolToInt(false); got != 0 {
 		t.Fatalf("boolToInt(false) = %d, want 0", got)
+	}
+}
+
+func TestStoreDeleteProjectRemovesAssociatedSessions(t *testing.T) {
+	s := newTestStore(t)
+	root := filepath.Join(t.TempDir(), "meeting-temp")
+	project, err := s.CreateProject("Meeting Temp", "meeting-key", root, "meeting", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if err := s.SetActiveProjectID(project.ID); err != nil {
+		t.Fatalf("SetActiveProjectID() error: %v", err)
+	}
+	chatSession, err := s.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+	if _, err := s.AddChatMessage(chatSession.ID, "assistant", "saved output", "saved output", "markdown"); err != nil {
+		t.Fatalf("AddChatMessage() error: %v", err)
+	}
+	if err := s.AddChatEvent(chatSession.ID, "turn-1", "assistant_output", `{"ok":true}`); err != nil {
+		t.Fatalf("AddChatEvent() error: %v", err)
+	}
+	participantSession, err := s.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession() error: %v", err)
+	}
+	if _, err := s.AddParticipantSegment(ParticipantSegment{
+		SessionID: participantSession.ID,
+		StartTS:   100,
+		EndTS:     101,
+		Text:      "text artifact only",
+		Status:    "final",
+	}); err != nil {
+		t.Fatalf("AddParticipantSegment() error: %v", err)
+	}
+	if err := s.AddParticipantEvent(participantSession.ID, 0, "segment_committed", `{"text":"text artifact only"}`); err != nil {
+		t.Fatalf("AddParticipantEvent() error: %v", err)
+	}
+	if err := s.UpsertParticipantRoomState(participantSession.ID, "summary", `["Acme"]`, `["Decision"]`); err != nil {
+		t.Fatalf("UpsertParticipantRoomState() error: %v", err)
+	}
+
+	if err := s.DeleteProject(project.ID); err != nil {
+		t.Fatalf("DeleteProject() error: %v", err)
+	}
+	if _, err := s.GetProject(project.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetProject(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := s.GetChatSession(chatSession.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetChatSession(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := s.GetParticipantSession(participantSession.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetParticipantSession(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+	activeID, err := s.ActiveProjectID()
+	if err != nil {
+		t.Fatalf("ActiveProjectID() error: %v", err)
+	}
+	if activeID != "" {
+		t.Fatalf("ActiveProjectID() = %q, want empty", activeID)
 	}
 }

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -23,11 +23,12 @@ import (
 const projectServeStartTimeout = 10 * time.Second
 
 type projectCreateRequest struct {
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
-	Path     string `json:"path"`
-	MCPURL   string `json:"mcp_url"`
-	Activate *bool  `json:"activate"`
+	Name            string `json:"name"`
+	Kind            string `json:"kind"`
+	Path            string `json:"path"`
+	MCPURL          string `json:"mcp_url"`
+	SourceProjectID string `json:"source_project_id"`
+	Activate        *bool  `json:"activate"`
 }
 
 type projectAPIModel struct {
@@ -101,13 +102,26 @@ type projectActivityItem struct {
 func normalizeProjectKindInput(kind, path string) string {
 	cleanKind := strings.ToLower(strings.TrimSpace(kind))
 	switch cleanKind {
-	case "managed", "linked":
+	case "managed", "linked", "meeting", "task":
 		return cleanKind
 	}
 	if strings.TrimSpace(path) != "" {
 		return "linked"
 	}
 	return "managed"
+}
+
+func isTemporaryProjectKind(kind string) bool {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "meeting", "task":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTemporaryProject(project store.Project) bool {
+	return isTemporaryProjectKind(project.Kind)
 }
 
 func defaultProjectNameFromPath(path string) string {
@@ -145,6 +159,14 @@ func slugifyProjectName(name string) string {
 		return "project"
 	}
 	return slug
+}
+
+func defaultTemporaryProjectName(kind string, now time.Time) string {
+	label := "Task"
+	if strings.EqualFold(strings.TrimSpace(kind), "meeting") {
+		label = "Meeting"
+	}
+	return fmt.Sprintf("%s %s", label, now.Format("2006-01-02 15:04"))
 }
 
 func isNoRows(err error) bool {
@@ -423,10 +445,67 @@ func (a *App) nextManagedProjectPath(name string) (string, error) {
 	return "", errors.New("unable to allocate managed project path")
 }
 
+func (a *App) nextTemporaryProjectPath(kind, name string) (string, error) {
+	baseDir := filepath.Join(a.dataDir, "projects", "temporary", strings.ToLower(strings.TrimSpace(kind)))
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return "", err
+	}
+	slug := slugifyProjectName(name)
+	for i := 0; i < 500; i++ {
+		candidate := slug
+		if i > 0 {
+			candidate = fmt.Sprintf("%s-%d", slug, i+1)
+		}
+		path := filepath.Join(baseDir, candidate)
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			return path, nil
+		}
+	}
+	return "", errors.New("unable to allocate temporary project path")
+}
+
+func (a *App) projectSourceByID(projectID string) (store.Project, bool, error) {
+	id := strings.TrimSpace(projectID)
+	if id == "" {
+		return store.Project{}, false, nil
+	}
+	project, err := a.store.GetProject(id)
+	if err != nil {
+		return store.Project{}, false, err
+	}
+	if isHubProject(project) {
+		return store.Project{}, false, nil
+	}
+	return project, true, nil
+}
+
+func (a *App) inheritProjectSettings(targetID string, source store.Project) error {
+	if strings.TrimSpace(source.ChatModel) != "" {
+		if err := a.store.UpdateProjectChatModel(targetID, source.ChatModel); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(source.ChatModelReasoningEffort) != "" {
+		if err := a.store.UpdateProjectChatModelReasoningEffort(targetID, source.ChatModelReasoningEffort); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(source.CompanionConfigJSON) != "" {
+		if err := a.store.UpdateProjectCompanionConfig(targetID, source.CompanionConfigJSON); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (a *App) createProject(req projectCreateRequest) (store.Project, bool, error) {
 	kind := normalizeProjectKindInput(req.Kind, req.Path)
 	name := strings.TrimSpace(req.Name)
 	mcpURL := strings.TrimSpace(req.MCPURL)
+	sourceProject, hasSource, err := a.projectSourceByID(req.SourceProjectID)
+	if err != nil {
+		return store.Project{}, false, err
+	}
 
 	var absRoot string
 	switch kind {
@@ -441,6 +520,25 @@ func (a *App) createProject(req projectCreateRequest) (store.Project, bool, erro
 		}
 		if !info.IsDir() {
 			return store.Project{}, false, errors.New("path must be a directory")
+		}
+		boot, err := protocol.BootstrapProject(rootPath)
+		if err != nil {
+			return store.Project{}, false, err
+		}
+		absRoot = filepath.Clean(boot.Paths.ProjectDir)
+	case "meeting", "task":
+		if strings.TrimSpace(req.Path) != "" {
+			return store.Project{}, false, errors.New("path is not supported for temporary projects")
+		}
+		if name == "" {
+			name = defaultTemporaryProjectName(kind, time.Now())
+		}
+		rootPath, err := a.nextTemporaryProjectPath(kind, name)
+		if err != nil {
+			return store.Project{}, false, err
+		}
+		if err := os.MkdirAll(rootPath, 0o755); err != nil {
+			return store.Project{}, false, err
 		}
 		boot, err := protocol.BootstrapProject(rootPath)
 		if err != nil {
@@ -491,7 +589,84 @@ func (a *App) createProject(req projectCreateRequest) (store.Project, bool, erro
 		}
 		return store.Project{}, false, err
 	}
+	if hasSource {
+		if err := a.inheritProjectSettings(created.ID, sourceProject); err != nil {
+			return store.Project{}, false, err
+		}
+		refreshed, refreshErr := a.store.GetProject(created.ID)
+		if refreshErr != nil {
+			return store.Project{}, false, refreshErr
+		}
+		created = refreshed
+	}
 	return created, true, nil
+}
+
+func (a *App) persistTemporaryProject(projectID string) (store.Project, error) {
+	project, err := a.store.GetProject(strings.TrimSpace(projectID))
+	if err != nil {
+		return store.Project{}, err
+	}
+	if !isTemporaryProject(project) {
+		return store.Project{}, errors.New("project is not temporary")
+	}
+	if err := a.store.UpdateProjectKind(project.ID, "managed"); err != nil {
+		return store.Project{}, err
+	}
+	return a.store.GetProject(project.ID)
+}
+
+func (a *App) temporaryProjectDiscardRoot(project store.Project) string {
+	root := filepath.Clean(project.RootPath)
+	base := filepath.Clean(filepath.Join(a.dataDir, "projects", "temporary"))
+	if !pathWithinRoot(root, base) {
+		return ""
+	}
+	return root
+}
+
+func (a *App) fallbackProjectAfterDiscard(discardedProjectID string) (store.Project, error) {
+	if hub, err := a.ensureHubProject(); err == nil && hub.ID != strings.TrimSpace(discardedProjectID) {
+		return hub, nil
+	}
+	defaultProject, err := a.ensureDefaultProjectRecord()
+	if err == nil && defaultProject.ID != strings.TrimSpace(discardedProjectID) {
+		return defaultProject, nil
+	}
+	projects, err := a.store.ListProjects()
+	if err != nil {
+		return store.Project{}, err
+	}
+	for _, project := range projects {
+		if project.ID != strings.TrimSpace(discardedProjectID) {
+			return project, nil
+		}
+	}
+	return store.Project{}, sql.ErrNoRows
+}
+
+func (a *App) discardTemporaryProject(projectID string) (store.Project, error) {
+	project, err := a.store.GetProject(strings.TrimSpace(projectID))
+	if err != nil {
+		return store.Project{}, err
+	}
+	if !isTemporaryProject(project) {
+		return store.Project{}, errors.New("project is not temporary")
+	}
+	discardRoot := a.temporaryProjectDiscardRoot(project)
+	fallback, fallbackErr := a.fallbackProjectAfterDiscard(project.ID)
+	if err := a.store.DeleteProject(project.ID); err != nil {
+		return store.Project{}, err
+	}
+	if discardRoot != "" {
+		if removeErr := os.RemoveAll(discardRoot); removeErr != nil {
+			return store.Project{}, removeErr
+		}
+	}
+	if fallbackErr != nil {
+		return store.Project{}, fallbackErr
+	}
+	return a.activateProject(fallback.ID)
 }
 
 func (a *App) handleProjectCreate(w http.ResponseWriter, r *http.Request) {
@@ -528,6 +703,66 @@ func (a *App) handleProjectCreate(w http.ResponseWriter, r *http.Request) {
 		"created":   created,
 		"activated": activate,
 		"project":   item,
+	})
+}
+
+func (a *App) handleTemporaryProjectPersist(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	projectID := strings.TrimSpace(chi.URLParam(r, "project_id"))
+	if projectID == "" {
+		http.Error(w, "project_id is required", http.StatusBadRequest)
+		return
+	}
+	project, err := a.persistTemporaryProject(projectID)
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "project not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	item, err := a.buildProjectAPIModel(project)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":      true,
+		"project": item,
+	})
+}
+
+func (a *App) handleTemporaryProjectDiscard(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	projectID := strings.TrimSpace(chi.URLParam(r, "project_id"))
+	if projectID == "" {
+		http.Error(w, "project_id is required", http.StatusBadRequest)
+		return
+	}
+	activeProject, err := a.discardTemporaryProject(projectID)
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "project not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	item, err := a.buildProjectAPIModel(activeProject)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":                true,
+		"discarded_project": projectID,
+		"active_project_id": activeProject.ID,
+		"active_project":    item,
 	})
 }
 

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -1,12 +1,16 @@
 package web
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
 )
 
 type projectsListResponse struct {
@@ -611,5 +615,195 @@ func TestHubWelcomeListsProjects(t *testing.T) {
 	}
 	if projectName != "" && !strings.Contains(rrWelcome.Body.String(), projectName) {
 		t.Fatalf("hub welcome missing project name %q: %s", projectName, rrWelcome.Body.String())
+	}
+}
+
+func TestTemporaryProjectCreationCopiesSourceSettingsAndPersist(t *testing.T) {
+	app := newAuthedTestApp(t)
+	source, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("default project: %v", err)
+	}
+	if err := app.store.UpdateProjectChatModel(source.ID, "gpt"); err != nil {
+		t.Fatalf("UpdateProjectChatModel() error: %v", err)
+	}
+	if err := app.store.UpdateProjectChatModelReasoningEffort(source.ID, "xhigh"); err != nil {
+		t.Fatalf("UpdateProjectChatModelReasoningEffort() error: %v", err)
+	}
+	if err := app.store.UpdateProjectCompanionConfig(source.ID, `{"companion_enabled":true,"idle_surface":"black"}`); err != nil {
+		t.Fatalf("UpdateProjectCompanionConfig() error: %v", err)
+	}
+
+	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/projects", map[string]any{
+		"kind":              "meeting",
+		"source_project_id": source.ID,
+	})
+	if rrCreate.Code != http.StatusOK {
+		t.Fatalf("expected create 200, got %d: %s", rrCreate.Code, rrCreate.Body.String())
+	}
+	var createPayload struct {
+		OK      bool `json:"ok"`
+		Project struct {
+			ID        string `json:"id"`
+			Kind      string `json:"kind"`
+			RootPath  string `json:"root_path"`
+			ChatModel string `json:"chat_model"`
+		} `json:"project"`
+	}
+	if err := json.Unmarshal(rrCreate.Body.Bytes(), &createPayload); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if !createPayload.OK || createPayload.Project.ID == "" {
+		t.Fatalf("expected created project payload")
+	}
+	if createPayload.Project.Kind != "meeting" {
+		t.Fatalf("created kind = %q, want meeting", createPayload.Project.Kind)
+	}
+	if createPayload.Project.ChatModel != "gpt" {
+		t.Fatalf("created chat model = %q, want gpt", createPayload.Project.ChatModel)
+	}
+	if createPayload.Project.RootPath == source.RootPath {
+		t.Fatalf("temporary project root should differ from source root")
+	}
+	if !strings.Contains(filepath.ToSlash(createPayload.Project.RootPath), "/projects/temporary/meeting/") {
+		t.Fatalf("temporary root = %q, want temporary meeting path", createPayload.Project.RootPath)
+	}
+
+	created, err := app.store.GetProject(createPayload.Project.ID)
+	if err != nil {
+		t.Fatalf("GetProject(created) error: %v", err)
+	}
+	if created.ChatModel != "gpt" {
+		t.Fatalf("stored chat model = %q, want gpt", created.ChatModel)
+	}
+	if created.ChatModelReasoningEffort != "xhigh" {
+		t.Fatalf("stored reasoning effort = %q, want xhigh", created.ChatModelReasoningEffort)
+	}
+	if got := strings.TrimSpace(created.CompanionConfigJSON); got != `{"companion_enabled":true,"idle_surface":"black"}` {
+		t.Fatalf("stored companion config = %q", got)
+	}
+
+	rrPersist := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodPost,
+		"/api/projects/"+createPayload.Project.ID+"/persist",
+		map[string]any{},
+	)
+	if rrPersist.Code != http.StatusOK {
+		t.Fatalf("expected persist 200, got %d: %s", rrPersist.Code, rrPersist.Body.String())
+	}
+	var persistPayload struct {
+		OK      bool `json:"ok"`
+		Project struct {
+			ID   string `json:"id"`
+			Kind string `json:"kind"`
+		} `json:"project"`
+	}
+	if err := json.Unmarshal(rrPersist.Body.Bytes(), &persistPayload); err != nil {
+		t.Fatalf("decode persist response: %v", err)
+	}
+	if !persistPayload.OK {
+		t.Fatalf("expected persist ok=true")
+	}
+	if persistPayload.Project.Kind != "managed" {
+		t.Fatalf("persisted kind = %q, want managed", persistPayload.Project.Kind)
+	}
+}
+
+func TestTemporaryProjectDiscardRemovesProjectDataAndFallsBackToHub(t *testing.T) {
+	app := newAuthedTestApp(t)
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub: %v", err)
+	}
+
+	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/projects", map[string]any{
+		"kind": "task",
+	})
+	if rrCreate.Code != http.StatusOK {
+		t.Fatalf("expected create 200, got %d: %s", rrCreate.Code, rrCreate.Body.String())
+	}
+	var createPayload struct {
+		Project struct {
+			ID         string `json:"id"`
+			ProjectKey string `json:"project_key"`
+			RootPath   string `json:"root_path"`
+		} `json:"project"`
+	}
+	if err := json.Unmarshal(rrCreate.Body.Bytes(), &createPayload); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if createPayload.Project.ID == "" {
+		t.Fatalf("expected created task project id")
+	}
+	if err := os.WriteFile(filepath.Join(createPayload.Project.RootPath, "run-output.md"), []byte("saved output"), 0o644); err != nil {
+		t.Fatalf("WriteFile(run-output.md) error: %v", err)
+	}
+	chatSession, err := app.store.GetOrCreateChatSession(createPayload.Project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(chatSession.ID, "assistant", "saved output", "saved output", "markdown"); err != nil {
+		t.Fatalf("AddChatMessage() error: %v", err)
+	}
+	participantSession, err := app.store.AddParticipantSession(createPayload.Project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("AddParticipantSession() error: %v", err)
+	}
+	if _, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID: participantSession.ID,
+		StartTS:   100,
+		EndTS:     101,
+		Text:      "transcript only",
+		Status:    "final",
+	}); err != nil {
+		t.Fatalf("AddParticipantSegment() error: %v", err)
+	}
+	if err := app.store.UpsertParticipantRoomState(participantSession.ID, "summary", `["Acme"]`, `["Decision"]`); err != nil {
+		t.Fatalf("UpsertParticipantRoomState() error: %v", err)
+	}
+
+	rrDiscard := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodPost,
+		"/api/projects/"+createPayload.Project.ID+"/discard",
+		map[string]any{},
+	)
+	if rrDiscard.Code != http.StatusOK {
+		t.Fatalf("expected discard 200, got %d: %s", rrDiscard.Code, rrDiscard.Body.String())
+	}
+	var discardPayload struct {
+		OK              bool   `json:"ok"`
+		ActiveProjectID string `json:"active_project_id"`
+		ActiveProject   struct {
+			ID   string `json:"id"`
+			Kind string `json:"kind"`
+		} `json:"active_project"`
+	}
+	if err := json.Unmarshal(rrDiscard.Body.Bytes(), &discardPayload); err != nil {
+		t.Fatalf("decode discard response: %v", err)
+	}
+	if !discardPayload.OK {
+		t.Fatalf("expected discard ok=true")
+	}
+	if discardPayload.ActiveProjectID != hub.ID {
+		t.Fatalf("active_project_id = %q, want %q", discardPayload.ActiveProjectID, hub.ID)
+	}
+	if discardPayload.ActiveProject.Kind != "hub" {
+		t.Fatalf("active project kind = %q, want hub", discardPayload.ActiveProject.Kind)
+	}
+	if _, err := app.store.GetProject(createPayload.Project.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetProject(discarded) error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := app.store.GetChatSession(chatSession.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetChatSession(discarded) error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := app.store.GetParticipantSession(participantSession.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetParticipantSession(discarded) error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(createPayload.Project.RootPath); !os.IsNotExist(err) {
+		t.Fatalf("temporary project root still exists: %v", err)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -359,6 +359,8 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/projects/activity", a.handleProjectsActivity)
 	r.Post("/api/projects", a.handleProjectCreate)
 	r.Post("/api/projects/{project_id}/activate", a.handleProjectActivate)
+	r.Post("/api/projects/{project_id}/persist", a.handleTemporaryProjectPersist)
+	r.Post("/api/projects/{project_id}/discard", a.handleTemporaryProjectDiscard)
 	r.Post("/api/projects/{project_id}/chat-model", a.handleProjectChatModelUpdate)
 	r.Get("/api/projects/{project_id}/context", a.handleProjectContext)
 	r.Get("/api/projects/{project_id}/files", a.handleProjectFilesList)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -1356,6 +1356,11 @@ function isHubActive() {
   return isHubProject(activeProject());
 }
 
+function isTemporaryProjectKind(kind) {
+  const normalized = String(kind || '').trim().toLowerCase();
+  return normalized === 'meeting' || normalized === 'task';
+}
+
 function normalizeReasoningEffortOptions(rawEfforts) {
   const raw = Array.isArray(rawEfforts) ? rawEfforts : [];
   const clean = [];
@@ -3974,9 +3979,45 @@ function renderEdgeTopModelButtons() {
         })
         .catch((err) => {
           showStatus(`input mode failed: ${String(err?.message || err || 'unknown error')}`);
-        });
+      });
     });
     host.appendChild(inputButton);
+  }
+
+  const temporarySourceProjectID = project && !isHubProject(project) ? String(project.id || '').trim() : '';
+  const temporaryButtons = isTemporaryProjectKind(project?.kind)
+    ? [
+        {
+          className: 'edge-temp-persist-btn',
+          label: 'keep',
+          onClick: () => { void persistTemporaryProject(String(project?.id || '').trim()); },
+        },
+        {
+          className: 'edge-temp-discard-btn',
+          label: 'discard',
+          onClick: () => { void discardTemporaryProject(String(project?.id || '').trim()); },
+        },
+      ]
+    : [
+        {
+          className: 'edge-temp-meeting-btn',
+          label: 'meeting',
+          onClick: () => { void createTemporaryProject('meeting', temporarySourceProjectID); },
+        },
+        {
+          className: 'edge-temp-task-btn',
+          label: 'task',
+          onClick: () => { void createTemporaryProject('task', temporarySourceProjectID); },
+        },
+      ];
+  for (const action of temporaryButtons) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `edge-project-btn edge-model-btn ${action.className}`;
+    button.textContent = action.label;
+    button.disabled = state.projectSwitchInFlight || state.projectModelSwitchInFlight;
+    button.addEventListener('click', action.onClick);
+    host.appendChild(button);
   }
 }
 
@@ -4023,6 +4064,99 @@ async function switchProjectChatModel(modelAlias, reasoningEffort = '') {
   } finally {
     state.projectModelSwitchInFlight = false;
     renderEdgeTopModelButtons();
+  }
+}
+
+async function createTemporaryProject(kind, sourceProjectID = '') {
+  const projectKind = String(kind || '').trim().toLowerCase();
+  if (!isTemporaryProjectKind(projectKind)) return;
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
+  showStatus(`starting ${projectKind}...`);
+  const payload = {
+    kind: projectKind,
+    activate: true,
+  };
+  const sourceID = String(sourceProjectID || '').trim();
+  if (sourceID) {
+    payload.source_project_id = sourceID;
+  }
+  try {
+    const resp = await fetch(apiURL('projects'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const responsePayload = await resp.json();
+    const project = responsePayload?.project || {};
+    const projectID = String(project?.id || '').trim();
+    await fetchProjects();
+    if (projectID) {
+      await switchProject(projectID);
+      return;
+    }
+    showStatus(`${projectKind} ready`);
+  } catch (err) {
+    const message = String(err?.message || err || `${projectKind} start failed`);
+    appendPlainMessage('system', `${projectKind} start failed: ${message}`);
+    showStatus(`${projectKind} start failed: ${message}`);
+  }
+}
+
+async function persistTemporaryProject(projectID) {
+  const id = String(projectID || '').trim();
+  if (!id) return;
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
+  showStatus('saving session...');
+  try {
+    const resp = await fetch(apiURL(`projects/${encodeURIComponent(id)}/persist`), { method: 'POST' });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    if (payload?.project) {
+      upsertProject(payload.project);
+    }
+    await fetchProjects();
+    renderEdgeTopProjects();
+    renderEdgeTopModelButtons();
+    showStatus('session saved');
+  } catch (err) {
+    const message = String(err?.message || err || 'session save failed');
+    appendPlainMessage('system', `Session save failed: ${message}`);
+    showStatus(`session save failed: ${message}`);
+  }
+}
+
+async function discardTemporaryProject(projectID) {
+  const id = String(projectID || '').trim();
+  if (!id) return;
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
+  showStatus('discarding session...');
+  try {
+    const resp = await fetch(apiURL(`projects/${encodeURIComponent(id)}/discard`), { method: 'POST' });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    const nextProjectID = String(payload?.active_project_id || '').trim() || state.defaultProjectId || hubProject()?.id || '';
+    await fetchProjects();
+    if (nextProjectID) {
+      await switchProject(nextProjectID);
+      return;
+    }
+    renderEdgeTopProjects();
+    renderEdgeTopModelButtons();
+    showStatus('session discarded');
+  } catch (err) {
+    const message = String(err?.message || err || 'session discard failed');
+    appendPlainMessage('system', `Session discard failed: ${message}`);
+    showStatus(`session discard failed: ${message}`);
   }
 }
 

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -406,6 +406,14 @@
         run_state: { ...(harnessProjectRunStates[project.id] || project.run_state || {}) },
       };
     };
+    const nextHarnessProjectId = (kind) => {
+      const cleanKind = String(kind || 'project').trim().toLowerCase() || 'project';
+      let suffix = 1;
+      while (harnessProjects.some((project) => project.id === `${cleanKind}-${suffix}`)) {
+        suffix += 1;
+      }
+      return `${cleanKind}-${suffix}`;
+    };
 
     // Mock fetch for /api/setup etc.
     const _realFetch = window.fetch;
@@ -447,6 +455,48 @@
           startup_behavior: runtimeState.startup_behavior,
         }), { status: 200 });
       }
+      if (u.endsWith('/api/projects') && opts?.method === 'POST') {
+        let body = {};
+        try {
+          body = JSON.parse(String(opts?.body || '{}'));
+        } catch (_) {
+          body = {};
+        }
+        const kind = String(body?.kind || 'managed').trim().toLowerCase();
+        const id = nextHarnessProjectId(kind);
+        const label = kind === 'meeting' ? 'Meeting' : (kind === 'task' ? 'Task' : 'Project');
+        const project = {
+          id,
+          name: `${label} ${id.split('-').pop()}`,
+          kind,
+          project_key: `/tmp/${id}`,
+          root_path: `/tmp/${id}`,
+          chat_session_id: `chat-${id}`,
+          canvas_session_id: id,
+          chat_mode: 'chat',
+          chat_model: 'spark',
+          chat_model_reasoning_effort: 'low',
+          run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+        };
+        harnessProjects.push(project);
+        harnessProjectRunStates[id] = { ...project.run_state };
+        if (Boolean(body?.activate)) {
+          activeProjectId = id;
+        }
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'project_create',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { kind, project_id: id, source_project_id: String(body?.source_project_id || '').trim() },
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          created: true,
+          activated: Boolean(body?.activate),
+          project: cloneProject(id),
+        }), { status: 200 });
+      }
       if (u.includes('/api/projects') && u.includes('/activate')) {
         const activateId = decodeURIComponent(u.split('/api/projects/')[1].split('/activate')[0] || '').trim();
         const project = cloneProject(activateId);
@@ -460,6 +510,51 @@
         });
         return new Response(JSON.stringify({
           project,
+        }), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/persist') && opts?.method === 'POST') {
+        const projectId = decodeURIComponent(u.split('/api/projects/')[1].split('/persist')[0] || '').trim();
+        const index = harnessProjects.findIndex((project) => project.id === projectId);
+        if (index < 0) {
+          return new Response('project not found', { status: 404 });
+        }
+        harnessProjects[index] = {
+          ...harnessProjects[index],
+          kind: 'managed',
+        };
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'project_persist',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { project_id: projectId },
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          project: cloneProject(projectId),
+        }), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/discard') && opts?.method === 'POST') {
+        const projectId = decodeURIComponent(u.split('/api/projects/')[1].split('/discard')[0] || '').trim();
+        const index = harnessProjects.findIndex((project) => project.id === projectId);
+        if (index < 0) {
+          return new Response('project not found', { status: 404 });
+        }
+        harnessProjects.splice(index, 1);
+        delete harnessProjectRunStates[projectId];
+        activeProjectId = harnessProjects.some((project) => project.id === 'hub') ? 'hub' : (harnessProjects[0]?.id || '');
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'project_discard',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { project_id: projectId, active_project_id: activeProjectId },
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          discarded_project: projectId,
+          active_project_id: activeProjectId,
+          active_project: cloneProject(activeProjectId),
         }), { status: 200 });
       }
       if (u.includes('/api/hotword/status')) {

--- a/tests/playwright/hub-mode.spec.ts
+++ b/tests/playwright/hub-mode.spec.ts
@@ -167,3 +167,77 @@ test('system switch_project action routes through project activation', async ({ 
     );
   }, { timeout: 5_000 }).toBe(true);
 });
+
+test('temporary meeting can be spawned from the current project and persisted', async ({ page }) => {
+  await page.evaluate(() => {
+    document.getElementById('edge-top')?.classList.add('edge-pinned');
+  });
+  await page.locator('#edge-top-projects .edge-project-btn:not(.edge-hub-btn)').click();
+  await expect(page.locator('#edge-top-models .edge-temp-meeting-btn')).toBeVisible();
+
+  await page.locator('#edge-top-models .edge-temp-meeting-btn').click();
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_create'
+        && String(entry.payload?.kind || '') === 'meeting'
+        && String(entry.payload?.source_project_id || '') === 'test',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  const meetingButton = page.locator('#edge-top-projects .edge-project-btn.is-active').filter({ hasText: 'Meeting 1' });
+  await expect(meetingButton).toHaveCount(1);
+  await expect(page.locator('#edge-top-models .edge-temp-persist-btn')).toBeVisible();
+  await expect(page.locator('#edge-top-models .edge-temp-discard-btn')).toBeVisible();
+
+  await page.locator('#edge-top-models .edge-temp-persist-btn').click();
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_persist'
+        && String(entry.payload?.project_id || '') === 'meeting-1',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect(page.locator('#edge-top-models .edge-temp-persist-btn')).toHaveCount(0);
+  await expect(page.locator('#edge-top-models .edge-temp-discard-btn')).toHaveCount(0);
+  await expect(page.locator('#edge-top-models .edge-temp-meeting-btn')).toBeVisible();
+});
+
+test('temporary task can be spawned from hub and discarded', async ({ page }) => {
+  await page.evaluate(() => {
+    document.getElementById('edge-top')?.classList.add('edge-pinned');
+  });
+  await expect(page.locator('#edge-top-models .edge-temp-task-btn')).toBeVisible();
+
+  await page.locator('#edge-top-models .edge-temp-task-btn').click();
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_create'
+        && String(entry.payload?.kind || '') === 'task'
+        && String(entry.payload?.source_project_id || '') === '',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  const taskButton = page.locator('#edge-top-projects .edge-project-btn.is-active').filter({ hasText: 'Task 1' });
+  await expect(taskButton).toHaveCount(1);
+  await page.locator('#edge-top-models .edge-temp-discard-btn').click();
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_discard'
+        && String(entry.payload?.project_id || '') === 'task-1',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect(page.locator('#edge-top-projects .edge-hub-btn')).toHaveClass(/is-active/);
+});


### PR DESCRIPTION
## Summary
- add first-class temporary `meeting` and `task` project kinds
- add explicit persist/discard endpoints for temporary project lifecycles
- expose the flow in the existing edge controls and cover it in Playwright

## Verification
- Spawn temp projects from Hub or the current project:
  - `go test ./internal/store ./internal/web`
  - Excerpt: `ok   github.com/krystophny/tabura/internal/store`, `ok   github.com/krystophny/tabura/internal/web`
  - Backend coverage: `TestTemporaryProjectCreationCopiesSourceSettingsAndPersist`
  - `./scripts/playwright.sh tests/playwright/hub-mode.spec.ts`
  - Excerpt: `temporary meeting can be spawned from the current project and persisted`, `temporary task can be spawned from hub and discarded`, `9 passed (7.3s)`
- Explicit persist/discard at session end:
  - `go test ./internal/store ./internal/web`
  - Backend coverage: `TestTemporaryProjectCreationCopiesSourceSettingsAndPersist`, `TestTemporaryProjectDiscardRemovesProjectDataAndFallsBackToHub`
  - `./scripts/playwright.sh tests/playwright/hub-mode.spec.ts`
  - Excerpt: `temporary meeting can be spawned from the current project and persisted`, `temporary task can be spawned from hub and discarded`
- No separate storage model; temp projects keep normal project text/session data only:
  - `go test ./internal/store ./internal/web`
  - Backend coverage: `TestStoreDeleteProjectRemovesAssociatedSessions`, `TestTemporaryProjectDiscardRemovesProjectDataAndFallsBackToHub`
  - Evidence: discard deletes the temporary project root plus associated `chat_sessions` and `participant_sessions` records while using the normal project/session store paths
