### PR TITLE
fix: feat: project status indicators and unread tracking in projects (fixes #160)

### DIFF
--- a/internal/store/store_chat.go
+++ b/internal/store/store_chat.go
@@ -11,6 +11,8 @@ func normalizeChatMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "plan":
 		return "plan"
+	case "review":
+		return "review"
 	default:
 		return "chat"
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -346,6 +346,13 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	if updatedSession.Mode != "plan" {
 		t.Fatalf("mode = %q, want plan", updatedSession.Mode)
 	}
+	updatedSession, err = s.UpdateChatSessionMode(session.ID, "review")
+	if err != nil {
+		t.Fatalf("UpdateChatSessionMode(review) error: %v", err)
+	}
+	if updatedSession.Mode != "review" {
+		t.Fatalf("mode = %q, want review", updatedSession.Mode)
+	}
 	updatedSession, err = s.UpdateChatSessionMode(session.ID, "not-a-mode")
 	if err != nil {
 		t.Fatalf("UpdateChatSessionMode(invalid) error: %v", err)

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -166,7 +166,7 @@ func (a *App) handleChatSessionCreate(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		_ = a.store.TouchProject(resolvedProject.ID)
+		_ = a.markProjectSeen(resolvedProject)
 		if err := a.ensureProjectCanvasReady(resolvedProject); err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return

--- a/internal/web/chat_canvas.go
+++ b/internal/web/chat_canvas.go
@@ -168,6 +168,7 @@ func (a *App) writeCanvasFileBlock(projectKey, canvasSessionID string, block fil
 	}); err != nil {
 		return false
 	}
+	a.markProjectOutput(projectKey)
 	return true
 }
 
@@ -249,10 +250,10 @@ func (a *App) refreshCanvasFromDisk(projectKey string) bool {
 	if t == nil {
 		return false
 	}
-	return a.pushCanvasFileIfChanged(t)
+	return a.pushCanvasFileIfChanged(projectKey, t)
 }
 
-func (a *App) pushCanvasFileIfChanged(t *canvasFileTarget) bool {
+func (a *App) pushCanvasFileIfChanged(projectKey string, t *canvasFileTarget) bool {
 	diskBytes, err := os.ReadFile(t.filePath)
 	if err != nil {
 		return false
@@ -276,6 +277,7 @@ func (a *App) pushCanvasFileIfChanged(t *canvasFileTarget) bool {
 		"title":            t.title,
 		"markdown_or_text": diskContent,
 	})
+	a.markProjectOutput(projectKey)
 	return true
 }
 
@@ -330,6 +332,7 @@ func (a *App) watchCanvasFile(ctx context.Context, projectKey string) {
 				"title":            t.title,
 				"markdown_or_text": content,
 			})
+			a.markProjectOutput(projectKey)
 		case _, ok := <-watcher.Errors:
 			if !ok {
 				return

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -570,6 +570,7 @@ func (a *App) finalizeAssistantResponse(
 		}
 		*persistedText = chatMarkdown
 	}
+	a.markProjectOutput(projectKey)
 	tid := strings.TrimSpace(turnID)
 	if tid == "" {
 		tid = fallbackTurnID

--- a/internal/web/project_attention.go
+++ b/internal/web/project_attention.go
@@ -1,0 +1,67 @@
+package web
+
+import (
+	"strings"
+	"sync"
+)
+
+type projectAttentionTracker struct {
+	mu                 sync.Mutex
+	lastSeenAt         map[string]int64
+	lastCanvasChangeAt map[string]int64
+	lastReviewSubmitAt map[string]int64
+}
+
+func newProjectAttentionTracker() *projectAttentionTracker {
+	return &projectAttentionTracker{
+		lastSeenAt:         map[string]int64{},
+		lastCanvasChangeAt: map[string]int64{},
+		lastReviewSubmitAt: map[string]int64{},
+	}
+}
+
+func (t *projectAttentionTracker) markSeen(projectKey string, at int64) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" || at <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if at > t.lastSeenAt[key] {
+		t.lastSeenAt[key] = at
+	}
+}
+
+func (t *projectAttentionTracker) markCanvasChange(projectKey string, at int64) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" || at <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if at > t.lastCanvasChangeAt[key] {
+		t.lastCanvasChangeAt[key] = at
+	}
+}
+
+func (t *projectAttentionTracker) markReviewSubmitted(projectKey string, at int64) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" || at <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if at > t.lastReviewSubmitAt[key] {
+		t.lastReviewSubmitAt[key] = at
+	}
+}
+
+func (t *projectAttentionTracker) snapshot(projectKey string) (lastSeenAt, lastCanvasChangeAt, lastReviewSubmitAt int64) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" {
+		return 0, 0, 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.lastSeenAt[key], t.lastCanvasChangeAt[key], t.lastReviewSubmitAt[key]
+}

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -45,6 +45,8 @@ type projectAPIModel struct {
 	ChatModelReasoningEffort string          `json:"chat_model_reasoning_effort"`
 	CanvasSessionID          string          `json:"canvas_session_id"`
 	RunState                 projectRunState `json:"run_state"`
+	Unread                   bool            `json:"unread"`
+	ReviewPending            bool            `json:"review_pending"`
 }
 
 type projectChatModelRequest struct {
@@ -96,7 +98,10 @@ type projectActivityItem struct {
 	Name          string          `json:"name"`
 	Kind          string          `json:"kind"`
 	ChatSessionID string          `json:"chat_session_id"`
+	ChatMode      string          `json:"chat_mode"`
 	RunState      projectRunState `json:"run_state"`
+	Unread        bool            `json:"unread"`
+	ReviewPending bool            `json:"review_pending"`
 }
 
 func normalizeProjectKindInput(kind, path string) string {
@@ -339,6 +344,7 @@ func (a *App) buildProjectAPIModel(project store.Project) (projectAPIModel, erro
 	}
 	alias := a.effectiveProjectChatModelAlias(project)
 	effort := strings.TrimSpace(modelprofile.NormalizeReasoningEffort(alias, project.ChatModelReasoningEffort))
+	unread, reviewPending := a.projectUnreadState(project, session)
 	return projectAPIModel{
 		ID:                       project.ID,
 		Name:                     project.Name,
@@ -353,6 +359,8 @@ func (a *App) buildProjectAPIModel(project store.Project) (projectAPIModel, erro
 		ChatModelReasoningEffort: effort,
 		CanvasSessionID:          a.canvasSessionIDForProject(project),
 		RunState:                 a.projectRunStateForSession(session.ID),
+		Unread:                   unread,
+		ReviewPending:            reviewPending,
 	}, nil
 }
 
@@ -361,14 +369,73 @@ func (a *App) buildProjectActivityItem(project store.Project) (projectActivityIt
 	if err != nil {
 		return projectActivityItem{}, err
 	}
+	unread, reviewPending := a.projectUnreadState(project, session)
 	return projectActivityItem{
 		ProjectID:     project.ID,
 		ProjectKey:    project.ProjectKey,
 		Name:          project.Name,
 		Kind:          project.Kind,
 		ChatSessionID: session.ID,
+		ChatMode:      session.Mode,
 		RunState:      a.projectRunStateForSession(session.ID),
+		Unread:        unread,
+		ReviewPending: reviewPending,
 	}, nil
+}
+
+func (a *App) projectUnreadState(project store.Project, session store.ChatSession) (bool, bool) {
+	lastSeenAt, lastCanvasChangeAt, lastReviewSubmitAt := a.projectAttention.snapshot(project.ProjectKey)
+	dbSeenAt := project.LastOpenedAt * int64(time.Second)
+	if lastSeenAt < dbSeenAt {
+		lastSeenAt = dbSeenAt
+	}
+	reviewPending := strings.EqualFold(session.Mode, "review") && lastCanvasChangeAt > lastReviewSubmitAt
+	unread := lastCanvasChangeAt > lastSeenAt || reviewPending
+	activeProjectID, err := a.store.ActiveProjectID()
+	if err == nil && strings.TrimSpace(activeProjectID) == project.ID && !reviewPending {
+		unread = false
+	}
+	return unread, reviewPending
+}
+
+func (a *App) markProjectSeen(project store.Project) error {
+	if err := a.store.TouchProject(project.ID); err != nil {
+		return err
+	}
+	a.projectAttention.markSeen(project.ProjectKey, time.Now().UnixNano())
+	return nil
+}
+
+func (a *App) markProjectReviewSubmitted(project store.Project) error {
+	now := time.Now().UnixNano()
+	if err := a.store.TouchProject(project.ID); err != nil {
+		return err
+	}
+	a.projectAttention.markSeen(project.ProjectKey, now)
+	a.projectAttention.markReviewSubmitted(project.ProjectKey, now)
+	return nil
+}
+
+func (a *App) markProjectOutput(projectKey string) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" {
+		return
+	}
+	now := time.Now().UnixNano()
+	a.projectAttention.markCanvasChange(key, now)
+	project, err := a.store.GetProjectByProjectKey(key)
+	if err != nil {
+		return
+	}
+	activeProjectID, err := a.store.ActiveProjectID()
+	if err != nil || strings.TrimSpace(activeProjectID) != project.ID {
+		return
+	}
+	session, err := a.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil || strings.EqualFold(session.Mode, "review") {
+		return
+	}
+	a.projectAttention.markSeen(project.ProjectKey, now)
 }
 
 func (a *App) handleProjectsList(w http.ResponseWriter, r *http.Request) {
@@ -867,7 +934,7 @@ func (a *App) activateProject(projectID string) (store.Project, error) {
 	if err := a.store.SetActiveProjectID(project.ID); err != nil {
 		return store.Project{}, err
 	}
-	if err := a.store.TouchProject(project.ID); err != nil {
+	if err := a.markProjectSeen(project); err != nil {
 		return store.Project{}, err
 	}
 	return a.store.GetProject(project.ID)

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -26,6 +26,8 @@ type projectsListResponse struct {
 		ChatModel       string `json:"chat_model"`
 		ReasoningEffort string `json:"chat_model_reasoning_effort"`
 		CanvasSessionID string `json:"canvas_session_id"`
+		Unread          bool   `json:"unread"`
+		ReviewPending   bool   `json:"review_pending"`
 		RunState        struct {
 			ActiveTurns  int    `json:"active_turns"`
 			QueuedTurns  int    `json:"queued_turns"`
@@ -41,6 +43,9 @@ type projectsActivityResponse struct {
 	Projects []struct {
 		ProjectID     string `json:"project_id"`
 		ChatSessionID string `json:"chat_session_id"`
+		ChatMode      string `json:"chat_mode"`
+		Unread        bool   `json:"unread"`
+		ReviewPending bool   `json:"review_pending"`
 		RunState      struct {
 			ActiveTurns int    `json:"active_turns"`
 			QueuedTurns int    `json:"queued_turns"`
@@ -392,6 +397,92 @@ func TestProjectsActivityListsPerProjectRunState(t *testing.T) {
 		return
 	}
 	t.Fatalf("expected project %q in activity response", project.ID)
+}
+
+func TestProjectsActivityUnreadClearsOnActivate(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	linkedDir := t.TempDir()
+	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/projects", map[string]any{
+		"name":     "Unread Test",
+		"kind":     "linked",
+		"path":     filepath.Clean(linkedDir),
+		"activate": false,
+	})
+	if rrCreate.Code != http.StatusOK {
+		t.Fatalf("expected create 200, got %d: %s", rrCreate.Code, rrCreate.Body.String())
+	}
+	var createPayload struct {
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	}
+	if err := json.Unmarshal(rrCreate.Body.Bytes(), &createPayload); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	project, err := app.store.GetProject(createPayload.Project.ID)
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+
+	app.markProjectOutput(project.ProjectKey)
+
+	findActivity := func() projectsActivityResponse {
+		t.Helper()
+		rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/activity", map[string]any{})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected activity 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var payload projectsActivityResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("decode activity response: %v", err)
+		}
+		return payload
+	}
+
+	initial := findActivity()
+	foundUnread := false
+	for _, item := range initial.Projects {
+		if item.ProjectID != project.ID {
+			continue
+		}
+		foundUnread = true
+		if !item.Unread {
+			t.Fatalf("expected unread=true before activation")
+		}
+		if item.ReviewPending {
+			t.Fatalf("expected review_pending=false before activation")
+		}
+	}
+	if !foundUnread {
+		t.Fatalf("expected project %q in activity response", project.ID)
+	}
+
+	rrActivate := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodPost,
+		"/api/projects/"+project.ID+"/activate",
+		map[string]any{},
+	)
+	if rrActivate.Code != http.StatusOK {
+		t.Fatalf("expected activate 200, got %d: %s", rrActivate.Code, rrActivate.Body.String())
+	}
+
+	afterActivate := findActivity()
+	for _, item := range afterActivate.Projects {
+		if item.ProjectID != project.ID {
+			continue
+		}
+		if item.Unread {
+			t.Fatalf("expected unread=false after activation")
+		}
+		if item.ReviewPending {
+			t.Fatalf("expected review_pending=false after activation")
+		}
+		return
+	}
+	t.Fatalf("expected project %q in activity response after activation", project.ID)
 }
 
 func TestHubProjectRejectsModelUpdates(t *testing.T) {

--- a/internal/web/review_submit.go
+++ b/internal/web/review_submit.go
@@ -151,6 +151,10 @@ func (a *App) handleReviewSubmit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if err := a.markProjectReviewSubmitted(project); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	writeJSON(w, map[string]interface{}{
 		"ok":                     true,
 		"project_id":             project.ID,

--- a/internal/web/review_submit_test.go
+++ b/internal/web/review_submit_test.go
@@ -97,3 +97,92 @@ func TestReviewSubmitWritesMarkdownArtifact(t *testing.T) {
 		t.Fatalf("revision history missing heading: %s", string(historyContent))
 	}
 }
+
+func TestReviewSubmitClearsReviewPendingUnread(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.UpdateChatSessionMode(session.ID, "review"); err != nil {
+		t.Fatalf("set review mode: %v", err)
+	}
+
+	app.markProjectOutput(project.ProjectKey)
+
+	readActivity := func() projectsActivityResponse {
+		t.Helper()
+		rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/activity", nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("activity status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		var payload projectsActivityResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("decode activity response: %v", err)
+		}
+		return payload
+	}
+
+	assertState := func(unread, reviewPending bool) {
+		t.Helper()
+		payload := readActivity()
+		for _, item := range payload.Projects {
+			if item.ProjectID != project.ID {
+				continue
+			}
+			if item.ChatMode != "review" {
+				t.Fatalf("chat_mode = %q, want review", item.ChatMode)
+			}
+			if item.Unread != unread {
+				t.Fatalf("unread = %v, want %v", item.Unread, unread)
+			}
+			if item.ReviewPending != reviewPending {
+				t.Fatalf("review_pending = %v, want %v", item.ReviewPending, reviewPending)
+			}
+			return
+		}
+		t.Fatalf("expected project %q in activity response", project.ID)
+	}
+
+	assertState(true, true)
+
+	rrActivate := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodPost,
+		"/api/projects/"+project.ID+"/activate",
+		map[string]any{},
+	)
+	if rrActivate.Code != http.StatusOK {
+		t.Fatalf("activate status=%d body=%s", rrActivate.Code, rrActivate.Body.String())
+	}
+	assertState(true, true)
+
+	rrSubmit := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/review/submit", map[string]any{
+		"project_id":     project.ID,
+		"artifact_kind":  "text",
+		"artifact_title": "README.md",
+		"artifact_path":  "README.md",
+		"comments": []map[string]any{
+			{
+				"text": "Resolve before merge.",
+				"anchor": map[string]any{
+					"title": "README.md",
+					"line":  3,
+				},
+			},
+		},
+	})
+	if rrSubmit.Code != http.StatusOK {
+		t.Fatalf("review submit status=%d body=%s", rrSubmit.Code, rrSubmit.Body.String())
+	}
+	assertState(false, false)
+
+	app.markProjectOutput(project.ProjectKey)
+	assertState(true, true)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -98,6 +98,7 @@ type App struct {
 	turns            *chatTurnTracker
 	companionTurns   *companionPendingTurnTracker
 	companionRuntime *companionRuntimeTracker
+	projectAttention *projectAttentionTracker
 	tunnels          *tunnelRegistry
 	chatAppSessions  map[string]*appserver.Session
 	pendingDanger    map[string]*pendingDangerousAction
@@ -264,6 +265,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		turns:                         newChatTurnTracker(),
 		companionTurns:                newCompanionPendingTurnTracker(),
 		companionRuntime:              newCompanionRuntimeTracker(),
+		projectAttention:              newProjectAttentionTracker(),
 		tunnels:                       newTunnelRegistry(),
 		chatAppSessions:               map[string]*appserver.Session{},
 		pendingDanger:                 map[string]*pendingDangerousAction{},

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -2393,11 +2393,12 @@ function syncChatScroll(host) {
 }
 
 function setChatMode(mode) {
-  state.chatMode = String(mode || 'chat').toLowerCase() === 'plan' ? 'plan' : 'chat';
+  const normalized = String(mode || 'chat').toLowerCase();
+  state.chatMode = normalized === 'plan' || normalized === 'review' ? normalized : 'chat';
   const pill = document.getElementById('chat-mode-pill');
   if (pill) {
     pill.textContent = state.chatMode;
-    pill.className = `badge ${state.chatMode === 'plan' ? 'review' : ''}`;
+    pill.className = `badge ${state.chatMode === 'plan' || state.chatMode === 'review' ? 'review' : ''}`;
   }
 }
 
@@ -3879,8 +3880,11 @@ async function fetchProjects() {
   state.projects = projects.map((project) => ({
     ...project,
     id: String(project?.id || ''),
+    chat_mode: String(project?.chat_mode || 'chat'),
     chat_model_reasoning_effort: String(project?.chat_model_reasoning_effort || '').trim().toLowerCase(),
     run_state: normalizeProjectRunState(project?.run_state),
+    unread: Boolean(project?.unread),
+    review_pending: Boolean(project?.review_pending),
   })).filter((project) => project.id);
   state.defaultProjectId = String(payload?.default_project_id || '').trim();
   state.serverActiveProjectId = String(payload?.active_project_id || '').trim();
@@ -3917,10 +3921,13 @@ function projectRunStateSummary(project) {
 
 function upsertProject(project) {
   if (!project || !project.id) return;
+  project.chat_mode = String(project.chat_mode || 'chat');
   if (project.chat_model_reasoning_effort !== undefined) {
     project.chat_model_reasoning_effort = String(project.chat_model_reasoning_effort || '').trim().toLowerCase();
   }
   project.run_state = normalizeProjectRunState(project.run_state);
+  project.unread = Boolean(project.unread);
+  project.review_pending = Boolean(project.review_pending);
   const index = state.projects.findIndex((item) => item.id === project.id);
   if (index >= 0) {
     state.projects[index] = project;
@@ -4022,6 +4029,9 @@ function renderEdgeTopProjects() {
     }
     if (runState.is_working) {
       button.classList.add('is-working');
+    }
+    if (project.unread) {
+      button.classList.add('is-unread');
     }
     if (runState.status === 'running') {
       button.classList.add('is-running');
@@ -4457,7 +4467,7 @@ async function refreshAssistantActivity() {
 }
 
 async function refreshProjectRunStates() {
-  if (!isHubActive() || projectRunStatesInFlight) return;
+  if (projectRunStatesInFlight) return;
   projectRunStatesInFlight = true;
   try {
     const resp = await fetch(apiURL('projects/activity'), { cache: 'no-store' });
@@ -4471,7 +4481,10 @@ async function refreshProjectRunStates() {
       if (!existing) continue;
       upsertProject({
         ...existing,
+        chat_mode: item?.chat_mode || existing.chat_mode,
         run_state: item?.run_state,
+        unread: item?.unread,
+        review_pending: item?.review_pending,
       });
     }
     renderEdgeTopProjects();
@@ -4494,9 +4507,7 @@ function startAssistantActivityWatcher() {
       }
     }
     void refreshAssistantActivity();
-    if (isHubActive()) {
-      void refreshProjectRunStates();
-    }
+    void refreshProjectRunStates();
   };
   assistantActivityTimer = window.setInterval(tick, ASSISTANT_ACTIVITY_POLL_MS);
   tick();

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -985,7 +985,7 @@ body.keyboard-open .indicator.is-paused {
 }
 
 .indicator.is-recording { --cue-frame-color: #d92d20; }
-.indicator.is-working  { --cue-frame-color: #111111; }
+.indicator.is-working  { --cue-frame-color: #16a34a; }
 .indicator.is-listening { --cue-frame-color: #2563eb; }
 .indicator.is-paused   { --cue-frame-color: #111111; }
 
@@ -1043,10 +1043,11 @@ body.keyboard-open .indicator.is-paused {
 
 .indicator.is-working .stop-square {
   display: inline-flex;
-  width: calc(var(--cue-chip-size) * 0.75);
-  height: calc(var(--cue-chip-size) * 0.75);
-  border-radius: 1px;
-  background: #111111;
+  width: 0;
+  height: 0;
+  border-top: calc(var(--cue-chip-size) * 0.4) solid transparent;
+  border-bottom: calc(var(--cue-chip-size) * 0.4) solid transparent;
+  border-left: calc(var(--cue-chip-size) * 0.66) solid #16a34a;
 }
 
 .indicator.is-paused .pause-bars {
@@ -1085,8 +1086,9 @@ body.keyboard-open .indicator.is-paused {
   }
   .indicator .record-dot,
   .indicator .stop-square {
-    background: #111111;
+    background: transparent;
   }
+  .indicator.is-working .stop-square { border-left-color: #111111; }
   .indicator.is-paused .pause-bars::before,
   .indicator.is-paused .pause-bars::after {
     background: #111111;
@@ -1480,24 +1482,28 @@ body.panel-motion-enabled {
 }
 
 .edge-project-btn.is-working {
-  border-color: #b45309;
-  background: #fef3c7;
+  border-color: #16a34a;
+  background: #dcfce7;
 }
 
 .edge-project-btn.is-working::after {
-  content: "•";
+  content: "▶";
   margin-left: 0.35rem;
-  color: #b45309;
+  color: #16a34a;
 }
 
 .edge-project-btn.is-active.is-working {
-  border-color: #92400e;
-  background: #92400e;
-  color: #fffbeb;
+  border-color: #166534;
+  background: #166534;
+  color: #ecfdf5;
 }
 
 .edge-project-btn.is-active.is-working::after {
-  color: #fbbf24;
+  color: #bbf7d0;
+}
+
+.edge-project-btn.is-unread {
+  font-weight: 700;
 }
 
 .liability-modal {

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -380,6 +380,8 @@
         chat_mode: 'chat',
         chat_model: 'spark',
         chat_model_reasoning_effort: 'low',
+        unread: false,
+        review_pending: false,
         run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       },
       {
@@ -393,6 +395,8 @@
         chat_mode: 'chat',
         chat_model: 'spark',
         chat_model_reasoning_effort: 'low',
+        unread: false,
+        review_pending: false,
         run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       },
     ];
@@ -423,6 +427,20 @@
         ...harnessProjectRunStates,
         ...next,
       };
+    };
+    window.__setProjectActivity = (states) => {
+      const next = states && typeof states === 'object' ? states : {};
+      for (const [projectId, patch] of Object.entries(next)) {
+        const index = harnessProjects.findIndex((project) => project.id === projectId);
+        if (index < 0 || !patch || typeof patch !== 'object') continue;
+        harnessProjects[index] = {
+          ...harnessProjects[index],
+          ...patch,
+          unread: Boolean(patch.unread ?? harnessProjects[index].unread),
+          review_pending: Boolean(patch.review_pending ?? harnessProjects[index].review_pending),
+          chat_mode: String(patch.chat_mode || harnessProjects[index].chat_mode || 'chat'),
+        };
+      }
     };
     const cloneProject = (id) => {
       const project = harnessProjects.find((item) => item.id === id) || harnessProjects[0];
@@ -501,6 +519,8 @@
           chat_mode: 'chat',
           chat_model: 'spark',
           chat_model_reasoning_effort: 'low',
+          unread: false,
+          review_pending: false,
           run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
         };
         harnessProjects.push(project);
@@ -524,8 +544,18 @@
       }
       if (u.includes('/api/projects') && u.includes('/activate')) {
         const activateId = decodeURIComponent(u.split('/api/projects/')[1].split('/activate')[0] || '').trim();
+        const index = harnessProjects.findIndex((project) => project.id === activateId);
+        if (index < 0) {
+          return new Response('project not found', { status: 404 });
+        }
+        activeProjectId = harnessProjects[index].id;
+        if (!(harnessProjects[index].review_pending && harnessProjects[index].chat_mode === 'review')) {
+          harnessProjects[index] = {
+            ...harnessProjects[index],
+            unread: false,
+          };
+        }
         const project = cloneProject(activateId);
-        activeProjectId = project.id;
         window.__harnessLog.push({
           type: 'api_fetch',
           action: 'project_activate',
@@ -625,6 +655,9 @@
           name: project.name,
           kind: project.kind,
           chat_session_id: project.chat_session_id,
+          chat_mode: project.chat_mode,
+          unread: Boolean(project.unread),
+          review_pending: Boolean(project.review_pending),
           run_state: { ...(harnessProjectRunStates[project.id] || project.run_state || {}) },
         }));
         return new Response(JSON.stringify({ ok: true, projects }), { status: 200 });

--- a/tests/playwright/hub-mode.spec.ts
+++ b/tests/playwright/hub-mode.spec.ts
@@ -104,6 +104,39 @@ test('hub monitors project run state without activating the project', async ({ p
   await expect(projectButton).not.toHaveClass(/is-active/);
 });
 
+test('hub shows unread project state and activation clears it', async ({ page }) => {
+  await page.evaluate(() => {
+    document.getElementById('edge-top')?.classList.add('edge-pinned');
+  });
+  const hubButton = page.locator('#edge-top-projects .edge-hub-btn');
+  const projectButton = page.locator('#edge-top-projects .edge-project-btn:not(.edge-hub-btn)');
+
+  await hubButton.click();
+  await expect(hubButton).toHaveClass(/is-active/);
+
+  await page.evaluate(() => {
+    (window as any).__setProjectActivity({
+      test: { unread: true, review_pending: false, chat_mode: 'chat' },
+    });
+  });
+
+  await expect.poll(async () => projectButton.getAttribute('class'), { timeout: 5_000 }).toContain('is-unread');
+
+  await projectButton.click();
+  await expect(projectButton).not.toHaveClass(/is-unread/);
+
+  await hubButton.click();
+  await expect(hubButton).toHaveClass(/is-active/);
+
+  await page.evaluate(() => {
+    (window as any).__setProjectActivity({
+      test: { unread: true, review_pending: false, chat_mode: 'chat' },
+    });
+  });
+
+  await expect.poll(async () => projectButton.getAttribute('class'), { timeout: 5_000 }).toContain('is-unread');
+});
+
 test('system switch_model action updates project model state', async ({ page }) => {
   await page.evaluate(() => {
     document.getElementById('edge-top')?.classList.add('edge-pinned');


### PR DESCRIPTION
## Summary
- add per-project attention tracking so project APIs expose `unread` and `review_pending`
- keep review-mode projects unread until `/api/review/submit`, then re-trigger on later output
- switch working indicators from amber/black stop states to green play states and bold unread project buttons

## Verification
- Requirement 1. Working/idle status display
  - Code evidence: `rg -n "edge-project-btn.is-working|button.classList.add\('is-working'\)" internal/web/static/style.css internal/web/static/app.js`
  - Excerpt: `internal/web/static/style.css:1484` sets green working button colors; `internal/web/static/style.css:1489` renders `content: "▶"`; `internal/web/static/app.js:4031` only adds `is-working` when `run_state.is_working` is true, so idle buttons keep the default styling.
- Requirement 2. Full-screen working indicator stop -> play
  - Code evidence: `rg -n "indicator\.is-working|stop-square" internal/web/static/style.css`
  - Excerpt: `internal/web/static/style.css:988` changes `--cue-frame-color` to `#16a34a`; `internal/web/static/style.css:1044` repurposes `.stop-square` into a green triangle.
- Requirement 3. Edge-top project button working state amber -> green play
  - Code evidence: `rg -n "edge-project-btn.is-working|edge-project-btn.is-unread" internal/web/static/style.css`
  - Excerpt: `internal/web/static/style.css:1484-1505` switches the edge-top working state to green tones, `▶`, and adds bold unread styling.
- Requirement 4. Unread/needs-attention tracking
  - Backend code evidence: `rg -n "projectAttention|projectUnreadState|markProjectOutput|markProjectSeen\(" internal/web/project_attention.go internal/web/projects.go internal/web/chat_turn.go internal/web/chat_canvas.go`
  - Excerpt: `internal/web/project_attention.go:8-59` adds per-project seen/output/review timestamps; `internal/web/projects.go:386-438` computes `unread`/`review_pending`; `internal/web/chat_turn.go:573` and `internal/web/chat_canvas.go:171,280,335` mark project output.
  - Test evidence: `go test ./internal/web ./internal/store`
  - Output: `ok   github.com/krystophny/tabura/internal/web 3.457s`, `ok   github.com/krystophny/tabura/internal/store 1.176s`
  - Coverage added: `internal/web/projects_test.go:402` (`TestProjectsActivityUnreadClearsOnActivate`)
  - UI evidence: `./scripts/playwright.sh tests/playwright/hub-mode.spec.ts`
  - Output: `10 passed (10.8s)` including `hub shows unread project state and activation clears it`
- Requirement 5. Review mode exception
  - Backend code evidence: `rg -n "markProjectReviewSubmitted|reviewPending|normalizeChatMode" internal/web/projects.go internal/web/review_submit.go internal/store/store_chat.go`
  - Excerpt: `internal/web/projects.go:392-415` keeps unread sticky while `session.Mode == "review"`; `internal/web/review_submit.go:154` clears it on review submit; `internal/store/store_chat.go:10-16` preserves `review` chat mode.
  - Test evidence: `go test ./internal/web ./internal/store`
  - Output: `ok   github.com/krystophny/tabura/internal/web 3.457s`, `ok   github.com/krystophny/tabura/internal/store 1.176s`
  - Coverage added: `internal/web/review_submit_test.go:101` (`TestReviewSubmitClearsReviewPendingUnread`)
- Acceptance: ephemeral projects use the same activity path
  - UI evidence: `./scripts/playwright.sh tests/playwright/hub-mode.spec.ts`
  - Output: `10 passed (10.8s)` including the existing temporary-project flows `temporary meeting can be spawned from the current project and persisted` and `temporary task can be spawned from hub and discarded` after the unread polling changes.
