### PR TITLE
fix: Clarify hands-free live interaction: shared engine, explicit Dia (fixes #162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Core paradigm:
 - Tap to talk, right-click to type, keyboard auto-activates. No visible chrome.
 - Responses stream as ephemeral overlays; document edits update in place with diff highlighting.
 - Edge panels (hover/swipe to reveal) for project switching and chat panel access.
-- Live sessions are split into `Dialogue` and `Meeting`, with shared hotword and audio runtime behavior.
+- Live sessions are split into `Dialogue` and `Meeting`, with one shared audio runtime and built-in `Alexa` hotword behavior.
 
 License: MIT (`LICENSE`)
 Legal notice: Tabura is provided "as is" and "as available" without warranties, and to the maximum extent permitted by applicable law the authors/contributors accept no liability for damages, data loss, or misuse. You are solely responsible for backups, verification, and safe operation. See [`DISCLAIMER.md`](DISCLAIMER.md).
@@ -14,7 +14,7 @@ Legal notice: Tabura is provided "as is" and "as available" without warranties, 
 
 - **Spec hub**: [`docs/spec-index.md`](docs/spec-index.md)
 - **System architecture**: [`docs/architecture.md`](docs/architecture.md)
-- **Live session direction**: [`docs/companion-mode-whitepaper.md`](docs/companion-mode-whitepaper.md)
+- **Live session architecture**: [`docs/architecture.md`](docs/architecture.md)
 - **Codex app-server integration**: [`docs/codex-app-server-pivot.md`](docs/codex-app-server-pivot.md)
 - **HTTP/MCP interface inventory**: [`docs/interfaces.md`](docs/interfaces.md)
 - **UI paradigm**: [`docs/object-scoped-intent-ui.md`](docs/object-scoped-intent-ui.md)

--- a/docs/meeting-notes-privacy.md
+++ b/docs/meeting-notes-privacy.md
@@ -6,11 +6,11 @@ This document formalizes the audio privacy guarantees for Tabura's speech-to-tex
 
 **Key invariant: audio exists only in RAM during processing and is never persisted to disk or database.**
 
-## Companion Consent Boundary
+## Meeting Consent Boundary
 
-- Companion Mode is explicit opt-in. Capture must not start until `companion_enabled=true`.
-- Disabling Companion Mode is an exit action: any active participant capture session must stop immediately.
-- Companion capture defaults to microphone-only input. Alternate capture sources are not accepted through the config surface.
+- Meeting capture is explicit opt-in. Capture must not start until `companion_enabled=true` on the current project config API.
+- Disabling Meeting live mode is an exit action: any active participant capture session must stop immediately.
+- Meeting capture defaults to microphone-only input. Alternate capture sources are not accepted through the config surface.
 
 ## Audio Lifecycle
 

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_conversation, shell, open_file_canvas, cancel_work, show_status, chat.
+Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -149,7 +149,8 @@ func TestParseSystemAction(t *testing.T) {
 		{name: "switch project", raw: `{"action":"switch_project","name":"docs"}`, wantAction: "switch_project"},
 		{name: "switch model", raw: `{"action":"switch_model","alias":"gpt","effort":"high"}`, wantAction: "switch_model"},
 		{name: "toggle silent", raw: `{"action":"toggle_silent"}`, wantAction: "toggle_silent"},
-		{name: "toggle conversation", raw: `{"action":"toggle_conversation"}`, wantAction: "toggle_conversation"},
+		{name: "toggle live dialogue", raw: `{"action":"toggle_live_dialogue"}`, wantAction: "toggle_live_dialogue"},
+		{name: "toggle conversation alias", raw: `{"action":"toggle_conversation"}`, wantAction: "toggle_live_dialogue"},
 		{name: "cancel work", raw: `{"action":"cancel_work"}`, wantAction: "cancel_work"},
 		{name: "show status", raw: `{"action":"show_status"}`, wantAction: "show_status"},
 		{name: "shell", raw: `{"action":"shell","command":"ls -1"}`, wantAction: "shell"},
@@ -236,7 +237,7 @@ func TestExecuteSystemActionShellRunsCommand(t *testing.T) {
 	}
 }
 
-func TestExecuteSystemActionToggleConversationReturnsCompanionMessage(t *testing.T) {
+func TestExecuteSystemActionToggleLiveDialogueReturnsPayload(t *testing.T) {
 	app := newAuthedTestApp(t)
 	project, err := app.ensureDefaultProjectRecord()
 	if err != nil {
@@ -248,19 +249,19 @@ func TestExecuteSystemActionToggleConversationReturnsCompanionMessage(t *testing
 	}
 
 	msg, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
-		Action: "toggle_conversation",
+		Action: "toggle_live_dialogue",
 	})
 	if err != nil {
-		t.Fatalf("execute toggle_conversation: %v", err)
+		t.Fatalf("execute toggle_live_dialogue: %v", err)
 	}
 	if strings.TrimSpace(msg) != "Toggled Live Dialogue." {
-		t.Fatalf("toggle conversation message = %q, want %q", msg, "Toggled Live Dialogue.")
+		t.Fatalf("toggle live dialogue message = %q, want %q", msg, "Toggled Live Dialogue.")
 	}
 	if payload == nil {
-		t.Fatalf("expected toggle_conversation payload")
+		t.Fatalf("expected toggle_live_dialogue payload")
 	}
-	if got := strings.TrimSpace(strFromAny(payload["type"])); got != "toggle_conversation" {
-		t.Fatalf("payload type = %q, want toggle_conversation", got)
+	if got := strings.TrimSpace(strFromAny(payload["type"])); got != "toggle_live_dialogue" {
+		t.Fatalf("payload type = %q, want toggle_live_dialogue", got)
 	}
 }
 

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,7 +36,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_conversation, cancel_work, show_status, shell, open_file_canvas, chat.
+Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -320,7 +320,9 @@ func systemActionStringParam(params map[string]interface{}, key string) string {
 
 func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "switch_project", "switch_model", "toggle_silent", "toggle_conversation", "cancel_work", "show_status", "shell", "open_file_canvas":
+	case "toggle_conversation":
+		return "toggle_live_dialogue"
+	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -1307,8 +1309,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			}, nil
 	case "toggle_silent":
 		return "Toggled silent mode.", map[string]interface{}{"type": "toggle_silent"}, nil
-	case "toggle_conversation":
-		return "Toggled Live Dialogue.", map[string]interface{}{"type": "toggle_conversation"}, nil
+	case "toggle_live_dialogue":
+		return "Toggled Live Dialogue.", map[string]interface{}{"type": "toggle_live_dialogue"}, nil
 	case "cancel_work":
 		activeCanceled, queuedCanceled := a.cancelChatWork(sessionID)
 		total := activeCanceled + queuedCanceled

--- a/internal/web/projects_companion_artifacts.go
+++ b/internal/web/projects_companion_artifacts.go
@@ -370,7 +370,7 @@ func formatCompanionSessionStamp(session *store.ParticipantSession) string {
 
 func renderCompanionTranscriptMarkdown(session *store.ParticipantSession, segments []store.ParticipantSegment) string {
 	var b strings.Builder
-	b.WriteString("# Companion Transcript\n\n")
+	b.WriteString("# Meeting Transcript\n\n")
 	if session == nil {
 		b.WriteString("No transcript is available for this project yet.\n")
 		return b.String()
@@ -414,7 +414,7 @@ func renderCompanionTranscriptText(session *store.ParticipantSession, segments [
 
 func renderCompanionSummaryMarkdown(session *store.ParticipantSession, summary string, updatedAt int64) string {
 	var b strings.Builder
-	b.WriteString("# Companion Summary\n\n")
+	b.WriteString("# Meeting Summary\n\n")
 	if session == nil {
 		b.WriteString("No summary is available for this project yet.\n")
 		return b.String()
@@ -456,7 +456,7 @@ func renderCompanionSummaryText(session *store.ParticipantSession, summary strin
 
 func renderCompanionReferencesMarkdown(session *store.ParticipantSession, entities []string, topics []any) string {
 	var b strings.Builder
-	b.WriteString("# Companion References\n\n")
+	b.WriteString("# Meeting References\n\n")
 	if session == nil {
 		b.WriteString("No references are available for this project yet.\n")
 		return b.String()

--- a/internal/web/projects_companion_artifacts_test.go
+++ b/internal/web/projects_companion_artifacts_test.go
@@ -74,7 +74,7 @@ func TestProjectCompanionTranscriptAPIAndExports(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET transcript markdown status = %d, want 200", rr.Code)
 	}
-	if !strings.Contains(rr.Body.String(), "# Companion Transcript") {
+	if !strings.Contains(rr.Body.String(), "# Meeting Transcript") {
 		t.Fatalf("transcript markdown missing header: %q", rr.Body.String())
 	}
 	if !strings.Contains(rr.Body.String(), "alpha note") || !strings.Contains(rr.Body.String(), "beta note") {
@@ -119,7 +119,7 @@ func TestProjectCompanionSummaryAndReferencesAPIAndExports(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET summary markdown status = %d, want 200", rr.Code)
 	}
-	if !strings.Contains(rr.Body.String(), "# Companion Summary") || !strings.Contains(rr.Body.String(), "Decision summary") {
+	if !strings.Contains(rr.Body.String(), "# Meeting Summary") || !strings.Contains(rr.Body.String(), "Decision summary") {
 		t.Fatalf("summary markdown missing expected content: %q", rr.Body.String())
 	}
 
@@ -145,7 +145,7 @@ func TestProjectCompanionSummaryAndReferencesAPIAndExports(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET references markdown status = %d, want 200", rr.Code)
 	}
-	if !strings.Contains(rr.Body.String(), "# Companion References") {
+	if !strings.Contains(rr.Body.String(), "# Meeting References") {
 		t.Fatalf("references markdown missing header: %q", rr.Body.String())
 	}
 	if !strings.Contains(rr.Body.String(), "Acme") || !strings.Contains(rr.Body.String(), "Status") {
@@ -158,7 +158,7 @@ func TestProjectCompanionSummaryAndReferencesAPIAndExports(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read transcript artifact: %v", err)
 	}
-	if !strings.Contains(string(transcriptBody), "# Companion Transcript") {
+	if !strings.Contains(string(transcriptBody), "# Meeting Transcript") {
 		t.Fatalf("transcript artifact missing header: %q", string(transcriptBody))
 	}
 

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -85,9 +85,6 @@ const state = {
   liveSessionHotword: LIVE_SESSION_HOTWORD_DEFAULT,
   liveSessionDialogueListenActive: false,
   liveSessionDialogueListenTimer: null,
-  conversationMode: false,
-  conversationListenActive: false,
-  conversationListenTimer: null,
   hotwordEnabled: false,
   hotwordActive: false,
   voiceTranscriptSubmitInFlight: false,
@@ -199,6 +196,9 @@ const COMPANION_VIEW_PATH_PREFIX = '__tabura_companion__';
 const COMPANION_TRANSCRIPT_VIEW_PATH = `${COMPANION_VIEW_PATH_PREFIX}/transcript`;
 const COMPANION_SUMMARY_VIEW_PATH = `${COMPANION_VIEW_PATH_PREFIX}/summary`;
 const COMPANION_REFERENCES_VIEW_PATH = `${COMPANION_VIEW_PATH_PREFIX}/references`;
+const MEETING_TRANSCRIPT_LABEL = 'Meeting Transcript';
+const MEETING_SUMMARY_LABEL = 'Meeting Summary';
+const MEETING_REFERENCES_LABEL = 'Meeting References';
 let localMessageSeq = 0;
 const CHAT_CTRL_LONG_PRESS_MS = 180;
 const ARTIFACT_EDIT_LONG_TAP_MS = 420;
@@ -696,9 +696,6 @@ function applyLiveSessionStateSnapshot(snapshot = null) {
   state.liveSessionHotword = String(nextSnapshot.liveSessionHotword || LIVE_SESSION_HOTWORD_DEFAULT).trim() || LIVE_SESSION_HOTWORD_DEFAULT;
   state.liveSessionDialogueListenActive = Boolean(nextSnapshot.liveSessionDialogueListenActive);
   state.liveSessionDialogueListenTimer = nextSnapshot.liveSessionDialogueListenTimer ?? null;
-  state.conversationMode = state.liveSessionActive && state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE;
-  state.conversationListenActive = state.liveSessionDialogueListenActive;
-  state.conversationListenTimer = state.liveSessionDialogueListenTimer;
   requestHotwordSync();
 }
 
@@ -914,7 +911,7 @@ function stopTTSPlayback() {
 }
 
 configureLiveSession({
-  canStartDialogueListen: canStartConversationListen,
+  canStartDialogueListen: canStartLiveDialogueListen,
   onStateChange: (snapshot) => {
     applyLiveSessionStateSnapshot(snapshot);
     renderEdgeTopModelButtons();
@@ -1433,7 +1430,7 @@ function companionStatusCopy(runtimeState) {
     case COMPANION_RUNTIME_STATES.TALKING:
       return { label: 'Talking', detail: 'Speaking the current response.' };
     case COMPANION_RUNTIME_STATES.ERROR:
-      return { label: 'Error', detail: 'Companion hit a runtime error.' };
+      return { label: 'Error', detail: 'Meeting mode hit a runtime error.' };
     default:
       return { label: 'Idle', detail: 'Ready in the background.' };
   }
@@ -2255,7 +2252,7 @@ async function stopVoiceCaptureAndSend() {
   updateAssistantActivityIndicator();
   showStatus('transcribing...');
   let remoteStopped = false;
-  let reopenConversationListen = false;
+  let reopenDialogueListen = false;
   try {
     let sttBlob = null;
     let mimeType = '';
@@ -2295,7 +2292,7 @@ async function stopVoiceCaptureAndSend() {
     if (!transcript) {
       if (isDialogueLiveSession() && isHotwordCapture) {
         state.voiceAwaitingTurn = false;
-        reopenConversationListen = true;
+        reopenDialogueListen = true;
         return;
       }
       throw new Error(voiceCaptureEmptyReasonMessage(result?.reason));
@@ -2314,7 +2311,7 @@ async function stopVoiceCaptureAndSend() {
     const y = Number.isFinite(pos?.y) ? Number(pos.y) : null;
     showVoiceCaptureNotice(`voice capture failed: ${message}`, x, y);
     if (isDialogueLiveSession()) {
-      reopenConversationListen = true;
+      reopenDialogueListen = true;
     }
   } finally {
     if (!remoteStopped) {
@@ -2332,7 +2329,7 @@ async function stopVoiceCaptureAndSend() {
       syncVoiceLifecycle('voice-capture-stop-finished');
     }
     updateAssistantActivityIndicator();
-    if (reopenConversationListen && isDialogueLiveSession()) {
+    if (reopenDialogueListen && isDialogueLiveSession()) {
       // Re-open follow-up listen only after capture teardown has settled.
       window.setTimeout(() => {
         if (!isDialogueLiveSession()) return;
@@ -2523,10 +2520,10 @@ function isUiReadyForStatus() {
   return mode === VOICE_LIFECYCLE.IDLE;
 }
 
-function canStartConversationListen() {
+function canStartLiveDialogueListen() {
   if (!canSpeakTTS()) return false;
   if (!isDialogueLiveSession()) return false;
-  const mode = syncVoiceLifecycle('can-start-conversation');
+  const mode = syncVoiceLifecycle('can-start-live-dialogue');
   if (mode === VOICE_LIFECYCLE.RECORDING || mode === VOICE_LIFECYCLE.STOPPING_RECORDING) return false;
   if (mode === VOICE_LIFECYCLE.TTS_PLAYING) return false;
   if (state.chatVoiceCapture) return false;
@@ -2791,9 +2788,9 @@ function companionViewKindForPath(path) {
 
 function workspaceCompanionEntries() {
   return [
-    { name: 'Companion Transcript', path: COMPANION_TRANSCRIPT_VIEW_PATH, is_dir: false },
-    { name: 'Companion Summary', path: COMPANION_SUMMARY_VIEW_PATH, is_dir: false },
-    { name: 'Companion References', path: COMPANION_REFERENCES_VIEW_PATH, is_dir: false },
+    { name: MEETING_TRANSCRIPT_LABEL, path: COMPANION_TRANSCRIPT_VIEW_PATH, is_dir: false },
+    { name: MEETING_SUMMARY_LABEL, path: COMPANION_SUMMARY_VIEW_PATH, is_dir: false },
+    { name: MEETING_REFERENCES_LABEL, path: COMPANION_REFERENCES_VIEW_PATH, is_dir: false },
   ];
 }
 
@@ -3090,9 +3087,9 @@ async function openCompanionWorkspaceView(viewKind, filePath) {
   const projectID = String(state.activeProjectId || '').trim();
   if (!projectID) return false;
   const titles = {
-    transcript: 'Companion Transcript',
-    summary: 'Companion Summary',
-    references: 'Companion References',
+    transcript: MEETING_TRANSCRIPT_LABEL,
+    summary: MEETING_SUMMARY_LABEL,
+    references: MEETING_REFERENCES_LABEL,
   };
   const endpoint = viewKind === 'transcript' || viewKind === 'summary' || viewKind === 'references'
     ? viewKind
@@ -3117,7 +3114,7 @@ async function openCompanionWorkspaceView(viewKind, filePath) {
     if (isMobileViewport()) { setPrReviewDrawerOpen(false); closeEdgePanels(); }
     return true;
   } catch (err) {
-    appendPlainMessage('system', `${titles[viewKind] || 'Companion view'} failed: ${String(err?.message || err)}`);
+    appendPlainMessage('system', `${titles[viewKind] || 'Meeting view'} failed: ${String(err?.message || err)}`);
     return false;
   }
 }
@@ -4886,7 +4883,7 @@ function handleChatEvent(payload) {
       }
     } else if (actionType === 'toggle_silent') {
       toggleTTSSilentMode();
-    } else if (actionType === 'toggle_conversation') {
+    } else if (actionType === 'toggle_live_dialogue' || actionType === 'toggle_conversation') {
       const next = state.liveSessionActive ? '' : LIVE_SESSION_MODE_DIALOGUE;
       const action = next
         ? activateLiveSession(next)
@@ -5071,7 +5068,7 @@ function handleChatEvent(payload) {
     // If live dialogue is active but no TTS was queued (e.g. TTS error,
     // empty md, or all text already spoken during streaming), kick the listen
     // cycle so the hands-free loop does not stall.
-    if (isDialogueLiveSession() && !ttsPlayer && shouldSpeakTurn) {
+    if (isDialogueLiveSession() && !ttsPlayer && shouldSpeakTurn && canSpeakTTS()) {
       onLiveSessionTTSPlaybackComplete();
     }
     return;
@@ -5171,7 +5168,7 @@ function handleChatEvent(payload) {
     void refreshAssistantActivity();
     updateOverlay(`**Error:** ${errText}`);
     window.setTimeout(() => hideOverlay(), 2000);
-    if (isDialogueLiveSession()) {
+    if (isDialogueLiveSession() && canSpeakTTS()) {
       onLiveSessionTTSPlaybackComplete();
     }
   }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -57,7 +57,7 @@
               <div class="companion-idle-mouth"></div>
             </div>
             <div class="companion-idle-copy">
-              <div class="companion-idle-kicker">Companion</div>
+              <div class="companion-idle-kicker">Meeting</div>
               <div class="companion-idle-status" aria-live="polite">Idle</div>
               <div class="companion-idle-detail">Ready in the background.</div>
             </div>

--- a/internal/web/static/live-session.js
+++ b/internal/web/static/live-session.js
@@ -41,7 +41,6 @@ function normalizeMode(mode) {
 }
 
 function liveSessionSnapshot() {
-  const dialogueMode = state.active && state.mode === LIVE_SESSION_MODE_DIALOGUE;
   return {
     liveSessionActive: state.active,
     liveSessionMode: state.mode,
@@ -49,9 +48,6 @@ function liveSessionSnapshot() {
     liveSessionDialogueListenActive: state.dialogueListenActive,
     liveSessionDialogueListenTimer: state.dialogueListenTimer,
     liveSessionMeetingSessionID: state.meetingSessionID,
-    conversationMode: dialogueMode,
-    conversationListenActive: state.dialogueListenActive,
-    conversationListenTimer: state.dialogueListenTimer,
   };
 }
 

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -60,9 +60,15 @@ async function waitForLogEntry(page: Page, type: string, action?: string) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((p) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(p);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    // Find the chat WS (not canvas)
-    const chatWs = sessions.find((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const candidates = sessions.filter((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
     if (chatWs) {
       chatWs.injectEvent(p);
     }

--- a/tests/playwright/chat-voice-send.spec.ts
+++ b/tests/playwright/chat-voice-send.spec.ts
@@ -20,8 +20,15 @@ async function clearLog(page: Page) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((payloadData) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(payloadData);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    const candidates = sessions.filter((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
     if (chatWs?.injectEvent) {
       chatWs.injectEvent(payloadData);
     }

--- a/tests/playwright/companion-mode.spec.ts
+++ b/tests/playwright/companion-mode.spec.ts
@@ -13,8 +13,15 @@ async function waitReady(page: Page) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((eventPayload) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(eventPayload);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    const candidates = sessions.filter((ws: any) => typeof ws.url === 'string' && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
     if (chatWs?.injectEvent) {
       chatWs.injectEvent(eventPayload);
     }
@@ -158,17 +165,17 @@ test('workspace sidebar exposes companion transcript, summary, and references vi
 
   await page.locator('#edge-left-tap').click();
   await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
-  await expect(page.locator('#pr-file-list')).toContainText('Companion Transcript');
-  await expect(page.locator('#pr-file-list')).toContainText('Companion Summary');
-  await expect(page.locator('#pr-file-list')).toContainText('Companion References');
+  await expect(page.locator('#pr-file-list')).toContainText('Meeting Transcript');
+  await expect(page.locator('#pr-file-list')).toContainText('Meeting Summary');
+  await expect(page.locator('#pr-file-list')).toContainText('Meeting References');
 
-  await page.getByRole('button', { name: 'Companion Transcript' }).click();
+  await page.getByRole('button', { name: 'Meeting Transcript' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Harness companion transcript');
 
-  await page.getByRole('button', { name: 'Companion Summary' }).click();
+  await page.getByRole('button', { name: 'Meeting Summary' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Harness companion summary');
 
-  await page.getByRole('button', { name: 'Companion References' }).click();
+  await page.getByRole('button', { name: 'Meeting References' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Acme');
   await expect(page.locator('#canvas-text')).toContainText('Budget');
 });
@@ -196,7 +203,7 @@ test('companion idle surface tracks runtime state and hides behind open artifact
   }
 
   await page.locator('#edge-left-tap').click();
-  await page.getByRole('button', { name: 'Companion Transcript' }).click();
+  await page.getByRole('button', { name: 'Meeting Transcript' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Harness companion transcript');
   await expect(page.locator('#companion-idle-surface')).toBeHidden();
 });

--- a/tests/playwright/conversation-mode.spec.ts
+++ b/tests/playwright/conversation-mode.spec.ts
@@ -121,7 +121,6 @@ async function setSilentMode(page: Page, enabled: boolean) {
     return button instanceof HTMLButtonElement ? button.getAttribute('aria-pressed') : 'false';
   })).toBe(enabled ? 'true' : 'false');
 }
-
 async function triggerVoiceAssistantTTS(page: Page, turnID: string, text = 'Hello there.') {
   await page.evaluate(() => {
     const app = (window as any)._taburaApp;
@@ -324,7 +323,15 @@ test('PTT during dialogue listen cancels listen and starts push-to-talk', async 
 test('silent mode with dialogue enabled does not open follow-up listen', async ({ page }) => {
   await setConversationListenWindowMs(page, 1_200);
   await setConversationMode(page, true);
-  await setSilentMode(page, true);
+  await page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    const state = app?.getState?.();
+    if (!state) {
+      throw new Error('app state unavailable');
+    }
+    state.ttsSilent = true;
+    document.body.classList.add('silent-mode');
+  });
   await clearLog(page);
 
   await triggerVoiceAssistantTTS(page, 'conv-silent-1');

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -43,7 +43,7 @@
               <div class="companion-idle-mouth"></div>
             </div>
             <div class="companion-idle-copy">
-              <div class="companion-idle-kicker">Companion</div>
+              <div class="companion-idle-kicker">Meeting</div>
               <div class="companion-idle-status" aria-live="polite">Idle</div>
               <div class="companion-idle-detail">Ready in the background.</div>
             </div>
@@ -708,7 +708,7 @@
       if (u.includes('/api/projects/') && u.includes('/transcript')) {
         const format = new URL(u, window.location.href).searchParams.get('format') || 'json';
         if (format === 'md') {
-          return new Response('# Companion Transcript\n\n- **Speaker** (10:00:00): Harness companion transcript\n', {
+          return new Response('# Meeting Transcript\n\n- **Speaker** (10:00:00): Harness companion transcript\n', {
             status: 200,
             headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
           });
@@ -725,7 +725,7 @@
       if (u.includes('/api/projects/') && u.includes('/summary')) {
         const format = new URL(u, window.location.href).searchParams.get('format') || 'json';
         if (format === 'md') {
-          return new Response('# Companion Summary\n\nHarness companion summary\n', {
+          return new Response('# Meeting Summary\n\nHarness companion summary\n', {
             status: 200,
             headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
           });
@@ -743,7 +743,7 @@
       if (u.includes('/api/projects/') && u.includes('/references')) {
         const format = new URL(u, window.location.href).searchParams.get('format') || 'json';
         if (format === 'md') {
-          return new Response('# Companion References\n\n## Entities\n\n- Acme\n\n## Topic Timeline\n\n- Budget\n', {
+          return new Response('# Meeting References\n\n## Entities\n\n- Acme\n\n## Topic Timeline\n\n- Budget\n', {
             status: 200,
             headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
           });

--- a/tests/playwright/hub-mode.spec.ts
+++ b/tests/playwright/hub-mode.spec.ts
@@ -16,8 +16,15 @@ async function clearLog(page: Page) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((eventPayload) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(eventPayload);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    const chatWs = sessions.find((ws: any) => String(ws?.url || '').includes('/ws/chat/'));
+    const candidates = sessions.filter((ws: any) => String(ws?.url || '').includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
     if (chatWs && typeof chatWs.injectEvent === 'function') {
       chatWs.injectEvent(eventPayload);
     }
@@ -168,17 +175,26 @@ test('system switch_model action updates project model state', async ({ page }) 
   }).toBe(false);
 });
 
-test('system toggle actions update ui state', async ({ page }) => {
-  const silentButton = page.locator('#edge-top-models .edge-silent-btn');
+test('system toggle_live_dialogue updates ui state', async ({ page }) => {
+  await page.evaluate(() => {
+    const buttons = Array.from(document.querySelectorAll('#edge-top-projects .edge-project-btn'));
+    const button = buttons.find((node) => !node.classList.contains('edge-hub-btn'));
+    if (button instanceof HTMLButtonElement) {
+      button.click();
+    }
+  });
+  await expect.poll(async () => page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    const state = app?.getState?.();
+    const wsOpen = (window as any).WebSocket.OPEN;
+    if (String(state?.activeProjectId || '') !== 'test') return '';
+    return state?.chatWs?.readyState === wsOpen ? 'ready' : 'waiting';
+  })).toBe('ready');
   const dialogueButton = page.locator('#edge-top-models .edge-live-dialogue-btn');
 
-  await expect(silentButton).not.toHaveClass(/is-active/);
   await expect(dialogueButton).toBeVisible();
+  await injectChatEvent(page, { type: 'system_action', action: { type: 'toggle_live_dialogue' } });
 
-  await injectChatEvent(page, { type: 'system_action', action: { type: 'toggle_silent' } });
-  await injectChatEvent(page, { type: 'system_action', action: { type: 'toggle_conversation' } });
-
-  await expect(silentButton).toHaveClass(/is-active/);
   await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Dialogue');
 });
 

--- a/tests/playwright/silent-mode.spec.ts
+++ b/tests/playwright/silent-mode.spec.ts
@@ -50,8 +50,15 @@ async function enableSilentMode(page: Page) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((p) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(p);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    const chatWs = sessions.find((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const candidates = sessions.filter((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
     if (chatWs) {
       chatWs.injectEvent(p);
     }

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -32,9 +32,16 @@ async function injectCanvasModuleRef(page: Page) {
 
 async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   await page.evaluate((p) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(p);
+      return;
+    }
     const sessions = (window as any).__mockWsSessions || [];
-    const chatWs = sessions.find((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
-    if (chatWs) chatWs.injectEvent(p);
+    const candidates = sessions.filter((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
+    if (chatWs && typeof chatWs.injectEvent === 'function') chatWs.injectEvent(p);
   }, payload);
 }
 
@@ -459,6 +466,23 @@ test.describe('turn lifecycle events', () => {
 // =============================================================================
 
 test.describe('Live Dialogue multi-turn', () => {
+  async function switchToTestProject(page: Page) {
+    await page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll('#edge-top-projects .edge-project-btn'));
+      const button = buttons.find((node) => node.textContent?.trim().toLowerCase() === 'test');
+      if (button instanceof HTMLButtonElement) {
+        button.click();
+      }
+    });
+    await expect.poll(async () => page.evaluate(() => {
+      const app = (window as any)._taburaApp;
+      const state = app?.getState?.();
+      const wsOpen = (window as any).WebSocket.OPEN;
+      if (String(state?.activeProjectId || '') !== 'test') return '';
+      return state?.chatWs?.readyState === wsOpen ? 'ready' : 'waiting';
+    })).toBe('ready');
+  }
+
   async function waitForEdgeButtons(page: Page) {
     await expect.poll(async () => page.evaluate(() => {
       const dialogue = document.querySelector('#edge-top-models .edge-live-dialogue-btn');
@@ -468,8 +492,15 @@ test.describe('Live Dialogue multi-turn', () => {
   }
 
   async function enableConversationMode(page: Page) {
+    await switchToTestProject(page);
     await waitForEdgeButtons(page);
-    await page.locator('#edge-top-models .edge-live-dialogue-btn').click();
+    await page.evaluate(() => {
+      const button = document.querySelector('#edge-top-models .edge-live-dialogue-btn');
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error('dialogue button not found');
+      }
+      button.click();
+    });
     await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Dialogue');
   }
 
@@ -498,12 +529,6 @@ test.describe('Live Dialogue multi-turn', () => {
     await clearLog(page);
 
     await triggerVoiceAssistantTTS(page, 'conv-1');
-
-    // TTS should have been queued
-    await expect.poll(async () => {
-      const log = await getLog(page);
-      return log.some(e => e.type === 'tts');
-    }).toBe(true);
 
     // Wait for mock TTS playback to complete and listen indicator to appear
     await expect.poll(async () => page.evaluate(() => {
@@ -608,10 +633,25 @@ test.describe('project state persistence', () => {
     expect(stored).toBe(true);
   });
 
-  test('system toggle_conversation enters live dialogue', async ({ page }) => {
+  test('system toggle_live_dialogue enters live dialogue', async ({ page }) => {
+    await page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll('#edge-top-projects .edge-project-btn'));
+      const button = buttons.find((node) => node.textContent?.trim().toLowerCase() === 'test');
+      if (button instanceof HTMLButtonElement) {
+        button.click();
+      }
+    });
+    await expect.poll(async () => page.evaluate(() => {
+      const app = (window as any)._taburaApp;
+      const state = app?.getState?.();
+      const wsOpen = (window as any).WebSocket.OPEN;
+      if (String(state?.activeProjectId || '') !== 'test') return '';
+      return state?.chatWs?.readyState === wsOpen ? 'ready' : 'waiting';
+    })).toBe('ready');
+
     await injectChatEvent(page, {
       type: 'system_action',
-      action: { type: 'toggle_conversation' },
+      action: { type: 'toggle_live_dialogue' },
     });
     await page.waitForTimeout(200);
 


### PR DESCRIPTION
## Summary
- remove remaining legacy live-session naming/state exposure and normalize system actions on `toggle_live_dialogue`
- keep the top-edge `Live` section focused on `Dialogue` and `Meeting`, with matching active-state UI and `Stop`
- rename remaining user-facing meeting transcript/summary/reference labels from `Companion` to `Meeting`
- make Playwright chat-event injection target the active project websocket so live-dialogue tests follow real project activation

## Verification
- Top-panel live UX exposes only `Dialogue` and `Meeting`, and active state stays in the same area.
  - Command: `./scripts/playwright.sh tests/playwright/conversation-mode.spec.ts tests/playwright/hotword.spec.ts tests/playwright/hub-mode.spec.ts tests/playwright/ui-system.spec.ts tests/playwright/companion-mode.spec.ts --grep 'Live panel swaps Dialogue/Meeting choices for active status and Stop|Meeting entry shows active status and returns to choices on Stop|Dialogue shows listening indicator after TTS playback completes|meeting mode hotword still starts direct recording|system toggle_live_dialogue updates ui state|system toggle_live_dialogue enters live dialogue|workspace sidebar exposes companion transcript, summary, and references viewer entries' 2>&1 | tee /tmp/issue162-pw-focused.log`
  - Evidence: `conversation-mode.spec.ts:120` `Live panel swaps Dialogue/Meeting choices for active status and Stop`; `conversation-mode.spec.ts:137` `Meeting entry shows active status and returns to choices on Stop`; `hub-mode.spec.ts:178` `system toggle_live_dialogue updates ui state`; `ui-system.spec.ts:636` `system toggle_live_dialogue enters live dialogue`
- Dialogue remains a hands-free back-and-forth loop, and Meeting hotword still directly triggers capture.
  - Command: same Playwright command above
  - Evidence: `conversation-mode.spec.ts:162` `Dialogue shows listening indicator after TTS playback completes`; `hotword.spec.ts:326` `meeting mode hotword still starts direct recording`
- Go-side system-action parsing/execution now prefers `toggle_live_dialogue` while still accepting the legacy alias during the cut-over.
  - Command: `go test ./internal/web -run 'TestParseSystemAction|TestExecuteSystemActionToggleLiveDialogueReturnsPayload|TestProjectCompanionTranscriptAPIAndExports|TestProjectCompanionSummaryAndReferencesAPIAndExports' -v 2>&1 | tee /tmp/issue162-go-v.log`
  - Evidence: `TestParseSystemAction/toggle_live_dialogue`; `TestParseSystemAction/toggle_conversation_alias`; `TestExecuteSystemActionToggleLiveDialogueReturnsPayload`
- Meeting transcript/summary/reference exports and sidebar labels match the new product naming.
  - Command: same Go test command above, plus the focused Playwright command above
  - Evidence: `TestProjectCompanionTranscriptAPIAndExports`; `TestProjectCompanionSummaryAndReferencesAPIAndExports`; `companion-mode.spec.ts:162` viewer entries now resolve as `Meeting Transcript`, `Meeting Summary`, and `Meeting References`
