### PR TITLE
fix: Companion Mode umbrella: public modular core with narrow local c (fixes #128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Core paradigm:
 - Tap to talk, right-click to type, keyboard auto-activates. No visible chrome.
 - Responses stream as ephemeral overlays; document edits update in place with diff highlighting.
 - Edge panels (hover/swipe to reveal) for project switching and chat panel access.
-- Companion Mode is the planned unified assistant surface for live meetings, 1:1 conversations, and workday assistance.
+- Companion Mode is the active unified assistant surface for live meetings, 1:1 conversations, and workday assistance.
 
 License: MIT (`LICENSE`)
 Legal notice: Tabura is provided "as is" and "as available" without warranties, and to the maximum extent permitted by applicable law the authors/contributors accept no liability for damages, data loss, or misuse. You are solely responsible for backups, verification, and safe operation. See [`DISCLAIMER.md`](DISCLAIMER.md).
@@ -149,9 +149,9 @@ Zen canvas behavior:
 - Browser opens to tabula rasa (blank white screen) or last artifact.
 - Tap anywhere to start/stop voice recording. Right-click to type. Keyboard auto-activates.
 - Built-in VAD auto-stop detects utterance end and commits speech.
-- Planned Companion Mode is botless, local-first, and Whisper-backed by default.
-- If no document is displayed, planned Companion Mode is intended to show a full-screen minimal humanoid idle surface or optional black mode.
-- Meetings and long-running jobs are intended to become temporary projects with persisted text artifacts only.
+- Companion Mode is botless, local-first, and Whisper-backed by default.
+- If no document is displayed, Companion Mode shows a full-screen minimal humanoid idle surface or optional black mode.
+- Meetings and long-running jobs default to temporary projects with persisted text artifacts only.
 - Assistant output follows one path only:
   - chat-only (spoken), or
   - file-backed canvas (`:::file`) with canvas content rendered only on canvas.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,11 +95,11 @@ Chat hook flow:
 2. Tabura receives `canvas_import_handoff` with `handoff_id`.
 3. Tabura peeks/consumes producer handoff payload and renders artifact.
 
-## Current Voice Runtime and Planned Companion Convergence
+## Current Voice Runtime and Companion Mode
 
-Current runtime behavior still exposes a legacy conversation-mode path with a
-wake word. The active product direction is to converge that behavior into the
-planned Companion Mode documented in [`companion-mode-whitepaper.md`](companion-mode-whitepaper.md).
+Current runtime behavior still includes a legacy wake-word follow-up loop, but
+it now sits within the active Companion Mode surface documented in
+[`companion-mode-whitepaper.md`](companion-mode-whitepaper.md).
 
 Legacy conversation mode enables hands-free voice interaction via a wake word
 ("alexa" using openWakeWord's `alexa_v0.1.onnx` model).
@@ -123,7 +123,7 @@ State transitions:
 - **Listening** (blue border + pulse): follow-up window after TTS response (6s).
 - Follow-up timeout returns to **Paused** and restarts hotword monitoring.
 
-Planned Companion Mode differs from this legacy path in several ways:
+Companion Mode extends this legacy path in several ways:
 - it is project-scoped instead of a free-floating toggle
 - it always transcribes for context while active
 - it targets live meetings, 1:1 conversations, and workday presence with one model

--- a/docs/object-scoped-intent-ui.md
+++ b/docs/object-scoped-intent-ui.md
@@ -85,9 +85,9 @@ UI behavior targets minimal redraw and low-motion interaction:
 
 ## Companion Mode
 
-This section describes the planned successor to the current split between
-tap-to-record interaction and legacy conversation-mode behavior. It is a
-product-direction spec, not a claim that the runtime has already converged.
+This section describes the active continuous assistant surface. Some voice-loop
+internals still use legacy conversation naming, but that behavior belongs to
+Companion Mode rather than a separate product surface.
 
 Companion Mode is the single continuous assistant mode for:
 

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -236,6 +236,34 @@ func TestExecuteSystemActionShellRunsCommand(t *testing.T) {
 	}
 }
 
+func TestExecuteSystemActionToggleConversationReturnsCompanionMessage(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	msg, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
+		Action: "toggle_conversation",
+	})
+	if err != nil {
+		t.Fatalf("execute toggle_conversation: %v", err)
+	}
+	if strings.TrimSpace(msg) != "Toggled Companion Mode." {
+		t.Fatalf("toggle conversation message = %q, want %q", msg, "Toggled Companion Mode.")
+	}
+	if payload == nil {
+		t.Fatalf("expected toggle_conversation payload")
+	}
+	if got := strings.TrimSpace(strFromAny(payload["type"])); got != "toggle_conversation" {
+		t.Fatalf("payload type = %q, want toggle_conversation", got)
+	}
+}
+
 func TestExecuteSystemActionOpenFileCanvasShowsArtifact(t *testing.T) {
 	app := newAuthedTestApp(t)
 	project, err := app.ensureDefaultProjectRecord()

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -1308,7 +1308,7 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 	case "toggle_silent":
 		return "Toggled silent mode.", map[string]interface{}{"type": "toggle_silent"}, nil
 	case "toggle_conversation":
-		return "Toggled conversation mode.", map[string]interface{}{"type": "toggle_conversation"}, nil
+		return "Toggled Companion Mode.", map[string]interface{}{"type": "toggle_conversation"}, nil
 	case "cancel_work":
 		activeCanceled, queuedCanceled := a.cancelChatWork(sessionID)
 		total := activeCanceled + queuedCanceled

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -4106,7 +4106,7 @@ function renderEdgeTopModelButtons() {
     applyConversationStateSnapshot();
     renderEdgeTopModelButtons();
     updateAssistantActivityIndicator();
-    showStatus(enabled ? 'conversation mode on' : 'conversation mode off');
+    showStatus(enabled ? 'companion mode on' : 'companion mode off');
   });
   host.appendChild(convButton);
 
