### PR TITLE
fix: Add store CRUD operations for core domain model (fixes #174)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -3,6 +3,9 @@ package store
 type ArtifactKind string
 
 const (
+	ActorKindHuman = "human"
+	ActorKindAgent = "agent"
+
 	ArtifactKindEmail       ArtifactKind = "email"
 	ArtifactKindDocument    ArtifactKind = "document"
 	ArtifactKindPDF         ArtifactKind = "pdf"
@@ -12,7 +15,30 @@ const (
 	ArtifactKindGitHubPR    ArtifactKind = "github_pr"
 	ArtifactKindTranscript  ArtifactKind = "transcript"
 	ArtifactKindPlanNote    ArtifactKind = "plan_note"
+
+	ItemStateInbox   = "inbox"
+	ItemStateWaiting = "waiting"
+	ItemStateDone    = "done"
 )
+
+type ArtifactUpdate struct {
+	Kind     *ArtifactKind `json:"kind,omitempty"`
+	RefPath  *string       `json:"ref_path,omitempty"`
+	RefURL   *string       `json:"ref_url,omitempty"`
+	Title    *string       `json:"title,omitempty"`
+	MetaJSON *string       `json:"meta_json,omitempty"`
+}
+
+type ItemOptions struct {
+	State        string  `json:"state,omitempty"`
+	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
+	ArtifactID   *int64  `json:"artifact_id,omitempty"`
+	ActorID      *int64  `json:"actor_id,omitempty"`
+	VisibleAfter *string `json:"visible_after,omitempty"`
+	FollowUpAt   *string `json:"follow_up_at,omitempty"`
+	Source       *string `json:"source,omitempty"`
+	SourceRef    *string `json:"source_ref,omitempty"`
+}
 
 type Workspace struct {
 	ID        int64  `json:"id"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -2,8 +2,11 @@ package store
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -188,5 +191,303 @@ func TestDomainTypesExposeJSONTags(t *testing.T) {
 				t.Fatalf("%s.%s missing json tag", tc.name, field.Name)
 			}
 		}
+	}
+}
+
+func TestDomainCRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	workspaceAPath := filepath.Join(t.TempDir(), "workspace-a")
+	workspaceBPath := filepath.Join(t.TempDir(), "workspace-b")
+
+	workspaceA, err := s.CreateWorkspace("Workspace A", workspaceAPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(workspace-a) error: %v", err)
+	}
+	workspaceB, err := s.CreateWorkspace(" Workspace B ", workspaceBPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(workspace-b) error: %v", err)
+	}
+	gotByPath, err := s.GetWorkspaceByPath(workspaceBPath)
+	if err != nil {
+		t.Fatalf("GetWorkspaceByPath() error: %v", err)
+	}
+	if gotByPath.ID != workspaceB.ID {
+		t.Fatalf("GetWorkspaceByPath() ID = %d, want %d", gotByPath.ID, workspaceB.ID)
+	}
+	if _, err := s.CreateWorkspace("Duplicate", workspaceAPath); err == nil {
+		t.Fatal("expected duplicate workspace path error")
+	}
+	if err := s.SetActiveWorkspace(workspaceB.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces() error: %v", err)
+	}
+	if len(workspaces) != 2 {
+		t.Fatalf("ListWorkspaces() len = %d, want 2", len(workspaces))
+	}
+	if !workspaces[0].IsActive || workspaces[0].ID != workspaceB.ID {
+		t.Fatalf("ListWorkspaces() active workspace mismatch: %+v", workspaces)
+	}
+	workspaceA, err = s.GetWorkspace(workspaceA.ID)
+	if err != nil {
+		t.Fatalf("GetWorkspace(workspace-a) error: %v", err)
+	}
+	if workspaceA.IsActive {
+		t.Fatal("expected inactive workspace after SetActiveWorkspace")
+	}
+
+	human, err := s.CreateActor("Alice", ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor(Alice) error: %v", err)
+	}
+	agent, err := s.CreateActor("Codex", ActorKindAgent)
+	if err != nil {
+		t.Fatalf("CreateActor(Codex) error: %v", err)
+	}
+	if _, err := s.CreateActor("Nobody", "robot"); err == nil {
+		t.Fatal("expected invalid actor kind error")
+	}
+	actors, err := s.ListActors()
+	if err != nil {
+		t.Fatalf("ListActors() error: %v", err)
+	}
+	if len(actors) != 2 {
+		t.Fatalf("ListActors() len = %d, want 2", len(actors))
+	}
+	if actors[0].Name != "Alice" || actors[1].Name != "Codex" {
+		t.Fatalf("ListActors() names = %#v, want Alice/Codex", []string{actors[0].Name, actors[1].Name})
+	}
+	gotActor, err := s.GetActor(agent.ID)
+	if err != nil {
+		t.Fatalf("GetActor() error: %v", err)
+	}
+	if gotActor.Kind != ActorKindAgent {
+		t.Fatalf("GetActor().Kind = %q, want %q", gotActor.Kind, ActorKindAgent)
+	}
+
+	refPath := filepath.Join(t.TempDir(), "artifact.md")
+	refURL := "https://example.invalid/item/1"
+	title := "Plan draft"
+	metaJSON := `{"source":"unit"}`
+	artifact, err := s.CreateArtifact(ArtifactKindMarkdown, &refPath, &refURL, &title, &metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	gotArtifact, err := s.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if gotArtifact.Kind != ArtifactKindMarkdown || gotArtifact.Title == nil || *gotArtifact.Title != title {
+		t.Fatalf("GetArtifact() = %+v", gotArtifact)
+	}
+	updatedTitle := "Plan draft v2"
+	clearRefURL := ""
+	updatedKind := ArtifactKindDocument
+	if err := s.UpdateArtifact(artifact.ID, ArtifactUpdate{
+		Kind:   &updatedKind,
+		Title:  &updatedTitle,
+		RefURL: &clearRefURL,
+	}); err != nil {
+		t.Fatalf("UpdateArtifact() error: %v", err)
+	}
+	gotArtifact, err = s.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact(updated) error: %v", err)
+	}
+	if gotArtifact.Kind != ArtifactKindDocument {
+		t.Fatalf("GetArtifact(updated).Kind = %q, want %q", gotArtifact.Kind, ArtifactKindDocument)
+	}
+	if gotArtifact.RefURL != nil {
+		t.Fatalf("GetArtifact(updated).RefURL = %v, want nil", *gotArtifact.RefURL)
+	}
+	if gotArtifact.Title == nil || *gotArtifact.Title != updatedTitle {
+		t.Fatalf("GetArtifact(updated).Title = %v, want %q", gotArtifact.Title, updatedTitle)
+	}
+	artifacts, err := s.ListArtifactsByKind(ArtifactKindDocument)
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind() error: %v", err)
+	}
+	if len(artifacts) != 1 || artifacts[0].ID != artifact.ID {
+		t.Fatalf("ListArtifactsByKind() = %+v, want artifact %d", artifacts, artifact.ID)
+	}
+
+	source := "github"
+	sourceRef := "issue-174"
+	visibleAfter := "2026-03-09T10:00:00Z"
+	followUpAt := "2026-03-10T11:00:00Z"
+
+	inboxItem, err := s.CreateItem("Inbox item", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(inbox) error: %v", err)
+	}
+	artifactItem, err := s.CreateItem("Artifact item", ItemOptions{
+		ArtifactID: &artifact.ID,
+		Source:     &source,
+		SourceRef:  &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(artifact) error: %v", err)
+	}
+	workspaceItem, err := s.CreateItem("Workspace item", ItemOptions{
+		WorkspaceID: &workspaceA.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(workspace) error: %v", err)
+	}
+	assignedItem, err := s.CreateItem("Assigned item", ItemOptions{
+		State:        ItemStateWaiting,
+		WorkspaceID:  &workspaceB.ID,
+		ArtifactID:   &artifact.ID,
+		ActorID:      &human.ID,
+		VisibleAfter: &visibleAfter,
+		FollowUpAt:   &followUpAt,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(assigned) error: %v", err)
+	}
+	if assignedItem.WorkspaceID == nil || *assignedItem.WorkspaceID != workspaceB.ID {
+		t.Fatalf("CreateItem(assigned).WorkspaceID = %v, want %d", assignedItem.WorkspaceID, workspaceB.ID)
+	}
+	if assignedItem.ArtifactID == nil || *assignedItem.ArtifactID != artifact.ID {
+		t.Fatalf("CreateItem(assigned).ArtifactID = %v, want %d", assignedItem.ArtifactID, artifact.ID)
+	}
+	if assignedItem.ActorID == nil || *assignedItem.ActorID != human.ID {
+		t.Fatalf("CreateItem(assigned).ActorID = %v, want %d", assignedItem.ActorID, human.ID)
+	}
+
+	if err := s.AssignItem(artifactItem.ID, agent.ID); err != nil {
+		t.Fatalf("AssignItem() error: %v", err)
+	}
+	gotItem, err := s.GetItem(artifactItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(artifact assigned) error: %v", err)
+	}
+	if gotItem.ActorID == nil || *gotItem.ActorID != agent.ID {
+		t.Fatalf("GetItem(artifact assigned).ActorID = %v, want %d", gotItem.ActorID, agent.ID)
+	}
+	if err := s.AssignItem(artifactItem.ID, 9999); err == nil {
+		t.Fatal("expected assign to nonexistent actor error")
+	}
+
+	if err := s.UpdateItemTimes(inboxItem.ID, &visibleAfter, &followUpAt); err != nil {
+		t.Fatalf("UpdateItemTimes() error: %v", err)
+	}
+	gotItem, err = s.GetItem(inboxItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(updated times) error: %v", err)
+	}
+	if gotItem.VisibleAfter == nil || *gotItem.VisibleAfter != visibleAfter {
+		t.Fatalf("VisibleAfter = %v, want %q", gotItem.VisibleAfter, visibleAfter)
+	}
+	if gotItem.FollowUpAt == nil || *gotItem.FollowUpAt != followUpAt {
+		t.Fatalf("FollowUpAt = %v, want %q", gotItem.FollowUpAt, followUpAt)
+	}
+
+	if err := s.UpdateItemState(inboxItem.ID, ItemStateWaiting); err != nil {
+		t.Fatalf("UpdateItemState(waiting) error: %v", err)
+	}
+	if err := s.UpdateItemState(inboxItem.ID, ItemStateDone); err != nil {
+		t.Fatalf("UpdateItemState(done) error: %v", err)
+	}
+	if err := s.UpdateItemState(inboxItem.ID, ItemStateInbox); err == nil {
+		t.Fatal("expected invalid done -> inbox transition error")
+	}
+	if err := s.UpdateItemState(inboxItem.ID, "paused"); err == nil {
+		t.Fatal("expected invalid item state error")
+	}
+
+	waitingItems, err := s.ListItemsByState(ItemStateWaiting)
+	if err != nil {
+		t.Fatalf("ListItemsByState(waiting) error: %v", err)
+	}
+	if len(waitingItems) != 2 {
+		t.Fatalf("ListItemsByState(waiting) len = %d, want 2", len(waitingItems))
+	}
+	doneItems, err := s.ListItemsByState(ItemStateDone)
+	if err != nil {
+		t.Fatalf("ListItemsByState(done) error: %v", err)
+	}
+	if len(doneItems) != 1 || doneItems[0].ID != inboxItem.ID {
+		t.Fatalf("ListItemsByState(done) = %+v, want inbox item %d", doneItems, inboxItem.ID)
+	}
+	if _, err := s.ListItemsByState("paused"); err == nil {
+		t.Fatal("expected invalid ListItemsByState error")
+	}
+
+	if err := s.DeleteWorkspace(workspaceA.ID); err != nil {
+		t.Fatalf("DeleteWorkspace() error: %v", err)
+	}
+	workspaceItem, err = s.GetItem(workspaceItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(workspace item after workspace delete) error: %v", err)
+	}
+	if workspaceItem.WorkspaceID != nil {
+		t.Fatalf("workspace item WorkspaceID = %v, want nil", *workspaceItem.WorkspaceID)
+	}
+	if err := s.DeleteArtifact(artifact.ID); err != nil {
+		t.Fatalf("DeleteArtifact() error: %v", err)
+	}
+	artifactItem, err = s.GetItem(artifactItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(artifact item after artifact delete) error: %v", err)
+	}
+	if artifactItem.ArtifactID != nil {
+		t.Fatalf("artifact item ArtifactID = %v, want nil", *artifactItem.ArtifactID)
+	}
+	if err := s.DeleteActor(agent.ID); err != nil {
+		t.Fatalf("DeleteActor() error: %v", err)
+	}
+	artifactItem, err = s.GetItem(artifactItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(artifact item after actor delete) error: %v", err)
+	}
+	if artifactItem.ActorID != nil {
+		t.Fatalf("artifact item ActorID = %v, want nil", *artifactItem.ActorID)
+	}
+
+	if err := s.DeleteItem(assignedItem.ID); err != nil {
+		t.Fatalf("DeleteItem() error: %v", err)
+	}
+	if _, err := s.GetItem(assignedItem.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetItem(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestDomainConcurrentWorkspaceCreates(t *testing.T) {
+	s := newTestStore(t)
+
+	const count = 12
+	baseDir := t.TempDir()
+	errCh := make(chan error, count)
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := s.CreateWorkspace(
+				"Workspace",
+				filepath.Join(baseDir, fmt.Sprintf("workspace-%02d", i)),
+			)
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("CreateWorkspace() concurrent error: %v", err)
+		}
+	}
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces() error: %v", err)
+	}
+	if len(workspaces) != count {
+		t.Fatalf("ListWorkspaces() len = %d, want %d", len(workspaces), count)
 	}
 }

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -1,5 +1,14 @@
 package store
 
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
 func (s *Store) migrateDomainTables() error {
 	schema := `
 CREATE TABLE IF NOT EXISTS workspaces (
@@ -43,4 +52,656 @@ CREATE TABLE IF NOT EXISTS items (
 `
 	_, err := s.db.Exec(schema)
 	return err
+}
+
+func normalizeWorkspaceName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+func normalizeWorkspacePath(path string) string {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return filepath.Clean(abs)
+}
+
+func normalizeActorName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+func normalizeActorKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case ActorKindHuman:
+		return ActorKindHuman
+	case ActorKindAgent:
+		return ActorKindAgent
+	default:
+		return ""
+	}
+}
+
+func normalizeOptionalString(v *string) any {
+	if v == nil {
+		return nil
+	}
+	clean := strings.TrimSpace(*v)
+	if clean == "" {
+		return nil
+	}
+	return clean
+}
+
+func normalizeArtifactKind(kind ArtifactKind) ArtifactKind {
+	return ArtifactKind(strings.TrimSpace(string(kind)))
+}
+
+func normalizeItemState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "", ItemStateInbox:
+		return ItemStateInbox
+	case ItemStateWaiting:
+		return ItemStateWaiting
+	case ItemStateDone:
+		return ItemStateDone
+	default:
+		return ""
+	}
+}
+
+func validateItemTransition(current, next string) error {
+	if next == "" {
+		return errors.New("item state is required")
+	}
+	if current == ItemStateDone && next != ItemStateDone {
+		return fmt.Errorf("cannot transition item from %s to %s", current, next)
+	}
+	return nil
+}
+
+func scanWorkspace(
+	row interface {
+		Scan(dest ...any) error
+	},
+) (Workspace, error) {
+	var out Workspace
+	var isActive int
+	err := row.Scan(&out.ID, &out.Name, &out.DirPath, &isActive, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return Workspace{}, err
+	}
+	out.Name = normalizeWorkspaceName(out.Name)
+	out.DirPath = normalizeWorkspacePath(out.DirPath)
+	out.IsActive = isActive != 0
+	return out, nil
+}
+
+func scanActor(
+	row interface {
+		Scan(dest ...any) error
+	},
+) (Actor, error) {
+	var out Actor
+	err := row.Scan(&out.ID, &out.Name, &out.Kind, &out.CreatedAt)
+	if err != nil {
+		return Actor{}, err
+	}
+	out.Name = normalizeActorName(out.Name)
+	out.Kind = normalizeActorKind(out.Kind)
+	return out, nil
+}
+
+func scanArtifact(
+	row interface {
+		Scan(dest ...any) error
+	},
+) (Artifact, error) {
+	var (
+		out                              Artifact
+		refPath, refURL, title, metaJSON sql.NullString
+	)
+	err := row.Scan(&out.ID, &out.Kind, &refPath, &refURL, &title, &metaJSON, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return Artifact{}, err
+	}
+	out.Kind = normalizeArtifactKind(out.Kind)
+	out.RefPath = nullStringPointer(refPath)
+	out.RefURL = nullStringPointer(refURL)
+	out.Title = nullStringPointer(title)
+	out.MetaJSON = nullStringPointer(metaJSON)
+	return out, nil
+}
+
+func scanItem(
+	row interface {
+		Scan(dest ...any) error
+	},
+) (Item, error) {
+	var (
+		out                                         Item
+		workspaceID, artifactID, actorID            sql.NullInt64
+		visibleAfter, followUpAt, source, sourceRef sql.NullString
+	)
+	err := row.Scan(
+		&out.ID,
+		&out.Title,
+		&out.State,
+		&workspaceID,
+		&artifactID,
+		&actorID,
+		&visibleAfter,
+		&followUpAt,
+		&source,
+		&sourceRef,
+		&out.CreatedAt,
+		&out.UpdatedAt,
+	)
+	if err != nil {
+		return Item{}, err
+	}
+	out.Title = strings.TrimSpace(out.Title)
+	out.State = normalizeItemState(out.State)
+	out.WorkspaceID = nullInt64Pointer(workspaceID)
+	out.ArtifactID = nullInt64Pointer(artifactID)
+	out.ActorID = nullInt64Pointer(actorID)
+	out.VisibleAfter = nullStringPointer(visibleAfter)
+	out.FollowUpAt = nullStringPointer(followUpAt)
+	out.Source = nullStringPointer(source)
+	out.SourceRef = nullStringPointer(sourceRef)
+	return out, nil
+}
+
+func nullStringPointer(v sql.NullString) *string {
+	if !v.Valid {
+		return nil
+	}
+	value := strings.TrimSpace(v.String)
+	return &value
+}
+
+func nullInt64Pointer(v sql.NullInt64) *int64 {
+	if !v.Valid {
+		return nil
+	}
+	value := v.Int64
+	return &value
+}
+
+func (s *Store) CreateWorkspace(name, dirPath string) (Workspace, error) {
+	cleanName := normalizeWorkspaceName(name)
+	cleanPath := normalizeWorkspacePath(dirPath)
+	if cleanName == "" {
+		return Workspace{}, errors.New("workspace name is required")
+	}
+	if cleanPath == "" {
+		return Workspace{}, errors.New("workspace path is required")
+	}
+	res, err := s.db.Exec(`INSERT INTO workspaces (name, dir_path) VALUES (?, ?)`, cleanName, cleanPath)
+	if err != nil {
+		return Workspace{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Workspace{}, err
+	}
+	return s.GetWorkspace(id)
+}
+
+func (s *Store) GetWorkspace(id int64) (Workspace, error) {
+	return scanWorkspace(s.db.QueryRow(
+		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		 FROM workspaces
+		 WHERE id = ?`,
+		id,
+	))
+}
+
+func (s *Store) GetWorkspaceByPath(dirPath string) (Workspace, error) {
+	return scanWorkspace(s.db.QueryRow(
+		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		 FROM workspaces
+		 WHERE dir_path = ?`,
+		normalizeWorkspacePath(dirPath),
+	))
+}
+
+func (s *Store) ListWorkspaces() ([]Workspace, error) {
+	rows, err := s.db.Query(
+		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		 FROM workspaces`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Workspace
+	for rows.Next() {
+		workspace, err := scanWorkspace(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, workspace)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].IsActive != out[j].IsActive {
+			return out[i].IsActive
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+func (s *Store) SetActiveWorkspace(id int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`UPDATE workspaces SET is_active = 0, updated_at = datetime('now') WHERE is_active <> 0`); err != nil {
+		return err
+	}
+	res, err := tx.Exec(`UPDATE workspaces SET is_active = 1, updated_at = datetime('now') WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return tx.Commit()
+}
+
+func (s *Store) DeleteWorkspace(id int64) error {
+	res, err := s.db.Exec(`DELETE FROM workspaces WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) CreateActor(name, kind string) (Actor, error) {
+	cleanName := normalizeActorName(name)
+	cleanKind := normalizeActorKind(kind)
+	if cleanName == "" {
+		return Actor{}, errors.New("actor name is required")
+	}
+	if cleanKind == "" {
+		return Actor{}, errors.New("actor kind must be human or agent")
+	}
+	res, err := s.db.Exec(`INSERT INTO actors (name, kind) VALUES (?, ?)`, cleanName, cleanKind)
+	if err != nil {
+		return Actor{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Actor{}, err
+	}
+	return s.GetActor(id)
+}
+
+func (s *Store) GetActor(id int64) (Actor, error) {
+	return scanActor(s.db.QueryRow(
+		`SELECT id, name, kind, created_at
+		 FROM actors
+		 WHERE id = ?`,
+		id,
+	))
+}
+
+func (s *Store) ListActors() ([]Actor, error) {
+	rows, err := s.db.Query(`SELECT id, name, kind, created_at FROM actors`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Actor
+	for rows.Next() {
+		actor, err := scanActor(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, actor)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+func (s *Store) DeleteActor(id int64) error {
+	res, err := s.db.Exec(`DELETE FROM actors WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) CreateArtifact(kind ArtifactKind, refPath, refURL, title, metaJSON *string) (Artifact, error) {
+	cleanKind := normalizeArtifactKind(kind)
+	if cleanKind == "" {
+		return Artifact{}, errors.New("artifact kind is required")
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO artifacts (kind, ref_path, ref_url, title, meta_json)
+		 VALUES (?, ?, ?, ?, ?)`,
+		cleanKind,
+		normalizeOptionalString(refPath),
+		normalizeOptionalString(refURL),
+		normalizeOptionalString(title),
+		normalizeOptionalString(metaJSON),
+	)
+	if err != nil {
+		return Artifact{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Artifact{}, err
+	}
+	return s.GetArtifact(id)
+}
+
+func (s *Store) GetArtifact(id int64) (Artifact, error) {
+	return scanArtifact(s.db.QueryRow(
+		`SELECT id, kind, ref_path, ref_url, title, meta_json, created_at, updated_at
+		 FROM artifacts
+		 WHERE id = ?`,
+		id,
+	))
+}
+
+func (s *Store) ListArtifactsByKind(kind ArtifactKind) ([]Artifact, error) {
+	cleanKind := normalizeArtifactKind(kind)
+	if cleanKind == "" {
+		return nil, errors.New("artifact kind is required")
+	}
+	rows, err := s.db.Query(
+		`SELECT id, kind, ref_path, ref_url, title, meta_json, created_at, updated_at
+		 FROM artifacts
+		 WHERE kind = ?`,
+		cleanKind,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Artifact
+	for rows.Next() {
+		artifact, err := scanArtifact(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, artifact)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].UpdatedAt == out[j].UpdatedAt {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].UpdatedAt > out[j].UpdatedAt
+	})
+	return out, nil
+}
+
+func (s *Store) UpdateArtifact(id int64, updates ArtifactUpdate) error {
+	parts := []string{}
+	args := []any{}
+	if updates.Kind != nil {
+		cleanKind := normalizeArtifactKind(*updates.Kind)
+		if cleanKind == "" {
+			return errors.New("artifact kind is required")
+		}
+		parts = append(parts, "kind = ?")
+		args = append(args, cleanKind)
+	}
+	if updates.RefPath != nil {
+		parts = append(parts, "ref_path = ?")
+		args = append(args, normalizeOptionalString(updates.RefPath))
+	}
+	if updates.RefURL != nil {
+		parts = append(parts, "ref_url = ?")
+		args = append(args, normalizeOptionalString(updates.RefURL))
+	}
+	if updates.Title != nil {
+		parts = append(parts, "title = ?")
+		args = append(args, normalizeOptionalString(updates.Title))
+	}
+	if updates.MetaJSON != nil {
+		parts = append(parts, "meta_json = ?")
+		args = append(args, normalizeOptionalString(updates.MetaJSON))
+	}
+	if len(parts) == 0 {
+		_, err := s.GetArtifact(id)
+		return err
+	}
+	parts = append(parts, "updated_at = datetime('now')")
+	args = append(args, id)
+	res, err := s.db.Exec(`UPDATE artifacts SET `+stringsJoin(parts, ", ")+` WHERE id = ?`, args...)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) DeleteArtifact(id int64) error {
+	res, err := s.db.Exec(`DELETE FROM artifacts WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
+	cleanTitle := strings.TrimSpace(title)
+	cleanState := normalizeItemState(opts.State)
+	if cleanTitle == "" {
+		return Item{}, errors.New("item title is required")
+	}
+	if cleanState == "" {
+		return Item{}, errors.New("invalid item state")
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO items (
+			title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cleanTitle,
+		cleanState,
+		opts.WorkspaceID,
+		opts.ArtifactID,
+		opts.ActorID,
+		normalizeOptionalString(opts.VisibleAfter),
+		normalizeOptionalString(opts.FollowUpAt),
+		normalizeOptionalString(opts.Source),
+		normalizeOptionalString(opts.SourceRef),
+	)
+	if err != nil {
+		return Item{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Item{}, err
+	}
+	return s.GetItem(id)
+}
+
+func (s *Store) GetItem(id int64) (Item, error) {
+	return scanItem(s.db.QueryRow(
+		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		 FROM items
+		 WHERE id = ?`,
+		id,
+	))
+}
+
+func (s *Store) UpdateItemState(id int64, state string) error {
+	item, err := s.GetItem(id)
+	if err != nil {
+		return err
+	}
+	next := normalizeItemState(state)
+	if err := validateItemTransition(item.State, next); err != nil {
+		return err
+	}
+	res, err := s.db.Exec(
+		`UPDATE items SET state = ?, updated_at = datetime('now') WHERE id = ?`,
+		next,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) AssignItem(id, actorID int64) error {
+	if _, err := s.GetActor(actorID); err != nil {
+		return err
+	}
+	item, err := s.GetItem(id)
+	if err != nil {
+		return err
+	}
+	if item.State == ItemStateDone {
+		return fmt.Errorf("cannot assign item in %s state", item.State)
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET actor_id = ?, state = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		actorID,
+		ItemStateWaiting,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) UpdateItemTimes(id int64, visibleAfter, followUpAt *string) error {
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET visible_after = ?, follow_up_at = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		normalizeOptionalString(visibleAfter),
+		normalizeOptionalString(followUpAt),
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) DeleteItem(id int64) error {
+	res, err := s.db.Exec(`DELETE FROM items WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) ListItemsByState(state string) ([]Item, error) {
+	cleanState := normalizeItemState(state)
+	if cleanState == "" {
+		return nil, errors.New("invalid item state")
+	}
+	rows, err := s.db.Query(
+		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		 FROM items
+		 WHERE state = ?`,
+		cleanState,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Item
+	for rows.Next() {
+		item, err := scanItem(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].UpdatedAt == out[j].UpdatedAt {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].UpdatedAt > out[j].UpdatedAt
+	})
+	return out, nil
 }


### PR DESCRIPTION
## Summary
Implement the new Workspace/Actor/Artifact/Item store CRUD layer on top of the existing domain tables, including item state validation and assignment behavior.

## Verification
- All CRUD methods implemented and tested: `internal/store/store_domain.go` now provides workspace, actor, artifact, and item CRUD/query methods; `internal/store/domain_test.go` exercises create/read/update/delete flows for each type in `TestDomainCRUDRoundTrip`.
- Items queryable by state: `ListItemsByState` is implemented in `internal/store/store_domain.go` and verified in `TestDomainCRUDRoundTrip` for `waiting` and `done` items.
- Optional foreign keys work correctly: `TestDomainCRUDRoundTrip` creates items with no links, artifact-only links, workspace links, and actor links, then verifies `ON DELETE SET NULL` behavior after deleting linked workspaces/artifacts/actors.
- Tests pass with in-memory SQLite: `go test ./internal/store 2>&1 | tee /tmp/tabura-issue-174-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.213s`
- Old project/session store methods identified for deletion: the legacy replacement surfaces remain `internal/store/store_project.go` and `internal/store/store_chat.go`; this PR adds the new domain CRUD without introducing any compatibility shim around those legacy paths.
- Full coverage including edge cases and error paths: `TestDomainCRUDRoundTrip` covers duplicate workspace paths, invalid actor kind, invalid item state transition, assign-to-missing-actor, state filtering, and deletion cascades; `TestDomainConcurrentWorkspaceCreates` covers concurrent create access.