### PR TITLE
fix: Add artifact-based workspace inference (fixes #214)

### DIFF
--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -846,5 +847,221 @@ func TestResurfaceDueItems(t *testing.T) {
 		if item.State != tc.want {
 			t.Fatalf("%s state = %q, want %q", tc.name, item.State, tc.want)
 		}
+	}
+}
+
+func TestFindWorkspaceContainingPathPrefersDeepestMatch(t *testing.T) {
+	s := newTestStore(t)
+
+	rootDir := filepath.Join(t.TempDir(), "workspace-root")
+	nestedDir := filepath.Join(rootDir, "nested")
+	rootWorkspace, err := s.CreateWorkspace("Root", rootDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(root) error: %v", err)
+	}
+	nestedWorkspace, err := s.CreateWorkspace("Nested", nestedDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(nested) error: %v", err)
+	}
+
+	insideNested := filepath.Join(nestedDir, "docs", "note.md")
+	gotID, err := s.FindWorkspaceContainingPath(insideNested)
+	if err != nil {
+		t.Fatalf("FindWorkspaceContainingPath(inside nested) error: %v", err)
+	}
+	if gotID == nil || *gotID != nestedWorkspace.ID {
+		t.Fatalf("FindWorkspaceContainingPath(inside nested) = %v, want %d", gotID, nestedWorkspace.ID)
+	}
+
+	insideRootOnly := filepath.Join(rootDir, "readme.md")
+	gotID, err = s.FindWorkspaceContainingPath(insideRootOnly)
+	if err != nil {
+		t.Fatalf("FindWorkspaceContainingPath(inside root) error: %v", err)
+	}
+	if gotID == nil || *gotID != rootWorkspace.ID {
+		t.Fatalf("FindWorkspaceContainingPath(inside root) = %v, want %d", gotID, rootWorkspace.ID)
+	}
+
+	gotID, err = s.FindWorkspaceContainingPath(filepath.Join(t.TempDir(), "outside.md"))
+	if err != nil {
+		t.Fatalf("FindWorkspaceContainingPath(outside) error: %v", err)
+	}
+	if gotID != nil {
+		t.Fatalf("FindWorkspaceContainingPath(outside) = %v, want nil", *gotID)
+	}
+}
+
+func TestFindWorkspaceByGitRemoteMatchesUniqueWorkspace(t *testing.T) {
+	s := newTestStore(t)
+
+	repoA := filepath.Join(t.TempDir(), "workspace-a")
+	repoB := filepath.Join(t.TempDir(), "workspace-b")
+	repoC := filepath.Join(t.TempDir(), "workspace-c")
+	initGitRepoWithRemote(t, repoA, "git@github.com:owner/alpha.git")
+	initGitRepoWithRemote(t, repoB, "https://github.com/owner/beta.git")
+	initGitRepoWithRemote(t, repoC, "ssh://git@github.com/owner/alpha.git")
+
+	workspaceA, err := s.CreateWorkspace("Alpha A", repoA)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha a) error: %v", err)
+	}
+	if _, err := s.CreateWorkspace("Beta", repoB); err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	if _, err := s.CreateWorkspace("Alpha C", repoC); err != nil {
+		t.Fatalf("CreateWorkspace(alpha c) error: %v", err)
+	}
+
+	gotID, err := s.FindWorkspaceByGitRemote("owner/beta")
+	if err != nil {
+		t.Fatalf("FindWorkspaceByGitRemote(beta) error: %v", err)
+	}
+	if gotID == nil {
+		t.Fatal("FindWorkspaceByGitRemote(beta) = nil, want workspace ID")
+	}
+	gotWorkspace, err := s.GetWorkspace(*gotID)
+	if err != nil {
+		t.Fatalf("GetWorkspace(beta) error: %v", err)
+	}
+	if gotWorkspace.Name != "Beta" {
+		t.Fatalf("FindWorkspaceByGitRemote(beta) picked %q, want Beta", gotWorkspace.Name)
+	}
+
+	gotID, err = s.FindWorkspaceByGitRemote("owner/alpha")
+	if err != nil {
+		t.Fatalf("FindWorkspaceByGitRemote(alpha) error: %v", err)
+	}
+	if gotID != nil {
+		t.Fatalf("FindWorkspaceByGitRemote(alpha) = %v, want nil for ambiguous match", *gotID)
+	}
+
+	gotID, err = s.FindWorkspaceByGitRemote("owner/missing")
+	if err != nil {
+		t.Fatalf("FindWorkspaceByGitRemote(missing) error: %v", err)
+	}
+	if gotID != nil {
+		t.Fatalf("FindWorkspaceByGitRemote(missing) = %v, want nil", *gotID)
+	}
+
+	if workspaceA.ID == 0 {
+		t.Fatal("expected created workspace ID")
+	}
+}
+
+func TestInferWorkspaceForArtifact(t *testing.T) {
+	s := newTestStore(t)
+
+	docWorkspaceDir := filepath.Join(t.TempDir(), "docs")
+	docWorkspace, err := s.CreateWorkspace("Docs", docWorkspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(docs) error: %v", err)
+	}
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	initGitRepoWithRemote(t, repoDir, "https://github.com/owner/tabula.git")
+	repoWorkspace, err := s.CreateWorkspace("Repo", repoDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(repo) error: %v", err)
+	}
+
+	docPath := filepath.Join(docWorkspaceDir, "notes", "draft.md")
+	docArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, &docPath, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(doc) error: %v", err)
+	}
+	inferredDoc, err := s.InferWorkspaceForArtifact(docArtifact)
+	if err != nil {
+		t.Fatalf("InferWorkspaceForArtifact(doc) error: %v", err)
+	}
+	if inferredDoc == nil || *inferredDoc != docWorkspace.ID {
+		t.Fatalf("InferWorkspaceForArtifact(doc) = %v, want %d", inferredDoc, docWorkspace.ID)
+	}
+
+	issueURL := "https://github.com/owner/tabula/issues/214"
+	ghArtifact, err := s.CreateArtifact(ArtifactKindGitHubIssue, nil, &issueURL, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(github) error: %v", err)
+	}
+	inferredGitHub, err := s.InferWorkspaceForArtifact(ghArtifact)
+	if err != nil {
+		t.Fatalf("InferWorkspaceForArtifact(github) error: %v", err)
+	}
+	if inferredGitHub == nil || *inferredGitHub != repoWorkspace.ID {
+		t.Fatalf("InferWorkspaceForArtifact(github) = %v, want %d", inferredGitHub, repoWorkspace.ID)
+	}
+
+	metaJSON := `{"source_ref":"owner/tabula#PR-214"}`
+	prArtifact, err := s.CreateArtifact(ArtifactKindGitHubPR, nil, nil, nil, &metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact(github pr) error: %v", err)
+	}
+	inferredPR, err := s.InferWorkspaceForArtifact(prArtifact)
+	if err != nil {
+		t.Fatalf("InferWorkspaceForArtifact(github pr) error: %v", err)
+	}
+	if inferredPR == nil || *inferredPR != repoWorkspace.ID {
+		t.Fatalf("InferWorkspaceForArtifact(github pr) = %v, want %d", inferredPR, repoWorkspace.ID)
+	}
+
+	unknownURL := "https://github.com/owner/unknown/issues/1"
+	unknownArtifact, err := s.CreateArtifact(ArtifactKindGitHubIssue, nil, &unknownURL, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(unknown github) error: %v", err)
+	}
+	inferredUnknown, err := s.InferWorkspaceForArtifact(unknownArtifact)
+	if err != nil {
+		t.Fatalf("InferWorkspaceForArtifact(unknown github) error: %v", err)
+	}
+	if inferredUnknown != nil {
+		t.Fatalf("InferWorkspaceForArtifact(unknown github) = %v, want nil", *inferredUnknown)
+	}
+}
+
+func TestCreateItemInfersWorkspaceFromArtifactWithoutOverridingExplicitWorkspace(t *testing.T) {
+	s := newTestStore(t)
+
+	artifactWorkspaceDir := filepath.Join(t.TempDir(), "artifact-workspace")
+	explicitWorkspaceDir := filepath.Join(t.TempDir(), "explicit-workspace")
+	artifactWorkspace, err := s.CreateWorkspace("Artifact Workspace", artifactWorkspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(artifact) error: %v", err)
+	}
+	explicitWorkspace, err := s.CreateWorkspace("Explicit Workspace", explicitWorkspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(explicit) error: %v", err)
+	}
+
+	docPath := filepath.Join(artifactWorkspaceDir, "docs", "task.md")
+	artifact, err := s.CreateArtifact(ArtifactKindDocument, &docPath, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	inferredItem, err := s.CreateItem("Infer from artifact", ItemOptions{ArtifactID: &artifact.ID})
+	if err != nil {
+		t.Fatalf("CreateItem(inferred) error: %v", err)
+	}
+	if inferredItem.WorkspaceID == nil || *inferredItem.WorkspaceID != artifactWorkspace.ID {
+		t.Fatalf("CreateItem(inferred).WorkspaceID = %v, want %d", inferredItem.WorkspaceID, artifactWorkspace.ID)
+	}
+
+	explicitItem, err := s.CreateItem("Keep explicit workspace", ItemOptions{
+		ArtifactID:  &artifact.ID,
+		WorkspaceID: &explicitWorkspace.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(explicit) error: %v", err)
+	}
+	if explicitItem.WorkspaceID == nil || *explicitItem.WorkspaceID != explicitWorkspace.ID {
+		t.Fatalf("CreateItem(explicit).WorkspaceID = %v, want %d", explicitItem.WorkspaceID, explicitWorkspace.ID)
+	}
+}
+
+func initGitRepoWithRemote(t *testing.T, dirPath, remoteURL string) {
+	t.Helper()
+	if err := exec.Command("git", "init", dirPath).Run(); err != nil {
+		t.Fatalf("git init %s: %v", dirPath, err)
+	}
+	if err := exec.Command("git", "-C", dirPath, "remote", "add", "origin", remoteURL).Run(); err != nil {
+		t.Fatalf("git remote add origin %s: %v", dirPath, err)
 	}
 }

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -2,8 +2,11 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -344,6 +347,151 @@ func (s *Store) ListWorkspaces() ([]Workspace, error) {
 	return out, nil
 }
 
+func (s *Store) FindWorkspaceContainingPath(filePath string) (*int64, error) {
+	targetPath := normalizeWorkspacePath(filePath)
+	if targetPath == "" {
+		return nil, nil
+	}
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		return nil, err
+	}
+	var best *Workspace
+	for i := range workspaces {
+		rel, err := filepath.Rel(workspaces[i].DirPath, targetPath)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if best == nil || len(workspaces[i].DirPath) > len(best.DirPath) {
+			best = &workspaces[i]
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	return &best.ID, nil
+}
+
+func normalizeGitHubOwnerRepo(raw string) string {
+	clean := strings.TrimSpace(strings.ToLower(raw))
+	if clean == "" {
+		return ""
+	}
+	clean = strings.TrimSuffix(clean, ".git")
+	if idx := strings.Index(clean, "#"); idx >= 0 {
+		clean = clean[:idx]
+	}
+	clean = strings.Trim(clean, "/")
+	switch {
+	case strings.HasPrefix(clean, "git@github.com:"):
+		clean = strings.TrimPrefix(clean, "git@github.com:")
+	case strings.HasPrefix(clean, "ssh://git@github.com/"):
+		clean = strings.TrimPrefix(clean, "ssh://git@github.com/")
+	case strings.HasPrefix(clean, "https://github.com/"):
+		clean = strings.TrimPrefix(clean, "https://github.com/")
+	case strings.HasPrefix(clean, "http://github.com/"):
+		clean = strings.TrimPrefix(clean, "http://github.com/")
+	}
+	parts := strings.Split(clean, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
+func githubOwnerRepoFromURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	if !strings.EqualFold(parsed.Host, "github.com") {
+		return ""
+	}
+	return normalizeGitHubOwnerRepo(parsed.Path)
+}
+
+func githubOwnerRepoFromMeta(metaJSON string) string {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(metaJSON), &payload); err != nil {
+		return ""
+	}
+	for _, key := range []string{"owner_repo", "repo", "source_ref", "url", "html_url"} {
+		value, _ := payload[key].(string)
+		if repo := normalizeGitHubOwnerRepo(value); repo != "" {
+			return repo
+		}
+		if repo := githubOwnerRepoFromURL(value); repo != "" {
+			return repo
+		}
+	}
+	return ""
+}
+
+func workspaceGitRemoteOwnerRepo(dirPath string) (string, error) {
+	cmd := exec.Command("git", "-C", dirPath, "remote", "get-url", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", nil
+		}
+		return "", err
+	}
+	return normalizeGitHubOwnerRepo(string(output)), nil
+}
+
+func (s *Store) FindWorkspaceByGitRemote(ownerRepo string) (*int64, error) {
+	target := normalizeGitHubOwnerRepo(ownerRepo)
+	if target == "" {
+		return nil, nil
+	}
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		return nil, err
+	}
+	var matches []int64
+	for _, workspace := range workspaces {
+		repo, err := workspaceGitRemoteOwnerRepo(workspace.DirPath)
+		if err != nil {
+			return nil, err
+		}
+		if repo == target {
+			matches = append(matches, workspace.ID)
+		}
+	}
+	if len(matches) != 1 {
+		return nil, nil
+	}
+	return &matches[0], nil
+}
+
+func (s *Store) InferWorkspaceForArtifact(artifact Artifact) (*int64, error) {
+	switch artifact.Kind {
+	case ArtifactKindDocument, ArtifactKindMarkdown, ArtifactKindPDF:
+		if artifact.RefPath == nil {
+			return nil, nil
+		}
+		return s.FindWorkspaceContainingPath(*artifact.RefPath)
+	case ArtifactKindGitHubIssue, ArtifactKindGitHubPR:
+		var ownerRepo string
+		if artifact.RefURL != nil {
+			ownerRepo = githubOwnerRepoFromURL(*artifact.RefURL)
+		}
+		if ownerRepo == "" && artifact.MetaJSON != nil {
+			ownerRepo = githubOwnerRepoFromMeta(*artifact.MetaJSON)
+		}
+		if ownerRepo == "" {
+			return nil, nil
+		}
+		return s.FindWorkspaceByGitRemote(ownerRepo)
+	default:
+		return nil, nil
+	}
+}
+
 func (s *Store) SetActiveWorkspace(id int64) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -587,6 +735,17 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 	}
 	if cleanState == "" {
 		return Item{}, errors.New("invalid item state")
+	}
+	if opts.WorkspaceID == nil && opts.ArtifactID != nil {
+		artifact, err := s.GetArtifact(*opts.ArtifactID)
+		if err != nil {
+			return Item{}, err
+		}
+		inferredWorkspaceID, err := s.InferWorkspaceForArtifact(artifact)
+		if err != nil {
+			return Item{}, err
+		}
+		opts.WorkspaceID = inferredWorkspaceID
 	}
 	res, err := s.db.Exec(
 		`INSERT INTO items (


### PR DESCRIPTION
## Summary
- infer workspace from document, markdown, and PDF artifact paths using the deepest containing workspace
- infer workspace from GitHub issue and PR artifacts by matching owner/repo against workspace `origin` remotes
- apply inference automatically during `CreateItem` when `artifact_id` is set and `workspace_id` is omitted, while preserving explicit workspace assignments

## Verification
- GitHub artifacts infer workspace from repo -> git remote matching: `TestInferWorkspaceForArtifact` and `TestFindWorkspaceByGitRemoteMatchesUniqueWorkspace` cover issue/PR URL parsing, `source_ref` metadata, unique-match behavior, and ambiguous/no-match fallthrough. Verified with `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`
- File-based artifacts infer workspace from path containment: `TestFindWorkspaceContainingPathPrefersDeepestMatch` and `TestInferWorkspaceForArtifact` cover containment and nested-workspace preference. Verified with `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`
- Inference runs automatically on item creation from artifacts: `TestCreateItemInfersWorkspaceFromArtifactWithoutOverridingExplicitWorkspace` verifies `CreateItem(...{ArtifactID: ...})` auto-populates `workspace_id`. Verified with `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`
- Explicit workspace assignment never overridden: `TestCreateItemInfersWorkspaceFromArtifactWithoutOverridingExplicitWorkspace` verifies an explicit `workspace_id` is preserved even when the artifact points elsewhere. Verified with `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`
- No assignment on low confidence: `TestFindWorkspaceByGitRemoteMatchesUniqueWorkspace` and `TestInferWorkspaceForArtifact` verify nil inference for ambiguous git-remote matches and unknown repos. Verified with `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`
- Full test coverage for the new store methods and integration path: `go test ./internal/store 2>&1 | tee /tmp/tabula-issue-214-test.log` -> `ok   github.com/krystophny/tabura/internal/store 1.279s`