### PR TITLE
fix: Add dialogue intents to materialize Items from conversation (fixes #180)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,12 +36,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, chat.
+Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
+For item materialization requests use make_item, delegate_item, snooze_item, or split_items.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -322,7 +323,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas":
+	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -753,6 +754,18 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		}
 	}
 
+	if inlineItemAction := parseInlineItemIntent(trimmedText, time.Now().UTC()); inlineItemAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineItemAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return itemActionFailurePrefix(inlineItemAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+
 	if strings.TrimSpace(a.intentLLMURL) != "" {
 		llmActions, llmErr := a.classifyIntentPlanWithLLM(ctx, trimmedText)
 		if llmErr == nil {
@@ -773,6 +786,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 	localAction, localConfidence, localErr := a.classifyIntentLocally(ctx, trimmedText)
 	if localErr == nil && localAction != nil && localConfidence >= intentClassifierMinConfidence {
 		if normalized := normalizeSystemActionForExecution(localAction, trimmedText); normalized != nil {
+			if isItemSystemAction(normalized.Action) {
+				enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{normalized})
+				if len(enforced) == 0 {
+					return "", nil, false
+				}
+				message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+				if err != nil {
+					return itemActionFailurePrefix(normalized.Action) + err.Error(), nil, true
+				}
+				return message, payloads, true
+			}
 			// Route tool actions through Qwen plan decoding so one prompt can trigger
 			// multiple coordinated actions (e.g., shell + open_file_canvas).
 			if normalized.Action != "shell" && normalized.Action != "open_file_canvas" {
@@ -1321,6 +1345,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			return "", nil, err
 		}
 		return status, nil, nil
+	case "make_item", "delegate_item", "snooze_item", "split_items":
+		return a.createConversationItem(sessionID, session, action)
 	case "shell":
 		targetProject, err := a.systemActionTargetProject(session)
 		if err != nil {

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -1,0 +1,634 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+var (
+	itemTitlePrefixPattern = regexp.MustCompile(`^\s*(?:[#>*-]+|\d+[.)]|(?:\[[ xX]\]))\s*`)
+	itemDelegatePattern    = regexp.MustCompile(`(?i)^(?:delegate|assign)(?:\s+(?:this|it))?\s+to\s+(.+?)$`)
+	itemSplitPattern       = regexp.MustCompile(`(?i)^split\s+(?:this|it)\s+into\s+(.+?)\s+items?$`)
+)
+
+type conversationCanvasArtifact struct {
+	Kind  string
+	Title string
+	Path  string
+	Text  string
+}
+
+type conversationItemContext struct {
+	Title         string
+	AssistantText string
+	WorkspaceID   *int64
+	ArtifactID    *int64
+}
+
+func normalizeItemCommandText(raw string) string {
+	text := strings.ToLower(strings.TrimSpace(raw))
+	text = strings.Trim(text, " \t\r\n.!?,:;")
+	text = strings.TrimPrefix(text, "please ")
+	return strings.TrimSpace(text)
+}
+
+func parseInlineItemIntent(text string, now time.Time) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	switch normalized {
+	case "make this an item", "track this", "add to inbox":
+		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
+	case "later", "remind me later":
+		visibleAfter := defaultReminderTime(now)
+		return &SystemAction{
+			Action: "snooze_item",
+			Params: map[string]interface{}{"visible_after": visibleAfter},
+		}
+	}
+
+	if match := itemDelegatePattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
+		actor := cleanActorReference(match[1])
+		if actor != "" {
+			return &SystemAction{
+				Action: "delegate_item",
+				Params: map[string]interface{}{"actor": actor},
+			}
+		}
+	}
+
+	if visibleAfter, ok := parseReminderVisibleAfter(text, now); ok {
+		return &SystemAction{
+			Action: "snooze_item",
+			Params: map[string]interface{}{"visible_after": visibleAfter},
+		}
+	}
+
+	if match := itemSplitPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
+		if count, ok := parseItemSplitCount(match[1]); ok && count > 0 {
+			return &SystemAction{
+				Action: "split_items",
+				Params: map[string]interface{}{"count": count},
+			}
+		}
+	}
+	return nil
+}
+
+func cleanActorReference(raw string) string {
+	text := strings.TrimSpace(raw)
+	text = strings.Trim(text, " \t\r\n.!?,:;")
+	for _, suffix := range []string{" please", " thanks", " thank you"} {
+		if strings.HasSuffix(strings.ToLower(text), suffix) {
+			text = strings.TrimSpace(text[:len(text)-len(suffix)])
+		}
+	}
+	return strings.TrimSpace(text)
+}
+
+func parseReminderVisibleAfter(text string, now time.Time) (string, bool) {
+	lower := normalizeItemCommandText(text)
+	if strings.Contains(lower, "tomorrow") {
+		return defaultReminderTime(now), true
+	}
+	for weekday, name := range map[time.Weekday]string{
+		time.Monday:    "monday",
+		time.Tuesday:   "tuesday",
+		time.Wednesday: "wednesday",
+		time.Thursday:  "thursday",
+		time.Friday:    "friday",
+		time.Saturday:  "saturday",
+		time.Sunday:    "sunday",
+	} {
+		if strings.Contains(lower, name) {
+			return nextWeekdayReminderTime(now, weekday), true
+		}
+	}
+	return "", false
+}
+
+func defaultReminderTime(now time.Time) string {
+	base := now.UTC().Add(24 * time.Hour)
+	return time.Date(base.Year(), base.Month(), base.Day(), 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+}
+
+func nextWeekdayReminderTime(now time.Time, weekday time.Weekday) string {
+	base := now.UTC()
+	candidate := time.Date(base.Year(), base.Month(), base.Day(), 9, 0, 0, 0, time.UTC)
+	days := (int(weekday) - int(base.Weekday()) + 7) % 7
+	if days == 0 && !candidate.After(base) {
+		days = 7
+	}
+	if days == 0 {
+		days = 7
+	}
+	candidate = candidate.AddDate(0, 0, days)
+	return candidate.Format(time.RFC3339)
+}
+
+func parseItemSplitCount(raw string) (int, bool) {
+	value := normalizeItemCommandText(raw)
+	if value == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(value); err == nil && n > 0 {
+		return n, true
+	}
+	words := map[string]int{
+		"one":   1,
+		"two":   2,
+		"three": 3,
+		"four":  4,
+		"five":  5,
+		"six":   6,
+		"seven": 7,
+		"eight": 8,
+		"nine":  9,
+		"ten":   10,
+	}
+	n, ok := words[value]
+	return n, ok
+}
+
+func isItemSystemAction(action string) bool {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "make_item", "delegate_item", "snooze_item", "split_items":
+		return true
+	default:
+		return false
+	}
+}
+
+func itemActionFailurePrefix(action string) string {
+	if strings.EqualFold(strings.TrimSpace(action), "split_items") {
+		return "I couldn't create the items: "
+	}
+	return "I couldn't create the item: "
+}
+
+func systemActionActorName(params map[string]interface{}) string {
+	for _, key := range []string{"actor", "name", "target"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func systemActionVisibleAfter(params map[string]interface{}) string {
+	for _, key := range []string{"visible_after", "when"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func systemActionSplitCount(params map[string]interface{}) int {
+	switch value := params["count"].(type) {
+	case int:
+		if value > 0 {
+			return value
+		}
+	case int64:
+		if value > 0 {
+			return int(value)
+		}
+	case float64:
+		if value > 0 {
+			return int(value)
+		}
+	case string:
+		if count, ok := parseItemSplitCount(value); ok {
+			return count
+		}
+	}
+	return 0
+}
+
+func cleanConversationItemText(raw string) string {
+	clean := stripLangTags(stripCanvasFileMarkers(raw))
+	clean = strings.ReplaceAll(clean, "\r\n", "\n")
+	return strings.TrimSpace(clean)
+}
+
+func latestConversationAssistantText(messages []store.ChatMessage) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if !strings.EqualFold(strings.TrimSpace(messages[i].Role), "assistant") {
+			continue
+		}
+		content := strings.TrimSpace(messages[i].ContentPlain)
+		if content == "" {
+			content = strings.TrimSpace(messages[i].ContentMarkdown)
+		}
+		content = cleanConversationItemText(content)
+		if content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func deriveConversationItemTitle(text string, fallback string) string {
+	content := cleanConversationItemText(text)
+	if content == "" {
+		content = strings.TrimSpace(fallback)
+	}
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		title := strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(line, ""))
+		title = strings.Trim(title, " \t\r\n-:;,.")
+		if title == "" {
+			continue
+		}
+		if len(title) > 120 {
+			title = strings.TrimSpace(title[:117]) + "..."
+		}
+		return title
+	}
+	return ""
+}
+
+func deriveSplitItemTitles(text string, count int) ([]string, error) {
+	content := cleanConversationItemText(text)
+	if content == "" {
+		return nil, errors.New("no recent assistant output to split into items")
+	}
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !itemTitlePrefixPattern.MatchString(trimmed) {
+			continue
+		}
+		title := deriveConversationItemTitle(trimmed, "")
+		if title == "" {
+			continue
+		}
+		key := strings.ToLower(title)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, title)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no separate items found in recent assistant output")
+	}
+	if count > 0 && len(out) < count {
+		return nil, fmt.Errorf("found %d candidate items, need %d", len(out), count)
+	}
+	if count > 0 && len(out) > count {
+		out = out[:count]
+	}
+	return out, nil
+}
+
+func (a *App) resolveConversationCanvasArtifact(project store.Project) *conversationCanvasArtifact {
+	canvasSessionID := strings.TrimSpace(a.canvasSessionIDForProject(project))
+	if canvasSessionID == "" {
+		return nil
+	}
+	port, ok := a.tunnels.getPort(canvasSessionID)
+	if !ok {
+		return nil
+	}
+	status, err := a.mcpToolsCall(port, "canvas_status", map[string]interface{}{"session_id": canvasSessionID})
+	if err != nil {
+		return nil
+	}
+	active, _ := status["active_artifact"].(map[string]interface{})
+	if active == nil {
+		return nil
+	}
+	kind := strings.TrimSpace(fmt.Sprint(active["kind"]))
+	title := strings.TrimSpace(fmt.Sprint(active["title"]))
+	path := strings.TrimSpace(fmt.Sprint(active["path"]))
+	text := strings.TrimSpace(fmt.Sprint(active["text"]))
+	if kind == "" || kind == "<nil>" {
+		return nil
+	}
+	if title == "<nil>" {
+		title = ""
+	}
+	if path == "<nil>" {
+		path = ""
+	}
+	if text == "<nil>" {
+		text = ""
+	}
+	return &conversationCanvasArtifact{
+		Kind:  kind,
+		Title: title,
+		Path:  path,
+		Text:  text,
+	}
+}
+
+func conversationCanvasArtifactKind(canvas *conversationCanvasArtifact) store.ArtifactKind {
+	if canvas == nil {
+		return store.ArtifactKindPlanNote
+	}
+	switch strings.ToLower(strings.TrimSpace(canvas.Kind)) {
+	case "image_artifact":
+		return store.ArtifactKindImage
+	case "pdf_artifact":
+		return store.ArtifactKindPDF
+	case "text_artifact", "text":
+		title := strings.ToLower(strings.TrimSpace(canvas.Title))
+		switch filepath.Ext(title) {
+		case ".md", ".markdown":
+			return store.ArtifactKindMarkdown
+		default:
+			return store.ArtifactKindDocument
+		}
+	default:
+		return store.ArtifactKindPlanNote
+	}
+}
+
+func resolveConversationArtifactPath(cwd string, canvas *conversationCanvasArtifact) *string {
+	if canvas == nil {
+		return nil
+	}
+	if rawPath := strings.TrimSpace(canvas.Path); rawPath != "" {
+		if absPath, _, err := resolveCanvasFilePath(cwd, rawPath); err == nil {
+			return &absPath
+		}
+	}
+	if titlePath := resolveArtifactFilePath(cwd, canvas.Title); titlePath != "" {
+		return &titlePath
+	}
+	return nil
+}
+
+func conversationArtifactMeta(source string, text string) *string {
+	payload := map[string]string{
+		"source": source,
+	}
+	cleanText := strings.TrimSpace(text)
+	if cleanText != "" {
+		payload["text"] = cleanText
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	meta := string(raw)
+	return &meta
+}
+
+func (a *App) createConversationArtifact(project store.Project, title string, assistantText string, canvas *conversationCanvasArtifact) (*store.Artifact, error) {
+	if canvas == nil && strings.TrimSpace(assistantText) == "" {
+		return nil, nil
+	}
+	cwd := strings.TrimSpace(project.RootPath)
+	if cwd == "" {
+		cwd = strings.TrimSpace(a.cwdForProjectKey(project.ProjectKey))
+	}
+	artifactTitle := strings.TrimSpace(title)
+	if canvas != nil && strings.TrimSpace(canvas.Title) != "" {
+		artifactTitle = strings.TrimSpace(canvas.Title)
+	}
+	var titlePtr *string
+	if artifactTitle != "" {
+		titlePtr = &artifactTitle
+	}
+	if canvas != nil {
+		artifact, err := a.store.CreateArtifact(
+			conversationCanvasArtifactKind(canvas),
+			resolveConversationArtifactPath(cwd, canvas),
+			nil,
+			titlePtr,
+			conversationArtifactMeta("canvas", canvas.Text),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &artifact, nil
+	}
+	artifact, err := a.store.CreateArtifact(
+		store.ArtifactKindPlanNote,
+		nil,
+		nil,
+		titlePtr,
+		conversationArtifactMeta("assistant", assistantText),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &artifact, nil
+}
+
+func (a *App) resolveConversationWorkspaceID(project store.Project, artifact *store.Artifact) (*int64, error) {
+	if artifact != nil {
+		if inferred, err := a.store.InferWorkspaceForArtifact(*artifact); err != nil {
+			return nil, err
+		} else if inferred != nil {
+			return inferred, nil
+		}
+	}
+	rootPath := strings.TrimSpace(project.RootPath)
+	if rootPath == "" {
+		rootPath = strings.TrimSpace(a.cwdForProjectKey(project.ProjectKey))
+	}
+	if rootPath != "" {
+		if workspaceID, err := a.store.FindWorkspaceContainingPath(rootPath); err != nil {
+			return nil, err
+		} else if workspaceID != nil {
+			return workspaceID, nil
+		}
+	}
+	workspaces, err := a.store.ListWorkspaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, workspace := range workspaces {
+		if workspace.IsActive {
+			id := workspace.ID
+			return &id, nil
+		}
+	}
+	return nil, nil
+}
+
+func (a *App) buildConversationItemContext(sessionID string, project store.Project) (conversationItemContext, error) {
+	messages, err := a.store.ListChatMessages(sessionID, 200)
+	if err != nil {
+		return conversationItemContext{}, err
+	}
+	assistantText := latestConversationAssistantText(messages)
+	canvas := a.resolveConversationCanvasArtifact(project)
+	titleFallback := ""
+	if canvas != nil {
+		titleFallback = canvas.Title
+	}
+	title := deriveConversationItemTitle(assistantText, titleFallback)
+	if title == "" {
+		return conversationItemContext{}, errors.New("no recent assistant output to turn into an item")
+	}
+	artifact, err := a.createConversationArtifact(project, title, assistantText, canvas)
+	if err != nil {
+		return conversationItemContext{}, err
+	}
+	workspaceID, err := a.resolveConversationWorkspaceID(project, artifact)
+	if err != nil {
+		return conversationItemContext{}, err
+	}
+	ctx := conversationItemContext{
+		Title:         title,
+		AssistantText: assistantText,
+		WorkspaceID:   workspaceID,
+	}
+	if artifact != nil {
+		ctx.ArtifactID = &artifact.ID
+	}
+	return ctx, nil
+}
+
+func (a *App) resolveActorByName(name string) (store.Actor, error) {
+	cleanName := strings.TrimSpace(name)
+	if cleanName == "" {
+		return store.Actor{}, errors.New("actor name is required")
+	}
+	actors, err := a.store.ListActors()
+	if err != nil {
+		return store.Actor{}, err
+	}
+	var exact []store.Actor
+	var partial []store.Actor
+	for _, actor := range actors {
+		switch {
+		case strings.EqualFold(actor.Name, cleanName):
+			exact = append(exact, actor)
+		case strings.Contains(strings.ToLower(actor.Name), strings.ToLower(cleanName)):
+			partial = append(partial, actor)
+		}
+	}
+	switch {
+	case len(exact) == 1:
+		return exact[0], nil
+	case len(exact) > 1:
+		return store.Actor{}, fmt.Errorf("actor name %q is ambiguous", cleanName)
+	case len(partial) == 1:
+		return partial[0], nil
+	case len(partial) > 1:
+		return store.Actor{}, fmt.Errorf("actor name %q is ambiguous", cleanName)
+	default:
+		return store.Actor{}, fmt.Errorf("actor %q not found", cleanName)
+	}
+}
+
+func (a *App) createConversationItem(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	ctx, err := a.buildConversationItemContext(sessionID, targetProject)
+	if err != nil {
+		return "", nil, err
+	}
+
+	makeOpts := func() store.ItemOptions {
+		return store.ItemOptions{
+			WorkspaceID: ctx.WorkspaceID,
+			ArtifactID:  ctx.ArtifactID,
+		}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(action.Action)) {
+	case "make_item":
+		item, err := a.store.CreateItem(ctx.Title, makeOpts())
+		if err != nil {
+			return "", nil, err
+		}
+		artifactID := int64(0)
+		if ctx.ArtifactID != nil {
+			artifactID = *ctx.ArtifactID
+		}
+		return fmt.Sprintf("Created inbox item %q.", item.Title), map[string]interface{}{
+			"type":        "item_created",
+			"item_id":     item.ID,
+			"state":       item.State,
+			"title":       item.Title,
+			"artifact_id": artifactID,
+		}, nil
+	case "delegate_item":
+		actor, err := a.resolveActorByName(systemActionActorName(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		opts := makeOpts()
+		opts.State = store.ItemStateWaiting
+		opts.ActorID = &actor.ID
+		item, err := a.store.CreateItem(ctx.Title, opts)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Created waiting item %q for %s.", item.Title, actor.Name), map[string]interface{}{
+			"type":     "item_created",
+			"item_id":  item.ID,
+			"state":    item.State,
+			"title":    item.Title,
+			"actor_id": actor.ID,
+		}, nil
+	case "snooze_item":
+		visibleAfter := systemActionVisibleAfter(action.Params)
+		if visibleAfter == "" {
+			return "", nil, errors.New("visible_after is required")
+		}
+		opts := makeOpts()
+		opts.State = store.ItemStateWaiting
+		opts.VisibleAfter = &visibleAfter
+		item, err := a.store.CreateItem(ctx.Title, opts)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Created waiting item %q for %s.", item.Title, visibleAfter), map[string]interface{}{
+			"type":          "item_created",
+			"item_id":       item.ID,
+			"state":         item.State,
+			"title":         item.Title,
+			"visible_after": visibleAfter,
+		}, nil
+	case "split_items":
+		count := systemActionSplitCount(action.Params)
+		if count <= 0 {
+			return "", nil, errors.New("split item count is required")
+		}
+		titles, err := deriveSplitItemTitles(ctx.AssistantText, count)
+		if err != nil {
+			return "", nil, err
+		}
+		itemIDs := make([]int64, 0, len(titles))
+		for _, title := range titles {
+			item, createErr := a.store.CreateItem(title, makeOpts())
+			if createErr != nil {
+				return "", nil, createErr
+			}
+			itemIDs = append(itemIDs, item.ID)
+		}
+		return fmt.Sprintf("Created %d inbox items.", len(itemIDs)), map[string]interface{}{
+			"type":     "items_created",
+			"item_ids": itemIDs,
+			"count":    len(itemIDs),
+		}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported item action: %s", action.Action)
+	}
+}

--- a/internal/web/chat_items_test.go
+++ b/internal/web/chat_items_test.go
@@ -1,0 +1,312 @@
+package web
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func mustFirstItemByState(t *testing.T, app *App, state string) store.Item {
+	t.Helper()
+	items, err := app.store.ListItemsByState(state)
+	if err != nil {
+		t.Fatalf("ListItemsByState(%s) error: %v", state, err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("ListItemsByState(%s) len = %d, want 1", state, len(items))
+	}
+	return items[0]
+}
+
+func TestParseInlineItemIntent(t *testing.T) {
+	now := time.Date(2026, time.March, 8, 15, 4, 5, 0, time.UTC)
+
+	cases := []struct {
+		text       string
+		wantAction string
+		wantActor  string
+		wantWhen   string
+		wantCount  int
+	}{
+		{text: "make this an item", wantAction: "make_item"},
+		{text: "delegate this to Codex", wantAction: "delegate_item", wantActor: "Codex"},
+		{text: "remind me tomorrow", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
+		{text: "split this into three items", wantAction: "split_items", wantCount: 3},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineItemIntent(tc.text, now)
+			if action == nil {
+				t.Fatal("expected inline item action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if tc.wantActor != "" && systemActionActorName(action.Params) != tc.wantActor {
+				t.Fatalf("actor = %q, want %q", systemActionActorName(action.Params), tc.wantActor)
+			}
+			if tc.wantWhen != "" && systemActionVisibleAfter(action.Params) != tc.wantWhen {
+				t.Fatalf("visible_after = %q, want %q", systemActionVisibleAfter(action.Params), tc.wantWhen)
+			}
+			if tc.wantCount != 0 && systemActionSplitCount(action.Params) != tc.wantCount {
+				t.Fatalf("count = %d, want %d", systemActionSplitCount(action.Params), tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", "Refactor the parser pipeline\n\n- fold duplicate state handling", "Refactor the parser pipeline\n\n- fold duplicate state handling", "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "make this an item")
+	if !handled {
+		t.Fatal("expected item command to be handled")
+	}
+	if message != `Created inbox item "Refactor the parser pipeline".` {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "item_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if item.Title != "Refactor the parser pipeline" {
+		t.Fatalf("item title = %q", item.Title)
+	}
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.ArtifactID == nil {
+		t.Fatal("expected artifact to be linked")
+	}
+	artifact, err := app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindPlanNote {
+		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindPlanNote)
+	}
+	if artifact.MetaJSON == nil || !containsAll(*artifact.MetaJSON, `"source":"assistant"`, `Refactor the parser pipeline`) {
+		t.Fatalf("artifact meta_json = %v", artifact.MetaJSON)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionDelegateItemUsesActorAndCanvasArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	actor, err := app.store.CreateActor("Codex", store.ActorKindAgent)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", "Review the README cleanup plan", "Review the README cleanup plan", "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	readmePath := filepath.Join(project.RootPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# notes\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mock := &canvasMCPMock{
+		artifactTitle: "README.md",
+		artifactKind:  "text_artifact",
+		artifactText:  "# notes",
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port := serverPort(t, server.Listener.Addr())
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "delegate this to Codex")
+	if !handled {
+		t.Fatal("expected delegate command to be handled")
+	}
+	if message != `Created waiting item "Review the README cleanup plan" for Codex.` {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "item_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateWaiting)
+	if item.ActorID == nil || *item.ActorID != actor.ID {
+		t.Fatalf("actor_id = %v, want %d", item.ActorID, actor.ID)
+	}
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.ArtifactID == nil {
+		t.Fatal("expected canvas artifact to be linked")
+	}
+	artifact, err := app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindMarkdown {
+		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindMarkdown)
+	}
+	if artifact.RefPath == nil || *artifact.RefPath != readmePath {
+		t.Fatalf("artifact ref_path = %v, want %q", artifact.RefPath, readmePath)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSnoozeItemCreatesWaitingItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", "Follow up with the batching review", "Follow up with the batching review", "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	action := parseInlineItemIntent("remind me tomorrow", time.Date(2026, time.March, 8, 15, 4, 5, 0, time.UTC))
+	if action == nil {
+		t.Fatal("expected snooze action")
+	}
+	message, payload, err := app.executeSystemAction(session.ID, session, action)
+	if err != nil {
+		t.Fatalf("executeSystemAction() error: %v", err)
+	}
+	if message != `Created waiting item "Follow up with the batching review" for 2026-03-09T09:00:00Z.` {
+		t.Fatalf("message = %q", message)
+	}
+	if strFromAny(payload["visible_after"]) != "2026-03-09T09:00:00Z" {
+		t.Fatalf("payload = %#v", payload)
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateWaiting)
+	if item.VisibleAfter == nil || *item.VisibleAfter != "2026-03-09T09:00:00Z" {
+		t.Fatalf("visible_after = %v", item.VisibleAfter)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSplitItemsCreatesMultipleItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "- Capture failing test case\n- Patch the parser fallback\n- Add regression coverage"
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "split this into three items")
+	if !handled {
+		t.Fatal("expected split command to be handled")
+	}
+	if message != "Created 3 inbox items." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "items_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	items, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("inbox len = %d, want 3", len(items))
+	}
+}
+
+func TestClassifyAndExecuteSystemActionDelegateItemSurfacesMissingActor(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", "Prepare the handoff note", "Prepare the handoff note", "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "delegate this to Missing")
+	if !handled {
+		t.Fatal("expected missing-actor command to be handled")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != `I couldn't create the item: actor "Missing" not found` {
+		t.Fatalf("message = %q", message)
+	}
+}
+
+func serverPort(t *testing.T, addr net.Addr) int {
+	t.Helper()
+	tcp, ok := addr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr = %T, want *net.TCPAddr", addr)
+	}
+	return tcp.Port
+}
+
+func containsAll(text string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(text, part) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- add deterministic dialogue item intents for `make_item`, `delegate_item`, `snooze_item`, and `split_items`
- materialize items from recent assistant context, including workspace inference and artifact linkage from assistant text or the active canvas artifact
- surface explicit item-creation errors back through the local system-action path instead of silently falling through

## Verification
- [x] `"make this an item" creates inbox item from context`
  Evidence: `TestClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext` asserts a handled `make this an item` command, an inbox item titled `Refactor the parser pipeline`, workspace linkage, and a linked `plan_note` artifact sourced from the assistant output.
- [x] `"delegate this to Codex" creates assigned waiting item`
  Evidence: `TestClassifyAndExecuteSystemActionDelegateItemUsesActorAndCanvasArtifact` asserts a handled delegate command, `waiting` state, actor `Codex`, workspace linkage, and a linked canvas artifact at `README.md`.
- [x] `"remind me tomorrow" creates snoozed item`
  Evidence: `TestParseInlineItemIntent` derives `visible_after=2026-03-09T09:00:00Z`, and `TestClassifyAndExecuteSystemActionSnoozeItemCreatesWaitingItem` asserts the created item is `waiting` with that exact timestamp.
- [x] Items link to workspace and artifact when available
  Evidence: the make-item test verifies workspace + assistant artifact linkage; the delegate test verifies workspace + active canvas artifact linkage with a resolved file path.
- [x] Confirmation appears in chat/local action response
  Evidence: the make, delegate, and snooze tests each assert the returned confirmation text (`Created inbox item ...`, `Created waiting item ...`).
- [x] Error handling and split flow are covered
  Evidence: `TestClassifyAndExecuteSystemActionSplitItemsCreatesMultipleItems` asserts three inbox items are created from assistant bullets, and `TestClassifyAndExecuteSystemActionDelegateItemSurfacesMissingActor` asserts explicit user-facing failure for an unknown actor.
- [x] Focused verification command passes
  Evidence: `go test ./internal/web -run 'Test(ParseInlineItemIntent|ClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext|ClassifyAndExecuteSystemActionDelegateItemUsesActorAndCanvasArtifact|ClassifyAndExecuteSystemActionSnoozeItemCreatesWaitingItem|ClassifyAndExecuteSystemActionSplitItemsCreatesMultipleItems|ClassifyAndExecuteSystemActionDelegateItemSurfacesMissingActor)' 2>&1 | tee /tmp/test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.034s`
