### PR TITLE
fix: Companion Mode: radical cleanup of legacy code, docs, and compat (fixes #139)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,10 +27,12 @@ Runtime stack:
   - Browser APIs for chat sessions, canvas APIs, and chat/canvas websocket routes on the web listener.
 - `internal/extensions/host.go`
   - Legacy manifest-driven compatibility runtime pending contraction,
-    replacement, or removal.
+    replacement, or removal. Loads only `*.extension.json` manifests.
 - `internal/plugins/manager.go`
   - Legacy webhook compatibility runtime pending contraction, replacement, or
-    removal.
+    removal. Loads only legacy plugin `*.json` manifests and ignores
+    `*.extension.json` files so the two retained compatibility paths stay
+    distinct.
 - `internal/store/store.go`
   - SQLite persistence for auth and chat session/message history.
 - `internal/protocol/bootstrap.go`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -24,6 +24,9 @@ capability providers such as Helpy.
 - Core UI stays in core UI code
 - Meeting-notes behavior stays in core meeting-notes code
 - Privacy and safety invariants stay in core
+- Plugin manifests stay on the legacy `*.json` path; extension manifests stay on
+  `*.extension.json`, and the plugin loader ignores extension manifests so the
+  compatibility boundary stays explicit
 - Any remaining `internal/extensions` and `internal/plugins` code should be
   treated as transitional compatibility or interop code, not an expanding
   platform surface

--- a/internal/plugins/manager.go
+++ b/internal/plugins/manager.go
@@ -129,7 +129,7 @@ func New(opts Options) (*Manager, error) {
 			continue
 		}
 		name := strings.TrimSpace(entry.Name())
-		if name == "" || !strings.HasSuffix(strings.ToLower(name), ".json") {
+		if !isPluginManifestFileName(name) {
 			continue
 		}
 		files = append(files, filepath.Join(dir, name))
@@ -339,6 +339,14 @@ func compileManifest(cfg manifest) (runtimePlugin, error) {
 		timeout:   time.Duration(timeoutMS) * time.Millisecond,
 		secretEnv: strings.TrimSpace(cfg.SecretEnv),
 	}, nil
+}
+
+func isPluginManifestFileName(name string) bool {
+	clean := strings.ToLower(strings.TrimSpace(name))
+	if clean == "" || !strings.HasSuffix(clean, ".json") {
+		return false
+	}
+	return !strings.HasSuffix(clean, ".extension.json")
 }
 
 func normalizeHooks(in []string) []string {

--- a/internal/plugins/manager_test.go
+++ b/internal/plugins/manager_test.go
@@ -234,3 +234,42 @@ func TestManagerDecideMeetingPartnerSkipsInvalidDecision(t *testing.T) {
 		t.Fatalf("plugin_id = %q, want %q", decision.PluginID, "noop")
 	}
 }
+
+func TestManagerIgnoresExtensionManifestFiles(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"text":"plugin response"}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	writeManifest(t, dir, "01-plugin.json", map[string]any{
+		"id":       "plugin-only",
+		"kind":     "webhook",
+		"endpoint": server.URL,
+		"hooks":    []string{HookChatPreUserMessage},
+		"enabled":  true,
+	})
+	writeManifest(t, dir, "02-ignored.extension.json", map[string]any{
+		"id":       "extension-ignored",
+		"version":  "1.0.0",
+		"kind":     "webhook",
+		"endpoint": server.URL,
+		"hooks":    []string{HookChatPreUserMessage},
+		"enabled":  true,
+	})
+
+	mgr, err := New(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if got := mgr.Count(); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	list := mgr.List()
+	if len(list) != 1 {
+		t.Fatalf("list len = %d, want 1", len(list))
+	}
+	if got := strings.TrimSpace(list[0].ID); got != "plugin-only" {
+		t.Fatalf("plugin id = %q, want %q", got, "plugin-only")
+	}
+}

--- a/internal/web/plugins_test.go
+++ b/internal/web/plugins_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func writePluginManifest(t *testing.T, dir, name string, payload map[string]any) {
+func writeManifestFile(t *testing.T, dir, name string, payload map[string]any) {
 	t.Helper()
 	raw, err := json.Marshal(payload)
 	if err != nil {
@@ -20,6 +20,16 @@ func writePluginManifest(t *testing.T, dir, name string, payload map[string]any)
 	if err := os.WriteFile(filepath.Join(dir, name), raw, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
 	}
+}
+
+func writePluginManifest(t *testing.T, dir, name string, payload map[string]any) {
+	t.Helper()
+	writeManifestFile(t, dir, name, payload)
+}
+
+func writeExtensionManifest(t *testing.T, dir, name string, payload map[string]any) {
+	t.Helper()
+	writeManifestFile(t, dir, name, payload)
 }
 
 func newAuthedTestAppWithPluginDir(t *testing.T, pluginDir string) *App {
@@ -43,6 +53,14 @@ func TestRuntimeAndPluginInventoryEndpoints(t *testing.T) {
 	pluginDir := t.TempDir()
 	writePluginManifest(t, pluginDir, "rewrite.json", map[string]any{
 		"id":       "rewrite",
+		"kind":     "webhook",
+		"endpoint": server.URL,
+		"hooks":    []string{"chat.pre_user_message"},
+		"enabled":  true,
+	})
+	writePluginManifest(t, pluginDir, "ignored.extension.json", map[string]any{
+		"id":       "extension-ignored",
+		"version":  "1.0.0",
 		"kind":     "webhook",
 		"endpoint": server.URL,
 		"hooks":    []string{"chat.pre_user_message"},
@@ -338,7 +356,7 @@ func TestExtensionsInventoryEndpoint(t *testing.T) {
 	defer server.Close()
 
 	extensionDir := t.TempDir()
-	writePluginManifest(t, extensionDir, "meeting.extension.json", map[string]any{
+	writeExtensionManifest(t, extensionDir, "meeting.extension.json", map[string]any{
 		"id":       "meeting-partner",
 		"version":  "1.0.0",
 		"kind":     "webhook",
@@ -397,7 +415,7 @@ func TestExtensionCommandExecuteEndpoint(t *testing.T) {
 	defer server.Close()
 
 	extensionDir := t.TempDir()
-	writePluginManifest(t, extensionDir, "commands.extension.json", map[string]any{
+	writeExtensionManifest(t, extensionDir, "commands.extension.json", map[string]any{
 		"id":       "meeting-partner",
 		"version":  "1.0.0",
 		"kind":     "webhook",
@@ -407,7 +425,7 @@ func TestExtensionCommandExecuteEndpoint(t *testing.T) {
 			{
 				"id":          "meeting_partner.respond",
 				"title":       "Respond",
-				"description": "Respond in meeting mode",
+				"description": "Respond to participant",
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- contract the legacy compatibility boundary so plugin loading no longer accepts `*.extension.json` manifests
- add manager- and web-level tests that prove extension manifests are ignored by plugin inventory and keep extension fixtures explicit
- align the compatibility docs with the enforced manifest split and clean the stale "meeting mode" test wording

## Verification
- Requirement: retained compatibility code is explicitly justified and documented.
  Evidence: `docs/plugins.md` and `docs/architecture.md` now spell out the split between legacy plugin `*.json` manifests and extension `*.extension.json` manifests.
- Requirement: any retained interop API is narrower and easier to understand.
  Evidence: `internal/plugins/manager.go` now gates plugin discovery through `isPluginManifestFileName`, which excludes `*.extension.json` files from the plugin runtime.
- Requirement: test layout and expectations are easier to understand.
  Evidence: `internal/plugins/manager_test.go` adds `TestManagerIgnoresExtensionManifestFiles`; `internal/web/plugins_test.go` verifies runtime inventory ignores extension manifests and now uses a dedicated `writeExtensionManifest` helper.
- Command: `go test ./internal/plugins ./internal/web 2>&1 | tee /tmp/issue-139-test.log`
  Output excerpt:
  ```text
  ok   github.com/krystophny/tabura/internal/plugins 0.005s
  ok   github.com/krystophny/tabura/internal/web 3.167s
  ```