### PR TITLE
fix: Companion Mode: humanoid idle surface and black mode (fixes #134)

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -125,6 +125,11 @@ const state = {
     dirty: false,
   },
   inkSubmitInFlight: false,
+  companionEnabled: false,
+  companionIdleSurface: 'robot',
+  companionRuntimeState: 'idle',
+  companionRuntimeReason: 'idle',
+  companionProjectKey: '',
 };
 
 export function getState() {
@@ -135,7 +140,16 @@ function isVoiceTurn() {
   return state.lastInputOrigin === 'voice';
 }
 
-window._taburaApp = { getState, acquireMicStream, sttStart, sttSendBlob, sttStop, sttCancel };
+window._taburaApp = {
+  getState,
+  acquireMicStream,
+  sttStart,
+  sttSendBlob,
+  sttStop,
+  sttCancel,
+  refreshCompanionState,
+  syncCompanionIdleSurface,
+};
 
 void ensureVADLoaded();
 
@@ -202,6 +216,17 @@ const VOICE_LIFECYCLE = Object.freeze({
   AWAITING_TURN: 'awaiting_turn',
   ASSISTANT_WORKING: 'assistant_working',
   TTS_PLAYING: 'tts_playing',
+});
+const COMPANION_IDLE_SURFACES = Object.freeze({
+  ROBOT: 'robot',
+  BLACK: 'black',
+});
+const COMPANION_RUNTIME_STATES = Object.freeze({
+  IDLE: 'idle',
+  LISTENING: 'listening',
+  THINKING: 'thinking',
+  TALKING: 'talking',
+  ERROR: 'error',
 });
 let devReloadBootID = '';
 let devReloadTimer = null;
@@ -1340,6 +1365,107 @@ function activeProject() {
   return state.projects.find((project) => project.id === state.activeProjectId) || null;
 }
 
+function activeProjectKey() {
+  return String(activeProject()?.project_key || '').trim();
+}
+
+function normalizeCompanionIdleSurface(raw) {
+  return String(raw || '').trim().toLowerCase() === COMPANION_IDLE_SURFACES.BLACK
+    ? COMPANION_IDLE_SURFACES.BLACK
+    : COMPANION_IDLE_SURFACES.ROBOT;
+}
+
+function normalizeCompanionRuntimeState(raw) {
+  const stateName = String(raw || '').trim().toLowerCase();
+  if (stateName === COMPANION_RUNTIME_STATES.LISTENING) return COMPANION_RUNTIME_STATES.LISTENING;
+  if (stateName === COMPANION_RUNTIME_STATES.THINKING) return COMPANION_RUNTIME_STATES.THINKING;
+  if (stateName === COMPANION_RUNTIME_STATES.TALKING) return COMPANION_RUNTIME_STATES.TALKING;
+  if (stateName === COMPANION_RUNTIME_STATES.ERROR) return COMPANION_RUNTIME_STATES.ERROR;
+  return COMPANION_RUNTIME_STATES.IDLE;
+}
+
+function companionIdleSurfaceEl() {
+  return document.getElementById('companion-idle-surface');
+}
+
+function companionStatusCopy(runtimeState) {
+  switch (normalizeCompanionRuntimeState(runtimeState)) {
+    case COMPANION_RUNTIME_STATES.LISTENING:
+      return { label: 'Listening', detail: 'Ambient capture is live.' };
+    case COMPANION_RUNTIME_STATES.THINKING:
+      return { label: 'Thinking', detail: 'Working through the current request.' };
+    case COMPANION_RUNTIME_STATES.TALKING:
+      return { label: 'Talking', detail: 'Speaking the current response.' };
+    case COMPANION_RUNTIME_STATES.ERROR:
+      return { label: 'Error', detail: 'Companion hit a runtime error.' };
+    default:
+      return { label: 'Idle', detail: 'Ready in the background.' };
+  }
+}
+
+function hasVisibleCanvasArtifact() {
+  const activePane = document.querySelector('#canvas-viewport .canvas-pane.is-active');
+  if (!(activePane instanceof HTMLElement)) return false;
+  return window.getComputedStyle(activePane).display !== 'none';
+}
+
+function shouldShowCompanionIdleSurface() {
+  return Boolean(state.companionEnabled) && !hasVisibleCanvasArtifact() && !isHubActive();
+}
+
+function updateCompanionIdleSurface() {
+  const surface = companionIdleSurfaceEl();
+  if (!(surface instanceof HTMLElement)) return;
+  const visible = shouldShowCompanionIdleSurface();
+  const runtimeState = normalizeCompanionRuntimeState(state.companionRuntimeState);
+  const idleSurface = normalizeCompanionIdleSurface(state.companionIdleSurface);
+  const copy = companionStatusCopy(runtimeState);
+  surface.dataset.state = runtimeState;
+  surface.dataset.surface = idleSurface;
+  surface.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  surface.style.display = visible ? 'block' : 'none';
+  const statusNode = surface.querySelector('.companion-idle-status');
+  if (statusNode) statusNode.textContent = copy.label;
+  const detailNode = surface.querySelector('.companion-idle-detail');
+  if (detailNode) {
+    const runtimeDetail = String(state.companionRuntimeReason || '').trim();
+    detailNode.textContent = runtimeDetail && runtimeState !== COMPANION_RUNTIME_STATES.IDLE
+      ? runtimeDetail.replaceAll('_', ' ')
+      : copy.detail;
+  }
+}
+
+function syncCompanionIdleSurface() {
+  updateAssistantActivityIndicator();
+}
+
+function applyCompanionState(payload = {}) {
+  const config = payload?.config && typeof payload.config === 'object' ? payload.config : {};
+  state.companionEnabled = Boolean(
+    payload?.companion_enabled ?? config?.companion_enabled ?? state.companionEnabled,
+  );
+  state.companionIdleSurface = normalizeCompanionIdleSurface(
+    payload?.idle_surface ?? config?.idle_surface ?? state.companionIdleSurface,
+  );
+  state.companionRuntimeState = normalizeCompanionRuntimeState(
+    payload?.state ?? payload?.runtime?.state ?? state.companionRuntimeState,
+  );
+  state.companionRuntimeReason = String(
+    payload?.reason ?? payload?.runtime?.reason ?? state.companionRuntimeReason ?? '',
+  ).trim();
+  state.companionProjectKey = String(payload?.project_key || activeProjectKey()).trim();
+  updateCompanionIdleSurface();
+}
+
+function resetCompanionState() {
+  state.companionEnabled = false;
+  state.companionIdleSurface = COMPANION_IDLE_SURFACES.ROBOT;
+  state.companionRuntimeState = COMPANION_RUNTIME_STATES.IDLE;
+  state.companionRuntimeReason = 'idle';
+  state.companionProjectKey = '';
+  updateCompanionIdleSurface();
+}
+
 function isHubProject(project) {
   if (!project || typeof project !== 'object') return false;
   const kind = String(project.kind || '').trim().toLowerCase();
@@ -2377,6 +2503,7 @@ function beginConversationVoiceCapture() {
 }
 
 function currentIndicatorMode() {
+  if (shouldShowCompanionIdleSurface()) return '';
   const mode = state.voiceLifecycle;
   if (mode === VOICE_LIFECYCLE.RECORDING) return 'recording';
   if (mode === VOICE_LIFECYCLE.LISTENING) return 'listening';
@@ -2404,6 +2531,7 @@ function updateAssistantActivityIndicator() {
   }
   syncVoiceLifecycle('indicator-update');
   state.hotwordActive = isHotwordActive();
+  updateCompanionIdleSurface();
   const pos = getLastInputPosition();
   const px = Number.isFinite(pos?.x) && pos.x > 0 ? pos.x : Math.floor(window.innerWidth / 2);
   const py = Number.isFinite(pos?.y) && pos.y > 0 ? pos.y : Math.floor(window.innerHeight / 2);
@@ -3802,6 +3930,63 @@ function upsertProject(project) {
   renderEdgeTopModelButtons();
 }
 
+async function refreshCompanionState(projectID = state.activeProjectId) {
+  const project = state.projects.find((item) => item.id === String(projectID || '').trim()) || null;
+  if (!project || isHubProject(project)) {
+    resetCompanionState();
+    return null;
+  }
+  const resp = await fetch(apiURL(`projects/${encodeURIComponent(project.id)}/companion/state`), { cache: 'no-store' });
+  if (!resp.ok) {
+    resetCompanionState();
+    throw new Error(`companion state failed: HTTP ${resp.status}`);
+  }
+  const payload = await resp.json();
+  applyCompanionState(payload);
+  renderEdgeTopModelButtons();
+  updateAssistantActivityIndicator();
+  return payload;
+}
+
+async function updateCompanionConfig(patch) {
+  const project = activeProject();
+  if (!project || !project.id || isHubProject(project)) return null;
+  const resp = await fetch(apiURL(`projects/${encodeURIComponent(project.id)}/companion/config`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch || {}),
+  });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const payload = await resp.json();
+  applyCompanionState({
+    project_key: activeProjectKey(),
+    companion_enabled: payload?.companion_enabled,
+    idle_surface: payload?.idle_surface,
+    state: state.companionRuntimeState,
+    reason: state.companionRuntimeReason,
+  });
+  renderEdgeTopModelButtons();
+  updateAssistantActivityIndicator();
+  return payload;
+}
+
+async function toggleCompanionIdleSurfacePreference() {
+  const nextSurface = state.companionIdleSurface === COMPANION_IDLE_SURFACES.BLACK
+    ? COMPANION_IDLE_SURFACES.ROBOT
+    : COMPANION_IDLE_SURFACES.BLACK;
+  try {
+    await updateCompanionConfig({ idle_surface: nextSurface });
+    showStatus(nextSurface === COMPANION_IDLE_SURFACES.BLACK ? 'black mode on' : 'black mode off');
+  } catch (err) {
+    const message = String(err?.message || err || 'idle surface update failed');
+    appendPlainMessage('system', `Idle surface update failed: ${message}`);
+    showStatus(`idle surface failed: ${message}`);
+  }
+}
+
 function resolveInitialProjectID() {
   if (state.startupBehavior === 'hub_first') {
     const hub = hubProject();
@@ -3952,6 +4137,20 @@ function renderEdgeTopModelButtons() {
     toggleTTSSilentMode();
   });
   host.appendChild(silentButton);
+
+  const blackButton = document.createElement('button');
+  blackButton.type = 'button';
+  blackButton.className = 'edge-project-btn edge-model-btn edge-companion-surface-btn';
+  blackButton.textContent = 'black';
+  blackButton.setAttribute('aria-pressed', state.companionIdleSurface === COMPANION_IDLE_SURFACES.BLACK ? 'true' : 'false');
+  if (state.companionIdleSurface === COMPANION_IDLE_SURFACES.BLACK) {
+    blackButton.classList.add('is-active');
+  }
+  blackButton.disabled = !project || hubActive || state.projectSwitchInFlight || state.projectModelSwitchInFlight;
+  blackButton.addEventListener('click', () => {
+    void toggleCompanionIdleSurfacePreference();
+  });
+  host.appendChild(blackButton);
 
   const inputModes = [
     { id: 'voice', label: 'voice' },
@@ -4465,6 +4664,16 @@ function handleChatEvent(payload) {
   const type = String(payload?.type || '').trim();
   if (!type) return;
 
+  if (type === 'companion_state') {
+    const projectKey = String(payload?.project_key || '').trim();
+    const currentProjectKey = activeProjectKey();
+    if (!projectKey || !currentProjectKey || projectKey === currentProjectKey) {
+      applyCompanionState(payload);
+      updateAssistantActivityIndicator();
+    }
+    return;
+  }
+
   if (type === 'mode_changed') {
     setChatMode(payload.mode || 'chat');
     const message = String(payload.message || '').trim();
@@ -4817,6 +5026,7 @@ async function switchProject(projectID) {
   clearChatHistory();
   clearCanvas();
   clearWelcomeSurface();
+  resetCompanionState();
   state.workspaceOpenFilePath = '';
   state.workspaceStepInFlight = false;
   hideCanvasColumn();
@@ -4834,6 +5044,7 @@ async function switchProject(projectID) {
     await showWelcomeForActiveProject(true);
     await loadChatHistory();
     await refreshAssistantActivity();
+    await refreshCompanionState(project.id).catch(() => {});
     openChatWs();
     showStatus(`ready`);
   } catch (err) {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -46,6 +46,25 @@
         </div>
       </div>
 
+      <section id="companion-idle-surface" class="companion-idle-surface" aria-hidden="true">
+        <div class="companion-idle-shell">
+          <div class="companion-idle-frame">
+            <div class="companion-idle-face" aria-hidden="true">
+              <div class="companion-idle-brow companion-idle-brow-left"></div>
+              <div class="companion-idle-brow companion-idle-brow-right"></div>
+              <div class="companion-idle-eye companion-idle-eye-left"><span class="companion-idle-pupil"></span></div>
+              <div class="companion-idle-eye companion-idle-eye-right"><span class="companion-idle-pupil"></span></div>
+              <div class="companion-idle-mouth"></div>
+            </div>
+            <div class="companion-idle-copy">
+              <div class="companion-idle-kicker">Companion</div>
+              <div class="companion-idle-status" aria-live="polite">Idle</div>
+              <div class="companion-idle-detail">Ready in the background.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <div id="indicator" class="indicator" style="display:none">
         <span class="record-dot"></span>
         <span class="stop-square"></span>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -328,6 +328,266 @@ body.file-sidebar-enabled #pr-file-drawer-backdrop.is-open {
   font-weight: 600;
 }
 
+.companion-idle-surface {
+  --companion-bg: radial-gradient(circle at top, #f5f1e8 0%, #e7e1d5 42%, #d8d0c1 100%);
+  --companion-panel: rgba(255, 252, 246, 0.78);
+  --companion-panel-border: rgba(17, 17, 17, 0.14);
+  --companion-face: #111111;
+  --companion-face-soft: rgba(17, 17, 17, 0.12);
+  --companion-face-accent: #1d4ed8;
+  --companion-face-ring: rgba(29, 78, 216, 0.12);
+  --companion-copy: #111111;
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 18;
+  pointer-events: none;
+  background: var(--companion-bg);
+  color: var(--companion-copy);
+}
+
+.companion-idle-surface[data-surface="black"] {
+  --companion-bg: radial-gradient(circle at top, #202020 0%, #090909 60%, #000000 100%);
+  --companion-panel: rgba(6, 6, 6, 0.72);
+  --companion-panel-border: rgba(255, 255, 255, 0.12);
+  --companion-face: #f7f7f7;
+  --companion-face-soft: rgba(247, 247, 247, 0.14);
+  --companion-face-accent: #f7f7f7;
+  --companion-face-ring: rgba(247, 247, 247, 0.12);
+  --companion-copy: #f7f7f7;
+}
+
+.companion-idle-shell {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding:
+    calc(4rem + var(--safe-area-top))
+    calc(2rem + var(--safe-area-right))
+    calc(3rem + var(--safe-area-bottom))
+    calc(2rem + var(--safe-area-left));
+}
+
+.companion-idle-frame {
+  width: min(100%, 540px);
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+  padding: clamp(2rem, 5vw, 3rem);
+  border: 1px solid var(--companion-panel-border);
+  border-radius: 32px;
+  background: var(--companion-panel);
+  backdrop-filter: blur(14px);
+}
+
+.companion-idle-face {
+  width: clamp(180px, 28vw, 250px);
+  aspect-ratio: 1 / 1;
+  position: relative;
+  border: 5px solid var(--companion-face);
+  border-radius: 34%;
+  box-shadow:
+    inset 0 0 0 1px var(--companion-face-soft),
+    0 26px 60px rgba(0, 0, 0, 0.08);
+}
+
+.companion-idle-surface[data-surface="black"] .companion-idle-face {
+  box-shadow:
+    inset 0 0 0 1px var(--companion-face-soft),
+    0 26px 60px rgba(0, 0, 0, 0.35);
+}
+
+.companion-idle-brow,
+.companion-idle-eye,
+.companion-idle-mouth {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.companion-idle-brow {
+  top: 27%;
+  width: 24%;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--companion-face-soft);
+}
+
+.companion-idle-brow-left {
+  left: 33%;
+  transform: translateX(-50%) rotate(-4deg);
+}
+
+.companion-idle-brow-right {
+  left: 67%;
+  transform: translateX(-50%) rotate(4deg);
+}
+
+.companion-idle-eye {
+  top: 38%;
+  width: 20%;
+  height: 20%;
+  border: 4px solid var(--companion-face);
+  border-radius: 28px;
+  background: transparent;
+  overflow: hidden;
+}
+
+.companion-idle-eye-left {
+  left: 33%;
+}
+
+.companion-idle-eye-right {
+  left: 67%;
+}
+
+.companion-idle-pupil {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30%;
+  height: 30%;
+  border-radius: 50%;
+  background: var(--companion-face);
+  transform: translate(-50%, -50%);
+}
+
+.companion-idle-mouth {
+  top: 69%;
+  width: 28%;
+  height: 14%;
+  border: 4px solid var(--companion-face);
+  border-top: 0;
+  border-radius: 0 0 22px 22px;
+}
+
+.companion-idle-copy {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.companion-idle-kicker {
+  font-size: 0.82rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.companion-idle-status {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.companion-idle-detail {
+  max-width: 28ch;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  opacity: 0.76;
+}
+
+.companion-idle-surface[data-state="listening"] .companion-idle-face {
+  box-shadow:
+    inset 0 0 0 1px var(--companion-face-soft),
+    0 0 0 20px var(--companion-face-ring),
+    0 30px 70px rgba(0, 0, 0, 0.14);
+}
+
+.companion-idle-surface[data-state="listening"] .companion-idle-eye {
+  animation: companion-idle-listen 1.6s ease-in-out infinite;
+}
+
+.companion-idle-surface[data-state="listening"] .companion-idle-pupil {
+  background: var(--companion-face-accent);
+}
+
+.companion-idle-surface[data-state="thinking"] .companion-idle-eye-left .companion-idle-pupil,
+.companion-idle-surface[data-state="thinking"] .companion-idle-eye-right .companion-idle-pupil {
+  animation: companion-idle-think 1.2s ease-in-out infinite;
+}
+
+.companion-idle-surface[data-state="thinking"] .companion-idle-mouth {
+  width: 18%;
+  height: 8%;
+  border-radius: 999px;
+}
+
+.companion-idle-surface[data-state="talking"] .companion-idle-mouth {
+  border-top: 4px solid var(--companion-face);
+  border-radius: 18px;
+  animation: companion-idle-talk 0.75s ease-in-out infinite;
+}
+
+.companion-idle-surface[data-state="error"] {
+  --companion-face-accent: #b42318;
+}
+
+.companion-idle-surface[data-state="error"] .companion-idle-face {
+  border-color: var(--companion-face-accent);
+}
+
+.companion-idle-surface[data-state="error"] .companion-idle-eye {
+  border-color: var(--companion-face-accent);
+}
+
+.companion-idle-surface[data-state="error"] .companion-idle-pupil {
+  background: var(--companion-face-accent);
+}
+
+.companion-idle-surface[data-state="error"] .companion-idle-mouth {
+  top: 72%;
+  border-top: 4px solid var(--companion-face-accent);
+  border-bottom: 0;
+  border-radius: 22px 22px 0 0;
+}
+
+@keyframes companion-idle-listen {
+  0%, 100% {
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    transform: translateX(-50%) scale(1.08);
+  }
+}
+
+@keyframes companion-idle-think {
+  0%, 100% {
+    transform: translate(-50%, -50%);
+  }
+  50% {
+    transform: translate(-18%, -50%);
+  }
+}
+
+@keyframes companion-idle-talk {
+  0%, 100% {
+    height: 14%;
+  }
+  50% {
+    height: 21%;
+  }
+}
+
+@media (max-width: 767px) {
+  .companion-idle-shell {
+    padding:
+      calc(3rem + var(--safe-area-top))
+      calc(1rem + var(--safe-area-right))
+      calc(2rem + var(--safe-area-bottom))
+      calc(1rem + var(--safe-area-left));
+  }
+
+  .companion-idle-frame {
+    width: min(100%, 420px);
+    padding: 1.6rem 1.25rem 1.75rem;
+    gap: 1.1rem;
+  }
+}
+
 /* Canvas text */
 #canvas-text,
 #canvas-image,

--- a/tests/playwright/companion-mode.spec.ts
+++ b/tests/playwright/companion-mode.spec.ts
@@ -11,6 +11,147 @@ async function waitReady(page: Page) {
   }, null, { timeout: 8_000 });
 }
 
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((eventPayload) => {
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    if (chatWs?.injectEvent) {
+      chatWs.injectEvent(eventPayload);
+    }
+  }, payload);
+}
+
+async function setHarnessCompanionState(
+  page: Page,
+  {
+    enabled = true,
+    idleSurface = 'robot',
+    runtimeState = 'idle',
+    reason = '',
+  }: {
+    enabled?: boolean;
+    idleSurface?: 'robot' | 'black';
+    runtimeState?: 'idle' | 'listening' | 'thinking' | 'talking' | 'error';
+    reason?: string;
+  } = {},
+) {
+  await page.evaluate(async (nextState) => {
+    const app = (window as any)._taburaApp;
+    const appState = app?.getState?.();
+    if (appState) {
+      appState.projects = [
+        {
+          id: 'test',
+          name: 'Test',
+          kind: 'managed',
+          project_key: '/tmp/test',
+          root_path: '/tmp',
+          chat_session_id: 'chat-1',
+          canvas_session_id: 'local',
+          chat_mode: 'chat',
+          chat_model: 'spark',
+          chat_model_reasoning_effort: 'low',
+          run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+        },
+        {
+          id: 'hub',
+          name: 'Hub',
+          kind: 'hub',
+          project_key: '__hub__',
+          root_path: '/tmp/hub',
+          chat_session_id: 'chat-hub',
+          canvas_session_id: 'local',
+          chat_mode: 'chat',
+          chat_model: 'spark',
+          chat_model_reasoning_effort: 'low',
+          run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+        },
+      ];
+      appState.activeProjectId = 'test';
+      appState.hasArtifact = false;
+      appState.companionEnabled = Boolean(nextState.enabled);
+      appState.companionIdleSurface = String(nextState.idleSurface || 'robot');
+      appState.companionRuntimeState = String(nextState.runtimeState || 'idle');
+      appState.companionRuntimeReason = String(nextState.reason || nextState.runtimeState || 'idle');
+    }
+    document.querySelectorAll('#canvas-viewport .canvas-pane').forEach((node) => {
+      if (!(node instanceof HTMLElement)) return;
+      node.style.display = 'none';
+      node.classList.remove('is-active');
+    });
+    (window as any).__participantConfig = {
+      ...(window as any).__participantConfig,
+      companion_enabled: Boolean(nextState.enabled),
+      idle_surface: String(nextState.idleSurface || 'robot'),
+    };
+    (window as any).__companionRuntimeState = {
+      state: String(nextState.runtimeState || 'idle'),
+      reason: String(nextState.reason || nextState.runtimeState || 'idle'),
+      project_key: '/tmp/test',
+      updated_at: Math.floor(Date.now() / 1000),
+    };
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    if (chatWs?.injectEvent) {
+      chatWs.injectEvent({
+        type: 'companion_state',
+        project_key: '/tmp/test',
+        state: String(nextState.runtimeState || 'idle'),
+        reason: String(nextState.reason || nextState.runtimeState || 'idle'),
+        companion_enabled: Boolean(nextState.enabled),
+        idle_surface: String(nextState.idleSurface || 'robot'),
+      });
+    }
+    if (typeof app?.syncCompanionIdleSurface === 'function') {
+      app.syncCompanionIdleSurface();
+    }
+  }, { enabled, idleSurface, runtimeState, reason });
+}
+
+async function waitForCompanionSurface(page: Page, state: string, surface: string) {
+  await expect.poll(async () => page.evaluate(() => {
+    const node = document.getElementById('companion-idle-surface');
+    if (!(node instanceof HTMLElement)) return null;
+    return {
+      display: window.getComputedStyle(node).display,
+      state: node.dataset.state || '',
+      surface: node.dataset.surface || '',
+    };
+  })).toEqual({
+    display: 'block',
+    state,
+    surface,
+  });
+}
+
+async function switchToProject(page: Page, projectID: string) {
+  await page.evaluate((targetProjectID) => {
+    const buttons = Array.from(document.querySelectorAll('#edge-top-projects .edge-project-btn'));
+    const button = buttons.find((node) => node.textContent?.trim().toLowerCase() === targetProjectID);
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error(`project button not found: ${targetProjectID}`);
+    }
+    button.click();
+  }, projectID);
+  await expect.poll(async () => page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    return app?.getState?.().activeProjectId || '';
+  })).toBe(projectID);
+}
+
+async function clearCanvas(page: Page) {
+  await page.evaluate(() => {
+    const button = document.getElementById('btn-edge-rasa');
+    if (button instanceof HTMLButtonElement) {
+      button.click();
+    }
+  });
+  await expect.poll(async () => page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    return Boolean(app?.getState?.().hasArtifact);
+  })).toBe(false);
+}
+
 test('workspace sidebar exposes companion transcript, summary, and references viewer entries', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await waitReady(page);
@@ -30,4 +171,56 @@ test('workspace sidebar exposes companion transcript, summary, and references vi
   await page.getByRole('button', { name: 'Companion References' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Acme');
   await expect(page.locator('#canvas-text')).toContainText('Budget');
+});
+
+test('companion idle surface tracks runtime state and hides behind open artifacts', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+  await switchToProject(page, 'test');
+  await setHarnessCompanionState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
+  await clearCanvas(page);
+  await page.evaluate(() => {
+    (window as any)._taburaApp?.syncCompanionIdleSurface?.();
+  });
+
+  await waitForCompanionSurface(page, 'idle', 'robot');
+
+  for (const nextState of ['listening', 'thinking', 'talking', 'error'] as const) {
+    await setHarnessCompanionState(page, {
+      enabled: true,
+      idleSurface: 'robot',
+      runtimeState: nextState,
+      reason: nextState,
+    });
+    await waitForCompanionSurface(page, nextState, 'robot');
+  }
+
+  await page.locator('#edge-left-tap').click();
+  await page.getByRole('button', { name: 'Companion Transcript' }).click();
+  await expect(page.locator('#canvas-text')).toContainText('Harness companion transcript');
+  await expect(page.locator('#companion-idle-surface')).toBeHidden();
+});
+
+test('black mode toggle updates the companion idle surface preference', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+  await switchToProject(page, 'test');
+  await setHarnessCompanionState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
+  await clearCanvas(page);
+  await page.evaluate(() => {
+    (window as any)._taburaApp?.syncCompanionIdleSurface?.();
+  });
+
+  const blackButton = page.locator('#edge-top-models .edge-companion-surface-btn');
+  await expect(blackButton).toHaveAttribute('aria-pressed', 'false');
+  await page.evaluate(() => {
+    const button = document.querySelector('#edge-top-models .edge-companion-surface-btn');
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('black button missing');
+    }
+    button.click();
+  });
+
+  await waitForCompanionSurface(page, 'idle', 'black');
+  await expect(blackButton).toHaveAttribute('aria-pressed', 'true');
 });

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -32,6 +32,25 @@
         </div>
       </div>
 
+      <section id="companion-idle-surface" class="companion-idle-surface" aria-hidden="true">
+        <div class="companion-idle-shell">
+          <div class="companion-idle-frame">
+            <div class="companion-idle-face" aria-hidden="true">
+              <div class="companion-idle-brow companion-idle-brow-left"></div>
+              <div class="companion-idle-brow companion-idle-brow-right"></div>
+              <div class="companion-idle-eye companion-idle-eye-left"><span class="companion-idle-pupil"></span></div>
+              <div class="companion-idle-eye companion-idle-eye-right"><span class="companion-idle-pupil"></span></div>
+              <div class="companion-idle-mouth"></div>
+            </div>
+            <div class="companion-idle-copy">
+              <div class="companion-idle-kicker">Companion</div>
+              <div class="companion-idle-status" aria-live="polite">Idle</div>
+              <div class="companion-idle-detail">Ready in the background.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <div id="indicator" class="indicator" style="display:none">
         <span class="record-dot"></span>
         <span class="stop-square"></span>
@@ -392,6 +411,12 @@
       audio_persistence: 'none',
       capture_source: 'microphone',
     };
+    window.__companionRuntimeState = {
+      state: 'idle',
+      reason: 'idle',
+      project_key: '/tmp/test',
+      updated_at: Math.floor(Date.now() / 1000),
+    };
     window.__setProjectRunStates = (states) => {
       const next = states && typeof states === 'object' ? states : {};
       harnessProjectRunStates = {
@@ -698,6 +723,51 @@
           session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
           entities: ['Acme'],
           topic_timeline: ['Budget'],
+        }), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/companion/config') && opts?.method === 'PUT') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        window.__participantConfig = {
+          ...window.__participantConfig,
+          companion_enabled: Object.prototype.hasOwnProperty.call(body, 'companion_enabled')
+            ? Boolean(body.companion_enabled)
+            : Boolean(window.__participantConfig.companion_enabled),
+          language: String(body.language || window.__participantConfig.language || 'en'),
+          max_segment_duration_ms: Number(body.max_segment_duration_ms || window.__participantConfig.max_segment_duration_ms || 30000),
+          session_ram_cap_mb: Number(body.session_ram_cap_mb || window.__participantConfig.session_ram_cap_mb || 64),
+          stt_model: String(body.stt_model || window.__participantConfig.stt_model || 'whisper-1'),
+          idle_surface: String(body.idle_surface || window.__participantConfig.idle_surface || 'robot'),
+          audio_persistence: 'none',
+          capture_source: 'microphone',
+        };
+        return new Response(JSON.stringify(window.__participantConfig), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/companion/config')) {
+        return new Response(JSON.stringify(window.__participantConfig), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/companion/state')) {
+        const runtime = window.__companionRuntimeState || {};
+        return new Response(JSON.stringify({
+          ok: true,
+          project_id: activeProjectId,
+          project_key: String(runtime.project_key || '/tmp/test'),
+          state: String(runtime.state || 'idle'),
+          runtime: {
+            state: String(runtime.state || 'idle'),
+            reason: String(runtime.reason || 'idle'),
+            project_key: String(runtime.project_key || '/tmp/test'),
+            updated_at: Number(runtime.updated_at || Math.floor(Date.now() / 1000)),
+          },
+          companion_enabled: Boolean(window.__participantConfig.companion_enabled),
+          idle_surface: String(window.__participantConfig.idle_surface || 'robot'),
+          audio_persistence: 'none',
+          capture_source: 'microphone',
+          active_sessions: Boolean(window.__participantConfig.companion_enabled) ? 1 : 0,
+          active_session_id: Boolean(window.__participantConfig.companion_enabled) ? 'psess-harness-001' : '',
+          directed_speech_gate: { decision: 'disabled', reason: 'harness' },
+          interaction_policy: { decision: 'disabled', reason: 'harness' },
+          config: { ...window.__participantConfig },
         }), { status: 200 });
       }
       if (u.includes('/api/projects')) {


### PR DESCRIPTION
## Summary
- add a full-screen Companion idle surface wired to the existing companion runtime/config contract
- add a `black` preference toggle in the project controls for the alternate idle surface
- cover the new UI behavior in the Playwright harness and companion-mode spec

## Verification
- Requirement: Companion Mode can run with no floating chrome on a blank canvas.
  Evidence: `npx playwright test tests/playwright/companion-mode.spec.ts`
  Output: `✓  2 [chromium] › tests/playwright/companion-mode.spec.ts:176:5 › companion idle surface tracks runtime state and hides behind open artifacts (505ms)`
  Detail: the spec clears to Tabula Rasa, shows `#companion-idle-surface`, and keeps the artifact panes hidden until a document is opened.
- Requirement: the idle surface reflects runtime state clearly for `idle`, `listening`, `thinking`, `talking`, and `error`.
  Evidence: `npx playwright test tests/playwright/companion-mode.spec.ts`
  Output: `✓  2 [chromium] › tests/playwright/companion-mode.spec.ts:176:5 › companion idle surface tracks runtime state and hides behind open artifacts (505ms)`
  Detail: the spec drives each runtime state and asserts the idle surface `data-state` changes accordingly.
- Requirement: hide the idle surface whenever a canvas artifact/document is visible.
  Evidence: `npx playwright test tests/playwright/companion-mode.spec.ts`
  Output: `✓  2 [chromium] › tests/playwright/companion-mode.spec.ts:176:5 › companion idle surface tracks runtime state and hides behind open artifacts (505ms)`
  Detail: the spec opens `Companion Transcript`, verifies `#canvas-text` content, and asserts `#companion-idle-surface` becomes hidden.
- Requirement: black mode works as a preference, not a separate assistant mode.
  Evidence: `npx playwright test tests/playwright/companion-mode.spec.ts`
  Output: `✓  3 [chromium] › tests/playwright/companion-mode.spec.ts:204:5 › black mode toggle updates the companion idle surface preference (104ms)`
  Detail: the spec clicks `.edge-companion-surface-btn`, verifies `aria-pressed="true"`, and checks the idle surface switches to `data-surface="black"`.
- Regression guard: companion workspace artifacts still open from the sidebar.
  Evidence: `npx playwright test tests/playwright/companion-mode.spec.ts`
  Output: `✓  1 [chromium] › tests/playwright/companion-mode.spec.ts:155:5 › workspace sidebar exposes companion transcript, summary, and references viewer entries (796ms)`