@@ -4734,7 +4734,7 @@ function handleChatEvent(payload) {
       applyConversationStateSnapshot();
       renderEdgeTopModelButtons();
       updateAssistantActivityIndicator();
-      showStatus(enabled ? 'conversation mode on' : 'conversation mode off');
+      showStatus(enabled ? 'companion mode on' : 'companion mode off');
     }
     return;
   }
@@ -4902,9 +4902,9 @@ function handleChatEvent(payload) {
       }
     }
     state.canvasActionThisTurn = false;
-    // If conversation mode is active but no TTS was queued (e.g. TTS error,
+    // If Companion Mode is active but no TTS was queued (e.g. TTS error,
     // empty md, or all text already spoken during streaming), kick the listen
-    // cycle so conversation mode does not stall.
+    // cycle so Companion Mode does not stall.
     if (state.conversationMode && !ttsPlayer && shouldSpeakTurn) {
       onTTSPlaybackComplete();
     }

--- a/internal/web/static/conversation.js
+++ b/internal/web/static/conversation.js
@@ -1,6 +1,7 @@
 import { initVAD } from './vad.js';
 
-const CONVERSATION_MODE_STORAGE_KEY = 'tabura.conversationMode';
+const COMPANION_MODE_STORAGE_KEY = 'tabura.companionMode';
+const LEGACY_CONVERSATION_MODE_STORAGE_KEY = 'tabura.conversationMode';
 const CONVERSATION_LISTEN_DEFAULT_MS = 6000;
 const CONVERSATION_LISTEN_MIN_MS = 500;
 
