### PR TITLE
fix: Add GitHub issue to Item synchronization (fixes #185)

### DIFF
--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -948,6 +948,129 @@ func TestFindWorkspaceByGitRemoteMatchesUniqueWorkspace(t *testing.T) {
 	}
 }
 
+func TestGitHubRepoForWorkspace(t *testing.T) {
+	s := newTestStore(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	initGitRepoWithRemote(t, repoDir, "https://github.com/owner/tabula.git")
+	workspace, err := s.CreateWorkspace("Repo", repoDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(repo) error: %v", err)
+	}
+
+	repo, err := s.GitHubRepoForWorkspace(workspace.ID)
+	if err != nil {
+		t.Fatalf("GitHubRepoForWorkspace() error: %v", err)
+	}
+	if repo != "owner/tabula" {
+		t.Fatalf("GitHubRepoForWorkspace() = %q, want %q", repo, "owner/tabula")
+	}
+
+	missingRemoteDir := filepath.Join(t.TempDir(), "no-remote")
+	if err := exec.Command("git", "init", missingRemoteDir).Run(); err != nil {
+		t.Fatalf("git init %s: %v", missingRemoteDir, err)
+	}
+	noRemoteWorkspace, err := s.CreateWorkspace("No Remote", missingRemoteDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(no remote) error: %v", err)
+	}
+	repo, err = s.GitHubRepoForWorkspace(noRemoteWorkspace.ID)
+	if err != nil {
+		t.Fatalf("GitHubRepoForWorkspace(no remote) error: %v", err)
+	}
+	if repo != "" {
+		t.Fatalf("GitHubRepoForWorkspace(no remote) = %q, want empty", repo)
+	}
+}
+
+func TestSourceItemUpsertAndSyncState(t *testing.T) {
+	s := newTestStore(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "workspace")
+	workspace, err := s.CreateWorkspace("Workspace", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	artifactTitle := "Issue #12"
+	artifactURL := "https://github.com/owner/tabula/issues/12"
+	artifact, err := s.CreateArtifact(ArtifactKindGitHubIssue, nil, &artifactURL, &artifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	item, err := s.UpsertItemFromSource("github", "owner/tabula#12", "Initial issue title", &workspace.ID)
+	if err != nil {
+		t.Fatalf("UpsertItemFromSource(create) error: %v", err)
+	}
+	if item.State != ItemStateInbox {
+		t.Fatalf("created item state = %q, want %q", item.State, ItemStateInbox)
+	}
+	if err := s.UpdateItemArtifact(item.ID, &artifact.ID); err != nil {
+		t.Fatalf("UpdateItemArtifact() error: %v", err)
+	}
+
+	gotBySource, err := s.GetItemBySource("github", "owner/tabula#12")
+	if err != nil {
+		t.Fatalf("GetItemBySource() error: %v", err)
+	}
+	if gotBySource.ID != item.ID {
+		t.Fatalf("GetItemBySource() ID = %d, want %d", gotBySource.ID, item.ID)
+	}
+	if gotBySource.ArtifactID == nil || *gotBySource.ArtifactID != artifact.ID {
+		t.Fatalf("GetItemBySource().ArtifactID = %v, want %d", gotBySource.ArtifactID, artifact.ID)
+	}
+
+	updatedItem, err := s.UpsertItemFromSource("github", "owner/tabula#12", "Renamed issue title", nil)
+	if err != nil {
+		t.Fatalf("UpsertItemFromSource(update) error: %v", err)
+	}
+	if updatedItem.ID != item.ID {
+		t.Fatalf("updated item ID = %d, want %d", updatedItem.ID, item.ID)
+	}
+	if updatedItem.Title != "Renamed issue title" {
+		t.Fatalf("updated title = %q, want %q", updatedItem.Title, "Renamed issue title")
+	}
+	if updatedItem.WorkspaceID != nil {
+		t.Fatalf("updated WorkspaceID = %v, want nil", updatedItem.WorkspaceID)
+	}
+	items, err := s.ListItemsByState(ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("ListItemsByState(inbox) len = %d, want 1", len(items))
+	}
+
+	if err := s.SyncItemStateBySource("github", "owner/tabula#12", ItemStateDone); err != nil {
+		t.Fatalf("SyncItemStateBySource(done) error: %v", err)
+	}
+	doneItem, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(done) error: %v", err)
+	}
+	if doneItem.State != ItemStateDone {
+		t.Fatalf("done item state = %q, want %q", doneItem.State, ItemStateDone)
+	}
+
+	if err := s.SyncItemStateBySource("github", "owner/tabula#12", ItemStateInbox); err != nil {
+		t.Fatalf("SyncItemStateBySource(reopen) error: %v", err)
+	}
+	reopenedItem, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(reopened) error: %v", err)
+	}
+	if reopenedItem.State != ItemStateInbox {
+		t.Fatalf("reopened item state = %q, want %q", reopenedItem.State, ItemStateInbox)
+	}
+
+	if _, err := s.GetItemBySource("github", "owner/tabula#404"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetItemBySource(missing) error = %v, want sql.ErrNoRows", err)
+	}
+	if err := s.SyncItemStateBySource("github", "owner/tabula#404", ItemStateDone); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("SyncItemStateBySource(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
 func TestInferWorkspaceForArtifact(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -468,6 +468,14 @@ func (s *Store) FindWorkspaceByGitRemote(ownerRepo string) (*int64, error) {
 	return &matches[0], nil
 }
 
+func (s *Store) GitHubRepoForWorkspace(id int64) (string, error) {
+	workspace, err := s.GetWorkspace(id)
+	if err != nil {
+		return "", err
+	}
+	return workspaceGitRemoteOwnerRepo(workspace.DirPath)
+}
+
 func (s *Store) InferWorkspaceForArtifact(artifact Artifact) (*int64, error) {
 	switch artifact.Kind {
 	case ArtifactKindDocument, ArtifactKindMarkdown, ArtifactKindPDF:
@@ -778,6 +786,117 @@ func (s *Store) GetItem(id int64) (Item, error) {
 		 WHERE id = ?`,
 		id,
 	))
+}
+
+func (s *Store) GetItemBySource(source, sourceRef string) (Item, error) {
+	cleanSource := strings.TrimSpace(source)
+	cleanSourceRef := strings.TrimSpace(sourceRef)
+	if cleanSource == "" || cleanSourceRef == "" {
+		return Item{}, errors.New("item source and source_ref are required")
+	}
+	return scanItem(s.db.QueryRow(
+		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		 FROM items
+		 WHERE source = ? AND source_ref = ?`,
+		cleanSource,
+		cleanSourceRef,
+	))
+}
+
+func (s *Store) UpsertItemFromSource(source, sourceRef, title string, workspaceID *int64) (Item, error) {
+	cleanSource := strings.TrimSpace(source)
+	cleanSourceRef := strings.TrimSpace(sourceRef)
+	cleanTitle := strings.TrimSpace(title)
+	if cleanSource == "" || cleanSourceRef == "" {
+		return Item{}, errors.New("item source and source_ref are required")
+	}
+	if cleanTitle == "" {
+		return Item{}, errors.New("item title is required")
+	}
+
+	existing, err := s.GetItemBySource(cleanSource, cleanSourceRef)
+	switch {
+	case err == nil:
+		res, err := s.db.Exec(
+			`UPDATE items
+			 SET title = ?, workspace_id = ?, updated_at = datetime('now')
+			 WHERE id = ?`,
+			cleanTitle,
+			workspaceID,
+			existing.ID,
+		)
+		if err != nil {
+			return Item{}, err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return Item{}, err
+		}
+		if affected == 0 {
+			return Item{}, sql.ErrNoRows
+		}
+		return s.GetItem(existing.ID)
+	case !errors.Is(err, sql.ErrNoRows):
+		return Item{}, err
+	}
+
+	return s.CreateItem(cleanTitle, ItemOptions{
+		WorkspaceID: workspaceID,
+		Source:      &cleanSource,
+		SourceRef:   &cleanSourceRef,
+	})
+}
+
+func (s *Store) UpdateItemArtifact(id int64, artifactID *int64) error {
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET artifact_id = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		artifactID,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) SyncItemStateBySource(source, sourceRef, state string) error {
+	cleanSource := strings.TrimSpace(source)
+	cleanSourceRef := strings.TrimSpace(sourceRef)
+	cleanState := normalizeItemState(state)
+	if cleanSource == "" || cleanSourceRef == "" {
+		return errors.New("item source and source_ref are required")
+	}
+	if cleanState == "" {
+		return errors.New("invalid item state")
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET state = ?, updated_at = datetime('now')
+		 WHERE source = ? AND source_ref = ?`,
+		cleanState,
+		cleanSource,
+		cleanSourceRef,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (s *Store) UpdateItemState(id int64, state string) error {

--- a/internal/web/items_github.go
+++ b/internal/web/items_github.go
@@ -1,0 +1,254 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const githubIssueListTimeout = 60 * time.Second
+
+type itemGitHubSyncRequest struct {
+	WorkspaceID int64 `json:"workspace_id"`
+}
+
+type itemGitHubSyncResponse struct {
+	OK          bool   `json:"ok"`
+	WorkspaceID int64  `json:"workspace_id"`
+	Repo        string `json:"repo"`
+	Synced      int    `json:"synced"`
+	Open        int    `json:"open"`
+	Closed      int    `json:"closed"`
+}
+
+type ghIssueListLabel struct {
+	Name string `json:"name"`
+}
+
+type ghIssueListAssignee struct {
+	Login string `json:"login"`
+}
+
+type ghIssueListItem struct {
+	Number    int                   `json:"number"`
+	Title     string                `json:"title"`
+	URL       string                `json:"url"`
+	State     string                `json:"state"`
+	Labels    []ghIssueListLabel    `json:"labels"`
+	Assignees []ghIssueListAssignee `json:"assignees"`
+}
+
+func optionalTrimmedString(raw string) *string {
+	clean := strings.TrimSpace(raw)
+	if clean == "" {
+		return nil
+	}
+	return &clean
+}
+
+func githubIssueSourceRef(ownerRepo string, number int) string {
+	return fmt.Sprintf("%s#%d", strings.TrimSpace(ownerRepo), number)
+}
+
+func githubIssueItemState(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "open":
+		return store.ItemStateInbox, nil
+	case "closed":
+		return store.ItemStateDone, nil
+	default:
+		return "", fmt.Errorf("unsupported github issue state %q", raw)
+	}
+}
+
+func githubIssueArtifactMeta(ownerRepo string, issue ghIssueListItem) (*string, error) {
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if clean := strings.TrimSpace(label.Name); clean != "" {
+			labels = append(labels, clean)
+		}
+	}
+	assignees := make([]string, 0, len(issue.Assignees))
+	for _, assignee := range issue.Assignees {
+		if clean := strings.TrimSpace(assignee.Login); clean != "" {
+			assignees = append(assignees, clean)
+		}
+	}
+	payload := map[string]any{
+		"owner_repo": ownerRepo,
+		"number":     issue.Number,
+		"state":      strings.ToLower(strings.TrimSpace(issue.State)),
+		"url":        strings.TrimSpace(issue.URL),
+		"labels":     labels,
+		"assignees":  assignees,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func (a *App) listGitHubIssues(cwd string) ([]ghIssueListItem, error) {
+	runner := a.ghCommandRunner
+	if runner == nil {
+		runner = runGitHubCLI
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), githubIssueListTimeout)
+	defer cancel()
+
+	raw, err := runner(
+		ctx,
+		cwd,
+		"issue", "list",
+		"--state", "all",
+		"--limit", "500",
+		"--json", "number,title,url,state,labels,assignees",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var issues []ghIssueListItem
+	if err := json.Unmarshal([]byte(raw), &issues); err != nil {
+		return nil, fmt.Errorf("invalid github issue response: %w", err)
+	}
+	return issues, nil
+}
+
+func (a *App) syncGitHubIssueArtifact(item store.Item, ownerRepo string, issue ghIssueListItem) error {
+	title := strings.TrimSpace(issue.Title)
+	kind := store.ArtifactKindGitHubIssue
+	refURL := optionalTrimmedString(issue.URL)
+	metaJSON, err := githubIssueArtifactMeta(ownerRepo, issue)
+	if err != nil {
+		return err
+	}
+
+	createArtifact := func() (store.Artifact, error) {
+		return a.store.CreateArtifact(kind, nil, refURL, optionalTrimmedString(title), metaJSON)
+	}
+
+	if item.ArtifactID == nil {
+		artifact, err := createArtifact()
+		if err != nil {
+			return err
+		}
+		return a.store.UpdateItemArtifact(item.ID, &artifact.ID)
+	}
+
+	err = a.store.UpdateArtifact(*item.ArtifactID, store.ArtifactUpdate{
+		Kind:     &kind,
+		RefURL:   refURL,
+		Title:    optionalTrimmedString(title),
+		MetaJSON: metaJSON,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		artifact, createErr := createArtifact()
+		if createErr != nil {
+			return createErr
+		}
+		return a.store.UpdateItemArtifact(item.ID, &artifact.ID)
+	}
+	return err
+}
+
+func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error) {
+	workspace, err := a.store.GetWorkspace(workspaceID)
+	if err != nil {
+		return itemGitHubSyncResponse{}, err
+	}
+	repo, err := a.store.GitHubRepoForWorkspace(workspaceID)
+	if err != nil {
+		return itemGitHubSyncResponse{}, err
+	}
+	if strings.TrimSpace(repo) == "" {
+		return itemGitHubSyncResponse{}, errors.New("workspace has no GitHub origin remote")
+	}
+
+	issues, err := a.listGitHubIssues(workspace.DirPath)
+	if err != nil {
+		return itemGitHubSyncResponse{}, err
+	}
+
+	result := itemGitHubSyncResponse{
+		OK:          true,
+		WorkspaceID: workspace.ID,
+		Repo:        repo,
+		Synced:      len(issues),
+	}
+	for _, issue := range issues {
+		if issue.Number <= 0 {
+			return itemGitHubSyncResponse{}, errors.New("github issue number is required")
+		}
+		if strings.TrimSpace(issue.Title) == "" {
+			return itemGitHubSyncResponse{}, fmt.Errorf("github issue #%d title is required", issue.Number)
+		}
+
+		item, err := a.store.UpsertItemFromSource("github", githubIssueSourceRef(repo, issue.Number), issue.Title, &workspace.ID)
+		if err != nil {
+			return itemGitHubSyncResponse{}, err
+		}
+		if err := a.syncGitHubIssueArtifact(item, repo, issue); err != nil {
+			return itemGitHubSyncResponse{}, err
+		}
+
+		desiredState, err := githubIssueItemState(issue.State)
+		if err != nil {
+			return itemGitHubSyncResponse{}, err
+		}
+		switch desiredState {
+		case store.ItemStateDone:
+			result.Closed++
+			if item.State != store.ItemStateDone {
+				if err := a.store.CompleteItemBySource("github", githubIssueSourceRef(repo, issue.Number)); err != nil {
+					return itemGitHubSyncResponse{}, err
+				}
+			}
+		case store.ItemStateInbox:
+			result.Open++
+			if item.State == store.ItemStateDone {
+				if err := a.store.SyncItemStateBySource("github", githubIssueSourceRef(repo, issue.Number), store.ItemStateInbox); err != nil {
+					return itemGitHubSyncResponse{}, err
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+func (a *App) handleGitHubIssueSync(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req itemGitHubSyncRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.WorkspaceID <= 0 {
+		http.Error(w, "workspace_id is required", http.StatusBadRequest)
+		return
+	}
+
+	result, err := a.syncGitHubIssues(req.WorkspaceID)
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case strings.Contains(strings.ToLower(err.Error()), "no github origin remote"):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, err.Error(), http.StatusBadGateway)
+		}
+		return
+	}
+	writeJSON(w, result)
+}

--- a/internal/web/items_github_test.go
+++ b/internal/web/items_github_test.go
@@ -1,0 +1,185 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestGitHubIssueSyncAPI(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	repoDir := filepath.Join(t.TempDir(), "workspace")
+	initGitHubWorkspaceRepo(t, repoDir, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Repo", repoDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	var calls [][]string
+	var callCWDs []string
+	callCount := 0
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		callCWDs = append(callCWDs, cwd)
+		callCount++
+		switch callCount {
+		case 1:
+			return `[
+				{"number":12,"title":"Open bug","url":"https://github.com/owner/tabula/issues/12","state":"OPEN","labels":[{"name":"bug"}],"assignees":[{"login":"octocat"}]},
+				{"number":13,"title":"Closed task","url":"https://github.com/owner/tabula/issues/13","state":"CLOSED","labels":[],"assignees":[]}
+			]`, nil
+		case 2:
+			return `[
+				{"number":12,"title":"Open bug renamed","url":"https://github.com/owner/tabula/issues/12","state":"OPEN","labels":[{"name":"bug"}],"assignees":[{"login":"octocat"}]},
+				{"number":13,"title":"Closed task reopened","url":"https://github.com/owner/tabula/issues/13","state":"OPEN","labels":[{"name":"help wanted"}],"assignees":[]}
+			]`, nil
+		default:
+			t.Fatalf("unexpected gh invocation %d", callCount)
+			return "", nil
+		}
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var response itemGitHubSyncResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode first sync response: %v", err)
+	}
+	if response.Synced != 2 || response.Open != 1 || response.Closed != 1 {
+		t.Fatalf("first sync response = %+v, want synced=2 open=1 closed=1", response)
+	}
+
+	openItem, err := app.store.GetItemBySource("github", "owner/tabula#12")
+	if err != nil {
+		t.Fatalf("GetItemBySource(open) error: %v", err)
+	}
+	if openItem.State != store.ItemStateInbox {
+		t.Fatalf("open item state = %q, want %q", openItem.State, store.ItemStateInbox)
+	}
+	if openItem.WorkspaceID == nil || *openItem.WorkspaceID != workspace.ID {
+		t.Fatalf("open item workspace = %v, want %d", openItem.WorkspaceID, workspace.ID)
+	}
+	if openItem.ArtifactID == nil {
+		t.Fatal("expected open item artifact")
+	}
+	openArtifact, err := app.store.GetArtifact(*openItem.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact(open) error: %v", err)
+	}
+	if openArtifact.Kind != store.ArtifactKindGitHubIssue {
+		t.Fatalf("open artifact kind = %q, want %q", openArtifact.Kind, store.ArtifactKindGitHubIssue)
+	}
+	if openArtifact.RefURL == nil || *openArtifact.RefURL != "https://github.com/owner/tabula/issues/12" {
+		t.Fatalf("open artifact ref_url = %v, want issue URL", openArtifact.RefURL)
+	}
+	var openMeta map[string]any
+	if openArtifact.MetaJSON == nil {
+		t.Fatal("expected open artifact meta_json")
+	}
+	if err := json.Unmarshal([]byte(*openArtifact.MetaJSON), &openMeta); err != nil {
+		t.Fatalf("unmarshal open artifact meta_json: %v", err)
+	}
+	if openMeta["owner_repo"] != "owner/tabula" {
+		t.Fatalf("open artifact owner_repo = %v, want owner/tabula", openMeta["owner_repo"])
+	}
+	if openMeta["state"] != "open" {
+		t.Fatalf("open artifact state = %v, want open", openMeta["state"])
+	}
+
+	closedItem, err := app.store.GetItemBySource("github", "owner/tabula#13")
+	if err != nil {
+		t.Fatalf("GetItemBySource(closed) error: %v", err)
+	}
+	if closedItem.State != store.ItemStateDone {
+		t.Fatalf("closed item state = %q, want %q", closedItem.State, store.ItemStateDone)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	openItem, err = app.store.GetItemBySource("github", "owner/tabula#12")
+	if err != nil {
+		t.Fatalf("GetItemBySource(open, second sync) error: %v", err)
+	}
+	if openItem.Title != "Open bug renamed" {
+		t.Fatalf("open item title after resync = %q, want %q", openItem.Title, "Open bug renamed")
+	}
+	reopenedItem, err := app.store.GetItemBySource("github", "owner/tabula#13")
+	if err != nil {
+		t.Fatalf("GetItemBySource(reopened) error: %v", err)
+	}
+	if reopenedItem.ID != closedItem.ID {
+		t.Fatalf("reopened item ID = %d, want %d", reopenedItem.ID, closedItem.ID)
+	}
+	if reopenedItem.State != store.ItemStateInbox {
+		t.Fatalf("reopened item state = %q, want %q", reopenedItem.State, store.ItemStateInbox)
+	}
+	inboxItems, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(inboxItems) != 2 {
+		t.Fatalf("ListItemsByState(inbox) len = %d, want 2", len(inboxItems))
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("gh call count = %d, want 2", len(calls))
+	}
+	for i, args := range calls {
+		if callCWDs[i] != repoDir {
+			t.Fatalf("gh cwd[%d] = %q, want %q", i, callCWDs[i], repoDir)
+		}
+		command := strings.Join(args, " ")
+		if !strings.Contains(command, "issue list --state all --limit 500") {
+			t.Fatalf("gh args[%d] = %q, want issue list all", i, command)
+		}
+		if !strings.Contains(command, "--json number,title,url,state,labels,assignees") {
+			t.Fatalf("gh args[%d] = %q, want expected json fields", i, command)
+		}
+	}
+}
+
+func TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "workspace")
+	if err := exec.Command("git", "init", workspaceDir).Run(); err != nil {
+		t.Fatalf("git init %s: %v", workspaceDir, err)
+	}
+	workspace, err := app.store.CreateWorkspace("Repo", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("sync without remote status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func initGitHubWorkspaceRepo(t *testing.T, dirPath, remoteURL string) {
+	t.Helper()
+	if err := exec.Command("git", "init", dirPath).Run(); err != nil {
+		t.Fatalf("git init %s: %v", dirPath, err)
+	}
+	if err := exec.Command("git", "-C", dirPath, "remote", "add", "origin", remoteURL).Run(); err != nil {
+		t.Fatalf("git remote add origin %s: %v", dirPath, err)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -376,6 +376,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/projects/{project_id}/references", a.handleProjectCompanionReferences)
 	r.Post("/api/ink/submit", a.handleInkSubmit)
 	r.Post("/api/review/submit", a.handleReviewSubmit)
+	r.Post("/api/items/sync/github", a.handleGitHubIssueSync)
 	r.Put("/api/items/{item_id}/assign", a.handleItemAssign)
 	r.Put("/api/items/{item_id}/unassign", a.handleItemUnassign)
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)


### PR DESCRIPTION
## Summary
- add `POST /api/items/sync/github` for on-demand GitHub issue sync by workspace
- upsert source-backed items and GitHub issue artifacts without creating duplicates on re-sync
- derive the workspace repo from `git remote`, mark closed issues done, and reopen done items when the GitHub issue reopens

## Verification
- Open GitHub issues appear as inbox items: `go test ./internal/store ./internal/web 2>&1 | tee /tmp/test.log`
  Covered by `TestGitHubIssueSyncAPI`, which syncs issue `#12` and asserts `owner/tabula#12` is stored in `inbox`.
- Closed GitHub issues move items to done: same command.
  Covered by `TestGitHubIssueSyncAPI`, which syncs issue `#13` as `CLOSED` and asserts the linked item is `done`.
- Items link to a GitHub issue artifact with URL and metadata: same command.
  Covered by `TestGitHubIssueSyncAPI`, which asserts artifact kind `github_issue`, URL `https://github.com/owner/tabula/issues/12`, and `owner_repo/state` metadata.
- Sync is on-demand and not polling: same command.
  Verified by the new `POST /api/items/sync/github` route and `handleGitHubIssueSync` path exercised in `TestGitHubIssueSyncAPI`.
- No duplicates on re-sync: same command.
  Covered by `TestGitHubIssueSyncAPI`, which runs the sync twice, verifies the reopened item keeps the same ID, and checks the inbox contains exactly two items after re-sync.
- Workspace repo resolves from git remote: same command.
  Covered by `TestGitHubRepoForWorkspace`, which verifies `https://github.com/owner/tabula.git` resolves to `owner/tabula` and that a workspace without a remote returns empty.
- Full test coverage for store, integration, and edge cases: same command.
  `internal/store`: `TestSourceItemUpsertAndSyncState`, `TestGitHubRepoForWorkspace`
  `internal/web`: `TestGitHubIssueSyncAPI`, `TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote`
- Command output excerpt: `ok   github.com/krystophny/tabura/internal/store` and `ok   github.com/krystophny/tabura/internal/web`.
