### PR TITLE
fix: Add SQLite schema and Go types for Workspace, Artifact, Item (fixes #173)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -1,0 +1,57 @@
+package store
+
+type ArtifactKind string
+
+const (
+	ArtifactKindEmail       ArtifactKind = "email"
+	ArtifactKindDocument    ArtifactKind = "document"
+	ArtifactKindPDF         ArtifactKind = "pdf"
+	ArtifactKindMarkdown    ArtifactKind = "markdown"
+	ArtifactKindImage       ArtifactKind = "image"
+	ArtifactKindGitHubIssue ArtifactKind = "github_issue"
+	ArtifactKindGitHubPR    ArtifactKind = "github_pr"
+	ArtifactKindTranscript  ArtifactKind = "transcript"
+	ArtifactKindPlanNote    ArtifactKind = "plan_note"
+)
+
+type Workspace struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	DirPath   string `json:"dir_path"`
+	IsActive  bool   `json:"is_active"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type Actor struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at"`
+}
+
+type Artifact struct {
+	ID        int64        `json:"id"`
+	Kind      ArtifactKind `json:"kind"`
+	RefPath   *string      `json:"ref_path,omitempty"`
+	RefURL    *string      `json:"ref_url,omitempty"`
+	Title     *string      `json:"title,omitempty"`
+	MetaJSON  *string      `json:"meta_json,omitempty"`
+	CreatedAt string       `json:"created_at"`
+	UpdatedAt string       `json:"updated_at"`
+}
+
+type Item struct {
+	ID           int64   `json:"id"`
+	Title        string  `json:"title"`
+	State        string  `json:"state"`
+	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
+	ArtifactID   *int64  `json:"artifact_id,omitempty"`
+	ActorID      *int64  `json:"actor_id,omitempty"`
+	VisibleAfter *string `json:"visible_after,omitempty"`
+	FollowUpAt   *string `json:"follow_up_at,omitempty"`
+	Source       *string `json:"source,omitempty"`
+	SourceRef    *string `json:"source_ref,omitempty"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
+	s := newTestStore(t)
+
+	var foreignKeys int
+	if err := s.db.QueryRow(`PRAGMA foreign_keys`).Scan(&foreignKeys); err != nil {
+		t.Fatalf("read PRAGMA foreign_keys: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Fatalf("PRAGMA foreign_keys = %d, want 1", foreignKeys)
+	}
+
+	columns, err := s.TableColumns()
+	if err != nil {
+		t.Fatalf("TableColumns() error: %v", err)
+	}
+	for table, want := range map[string][]string{
+		"workspaces": {"id", "name", "dir_path", "is_active", "created_at", "updated_at"},
+		"actors":     {"id", "name", "kind", "created_at"},
+		"artifacts":  {"id", "kind", "ref_path", "ref_url", "title", "meta_json", "created_at", "updated_at"},
+		"items":      {"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
+	} {
+		got := make(map[string]bool, len(columns[table]))
+		for _, name := range columns[table] {
+			got[name] = true
+		}
+		for _, name := range want {
+			if !got[name] {
+				t.Fatalf("table %s missing column %s: %#v", table, name, columns[table])
+			}
+		}
+	}
+
+	targets := map[string]bool{}
+	rows, err := s.db.Query(`PRAGMA foreign_key_list(items)`)
+	if err != nil {
+		t.Fatalf("PRAGMA foreign_key_list(items) error: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			id, seq                                    int
+			table, from, to, onUpdate, onDelete, match string
+		)
+		if err := rows.Scan(&id, &seq, &table, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+			t.Fatalf("scan foreign key: %v", err)
+		}
+		targets[table] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate foreign keys: %v", err)
+	}
+	for _, table := range []string{"workspaces", "artifacts", "actors"} {
+		if !targets[table] {
+			t.Fatalf("items missing foreign key to %s", table)
+		}
+	}
+}
+
+func TestStoreMigratesDomainTablesOnExistingDatabase(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tabura.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	legacySchema := `
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  project_key TEXT NOT NULL UNIQUE,
+  root_path TEXT NOT NULL UNIQUE,
+  kind TEXT NOT NULL DEFAULT 'managed',
+  is_default INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE TABLE chat_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content_markdown TEXT NOT NULL DEFAULT '',
+  content_plain TEXT NOT NULL DEFAULT '',
+  render_format TEXT NOT NULL DEFAULT 'markdown',
+  created_at INTEGER NOT NULL
+);
+`
+	if _, err := db.Exec(legacySchema); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("store.New() on legacy db error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	columns, err := s.TableColumns()
+	if err != nil {
+		t.Fatalf("TableColumns() error: %v", err)
+	}
+	for _, table := range []string{"workspaces", "actors", "artifacts", "items"} {
+		if _, ok := columns[table]; !ok {
+			t.Fatalf("expected migrated table %s to exist", table)
+		}
+	}
+}
+
+func TestItemSchemaAllowsNilOptionalFields(t *testing.T) {
+	s := newTestStore(t)
+
+	res, err := s.db.Exec(`INSERT INTO items (title) VALUES ('triage me')`)
+	if err != nil {
+		t.Fatalf("insert item without optional fields: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId() error: %v", err)
+	}
+
+	var (
+		title                                       string
+		workspaceID, artifactID, actorID            sql.NullInt64
+		visibleAfter, followUpAt, source, sourceRef sql.NullString
+	)
+	err = s.db.QueryRow(`
+SELECT title, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+FROM items
+WHERE id = ?
+`, id).Scan(&title, &workspaceID, &artifactID, &actorID, &visibleAfter, &followUpAt, &source, &sourceRef)
+	if err != nil {
+		t.Fatalf("query item: %v", err)
+	}
+	if title != "triage me" {
+		t.Fatalf("title = %q, want triage me", title)
+	}
+	if workspaceID.Valid || artifactID.Valid || actorID.Valid || visibleAfter.Valid || followUpAt.Valid || source.Valid || sourceRef.Valid {
+		t.Fatalf("expected optional fields to remain NULL, got workspace=%v artifact=%v actor=%v visible_after=%v follow_up_at=%v source=%v source_ref=%v",
+			workspaceID, artifactID, actorID, visibleAfter, followUpAt, source, sourceRef)
+	}
+}
+
+func TestItemSchemaEnforcesForeignKeys(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.db.Exec(`INSERT INTO items (title, workspace_id) VALUES ('invalid', 999)`); err == nil {
+		t.Fatal("expected foreign key violation for missing workspace")
+	}
+	if _, err := s.db.Exec(`INSERT INTO items (title, artifact_id) VALUES ('invalid', 999)`); err == nil {
+		t.Fatal("expected foreign key violation for missing artifact")
+	}
+	if _, err := s.db.Exec(`INSERT INTO items (title, actor_id) VALUES ('invalid', 999)`); err == nil {
+		t.Fatal("expected foreign key violation for missing actor")
+	}
+}
+
+func TestDomainTypesExposeJSONTags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{name: "Workspace", typ: reflect.TypeOf(Workspace{})},
+		{name: "Actor", typ: reflect.TypeOf(Actor{})},
+		{name: "Artifact", typ: reflect.TypeOf(Artifact{})},
+		{name: "Item", typ: reflect.TypeOf(Item{})},
+	} {
+		for i := 0; i < tc.typ.NumField(); i++ {
+			field := tc.typ.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			if tag := field.Tag.Get("json"); tag == "" || tag == "-" {
+				t.Fatalf("%s.%s missing json tag", tc.name, field.Name)
+			}
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -74,6 +74,10 @@ func New(path string) (*Store, error) {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	s := &Store{db: db}
 	if err := s.migrate(); err != nil {
 		_ = db.Close()
@@ -259,7 +263,10 @@ CREATE TABLE IF NOT EXISTS participant_room_state (
 	if err := s.migrateProjectColumns(); err != nil {
 		return err
 	}
-	return s.migrateParticipantColumns()
+	if err := s.migrateParticipantColumns(); err != nil {
+		return err
+	}
+	return s.migrateDomainTables()
 }
 
 func (s *Store) migrateProjectColumns() error {

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -1,0 +1,46 @@
+package store
+
+func (s *Store) migrateDomainTables() error {
+	schema := `
+CREATE TABLE IF NOT EXISTS workspaces (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  dir_path TEXT NOT NULL UNIQUE,
+  is_active INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS actors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('human', 'agent')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS artifacts (
+  id INTEGER PRIMARY KEY,
+  kind TEXT NOT NULL,
+  ref_path TEXT,
+  ref_url TEXT,
+  title TEXT,
+  meta_json TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS items (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'done')),
+  workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
+  artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
+  actor_id INTEGER REFERENCES actors(id) ON DELETE SET NULL,
+  visible_after TEXT,
+  follow_up_at TEXT,
+  source TEXT,
+  source_ref TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`
+	_, err := s.db.Exec(schema)
+	return err
+}


### PR DESCRIPTION
## Summary
- add Workspace, Actor, Artifact, and Item domain types plus artifact kind constants in `internal/store/domain.go`
- add a dedicated domain-table migration for `workspaces`, `actors`, `artifacts`, and `items`, and enable SQLite foreign key enforcement in `Store.New`
- cover fresh-db migration, legacy-db migration, nullable item fields, foreign key enforcement, and JSON tags in `internal/store/domain_test.go`

## Verification
- Migration runs on fresh databases: `go test ./internal/store -run 'TestStoreMigratesDomainTablesOnFreshDatabase' -v`
  Excerpt: `--- PASS: TestStoreMigratesDomainTablesOnFreshDatabase`
- Migration runs on existing databases: `go test ./internal/store -run 'TestStoreMigratesDomainTablesOnExistingDatabase' -v`
  Excerpt: `--- PASS: TestStoreMigratesDomainTablesOnExistingDatabase`
- All four Go types have JSON tags: `go test ./internal/store -run 'TestDomainTypesExposeJSONTags' -v`
  Excerpt: `--- PASS: TestDomainTypesExposeJSONTags`
- Foreign key relationships are present and enforced at schema level: `go test ./internal/store -run 'TestStoreMigratesDomainTablesOnFreshDatabase|TestItemSchemaEnforcesForeignKeys' -v`
  Excerpt: `--- PASS: TestStoreMigratesDomainTablesOnFreshDatabase`
  Excerpt: `--- PASS: TestItemSchemaEnforcesForeignKeys`
- Items can exist with all optional fields nil: `go test ./internal/store -run 'TestItemSchemaAllowsNilOptionalFields' -v`
  Excerpt: `--- PASS: TestItemSchemaAllowsNilOptionalFields`
- No new code references old project/session tables, and no virtual filesystem abstraction was introduced: `git show --stat --name-only --format=medium HEAD`
  Excerpt: changed files are limited to `internal/store/domain.go`, `internal/store/domain_test.go`, `internal/store/store.go`, and `internal/store/store_domain.go`
- Targeted package verification: `go test ./internal/store/...`
  Excerpt: `ok   github.com/krystophny/tabura/internal/store 1.194s`