@@ -14,7 +15,10 @@ function parseOptionalBoolean(value) {
 
 function readConversationModePreference() {
   try {
-    const value = window.localStorage.getItem(CONVERSATION_MODE_STORAGE_KEY);
+    let value = window.localStorage.getItem(COMPANION_MODE_STORAGE_KEY);
+    if (value === null) {
+      value = window.localStorage.getItem(LEGACY_CONVERSATION_MODE_STORAGE_KEY);
+    }
     const parsed = parseOptionalBoolean(value);
     return parsed === true;
   } catch (_) {
@@ -24,7 +28,8 @@ function readConversationModePreference() {
 
 function persistConversationModePreference(enabled) {
   try {
-    window.localStorage.setItem(CONVERSATION_MODE_STORAGE_KEY, enabled ? 'true' : 'false');
+    window.localStorage.setItem(COMPANION_MODE_STORAGE_KEY, enabled ? 'true' : 'false');
+    window.localStorage.removeItem(LEGACY_CONVERSATION_MODE_STORAGE_KEY);
   } catch (_) {}
 }
 

--- a/services/intent-classifier/intents.json
+++ b/services/intent-classifier/intents.json
@@ -23,13 +23,13 @@
   {"text": "stop talking", "intent": "toggle_silent", "entities": {}},
   {"text": "toggle silent", "intent": "toggle_silent", "entities": {}},
 
-  {"text": "start conversation mode", "intent": "toggle_conversation", "entities": {}},
-  {"text": "enable continuous conversation", "intent": "toggle_conversation", "entities": {}},
+  {"text": "start companion mode", "intent": "toggle_conversation", "entities": {}},
+  {"text": "enable companion mode", "intent": "toggle_conversation", "entities": {}},
   {"text": "talk continuously", "intent": "toggle_conversation", "entities": {}},
-  {"text": "stop conversation mode", "intent": "toggle_conversation", "entities": {}},
-  {"text": "toggle conversation", "intent": "toggle_conversation", "entities": {}},
+  {"text": "stop companion mode", "intent": "toggle_conversation", "entities": {}},
+  {"text": "toggle companion mode", "intent": "toggle_conversation", "entities": {}},
   {"text": "keep listening after response", "intent": "toggle_conversation", "entities": {}},
-  {"text": "turn conversation mode on", "intent": "toggle_conversation", "entities": {}},
+  {"text": "turn companion mode on", "intent": "toggle_conversation", "entities": {}},
 
   {"text": "cancel current task", "intent": "cancel_work", "entities": {}},
   {"text": "stop all running work", "intent": "cancel_work", "entities": {}},

--- a/services/intent-classifier/main.py
+++ b/services/intent-classifier/main.py
@@ -33,7 +33,7 @@ ACTION_PATTERNS: list[tuple[re.Pattern[str], str, float]] = [
     (re.compile(r"\b(switch|change|set|use)\b.*\b(codex|gpt|spark|big model)\b", re.I), "switch_model", 0.98),
     (re.compile(r"\b(switch|change|go|open|activate|work in|move)\b.*\bproject\b", re.I), "switch_project", 0.94),
     (re.compile(r"\b(be quiet|mute|silent|disable speech|turn off voice|stop talking)\b", re.I), "toggle_silent", 0.99),
-    (re.compile(r"\b(conversation mode|continuous conversation|keep listening|toggle conversation)\b", re.I), "toggle_conversation", 0.99),
+    (re.compile(r"\b(companion mode|conversation mode|continuous conversation|keep listening|toggle (?:conversation|companion))\b", re.I), "toggle_conversation", 0.99),
     (re.compile(r"\b(cancel|abort|halt|stop now|interrupt)\b", re.I), "cancel_work", 0.96),
     (re.compile(r"\b(status|progress|current activity|how are we doing)\b", re.I), "show_status", 0.94),
 ]

--- a/tests/playwright/chat-voice-send.spec.ts
+++ b/tests/playwright/chat-voice-send.spec.ts
@@ -217,7 +217,7 @@ async function setConversationMode(page: Page, enabled: boolean) {
   await page.evaluate((target) => {
     const button = document.querySelector('#edge-top-models .edge-conv-btn');
     if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('conversation button not found');
+      throw new Error('companion mode button not found');
     }
     const current = button.getAttribute('aria-pressed') === 'true';
     if (current !== target) {

--- a/tests/playwright/conversation-mode.spec.ts
+++ b/tests/playwright/conversation-mode.spec.ts
@@ -57,7 +57,7 @@ async function setConversationMode(page: Page, enabled: boolean) {
   await page.evaluate((target) => {
     const button = document.querySelector('#edge-top-models .edge-conv-btn');
     if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('conversation button not found');
+      throw new Error('companion mode button not found');
     }
     const current = button.getAttribute('aria-pressed') === 'true';
     if (current !== target) {
@@ -103,14 +103,15 @@ async function triggerVoiceAssistantTTS(page: Page, turnID: string, text = 'Hell
 test.beforeEach(async ({ page }) => {
   await waitReady(page);
   await page.evaluate(() => {
+    window.localStorage.removeItem('tabura.companionMode');
     window.localStorage.removeItem('tabura.conversationMode');
   });
 });
 
-test('conversation mode toggle persists in localStorage', async ({ page }) => {
+test('Companion Mode toggle persists in localStorage', async ({ page }) => {
   await setConversationMode(page, true);
 
-  const persisted = await page.evaluate(() => window.localStorage.getItem('tabura.conversationMode'));
+  const persisted = await page.evaluate(() => window.localStorage.getItem('tabura.companionMode'));
   expect(persisted).toBe('true');
 
   await page.reload();
@@ -122,7 +123,28 @@ test('conversation mode toggle persists in localStorage', async ({ page }) => {
   })).toBe('true');
 });
 
-test('conversation mode shows listening indicator after TTS playback completes', async ({ page }) => {
+test('Companion Mode reads the legacy localStorage key once and rewrites to the new key', async ({ page }) => {
+  await page.evaluate(() => {
+    window.localStorage.setItem('tabura.conversationMode', 'true');
+  });
+
+  await page.reload();
+  await page.waitForTimeout(200);
+  await waitForEdgeButtons(page);
+  await expect.poll(async () => page.evaluate(() => {
+    const button = document.querySelector('#edge-top-models .edge-conv-btn');
+    return button instanceof HTMLButtonElement ? button.getAttribute('aria-pressed') : 'false';
+  })).toBe('true');
+
+  await setConversationMode(page, false);
+  const keys = await page.evaluate(() => ({
+    legacy: window.localStorage.getItem('tabura.conversationMode'),
+    current: window.localStorage.getItem('tabura.companionMode'),
+  }));
+  expect(keys).toEqual({ legacy: null, current: 'false' });
+});
+
+test('Companion Mode shows listening indicator after TTS playback completes', async ({ page }) => {
   await setConversationListenWindowMs(page, 1_200);
   await setConversationMode(page, true);
   await clearLog(page);
@@ -140,7 +162,7 @@ test('conversation mode shows listening indicator after TTS playback completes',
   })).toBe(true);
 });
 
-test('conversation mode off does not open listening indicator after TTS', async ({ page }) => {
+test('Companion Mode off does not open listening indicator after TTS', async ({ page }) => {
   await setConversationListenWindowMs(page, 1_200);
   await setConversationMode(page, false);
   await clearLog(page);

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -27,6 +27,7 @@ async function waitReady(page: Page, query = '') {
   }, null, { timeout: 5_000 });
   await page.waitForTimeout(200);
   await page.evaluate(() => {
+    window.localStorage.removeItem('tabura.companionMode');
     window.localStorage.removeItem('tabura.conversationMode');
   });
 }
@@ -72,7 +73,7 @@ async function setConversationMode(page: Page, enabled: boolean) {
   await page.evaluate((target) => {
     const button = document.querySelector('#edge-top-models .edge-conv-btn');
     if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('conversation button not found');
+      throw new Error('companion mode button not found');
     }
     const current = button.getAttribute('aria-pressed') === 'true';
     if (current !== target) {
@@ -246,7 +247,7 @@ test('hotword is paused while TTS playback is active', async ({ page }) => {
   expect(log.some((entry) => entry.type === 'hotword' && entry.action === 'stop')).toBe(true);
 });
 
-test('conversation mode off keeps hotword disabled', async ({ page }) => {
+test('Companion Mode off keeps hotword disabled', async ({ page }) => {
   await waitReady(page);
   await setConversationListenWindowMs(page, 1_200);
   await setConversationMode(page, false);
@@ -284,7 +285,7 @@ test('hotword init failure degrades gracefully with no crash', async ({ page }) 
   })).toBe(true);
 });
 
-test('conversation mode with hotword active shows pause indicator', async ({ page }) => {
+test('Companion Mode with hotword active shows pause indicator', async ({ page }) => {
   await waitReady(page);
   await setConversationMode(page, true);
   await waitForHotwordStart(page);

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -455,10 +455,10 @@ test.describe('turn lifecycle events', () => {
 
 
 // =============================================================================
-// Conversation mode: multi-turn loop
+// Companion Mode: multi-turn loop
 // =============================================================================
 
-test.describe('conversation mode multi-turn', () => {
+test.describe('Companion Mode multi-turn', () => {
   async function waitForEdgeButtons(page: Page) {
     await expect.poll(async () => page.evaluate(() => {
       const conv = document.querySelector('#edge-top-models .edge-conv-btn');
@@ -471,7 +471,7 @@ test.describe('conversation mode multi-turn', () => {
     await waitForEdgeButtons(page);
     await page.evaluate(() => {
       const button = document.querySelector('#edge-top-models .edge-conv-btn');
-      if (!(button instanceof HTMLButtonElement)) throw new Error('conversation button not found');
+      if (!(button instanceof HTMLButtonElement)) throw new Error('companion mode button not found');
       if (button.getAttribute('aria-pressed') !== 'true') button.click();
     });
     await expect.poll(async () => page.evaluate(() => {
@@ -497,11 +497,12 @@ test.describe('conversation mode multi-turn', () => {
     await injectCanvasModuleRef(page);
     await page.evaluate(() => {
       window.localStorage.removeItem('tabura.conversationMode');
+      window.localStorage.removeItem('tabura.companionMode');
       (window as any).__taburaConversationListenMs = 1200;
     });
   });
 
-  test('TTS playback completion triggers listen window in conversation mode', async ({ page }) => {
+  test('TTS playback completion triggers listen window in Companion Mode', async ({ page }) => {
     await enableConversationMode(page);
     await clearLog(page);
 
@@ -538,7 +539,7 @@ test.describe('conversation mode multi-turn', () => {
     });
     await page.waitForTimeout(500);
 
-    // Even with empty message, conversation mode should not stall
+    // Even with empty message, Companion Mode should not stall
     // (onTTSPlaybackComplete should have been called as recovery)
     // Verify no unhandled rejections
     const log = await getLog(page);
@@ -616,7 +617,7 @@ test.describe('project state persistence', () => {
     expect(stored).toBe(true);
   });
 
-  test('conversation mode persists in localStorage', async ({ page }) => {
+  test('Companion Mode persists in localStorage', async ({ page }) => {
     await injectChatEvent(page, {
       type: 'system_action',
       action: { type: 'toggle_conversation' },
@@ -624,7 +625,7 @@ test.describe('project state persistence', () => {
     await page.waitForTimeout(200);
 
     const stored = await page.evaluate(() => {
-      return localStorage.getItem('tabura.conversationMode');
+      return localStorage.getItem('tabura.companionMode');
     });
     expect(stored).toBe('true');
   });


### PR DESCRIPTION
## Summary
- replace remaining public-facing conversation-mode wording with Companion Mode in the runtime, docs, and intent classifier phrases
- persist the setting under `tabura.companionMode` with a one-way read fallback from the legacy key
- add focused regression coverage for the renamed system action text and storage-key migration

## Verification
- Requirement: roadmap workstreams for Companion Mode are closed before the umbrella issue is wrapped.
```text
$ gh issue list --state all --limit 500 --json number,state,title --jq '.[ ] | select(.number >= 129 and .number <= 140) | [.number,.state,.title] | @tsv'
140	OPEN	Release gate: ship next version only after Companion roadmap and compatibility cleanup are verified
139	CLOSED	Companion Mode: radical cleanup of legacy code, docs, and compatibility surfaces
137	CLOSED	Companion Mode: transcript memory and context builder
138	CLOSED	Companion Mode: consent, privacy, and visible-state safeguards
136	CLOSED	Companion Mode: runtime state machine and websocket protocol
135	CLOSED	Companion Mode: temporary projects for meetings and long-running tasks
134	CLOSED	Companion Mode: humanoid idle surface and black mode
133	CLOSED	Companion Mode: single active run per project and Hub run monitor
132	CLOSED	Companion Mode: room memory and entity timeline
131	CLOSED	Companion Mode: interaction policies and interruption handling
130	CLOSED	Companion Mode: assistant response execution from transcript triggers
129	CLOSED	Companion Mode: directed-speech gate from transcript context
```
- Requirement: docs describe Companion Mode as the active direction and public runtime copy uses the active name.
```text
$ rg -n "active unified assistant surface|active continuous assistant surface|active Companion Mode surface|companion mode on|Toggled Companion Mode|tabura\.companionMode|start companion mode" README.md docs/architecture.md docs/object-scoped-intent-ui.md internal/web/static/app.js internal/web/static/conversation.js internal/web/chat_intent.go services/intent-classifier/intents.json
services/intent-classifier/intents.json:26:  {"text": "start companion mode", "intent": "toggle_conversation", "entities": {}},
services/intent-classifier/intents.json:32:  {"text": "turn companion mode on", "intent": "toggle_conversation", "entities": {}},
internal/web/chat_intent.go:1311:		return "Toggled Companion Mode.", map[string]interface{}{"type": "toggle_conversation"}, nil
internal/web/static/conversation.js:3:const COMPANION_MODE_STORAGE_KEY = 'tabura.companionMode';
internal/web/static/app.js:4109:    showStatus(enabled ? 'companion mode on' : 'companion mode off');
internal/web/static/app.js:4737:      showStatus(enabled ? 'companion mode on' : 'companion mode off');
docs/object-scoped-intent-ui.md:88:This section describes the active continuous assistant surface. Some voice-loop
docs/architecture.md:101:it now sits within the active Companion Mode surface documented in
README.md:8:- Companion Mode is the active unified assistant surface for live meetings, 1:1 conversations, and workday assistance.
```
- Requirement: the runtime and coverage agree on the renamed Companion Mode behavior, storage migration, and user-visible status flow.
```text
$ go test ./internal/web/...
ok  github.com/krystophny/tabura/internal/web  3.179s

$ ./scripts/playwright.sh tests/playwright/conversation-mode.spec.ts tests/playwright/hotword.spec.ts tests/playwright/ui-system.spec.ts tests/playwright/companion-mode.spec.ts
  ✓   3 [chromium] › tests/playwright/conversation-mode.spec.ts:126:5 › Companion Mode reads the legacy localStorage key once and rewrites to the new key
  ✓  16 [chromium] › tests/playwright/hotword.spec.ts:250:5 › Companion Mode off keeps hotword disabled
  ✓  41 [chromium] › tests/playwright/ui-system.spec.ts:505:7 › Companion Mode multi-turn › TTS playback completion triggers listen window in Companion Mode
  ✓  46 [chromium] › tests/playwright/ui-system.spec.ts:620:7 › project state persistence › Companion Mode persists in localStorage
  ✓   2 [chromium] › tests/playwright/companion-mode.spec.ts:155:5 › workspace sidebar exposes companion transcript, summary, and references viewer entries
  74 passed (49.6s)
```
