### PR TITLE
fix: Add time-based item resurfacing scheduler (fixes #179)

### DIFF
--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -590,5 +591,87 @@ func TestDomainConcurrentWorkspaceCreates(t *testing.T) {
 	}
 	if len(workspaces) != count {
 		t.Fatalf("ListWorkspaces() len = %d, want %d", len(workspaces), count)
+	}
+}
+
+func TestResurfaceDueItems(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Date(2026, time.March, 8, 10, 0, 0, 0, time.UTC)
+	past := now.Add(-30 * time.Minute).Format(time.RFC3339)
+	future := now.Add(30 * time.Minute).Format(time.RFC3339)
+
+	pastVisible, err := s.CreateItem("past visible_after", ItemOptions{
+		State:        ItemStateWaiting,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(past visible_after) error: %v", err)
+	}
+	pastFollowUp, err := s.CreateItem("past follow_up_at", ItemOptions{
+		State:      ItemStateWaiting,
+		FollowUpAt: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(past follow_up_at) error: %v", err)
+	}
+	futureWaiting, err := s.CreateItem("future waiting", ItemOptions{
+		State:        ItemStateWaiting,
+		VisibleAfter: &future,
+		FollowUpAt:   &future,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(future waiting) error: %v", err)
+	}
+	bothTimes, err := s.CreateItem("both timestamps", ItemOptions{
+		State:        ItemStateWaiting,
+		VisibleAfter: &future,
+		FollowUpAt:   &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(both timestamps) error: %v", err)
+	}
+	inboxItem, err := s.CreateItem("already inbox", ItemOptions{
+		State:        ItemStateInbox,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(already inbox) error: %v", err)
+	}
+	doneItem, err := s.CreateItem("already done", ItemOptions{
+		State:        ItemStateDone,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(already done) error: %v", err)
+	}
+
+	count, err := s.ResurfaceDueItems(now)
+	if err != nil {
+		t.Fatalf("ResurfaceDueItems() error: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("ResurfaceDueItems() count = %d, want 3", count)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   int64
+		want string
+	}{
+		{name: "past visible_after", id: pastVisible.ID, want: ItemStateInbox},
+		{name: "past follow_up_at", id: pastFollowUp.ID, want: ItemStateInbox},
+		{name: "both timestamps", id: bothTimes.ID, want: ItemStateInbox},
+		{name: "future waiting", id: futureWaiting.ID, want: ItemStateWaiting},
+		{name: "already inbox", id: inboxItem.ID, want: ItemStateInbox},
+		{name: "already done", id: doneItem.ID, want: ItemStateDone},
+	} {
+		item, err := s.GetItem(tc.id)
+		if err != nil {
+			t.Fatalf("GetItem(%s) error: %v", tc.name, err)
+		}
+		if item.State != tc.want {
+			t.Fatalf("%s state = %q, want %q", tc.name, item.State, tc.want)
+		}
 	}
 }

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 func (s *Store) migrateDomainTables() error {
@@ -786,6 +787,32 @@ func (s *Store) UpdateItemTimes(id int64, visibleAfter, followUpAt *string) erro
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+func (s *Store) ResurfaceDueItems(now time.Time) (int, error) {
+	cutoff := now.UTC().Format(time.RFC3339Nano)
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET state = ?, updated_at = datetime('now')
+		 WHERE state = ?
+		   AND (
+		     (visible_after IS NOT NULL AND trim(visible_after) <> '' AND datetime(visible_after) <= datetime(?))
+		     OR
+		     (follow_up_at IS NOT NULL AND trim(follow_up_at) <> '' AND datetime(follow_up_at) <= datetime(?))
+		   )`,
+		ItemStateInbox,
+		ItemStateWaiting,
+		cutoff,
+		cutoff,
+	)
+	if err != nil {
+		return 0, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
 }
 
 func (s *Store) DeleteItem(id int64) error {

--- a/internal/web/items_resurface.go
+++ b/internal/web/items_resurface.go
@@ -1,0 +1,69 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+)
+
+const itemResurfaceInterval = 60 * time.Second
+
+func (a *App) startItemResurfacer() {
+	if a == nil || a.shutdownCtx == nil {
+		return
+	}
+	a.workerWG.Add(1)
+	go func() {
+		defer a.workerWG.Done()
+		a.runItemResurfacer(a.shutdownCtx, itemResurfaceInterval)
+	}()
+}
+
+func (a *App) runItemResurfacer(ctx context.Context, interval time.Duration) {
+	if a == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if _, err := a.resurfaceDueItems(now); err != nil {
+				log.Printf("items resurfacer: %v", err)
+			}
+		}
+	}
+}
+
+func (a *App) resurfaceDueItems(now time.Time) (int, error) {
+	if a == nil || a.store == nil {
+		return 0, nil
+	}
+	count, err := a.store.ResurfaceDueItems(now)
+	if err != nil {
+		return 0, err
+	}
+	if count > 0 {
+		a.broadcastItemsResurfaced(count)
+	}
+	return count, nil
+}
+
+func (a *App) broadcastItemsResurfaced(count int) {
+	if a == nil || count <= 0 {
+		return
+	}
+	encoded, err := json.Marshal(map[string]interface{}{
+		"type":  "items_resurfaced",
+		"count": count,
+	})
+	if err != nil {
+		return
+	}
+	a.hub.forEachChatConn(func(conn *chatWSConn) {
+		_ = conn.writeText(encoded)
+	})
+}

--- a/internal/web/items_resurface_test.go
+++ b/internal/web/items_resurface_test.go
@@ -1,0 +1,108 @@
+package web
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestItemResurfacerTickerMovesDueItemsBackToInbox(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	past := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	future := time.Now().UTC().Add(time.Minute).Format(time.RFC3339)
+	dueItem, err := app.store.CreateItem("due", store.ItemOptions{
+		State:        store.ItemStateWaiting,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(due) error: %v", err)
+	}
+	futureItem, err := app.store.CreateItem("future", store.ItemOptions{
+		State:        store.ItemStateWaiting,
+		VisibleAfter: &future,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(future) error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.runItemResurfacer(ctx, 10*time.Millisecond)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		item, err := app.store.GetItem(dueItem.ID)
+		if err != nil {
+			t.Fatalf("GetItem(due) error: %v", err)
+		}
+		if item.State == store.ItemStateInbox {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dueItem, err = app.store.GetItem(dueItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(due, final) error: %v", err)
+	}
+	if dueItem.State != store.ItemStateInbox {
+		t.Fatalf("due item state = %q, want %q", dueItem.State, store.ItemStateInbox)
+	}
+	futureItem, err = app.store.GetItem(futureItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(future, final) error: %v", err)
+	}
+	if futureItem.State != store.ItemStateWaiting {
+		t.Fatalf("future item state = %q, want %q", futureItem.State, store.ItemStateWaiting)
+	}
+}
+
+func TestItemResurfaceBroadcastsWebsocketNotification(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	past := time.Date(2026, time.March, 8, 10, 0, 0, 0, time.UTC)
+	pastValue := past.Add(-time.Minute).Format(time.RFC3339)
+	_, err = app.store.CreateItem("due", store.ItemOptions{
+		State:        store.ItemStateWaiting,
+		VisibleAfter: &pastValue,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	count, err := app.resurfaceDueItems(past)
+	if err != nil {
+		t.Fatalf("resurfaceDueItems() error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("resurfaceDueItems() count = %d, want 1", count)
+	}
+
+	payload := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "items_resurfaced")
+	if got, ok := payload["count"].(float64); !ok || int(got) != 1 {
+		t.Fatalf("items_resurfaced count = %#v, want 1", payload["count"])
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -287,6 +287,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		_ = s.Close()
 		return nil, err
 	}
+	app.startItemResurfacer()
 	return app, nil
 }
 


### PR DESCRIPTION
## Summary
- add `Store.ResurfaceDueItems(now)` to bulk-return due waiting items to the inbox using datetime comparisons
- start a background resurfacer in `App` and broadcast `items_resurfaced` websocket events when items move
- cover store behavior, periodic ticking, and websocket notification with focused tests

## Verification
- [x] Past `visible_after` items move to inbox
  - `TestResurfaceDueItems` in `internal/store/domain_test.go` creates a waiting item with past `visible_after` and asserts the state becomes `inbox`.
- [x] Past `follow_up_at` items move to inbox
  - `TestResurfaceDueItems` creates a waiting item with past `follow_up_at` and a mixed timestamp item (`visible_after` future, `follow_up_at` past) and asserts both resurface.
- [x] Future timestamps not triggered early
  - `TestResurfaceDueItems` and `TestItemResurfacerTickerMovesDueItemsBackToInbox` keep a future-dated waiting item in `waiting`.
- [x] WS notification on resurfacing
  - `TestItemResurfaceBroadcastsWebsocketNotification` asserts the chat websocket receives `{"type":"items_resurfaced","count":1}` after resurfacing a due item.
- [x] Runs periodically without blocking
  - `TestItemResurfacerTickerMovesDueItemsBackToInbox` runs `runItemResurfacer(ctx, 10*time.Millisecond)` and verifies the due item returns to inbox while the future item stays waiting.

Command:
```text
go test ./internal/store ./internal/web -run 'TestResurfaceDueItems|TestItemResurfacerTickerMovesDueItemsBackToInbox|TestItemResurfaceBroadcastsWebsocketNotification'\nok   github.com/krystophny/tabura/internal/store 0.008s\nok   github.com/krystophny/tabura/internal/web 0.029s\n```