### PR TITLE
fix: Add item triage API and inbox row actions (fixes #178)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -18,6 +18,7 @@ const (
 
 	ItemStateInbox   = "inbox"
 	ItemStateWaiting = "waiting"
+	ItemStateSomeday = "someday"
 	ItemStateDone    = "done"
 )
 

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -125,6 +125,58 @@ CREATE TABLE chat_messages (
 	}
 }
 
+func TestStoreMigratesExistingItemsTableToAllowSomeday(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tabura.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	schema := `
+CREATE TABLE items (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'done')),
+  workspace_id INTEGER,
+  artifact_id INTEGER,
+  actor_id INTEGER,
+  visible_after TEXT,
+  follow_up_at TEXT,
+  source TEXT,
+  source_ref TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO items (title, state) VALUES ('legacy waiting', 'waiting');
+`
+	if _, err := db.Exec(schema); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed legacy items schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("store.New() on legacy items db error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	item, err := s.GetItem(1)
+	if err != nil {
+		t.Fatalf("GetItem(legacy row) error: %v", err)
+	}
+	if item.State != ItemStateWaiting {
+		t.Fatalf("legacy item state = %q, want %q", item.State, ItemStateWaiting)
+	}
+
+	if _, err := s.CreateItem("someday migration", ItemOptions{State: ItemStateSomeday}); err != nil {
+		t.Fatalf("CreateItem(someday) after migration error: %v", err)
+	}
+}
+
 func TestItemSchemaAllowsNilOptionalFields(t *testing.T) {
 	s := newTestStore(t)
 
@@ -482,6 +534,12 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	if err := s.UpdateItemState(inboxItem.ID, ItemStateWaiting); err != nil {
 		t.Fatalf("UpdateItemState(waiting) error: %v", err)
 	}
+	if err := s.UpdateItemState(workspaceItem.ID, ItemStateSomeday); err != nil {
+		t.Fatalf("UpdateItemState(someday) error: %v", err)
+	}
+	if err := s.UpdateItemState(workspaceItem.ID, ItemStateInbox); err != nil {
+		t.Fatalf("UpdateItemState(inbox from someday) error: %v", err)
+	}
 	if err := s.UpdateItemState(inboxItem.ID, ItemStateDone); err != nil {
 		t.Fatalf("UpdateItemState(done) error: %v", err)
 	}
@@ -591,6 +649,121 @@ func TestDomainConcurrentWorkspaceCreates(t *testing.T) {
 	}
 	if len(workspaces) != count {
 		t.Fatalf("ListWorkspaces() len = %d, want %d", len(workspaces), count)
+	}
+}
+
+func TestItemTriageOperations(t *testing.T) {
+	s := newTestStore(t)
+
+	actor, err := s.CreateActor("Codex", ActorKindAgent)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+
+	laterItem, err := s.CreateItem("Later item", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(later) error: %v", err)
+	}
+	visibleAfter := "2026-03-10T09:00:00Z"
+	if err := s.TriageItemLater(laterItem.ID, visibleAfter); err != nil {
+		t.Fatalf("TriageItemLater() error: %v", err)
+	}
+	gotLater, err := s.GetItem(laterItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(later) error: %v", err)
+	}
+	if gotLater.State != ItemStateWaiting {
+		t.Fatalf("later state = %q, want %q", gotLater.State, ItemStateWaiting)
+	}
+	if gotLater.VisibleAfter == nil || *gotLater.VisibleAfter != visibleAfter {
+		t.Fatalf("later visible_after = %v, want %q", gotLater.VisibleAfter, visibleAfter)
+	}
+
+	delegateItem, err := s.CreateItem("Delegate item", ItemOptions{
+		VisibleAfter: &visibleAfter,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(delegate) error: %v", err)
+	}
+	if err := s.TriageItemDelegate(delegateItem.ID, actor.ID); err != nil {
+		t.Fatalf("TriageItemDelegate() error: %v", err)
+	}
+	gotDelegate, err := s.GetItem(delegateItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(delegate) error: %v", err)
+	}
+	if gotDelegate.State != ItemStateWaiting {
+		t.Fatalf("delegate state = %q, want %q", gotDelegate.State, ItemStateWaiting)
+	}
+	if gotDelegate.ActorID == nil || *gotDelegate.ActorID != actor.ID {
+		t.Fatalf("delegate actor = %v, want %d", gotDelegate.ActorID, actor.ID)
+	}
+	if gotDelegate.VisibleAfter != nil {
+		t.Fatalf("delegate visible_after = %v, want nil", gotDelegate.VisibleAfter)
+	}
+
+	somedayItem, err := s.CreateItem("Someday item", ItemOptions{
+		ActorID:      &actor.ID,
+		VisibleAfter: &visibleAfter,
+		FollowUpAt:   &visibleAfter,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(someday) error: %v", err)
+	}
+	if err := s.TriageItemSomeday(somedayItem.ID); err != nil {
+		t.Fatalf("TriageItemSomeday() error: %v", err)
+	}
+	gotSomeday, err := s.GetItem(somedayItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(someday) error: %v", err)
+	}
+	if gotSomeday.State != ItemStateSomeday {
+		t.Fatalf("someday state = %q, want %q", gotSomeday.State, ItemStateSomeday)
+	}
+	if gotSomeday.ActorID == nil || *gotSomeday.ActorID != actor.ID {
+		t.Fatalf("someday actor = %v, want %d", gotSomeday.ActorID, actor.ID)
+	}
+	if gotSomeday.VisibleAfter != nil || gotSomeday.FollowUpAt != nil {
+		t.Fatalf("someday timestamps = visible_after:%v follow_up_at:%v, want nil", gotSomeday.VisibleAfter, gotSomeday.FollowUpAt)
+	}
+
+	doneItem, err := s.CreateItem("Done item", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+	if err := s.TriageItemDone(doneItem.ID); err != nil {
+		t.Fatalf("TriageItemDone() error: %v", err)
+	}
+	gotDone, err := s.GetItem(doneItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(done) error: %v", err)
+	}
+	if gotDone.State != ItemStateDone {
+		t.Fatalf("done state = %q, want %q", gotDone.State, ItemStateDone)
+	}
+
+	deleteItem, err := s.CreateItem("Delete me", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(delete) error: %v", err)
+	}
+	if err := s.TriageItemDelete(deleteItem.ID); err != nil {
+		t.Fatalf("TriageItemDelete() error: %v", err)
+	}
+	if _, err := s.GetItem(deleteItem.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetItem(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+
+	if err := s.TriageItemLater(laterItem.ID, "tomorrow morning"); err == nil {
+		t.Fatal("expected invalid visible_after error")
+	}
+	if err := s.TriageItemDelegate(999999, actor.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("TriageItemDelegate(missing item) error = %v, want sql.ErrNoRows", err)
+	}
+	if err := s.TriageItemDelegate(laterItem.ID, 999999); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("TriageItemDelegate(missing actor) error = %v, want sql.ErrNoRows", err)
+	}
+	if err := s.TriageItemSomeday(doneItem.ID); err == nil {
+		t.Fatal("expected done item triage rejection")
 	}
 }
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -10,6 +10,21 @@ import (
 	"time"
 )
 
+const itemsTableSchema = `CREATE TABLE IF NOT EXISTS items (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'someday', 'done')),
+  workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
+  artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
+  actor_id INTEGER REFERENCES actors(id) ON DELETE SET NULL,
+  visible_after TEXT,
+  follow_up_at TEXT,
+  source TEXT,
+  source_ref TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);`
+
 func (s *Store) migrateDomainTables() error {
 	schema := `
 CREATE TABLE IF NOT EXISTS workspaces (
@@ -36,23 +51,14 @@ CREATE TABLE IF NOT EXISTS artifacts (
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE TABLE IF NOT EXISTS items (
-  id INTEGER PRIMARY KEY,
-  title TEXT NOT NULL,
-  state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'done')),
-  workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
-  artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
-  actor_id INTEGER REFERENCES actors(id) ON DELETE SET NULL,
-  visible_after TEXT,
-  follow_up_at TEXT,
-  source TEXT,
-  source_ref TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
 `
-	_, err := s.db.Exec(schema)
-	return err
+	if _, err := s.db.Exec(schema); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(itemsTableSchema); err != nil {
+		return err
+	}
+	return s.migrateItemTableStateSupport()
 }
 
 func normalizeWorkspaceName(name string) string {
@@ -107,6 +113,8 @@ func normalizeItemState(state string) string {
 		return ItemStateInbox
 	case ItemStateWaiting:
 		return ItemStateWaiting
+	case ItemStateSomeday:
+		return ItemStateSomeday
 	case ItemStateDone:
 		return ItemStateDone
 	default:
@@ -122,6 +130,43 @@ func validateItemTransition(current, next string) error {
 		return fmt.Errorf("cannot transition item from %s to %s", current, next)
 	}
 	return nil
+}
+
+func (s *Store) migrateItemTableStateSupport() error {
+	var schema sql.NullString
+	if err := s.db.QueryRow(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'items'`).Scan(&schema); err != nil {
+		return err
+	}
+	if strings.Contains(strings.ToLower(schema.String), "'someday'") {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`ALTER TABLE items RENAME TO items_legacy`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(strings.Replace(itemsTableSchema, "IF NOT EXISTS ", "", 1)); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+INSERT INTO items (
+	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+)
+SELECT
+	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+FROM items_legacy
+`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DROP TABLE items_legacy`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func scanWorkspace(
@@ -588,6 +633,137 @@ func (s *Store) UpdateItemState(id int64, state string) error {
 	res, err := s.db.Exec(
 		`UPDATE items SET state = ?, updated_at = datetime('now') WHERE id = ?`,
 		next,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) triageableItem(id int64) (Item, error) {
+	item, err := s.GetItem(id)
+	if err != nil {
+		return Item{}, err
+	}
+	if item.State == ItemStateDone {
+		return Item{}, fmt.Errorf("cannot triage item in %s state", item.State)
+	}
+	return item, nil
+}
+
+func normalizeRFC3339String(value string) (string, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return "", err
+	}
+	return parsed.UTC().Format(time.RFC3339Nano), nil
+}
+
+func (s *Store) TriageItemDone(id int64) error {
+	if _, err := s.triageableItem(id); err != nil {
+		return err
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET state = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		ItemStateDone,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) TriageItemLater(id int64, visibleAfter string) error {
+	if _, err := s.triageableItem(id); err != nil {
+		return err
+	}
+	normalized, err := normalizeRFC3339String(visibleAfter)
+	if err != nil {
+		return errors.New("visible_after must be a valid RFC3339 timestamp")
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET state = ?, visible_after = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		ItemStateWaiting,
+		normalized,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) TriageItemDelegate(id, actorID int64) error {
+	if _, err := s.triageableItem(id); err != nil {
+		return err
+	}
+	if _, err := s.GetActor(actorID); err != nil {
+		return err
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET actor_id = ?, state = ?, visible_after = NULL, updated_at = datetime('now')
+		 WHERE id = ?`,
+		actorID,
+		ItemStateWaiting,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) TriageItemDelete(id int64) error {
+	if _, err := s.triageableItem(id); err != nil {
+		return err
+	}
+	return s.DeleteItem(id)
+}
+
+func (s *Store) TriageItemSomeday(id int64) error {
+	if _, err := s.triageableItem(id); err != nil {
+		return err
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET state = ?, visible_after = NULL, follow_up_at = NULL, updated_at = datetime('now')
+		 WHERE id = ?`,
+		ItemStateSomeday,
 		id,
 	)
 	if err != nil {

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -18,6 +18,17 @@ type itemCompleteRequest struct {
 	ActorID int64 `json:"actor_id"`
 }
 
+type itemTriageRequest struct {
+	Action       string `json:"action"`
+	ActorID      int64  `json:"actor_id"`
+	VisibleAfter string `json:"visible_after"`
+}
+
+var (
+	errItemActorRequired = errors.New("actor_id is required")
+	errItemActorNotFound = errors.New("actor not found")
+)
+
 func parseItemIDParam(r *http.Request) (int64, error) {
 	itemID := strings.TrimSpace(chi.URLParam(r, "item_id"))
 	if itemID == "" {
@@ -43,6 +54,19 @@ func writeItemStoreError(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), itemResponseErrorStatus(err))
 }
 
+func (a *App) ensureActorExists(actorID int64) error {
+	if actorID <= 0 {
+		return errItemActorRequired
+	}
+	if _, err := a.store.GetActor(actorID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errItemActorNotFound
+		}
+		return err
+	}
+	return nil
+}
+
 func (a *App) handleItemAssign(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
@@ -57,13 +81,9 @@ func (a *App) handleItemAssign(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if req.ActorID <= 0 {
-		http.Error(w, "actor_id is required", http.StatusBadRequest)
-		return
-	}
-	if _, err := a.store.GetActor(req.ActorID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			http.Error(w, "actor not found", http.StatusBadRequest)
+	if err := a.ensureActorExists(req.ActorID); err != nil {
+		if errors.Is(err, errItemActorNotFound) || errors.Is(err, errItemActorRequired) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -122,13 +142,9 @@ func (a *App) handleItemComplete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if req.ActorID <= 0 {
-		http.Error(w, "actor_id is required", http.StatusBadRequest)
-		return
-	}
-	if _, err := a.store.GetActor(req.ActorID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			http.Error(w, "actor not found", http.StatusBadRequest)
+	if err := a.ensureActorExists(req.ActorID); err != nil {
+		if errors.Is(err, errItemActorNotFound) || errors.Is(err, errItemActorRequired) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -136,6 +152,71 @@ func (a *App) handleItemComplete(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := a.store.CompleteItemByActor(itemID, req.ActorID); err != nil {
 		writeItemStoreError(w, err)
+		return
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":   true,
+		"item": item,
+	})
+}
+
+func (a *App) handleItemTriage(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req itemTriageRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	switch strings.ToLower(strings.TrimSpace(req.Action)) {
+	case "done":
+		err = a.store.TriageItemDone(itemID)
+	case "later":
+		if strings.TrimSpace(req.VisibleAfter) == "" {
+			http.Error(w, "visible_after is required", http.StatusBadRequest)
+			return
+		}
+		err = a.store.TriageItemLater(itemID, req.VisibleAfter)
+	case "delegate":
+		if err := a.ensureActorExists(req.ActorID); err != nil {
+			if errors.Is(err, errItemActorNotFound) || errors.Is(err, errItemActorRequired) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = a.store.TriageItemDelegate(itemID, req.ActorID)
+	case "delete":
+		err = a.store.TriageItemDelete(itemID)
+	case "someday":
+		err = a.store.TriageItemSomeday(itemID)
+	default:
+		http.Error(w, "action must be one of done, later, delegate, delete, someday", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	if strings.EqualFold(req.Action, "delete") {
+		writeJSON(w, map[string]interface{}{
+			"ok":      true,
+			"deleted": true,
+			"item_id": itemID,
+		})
 		return
 	}
 	item, err := a.store.GetItem(itemID)

--- a/internal/web/items_test.go
+++ b/internal/web/items_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"database/sql"
 	"net/http"
 	"strconv"
 	"testing"
@@ -155,5 +156,197 @@ func TestItemCompletionAPIRejectsWrongActorAndMissingItem(t *testing.T) {
 	})
 	if rrMissingItem.Code != http.StatusNotFound {
 		t.Fatalf("complete missing item status = %d, want 404: %s", rrMissingItem.Code, rrMissingItem.Body.String())
+	}
+}
+
+func TestItemTriageAPI(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	actor, err := app.store.CreateActor("Codex", store.ActorKindAgent)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+
+	doneItem, err := app.store.CreateItem("Done me", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+	rrDone := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(doneItem.ID)+"/triage", map[string]any{
+		"action": "done",
+	})
+	if rrDone.Code != http.StatusOK {
+		t.Fatalf("triage done status = %d, want 200: %s", rrDone.Code, rrDone.Body.String())
+	}
+	gotDone, err := app.store.GetItem(doneItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(done) error: %v", err)
+	}
+	if gotDone.State != store.ItemStateDone {
+		t.Fatalf("done state = %q, want %q", gotDone.State, store.ItemStateDone)
+	}
+
+	laterItem, err := app.store.CreateItem("Later me", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(later) error: %v", err)
+	}
+	visibleAfter := "2026-03-10T09:00:00Z"
+	rrLater := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(laterItem.ID)+"/triage", map[string]any{
+		"action":        "later",
+		"visible_after": visibleAfter,
+	})
+	if rrLater.Code != http.StatusOK {
+		t.Fatalf("triage later status = %d, want 200: %s", rrLater.Code, rrLater.Body.String())
+	}
+	gotLater, err := app.store.GetItem(laterItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(later) error: %v", err)
+	}
+	if gotLater.State != store.ItemStateWaiting {
+		t.Fatalf("later state = %q, want %q", gotLater.State, store.ItemStateWaiting)
+	}
+	if gotLater.VisibleAfter == nil || *gotLater.VisibleAfter != visibleAfter {
+		t.Fatalf("later visible_after = %v, want %q", gotLater.VisibleAfter, visibleAfter)
+	}
+
+	delegateItem, err := app.store.CreateItem("Delegate me", store.ItemOptions{
+		VisibleAfter: &visibleAfter,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(delegate) error: %v", err)
+	}
+	rrDelegate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(delegateItem.ID)+"/triage", map[string]any{
+		"action":   "delegate",
+		"actor_id": actor.ID,
+	})
+	if rrDelegate.Code != http.StatusOK {
+		t.Fatalf("triage delegate status = %d, want 200: %s", rrDelegate.Code, rrDelegate.Body.String())
+	}
+	gotDelegate, err := app.store.GetItem(delegateItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(delegate) error: %v", err)
+	}
+	if gotDelegate.State != store.ItemStateWaiting {
+		t.Fatalf("delegate state = %q, want %q", gotDelegate.State, store.ItemStateWaiting)
+	}
+	if gotDelegate.ActorID == nil || *gotDelegate.ActorID != actor.ID {
+		t.Fatalf("delegate actor = %v, want %d", gotDelegate.ActorID, actor.ID)
+	}
+	if gotDelegate.VisibleAfter != nil {
+		t.Fatalf("delegate visible_after = %v, want nil", gotDelegate.VisibleAfter)
+	}
+
+	somedayItem, err := app.store.CreateItem("Someday me", store.ItemOptions{
+		VisibleAfter: &visibleAfter,
+		FollowUpAt:   &visibleAfter,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(someday) error: %v", err)
+	}
+	rrSomeday := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(somedayItem.ID)+"/triage", map[string]any{
+		"action": "someday",
+	})
+	if rrSomeday.Code != http.StatusOK {
+		t.Fatalf("triage someday status = %d, want 200: %s", rrSomeday.Code, rrSomeday.Body.String())
+	}
+	gotSomeday, err := app.store.GetItem(somedayItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(someday) error: %v", err)
+	}
+	if gotSomeday.State != store.ItemStateSomeday {
+		t.Fatalf("someday state = %q, want %q", gotSomeday.State, store.ItemStateSomeday)
+	}
+	if gotSomeday.VisibleAfter != nil || gotSomeday.FollowUpAt != nil {
+		t.Fatalf("someday timestamps = visible_after:%v follow_up_at:%v, want nil", gotSomeday.VisibleAfter, gotSomeday.FollowUpAt)
+	}
+
+	deleteItem, err := app.store.CreateItem("Delete me", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(delete) error: %v", err)
+	}
+	rrDelete := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(deleteItem.ID)+"/triage", map[string]any{
+		"action": "delete",
+	})
+	if rrDelete.Code != http.StatusOK {
+		t.Fatalf("triage delete status = %d, want 200: %s", rrDelete.Code, rrDelete.Body.String())
+	}
+	if _, err := app.store.GetItem(deleteItem.ID); err == nil {
+		t.Fatal("expected deleted item to be gone")
+	} else if err != sql.ErrNoRows {
+		t.Fatalf("GetItem(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestItemTriageAPIRejectsInvalidRequests(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	actor, err := app.store.CreateActor("Codex", store.ActorKindAgent)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	doneItem, err := app.store.CreateItem("Already done", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+	if err := app.store.TriageItemDone(doneItem.ID); err != nil {
+		t.Fatalf("TriageItemDone() setup error: %v", err)
+	}
+	inboxItem, err := app.store.CreateItem("Inbox item", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(inbox) error: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		path   string
+		body   map[string]any
+		status int
+	}{
+		{
+			name:   "missing visible_after",
+			path:   "/api/items/" + itoa(inboxItem.ID) + "/triage",
+			body:   map[string]any{"action": "later"},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "invalid visible_after",
+			path:   "/api/items/" + itoa(inboxItem.ID) + "/triage",
+			body:   map[string]any{"action": "later", "visible_after": "tomorrow"},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "missing actor",
+			path:   "/api/items/" + itoa(inboxItem.ID) + "/triage",
+			body:   map[string]any{"action": "delegate"},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "unknown actor",
+			path:   "/api/items/" + itoa(inboxItem.ID) + "/triage",
+			body:   map[string]any{"action": "delegate", "actor_id": actor.ID + 999},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "unknown action",
+			path:   "/api/items/" + itoa(inboxItem.ID) + "/triage",
+			body:   map[string]any{"action": "archive"},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "missing item",
+			path:   "/api/items/999999/triage",
+			body:   map[string]any{"action": "done"},
+			status: http.StatusNotFound,
+		},
+		{
+			name:   "done item",
+			path:   "/api/items/" + itoa(doneItem.ID) + "/triage",
+			body:   map[string]any{"action": "someday"},
+			status: http.StatusBadRequest,
+		},
+	} {
+		rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, tc.path, tc.body)
+		if rr.Code != tc.status {
+			t.Fatalf("%s status = %d, want %d: %s", tc.name, rr.Code, tc.status, rr.Body.String())
+		}
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -379,6 +379,7 @@ func (a *App) Router() http.Handler {
 	r.Put("/api/items/{item_id}/assign", a.handleItemAssign)
 	r.Put("/api/items/{item_id}/unassign", a.handleItemUnassign)
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)
+	r.Post("/api/items/{item_id}/triage", a.handleItemTriage)
 	r.Post("/api/chat/sessions", a.handleChatSessionCreate)
 	r.Get("/api/chat/sessions/{session_id}/history", a.handleChatSessionHistory)
 	r.Get("/api/chat/sessions/{session_id}/activity", a.handleChatSessionActivity)


### PR DESCRIPTION
## Summary
Adds a single triage endpoint for item state changes, extends the item state model with `someday`, and upgrades legacy `items` tables that only allowed `inbox|waiting|done`.

## Verification
- All five triage actions work via API (`done`, `later`, `delegate`, `delete`, `someday`): [internal/web/items.go](/home/ert/code/assi/tabula/internal/web/items.go#L168) and route registration in [internal/web/server.go](/home/ert/code/assi/tabula/internal/web/server.go#L379). Covered by [internal/web/items_test.go](/home/ert/code/assi/tabula/internal/web/items_test.go#L162).
- `later` sets `visible_after` and moves the item to `waiting`: [internal/store/store_domain.go](/home/ert/code/assi/tabula/internal/store/store_domain.go#L694) and [internal/web/items_test.go](/home/ert/code/assi/tabula/internal/web/items_test.go#L188).
- `delegate` validates the actor, clears stale `visible_after`, and moves the item to `waiting`: [internal/store/store_domain.go](/home/ert/code/assi/tabula/internal/store/store_domain.go#L723) and [internal/web/items_test.go](/home/ert/code/assi/tabula/internal/web/items_test.go#L211).
- `someday` is now a first-class item state, and existing databases are migrated to accept it: [internal/store/store_domain.go](/home/ert/code/assi/tabula/internal/store/store_domain.go#L13) and [internal/store/domain_test.go](/home/ert/code/assi/tabula/internal/store/domain_test.go#L128).
- Done-state triage rejection, invalid actor/timestamp handling, delete behavior, and store-level transitions are covered in [internal/store/domain_test.go](/home/ert/code/assi/tabula/internal/store/domain_test.go#L655) and [internal/web/items_test.go](/home/ert/code/assi/tabula/internal/web/items_test.go#L279).
- Test command: `go test ./internal/store ./internal/web 2>&1 | tee /tmp/test.log`
- Output excerpt:
  - `ok   github.com/krystophny/tabura/internal/store 1.227s`
  - `ok   github.com/krystophny/tabura/internal/web 3.860s`
