### PR TITLE
fix: Companion Mode: transcript memory and context builder (fixes #137)

### DIFF
--- a/internal/web/chat_prompt.go
+++ b/internal/web/chat_prompt.go
@@ -102,10 +102,14 @@ type canvasContext struct {
 }
 
 func buildPromptFromHistory(mode string, messages []store.ChatMessage, canvas *canvasContext) string {
-	return buildPromptFromHistoryForMode(mode, messages, canvas, turnOutputModeVoice, "")
+	return buildPromptFromHistoryForModeWithCompanion(mode, messages, canvas, nil, turnOutputModeVoice, "")
 }
 
 func buildPromptFromHistoryForMode(mode string, messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
+	return buildPromptFromHistoryForModeWithCompanion(mode, messages, canvas, nil, outputMode, modelAlias)
+}
+
+func buildPromptFromHistoryForModeWithCompanion(mode string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
 	isVoiceMode := isVoiceOutputMode(outputMode)
 	const maxHistory = 80
 	if len(messages) > maxHistory {
@@ -135,6 +139,7 @@ func buildPromptFromHistoryForMode(mode string, messages []store.ChatMessage, ca
 		b.WriteString("You are in plan mode. Focus on analysis, design, and specification before implementation.\n\n")
 	}
 
+	appendCompanionPromptContext(&b, companion)
 	b.WriteString("Conversation transcript:\n")
 	for _, msg := range messages {
 		content := strings.TrimSpace(msg.ContentPlain)
@@ -162,10 +167,14 @@ func buildPromptFromHistoryForMode(mode string, messages []store.ChatMessage, ca
 // buildTurnPrompt constructs a prompt for a resumed thread: only the latest
 // user message plus optional canvas context update.
 func buildTurnPrompt(messages []store.ChatMessage, canvas *canvasContext) string {
-	return buildTurnPromptForMode(messages, canvas, turnOutputModeVoice, "")
+	return buildTurnPromptForModeWithCompanion(messages, canvas, nil, turnOutputModeVoice, "")
 }
 
 func buildTurnPromptForMode(messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
+	return buildTurnPromptForModeWithCompanion(messages, canvas, nil, outputMode, modelAlias)
+}
+
+func buildTurnPromptForModeWithCompanion(messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
 	isVoiceMode := isVoiceOutputMode(outputMode)
 	_ = modelAlias
 	var lastUserMsg string
@@ -188,6 +197,7 @@ func buildTurnPromptForMode(messages []store.ChatMessage, canvas *canvasContext,
 			fmt.Fprintf(&b, "[Active artifact tab: %q (kind: %s)]\n\n", canvas.ArtifactTitle, canvas.ArtifactKind)
 		}
 	}
+	appendCompanionPromptContext(&b, companion)
 	b.WriteString(lastUserMsg)
 	return b.String()
 }

--- a/internal/web/chat_prompt_companion.go
+++ b/internal/web/chat_prompt_companion.go
@@ -1,0 +1,236 @@
+package web
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	companionPromptEntityLimit          = 8
+	companionPromptTopicLimit           = 6
+	companionPromptRecentSegmentLimit   = 8
+	companionPromptRecentCharLimit      = 1200
+	companionPromptSummaryCharLimit     = 480
+	companionPromptSegmentTextCharLimit = 240
+)
+
+type companionPromptSegment struct {
+	Speaker string
+	At      int64
+	Text    string
+}
+
+type companionPromptContext struct {
+	SessionID        string
+	StartedAt        int64
+	SummaryText      string
+	Entities         []string
+	RecentTopics     []string
+	RecentTranscript []companionPromptSegment
+	OmittedSegments  int
+}
+
+func (a *App) loadCompanionPromptContext(projectKey string) *companionPromptContext {
+	if a == nil || a.store == nil {
+		return nil
+	}
+	sessions, err := a.store.ListParticipantSessions(strings.TrimSpace(projectKey))
+	if err != nil {
+		return nil
+	}
+	session, err := selectProjectCompanionSession(sessions, "")
+	if err != nil || session == nil {
+		return nil
+	}
+
+	var memory companionRoomMemory
+	if loaded, loadErr := a.loadCompanionRoomMemory(session.ID); loadErr == nil {
+		memory = loaded
+	}
+
+	segments := []store.ParticipantSegment{}
+	if loaded, loadErr := a.store.ListParticipantSegments(session.ID, 0, 0); loadErr == nil {
+		segments = loaded
+	}
+
+	ctx := buildCompanionPromptContext(session, memory, segments)
+	if ctx.empty() {
+		return nil
+	}
+	return ctx
+}
+
+func buildCompanionPromptContext(session *store.ParticipantSession, memory companionRoomMemory, segments []store.ParticipantSegment) *companionPromptContext {
+	if session == nil {
+		return nil
+	}
+	ctx := &companionPromptContext{
+		SessionID:   strings.TrimSpace(session.ID),
+		StartedAt:   session.StartedAt,
+		SummaryText: truncatePromptValue(memory.SummaryText, companionPromptSummaryCharLimit),
+		Entities:    append([]string(nil), firstNonEmptyStrings(memory.Entities, companionPromptEntityLimit)...),
+		RecentTopics: append([]string(nil),
+			firstNonEmptyStrings(companionPromptTopics(memory.TopicTimeline), companionPromptTopicLimit)...),
+	}
+	ctx.RecentTranscript, ctx.OmittedSegments = compactCompanionPromptSegments(segments)
+	return ctx
+}
+
+func (c *companionPromptContext) empty() bool {
+	if c == nil {
+		return true
+	}
+	return strings.TrimSpace(c.SummaryText) == "" &&
+		len(c.Entities) == 0 &&
+		len(c.RecentTopics) == 0 &&
+		len(c.RecentTranscript) == 0
+}
+
+func appendCompanionPromptContext(b *strings.Builder, ctx *companionPromptContext) {
+	if b == nil || ctx == nil || ctx.empty() {
+		return
+	}
+	b.WriteString("## Companion Context\n")
+	if ctx.SessionID != "" {
+		fmt.Fprintf(b, "- Session: %q", ctx.SessionID)
+		if ctx.StartedAt > 0 {
+			fmt.Fprintf(b, " (started %s)", time.Unix(ctx.StartedAt, 0).UTC().Format(time.RFC3339))
+		}
+		b.WriteString("\n")
+	}
+	if ctx.SummaryText != "" {
+		fmt.Fprintf(b, "- Summary: %s\n", ctx.SummaryText)
+	}
+	if len(ctx.Entities) > 0 {
+		fmt.Fprintf(b, "- Entities: %s\n", strings.Join(ctx.Entities, ", "))
+	}
+	if len(ctx.RecentTopics) > 0 {
+		fmt.Fprintf(b, "- Recent topics: %s\n", strings.Join(ctx.RecentTopics, "; "))
+	}
+	if len(ctx.RecentTranscript) > 0 {
+		b.WriteString("- Recent transcript:\n")
+		for _, seg := range ctx.RecentTranscript {
+			speaker := strings.TrimSpace(seg.Speaker)
+			if speaker == "" {
+				speaker = "Speaker"
+			}
+			stamp := "n/a"
+			if seg.At > 0 {
+				stamp = time.Unix(seg.At, 0).UTC().Format("15:04:05")
+			}
+			fmt.Fprintf(b, "  - [%s] %s: %s\n", stamp, speaker, seg.Text)
+		}
+		if ctx.OmittedSegments > 0 {
+			fmt.Fprintf(b, "  - Older transcript omitted: %d earlier segments.\n", ctx.OmittedSegments)
+		}
+	}
+	b.WriteString("\n")
+}
+
+func compactCompanionPromptSegments(segments []store.ParticipantSegment) ([]companionPromptSegment, int) {
+	if len(segments) == 0 {
+		return nil, 0
+	}
+	selected := make([]companionPromptSegment, 0, minInt(len(segments), companionPromptRecentSegmentLimit))
+	usedChars := 0
+	omitted := 0
+
+	for i := len(segments) - 1; i >= 0; i-- {
+		text := truncatePromptValue(segments[i].Text, companionPromptSegmentTextCharLimit)
+		if text == "" {
+			continue
+		}
+		segChars := len(text)
+		if len(selected) >= companionPromptRecentSegmentLimit || (usedChars+segChars > companionPromptRecentCharLimit && len(selected) > 0) {
+			omitted++
+			continue
+		}
+		selected = append(selected, companionPromptSegment{
+			Speaker: strings.TrimSpace(segments[i].Speaker),
+			At:      maxPromptInt64(segments[i].CommittedAt, maxPromptInt64(segments[i].EndTS, segments[i].StartTS)),
+			Text:    text,
+		})
+		usedChars += segChars
+	}
+
+	for i, j := 0, len(selected)-1; i < j; i, j = i+1, j-1 {
+		selected[i], selected[j] = selected[j], selected[i]
+	}
+	return selected, omitted
+}
+
+func companionPromptTopics(items []any) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	seen := map[string]struct{}{}
+	for i := len(items) - 1; i >= 0 && len(out) < companionPromptTopicLimit; i-- {
+		value := truncatePromptValue(formatCompanionTopicTimelineItem(items[i]), companionPromptSegmentTextCharLimit)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+func firstNonEmptyStrings(values []string, limit int) []string {
+	if len(values) == 0 || limit <= 0 {
+		return nil
+	}
+	out := make([]string, 0, minInt(len(values), limit))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		clean := strings.TrimSpace(value)
+		if clean == "" {
+			continue
+		}
+		key := strings.ToLower(clean)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, clean)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+func truncatePromptValue(value string, limit int) string {
+	clean := strings.TrimSpace(strings.Join(strings.Fields(value), " "))
+	if clean == "" || limit <= 0 || len(clean) <= limit {
+		return clean
+	}
+	if limit <= 3 {
+		return clean[:limit]
+	}
+	return strings.TrimSpace(clean[:limit-3]) + "..."
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxPromptInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/web/chat_prompt_companion_test.go
+++ b/internal/web/chat_prompt_companion_test.go
@@ -1,0 +1,64 @@
+package web
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestBuildPromptFromHistoryForModeWithCompanionCompactsContext(t *testing.T) {
+	session := &store.ParticipantSession{ID: "psess-1", StartedAt: 1710000000}
+	memory := companionRoomMemory{
+		SummaryText: "Budget review remains blocked on owner confirmation for the Acme Cloud rollout.",
+		Entities:    []string{"Acme Cloud", "Budget", "Alice", "Budget"},
+		TopicTimeline: []any{
+			map[string]any{"topic": "Kickoff"},
+			map[string]any{"topic": "Budget review"},
+			map[string]any{"topic": "Owner follow-up"},
+		},
+	}
+	segments := make([]store.ParticipantSegment, 0, 10)
+	for i := 0; i < 10; i++ {
+		segments = append(segments, store.ParticipantSegment{
+			SessionID:   session.ID,
+			StartTS:     int64(100 + i),
+			CommittedAt: int64(100 + i),
+			Speaker:     "Alice",
+			Text:        fmt.Sprintf("segment-%d %s", i, strings.Repeat("detail ", 40)),
+			Status:      "final",
+		})
+	}
+
+	ctx := buildCompanionPromptContext(session, memory, segments)
+	prompt := buildPromptFromHistoryForModeWithCompanion("chat", []store.ChatMessage{{
+		Role:         "user",
+		ContentPlain: "What changed?",
+	}}, nil, ctx, turnOutputModeVoice, "")
+
+	if !strings.Contains(prompt, "## Companion Context") {
+		t.Fatal("prompt should include companion context section")
+	}
+	if !strings.Contains(prompt, "Summary: Budget review remains blocked on owner confirmation") {
+		t.Fatalf("prompt missing summary: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Entities: Acme Cloud, Budget, Alice") {
+		t.Fatalf("prompt missing entities: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Recent topics: Kickoff; Budget review; Owner follow-up") {
+		t.Fatalf("prompt missing recent topics: %q", prompt)
+	}
+	if !strings.Contains(prompt, "segment-9") {
+		t.Fatalf("prompt missing newest segment: %q", prompt)
+	}
+	if strings.Contains(prompt, "segment-0") {
+		t.Fatalf("prompt should omit oldest compacted segment: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Older transcript omitted:") {
+		t.Fatalf("prompt should report omitted transcript segments: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Conversation transcript:\nUSER:\nWhat changed?") {
+		t.Fatalf("prompt missing conversation transcript: %q", prompt)
+	}
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -56,11 +56,12 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 	}
 
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
+	companionCtx := a.loadCompanionPromptContext(session.ProjectKey)
 	var prompt string
 	if resumed {
-		prompt = buildTurnPromptForMode(messages, canvasCtx, outputMode, profile.Alias)
+		prompt = buildTurnPromptForModeWithCompanion(messages, canvasCtx, companionCtx, outputMode, profile.Alias)
 	} else {
-		prompt = buildPromptFromHistoryForMode(session.Mode, messages, canvasCtx, outputMode, profile.Alias)
+		prompt = buildPromptFromHistoryForModeWithCompanion(session.Mode, messages, canvasCtx, companionCtx, outputMode, profile.Alias)
 		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
 	}
 	if strings.TrimSpace(prompt) == "" {

--- a/internal/web/companion_response_trigger_test.go
+++ b/internal/web/companion_response_trigger_test.go
@@ -14,7 +14,13 @@ import (
 )
 
 func newCompanionAppServerClient(t *testing.T, assistantMessage string) *appserver.Client {
+	client, _ := newCompanionAppServerClientWithCapture(t, assistantMessage)
+	return client
+}
+
+func newCompanionAppServerClientWithCapture(t *testing.T, assistantMessage string) (*appserver.Client, <-chan string) {
 	t.Helper()
+	promptCh := make(chan string, 4)
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -47,6 +53,12 @@ func newCompanionAppServerClient(t *testing.T, assistantMessage string) *appserv
 					},
 				})
 			case "turn/start":
+				if prompt := appServerPromptFromRPC(msg); strings.TrimSpace(prompt) != "" {
+					select {
+					case promptCh <- prompt:
+					default:
+					}
+				}
 				_ = conn.WriteJSON(map[string]interface{}{
 					"id": msg["id"],
 					"result": map[string]interface{}{
@@ -81,7 +93,24 @@ func newCompanionAppServerClient(t *testing.T, assistantMessage string) *appserv
 	if err != nil {
 		t.Fatalf("new appserver client: %v", err)
 	}
-	return client
+	return client, promptCh
+}
+
+func appServerPromptFromRPC(msg map[string]interface{}) string {
+	params, _ := msg["params"].(map[string]interface{})
+	if params == nil {
+		return ""
+	}
+	input, _ := params["input"].([]interface{})
+	if len(input) == 0 {
+		return ""
+	}
+	first, _ := input[0].(map[string]interface{})
+	if first == nil {
+		return ""
+	}
+	text, _ := first["text"].(string)
+	return strings.TrimSpace(text)
 }
 
 func waitForAssistantMessage(t *testing.T, app *App, sessionID, want string) {
@@ -94,6 +123,17 @@ func waitForAssistantMessage(t *testing.T, app *App, sessionID, want string) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for assistant message %q", want)
+}
+
+func waitForCapturedPrompt(t *testing.T, promptCh <-chan string) string {
+	t.Helper()
+	select {
+	case prompt := <-promptCh:
+		return prompt
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for captured prompt")
+		return ""
+	}
 }
 
 func TestCompanionResponseTriggerExecutesAssistantTurn(t *testing.T) {
@@ -510,5 +550,119 @@ func TestCompanionResponseTriggerInterruptsPendingTurn(t *testing.T) {
 	}
 	if !foundReplacementTrigger {
 		t.Fatal("expected assistant_triggered event for the replacement segment")
+	}
+}
+
+func TestCompanionResponseTriggerIncludesProjectScopedCompanionContext(t *testing.T) {
+	t.Setenv("TABURA_INTENT_CLASSIFIER_URL", "off")
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	client, promptCh := newCompanionAppServerClientWithCapture(t, "Companion reply.")
+	app.appServerClient = client
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+
+	participantSession, err := app.store.AddParticipantSession(project.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	if err := app.store.UpsertParticipantRoomState(
+		participantSession.ID,
+		"Budget review remains blocked on owner confirmation.",
+		`["Acme Cloud","Budget","Alice"]`,
+		`[{"topic":"Budget review"},{"topic":"Owner follow-up"}]`,
+	); err != nil {
+		t.Fatalf("upsert participant room state: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+			SessionID:   participantSession.ID,
+			StartTS:     int64(100 + i),
+			EndTS:       int64(100 + i),
+			CommittedAt: int64(100 + i),
+			Speaker:     "Alice",
+			Text:        strings.Join([]string{"budget-segment", strings.Repeat("detail", 40)}, "-"),
+			Status:      "final",
+		}); err != nil {
+			t.Fatalf("add participant segment %d: %v", i, err)
+		}
+	}
+
+	otherProject, err := app.store.CreateProject("Other Project", "other-project", t.TempDir(), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("create other project: %v", err)
+	}
+	otherSession, err := app.store.AddParticipantSession(otherProject.ProjectKey, "{}")
+	if err != nil {
+		t.Fatalf("add other participant session: %v", err)
+	}
+	if err := app.store.UpsertParticipantRoomState(otherSession.ID, "Zeus takeover planning.", `["Zeus","Mallory"]`, `[{"topic":"Zeus"}]`); err != nil {
+		t.Fatalf("upsert other participant room state: %v", err)
+	}
+	if _, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   otherSession.ID,
+		StartTS:     500,
+		EndTS:       500,
+		CommittedAt: 500,
+		Speaker:     "Mallory",
+		Text:        "Zeus takeover planning should stay isolated.",
+		Status:      "final",
+	}); err != nil {
+		t.Fatalf("add other participant segment: %v", err)
+	}
+
+	seg, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     200,
+		EndTS:       201,
+		Text:        "Tabura, what changed in the budget review?",
+		CommittedAt: 202,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, seg.ID, "segment_committed", `{"text":"Tabura, what changed in the budget review?"}`); err != nil {
+		t.Fatalf("add participant committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, seg)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	waitForAssistantMessage(t, app, chatSession.ID, "Companion reply.")
+
+	prompt := waitForCapturedPrompt(t, promptCh)
+	if !strings.Contains(prompt, "## Companion Context") {
+		t.Fatalf("prompt missing companion context: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Summary: Budget review remains blocked on owner confirmation.") {
+		t.Fatalf("prompt missing summary: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Entities: Acme Cloud, Budget, Alice") {
+		t.Fatalf("prompt missing entities: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Recent topics: Budget review; Owner follow-up") {
+		t.Fatalf("prompt missing recent topics: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Older transcript omitted:") {
+		t.Fatalf("prompt missing transcript compaction marker: %q", prompt)
+	}
+	if strings.Contains(prompt, "Zeus") || strings.Contains(prompt, "Mallory") {
+		t.Fatalf("prompt leaked cross-project context: %q", prompt)
 	}
 }


### PR DESCRIPTION
## Summary
- build project-scoped companion prompt context from the active/latest participant session summary, entities, topic timeline, and a compacted recent transcript window
- inject that companion context into both fresh-history and resumed-turn prompt construction for assistant turns
- add prompt-level and app-server integration tests that verify compaction behavior and cross-project isolation

## Verification
- Requirement: rolling transcript buffer and compaction keep long sessions usable without prompt blow-up
  Evidence: `go test ./internal/web -run 'TestBuildPromptFromHistoryForModeWithCompanionCompactsContext|TestCompanionResponseTriggerIncludesProjectScopedCompanionContext' -v`
  Output excerpt:
  ```text
  === RUN   TestBuildPromptFromHistoryForModeWithCompanionCompactsContext
  --- PASS: TestBuildPromptFromHistoryForModeWithCompanionCompactsContext (0.00s)
  ```
  The test in `internal/web/chat_prompt_companion_test.go` proves the packaged prompt keeps the newest transcript entries, drops older ones, and emits an `Older transcript omitted` marker.
- Requirement: project-scoped memory is packaged into assistant responses and does not leak across projects
  Evidence: `go test ./internal/web -run 'TestBuildPromptFromHistoryForModeWithCompanionCompactsContext|TestCompanionResponseTriggerIncludesProjectScopedCompanionContext' -v`
  Output excerpt:
  ```text
  === RUN   TestCompanionResponseTriggerIncludesProjectScopedCompanionContext
  --- PASS: TestCompanionResponseTriggerIncludesProjectScopedCompanionContext (0.04s)
  ```
  The integration test captures the real app-server `turn/start` prompt and asserts it includes the active project's summary, entities, and topics while excluding `Zeus` and `Mallory` from another project.
- Requirement: the touched assistant-turn path remains green end-to-end in the modified package
  Evidence: `go test ./internal/web 2>&1 | tee /tmp/test.log`
  Output excerpt:
  ```text
  ok   github.com/krystophny/tabura/internal/web	3.176s
  ```
