### PR TITLE
fix: Add dialogue command to create GitHub issue from Item (fixes #187)

### DIFF
--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -1071,6 +1071,40 @@ func TestSourceItemUpsertAndSyncState(t *testing.T) {
 	}
 }
 
+func TestUpdateItemSource(t *testing.T) {
+	s := newTestStore(t)
+
+	item, err := s.CreateItem("Promote me", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	if err := s.UpdateItemSource(item.ID, "github", "owner/tabula#77"); err != nil {
+		t.Fatalf("UpdateItemSource() error: %v", err)
+	}
+
+	updated, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if updated.Source == nil || *updated.Source != "github" {
+		t.Fatalf("updated.Source = %v, want github", updated.Source)
+	}
+	if updated.SourceRef == nil || *updated.SourceRef != "owner/tabula#77" {
+		t.Fatalf("updated.SourceRef = %v, want owner/tabula#77", updated.SourceRef)
+	}
+
+	other, err := s.CreateItem("Other item", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(other) error: %v", err)
+	}
+	if err := s.UpdateItemSource(other.ID, "github", "owner/tabula#77"); err == nil {
+		t.Fatal("expected duplicate source/source_ref error")
+	}
+	if err := s.UpdateItemSource(9999, "github", "owner/tabula#88"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("UpdateItemSource(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
 func TestInferWorkspaceForArtifact(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -868,6 +868,40 @@ func (s *Store) UpdateItemArtifact(id int64, artifactID *int64) error {
 	return nil
 }
 
+func (s *Store) UpdateItemSource(id int64, source, sourceRef string) error {
+	cleanSource := strings.TrimSpace(source)
+	cleanSourceRef := strings.TrimSpace(sourceRef)
+	if cleanSource == "" || cleanSourceRef == "" {
+		return errors.New("item source and source_ref are required")
+	}
+	existing, err := s.GetItemBySource(cleanSource, cleanSourceRef)
+	switch {
+	case err == nil && existing.ID != id:
+		return fmt.Errorf("item source %s:%s is already linked to item %d", cleanSource, cleanSourceRef, existing.ID)
+	case err != nil && !errors.Is(err, sql.ErrNoRows):
+		return err
+	}
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET source = ?, source_ref = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		cleanSource,
+		cleanSourceRef,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 func (s *Store) SyncItemStateBySource(source, sourceRef, state string) error {
 	cleanSource := strings.TrimSpace(source)
 	cleanSourceRef := strings.TrimSpace(sourceRef)

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,13 +36,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, chat.
+Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, create_github_issue, create_github_issue_split, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization requests use make_item, delegate_item, snooze_item, or split_items.
+For item materialization requests use make_item, delegate_item, snooze_item, split_items, create_github_issue, or create_github_issue_split.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -323,7 +323,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items":
+	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -765,6 +765,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		}
 		return message, payloads, true
 	}
+	if inlineGitHubActions := parseInlineGitHubIssueActions(trimmedText); len(inlineGitHubActions) > 0 {
+		enforced := enforceRoutingPolicy(trimmedText, inlineGitHubActions)
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return githubIssueActionFailurePrefix(enforced) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
 
 	if strings.TrimSpace(a.intentLLMURL) != "" {
 		llmActions, llmErr := a.classifyIntentPlanWithLLM(ctx, trimmedText)
@@ -793,6 +804,9 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 				}
 				message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 				if err != nil {
+					if strings.HasPrefix(normalized.Action, "create_github_issue") {
+						return githubIssueActionFailurePrefix(enforced) + err.Error(), nil, true
+					}
 					return itemActionFailurePrefix(normalized.Action) + err.Error(), nil, true
 				}
 				return message, payloads, true
@@ -1347,6 +1361,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return status, nil, nil
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
+	case "create_github_issue", "create_github_issue_split":
+		return a.createGitHubIssueFromConversation(sessionID, session, action)
 	case "shell":
 		targetProject, err := a.systemActionTargetProject(session)
 		if err != nil {

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -29,6 +29,7 @@ type conversationCanvasArtifact struct {
 type conversationItemContext struct {
 	Title         string
 	AssistantText string
+	BodyText      string
 	WorkspaceID   *int64
 	ArtifactID    *int64
 }
@@ -158,7 +159,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
 		return true
 	default:
 		return false
@@ -166,6 +167,10 @@ func isItemSystemAction(action string) bool {
 }
 
 func itemActionFailurePrefix(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "create_github_issue", "create_github_issue_split":
+		return "I couldn't create the GitHub issue: "
+	}
 	if strings.EqualFold(strings.TrimSpace(action), "split_items") {
 		return "I couldn't create the items: "
 	}
@@ -482,6 +487,10 @@ func (a *App) buildConversationItemContext(sessionID string, project store.Proje
 	if title == "" {
 		return conversationItemContext{}, errors.New("no recent assistant output to turn into an item")
 	}
+	bodyText := assistantText
+	if canvas != nil && strings.TrimSpace(canvas.Text) != "" {
+		bodyText = cleanConversationItemText(canvas.Text)
+	}
 	artifact, err := a.createConversationArtifact(project, title, assistantText, canvas)
 	if err != nil {
 		return conversationItemContext{}, err
@@ -493,6 +502,7 @@ func (a *App) buildConversationItemContext(sessionID string, project store.Proje
 	ctx := conversationItemContext{
 		Title:         title,
 		AssistantText: assistantText,
+		BodyText:      bodyText,
 		WorkspaceID:   workspaceID,
 	}
 	if artifact != nil {
@@ -608,8 +618,8 @@ func (a *App) createConversationItem(sessionID string, session store.ChatSession
 		}, nil
 	case "split_items":
 		count := systemActionSplitCount(action.Params)
-		if count <= 0 {
-			return "", nil, errors.New("split item count is required")
+		if count < 0 {
+			return "", nil, errors.New("split item count must be positive")
 		}
 		titles, err := deriveSplitItemTitles(ctx.AssistantText, count)
 		if err != nil {

--- a/internal/web/chat_items_github.go
+++ b/internal/web/chat_items_github.go
@@ -1,0 +1,459 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+var (
+	githubIssueURLNumberPattern = regexp.MustCompile(`/issues/([0-9]+)`)
+)
+
+func parseInlineGitHubIssueActions(text string) []*SystemAction {
+	normalized := normalizeItemCommandText(text)
+	if normalized == "" {
+		return nil
+	}
+	params := parseGitHubIssueCommandParams(text)
+	if isSplitGitHubIssueCommand(normalized) {
+		return []*SystemAction{
+			{Action: "split_items", Params: map[string]interface{}{"count": 0}},
+			{Action: "create_github_issue", Params: params},
+		}
+	}
+	if !isCreateGitHubIssueCommand(normalized) {
+		return nil
+	}
+	return []*SystemAction{{Action: "create_github_issue", Params: params}}
+}
+
+func isSplitGitHubIssueCommand(normalized string) bool {
+	if !strings.HasPrefix(normalized, "split ") {
+		return false
+	}
+	return strings.Contains(normalized, "local item") && strings.Contains(normalized, "github issue")
+}
+
+func isCreateGitHubIssueCommand(normalized string) bool {
+	switch {
+	case strings.HasPrefix(normalized, "file this as an issue"),
+		strings.HasPrefix(normalized, "file it as an issue"),
+		strings.HasPrefix(normalized, "file this as a github issue"),
+		strings.HasPrefix(normalized, "file it as a github issue"):
+		return true
+	}
+	if strings.Contains(normalized, "github issue") || strings.Contains(normalized, " as an issue") {
+		for _, prefix := range []string{"create ", "open ", "file "} {
+			if strings.HasPrefix(normalized, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func parseGitHubIssueCommandParams(text string) map[string]interface{} {
+	params := map[string]interface{}{}
+	if labels := extractGitHubLabels(text); len(labels) > 0 {
+		params["labels"] = labels
+	}
+	if assignees := extractGitHubAssignees(text); len(assignees) > 0 {
+		params["assignees"] = assignees
+	}
+	return params
+}
+
+func extractGitHubLabels(text string) []string {
+	segment := extractGitHubCommandSegment(text, []string{
+		" label it ",
+		" labels ",
+		" label ",
+		" with labels ",
+	})
+	return parseGitHubTokenList(segment, false)
+}
+
+func extractGitHubAssignees(text string) []string {
+	segment := extractGitHubCommandSegment(text, []string{
+		" assign it to ",
+		" assign to ",
+		" assignees ",
+		" assignee ",
+	})
+	return parseGitHubTokenList(segment, true)
+}
+
+func extractGitHubCommandSegment(text string, markers []string) string {
+	lower := " " + strings.ToLower(strings.TrimSpace(text)) + " "
+	raw := " " + strings.TrimSpace(text) + " "
+	start := -1
+	matchedMarker := ""
+	for _, marker := range markers {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			continue
+		}
+		if start == -1 || idx < start {
+			start = idx
+			matchedMarker = marker
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	segment := raw[start+len(matchedMarker):]
+	end := len(segment)
+	for _, marker := range []string{" assign it to ", " assign to ", " assignees ", " assignee ", " label it ", " labels ", " label ", " with labels "} {
+		if strings.EqualFold(marker, matchedMarker) {
+			continue
+		}
+		if idx := strings.Index(strings.ToLower(segment), marker); idx >= 0 && idx < end {
+			end = idx
+		}
+	}
+	return strings.TrimSpace(segment[:end])
+}
+
+func parseGitHubTokenList(raw string, stripAt bool) []string {
+	clean := strings.TrimSpace(raw)
+	clean = strings.Trim(clean, " \t\r\n.!?,:;")
+	if clean == "" {
+		return nil
+	}
+	for _, prefix := range []string{"with ", "as ", "it ", "them "} {
+		if strings.HasPrefix(strings.ToLower(clean), prefix) {
+			clean = strings.TrimSpace(clean[len(prefix):])
+		}
+	}
+	clean = strings.ReplaceAll(clean, " and ", ",")
+	parts := strings.Split(clean, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		token = strings.Trim(token, " \t\r\n.!?,:;")
+		token = strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(token, " and"), "and "))
+		if stripAt {
+			token = strings.TrimPrefix(token, "@")
+		}
+		if token == "" {
+			continue
+		}
+		key := strings.ToLower(token)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, token)
+	}
+	return out
+}
+
+func systemActionStringListParam(params map[string]interface{}, keys ...string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	appendTokens := func(tokens []string) {
+		for _, token := range tokens {
+			clean := strings.TrimSpace(token)
+			if clean == "" {
+				continue
+			}
+			key := strings.ToLower(clean)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, clean)
+		}
+	}
+	for _, key := range keys {
+		value, ok := params[key]
+		if !ok || value == nil {
+			continue
+		}
+		switch typed := value.(type) {
+		case []string:
+			appendTokens(typed)
+		case []interface{}:
+			tokens := make([]string, 0, len(typed))
+			for _, item := range typed {
+				if token := strings.TrimSpace(fmt.Sprint(item)); token != "" && token != "<nil>" {
+					tokens = append(tokens, token)
+				}
+			}
+			appendTokens(tokens)
+		case string:
+			appendTokens(parseGitHubTokenList(typed, false))
+		default:
+			token := strings.TrimSpace(fmt.Sprint(typed))
+			if token != "" && token != "<nil>" {
+				appendTokens(parseGitHubTokenList(token, false))
+			}
+		}
+	}
+	return out
+}
+
+func githubIssueActionFailurePrefix(actions []*SystemAction) string {
+	if len(actions) > 1 {
+		return "I couldn't complete the GitHub issue workflow: "
+	}
+	return "I couldn't create the GitHub issue: "
+}
+
+func conversationGitHubIssueBody(ctx conversationItemContext) string {
+	body := cleanConversationItemText(ctx.BodyText)
+	if body != "" {
+		return body
+	}
+	return strings.TrimSpace(ctx.Title)
+}
+
+func parseGitHubIssueNumberFromURL(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	for _, line := range strings.Split(trimmed, "\n") {
+		candidate := strings.TrimSpace(line)
+		if candidate == "" {
+			continue
+		}
+		match := githubIssueURLNumberPattern.FindStringSubmatch(candidate)
+		if len(match) != 2 {
+			continue
+		}
+		number, err := strconv.Atoi(match[1])
+		if err == nil && number > 0 {
+			return number, nil
+		}
+	}
+	return 0, fmt.Errorf("could not parse GitHub issue number from %q", trimmed)
+}
+
+func (a *App) createGitHubIssueInWorkspace(cwd, title, body string, labels, assignees []string) (ghIssueListItem, error) {
+	runner := a.ghCommandRunner
+	if runner == nil {
+		runner = runGitHubCLI
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), githubIssueListTimeout)
+	defer cancel()
+
+	cleanTitle := strings.TrimSpace(title)
+	if cleanTitle == "" {
+		return ghIssueListItem{}, errors.New("github issue title is required")
+	}
+	cleanBody := strings.TrimSpace(body)
+	if cleanBody == "" {
+		cleanBody = cleanTitle
+	}
+	args := []string{"issue", "create", "--title", cleanTitle, "--body", cleanBody}
+	for _, label := range labels {
+		if clean := strings.TrimSpace(label); clean != "" {
+			args = append(args, "--label", clean)
+		}
+	}
+	for _, assignee := range assignees {
+		if clean := strings.TrimSpace(strings.TrimPrefix(assignee, "@")); clean != "" {
+			args = append(args, "--assignee", clean)
+		}
+	}
+	createRaw, err := runner(ctx, cwd, args...)
+	if err != nil {
+		return ghIssueListItem{}, err
+	}
+	number, err := parseGitHubIssueNumberFromURL(createRaw)
+	if err != nil {
+		return ghIssueListItem{}, err
+	}
+	viewRaw, err := runner(
+		ctx,
+		cwd,
+		"issue", "view", strconv.Itoa(number),
+		"--json", "number,title,url,state,labels,assignees",
+	)
+	if err != nil {
+		return ghIssueListItem{}, err
+	}
+	var issue ghIssueListItem
+	if err := json.Unmarshal([]byte(viewRaw), &issue); err != nil {
+		return ghIssueListItem{}, fmt.Errorf("invalid github issue response: %w", err)
+	}
+	if issue.Number <= 0 {
+		return ghIssueListItem{}, errors.New("github issue number is required")
+	}
+	if strings.TrimSpace(issue.Title) == "" {
+		return ghIssueListItem{}, fmt.Errorf("github issue #%d title is required", issue.Number)
+	}
+	return issue, nil
+}
+
+func conversationItemCandidateScore(item store.Item, ctx conversationItemContext) int {
+	score := 0
+	if ctx.ArtifactID != nil && item.ArtifactID != nil && *ctx.ArtifactID == *item.ArtifactID {
+		score += 100
+	}
+	if strings.EqualFold(strings.TrimSpace(item.Title), strings.TrimSpace(ctx.Title)) {
+		score += 40
+	}
+	if ctx.WorkspaceID != nil && item.WorkspaceID != nil && *ctx.WorkspaceID == *item.WorkspaceID {
+		score += 20
+	}
+	if score == 0 {
+		return -1
+	}
+	return score
+}
+
+func linkedItemSourceDescription(item store.Item) string {
+	source := strings.TrimSpace(stringFromPointer(item.Source))
+	sourceRef := strings.TrimSpace(stringFromPointer(item.SourceRef))
+	switch {
+	case source != "" && sourceRef != "":
+		return source + " " + sourceRef
+	case sourceRef != "":
+		return sourceRef
+	default:
+		return source
+	}
+}
+
+func stringFromPointer(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func (a *App) findConversationPromotionItem(ctx conversationItemContext) (*store.Item, error) {
+	var best *store.Item
+	bestScore := -1
+	for _, state := range []string{
+		store.ItemStateInbox,
+		store.ItemStateWaiting,
+		store.ItemStateSomeday,
+		store.ItemStateDone,
+	} {
+		items, err := a.store.ListItemsByState(state)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			score := conversationItemCandidateScore(item, ctx)
+			if score < 0 {
+				continue
+			}
+			if best == nil || score > bestScore || (score == bestScore && item.ID > best.ID) {
+				candidate := item
+				best = &candidate
+				bestScore = score
+			}
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	if source := linkedItemSourceDescription(*best); source != "" {
+		return nil, fmt.Errorf("item is already linked to %s", source)
+	}
+	return best, nil
+}
+
+func (a *App) createGitHubIssueFromConversation(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	ctx, err := a.buildConversationItemContext(sessionID, targetProject)
+	if err != nil {
+		return "", nil, err
+	}
+	if ctx.WorkspaceID == nil {
+		return "", nil, errors.New("no workspace is linked to this conversation")
+	}
+	workspace, err := a.store.GetWorkspace(*ctx.WorkspaceID)
+	if err != nil {
+		return "", nil, err
+	}
+	repo, err := a.store.GitHubRepoForWorkspace(workspace.ID)
+	if err != nil {
+		return "", nil, err
+	}
+	if strings.TrimSpace(repo) == "" {
+		return "", nil, errors.New("workspace has no GitHub origin remote")
+	}
+
+	existingItem, err := a.findConversationPromotionItem(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	title := strings.TrimSpace(ctx.Title)
+	body := conversationGitHubIssueBody(ctx)
+	labels := systemActionStringListParam(action.Params, "labels", "label")
+	assignees := systemActionStringListParam(action.Params, "assignees", "assignee")
+	for i, assignee := range assignees {
+		assignees[i] = strings.TrimSpace(strings.TrimPrefix(assignee, "@"))
+	}
+
+	issue, err := a.createGitHubIssueInWorkspace(workspace.DirPath, title, body, labels, assignees)
+	if err != nil {
+		return "", nil, err
+	}
+
+	source := "github"
+	sourceRef := githubIssueSourceRef(repo, issue.Number)
+	var item store.Item
+	if existingItem == nil {
+		opts := store.ItemOptions{
+			WorkspaceID: &workspace.ID,
+			ArtifactID:  ctx.ArtifactID,
+			Source:      &source,
+			SourceRef:   &sourceRef,
+		}
+		item, err = a.store.CreateItem(title, opts)
+		if err != nil {
+			return "", nil, err
+		}
+	} else {
+		item = *existingItem
+		if item.ArtifactID == nil && ctx.ArtifactID != nil {
+			if err := a.store.UpdateItemArtifact(item.ID, ctx.ArtifactID); err != nil {
+				return "", nil, err
+			}
+			item.ArtifactID = ctx.ArtifactID
+		}
+		if err := a.store.UpdateItemSource(item.ID, source, sourceRef); err != nil {
+			return "", nil, err
+		}
+	}
+	if err := a.syncGitHubIssueArtifact(item, repo, issue); err != nil {
+		return "", nil, err
+	}
+	updated, err := a.store.GetItem(item.ID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	payload := map[string]interface{}{
+		"type":       "github_issue_created",
+		"item_id":    updated.ID,
+		"issue_no":   issue.Number,
+		"issue_url":  strings.TrimSpace(issue.URL),
+		"source":     source,
+		"source_ref": sourceRef,
+		"state":      updated.State,
+		"title":      updated.Title,
+	}
+	if len(labels) > 0 {
+		payload["labels"] = labels
+	}
+	if len(assignees) > 0 {
+		payload["assignees"] = assignees
+	}
+	return fmt.Sprintf("Created GitHub issue #%d: %s", issue.Number, strings.TrimSpace(issue.URL)), payload, nil
+}

--- a/internal/web/chat_items_github_test.go
+++ b/internal/web/chat_items_github_test.go
@@ -1,0 +1,333 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineGitHubIssueActions(t *testing.T) {
+	t.Run("create issue with labels and assignees", func(t *testing.T) {
+		actions := parseInlineGitHubIssueActions("Create a GitHub issue from this and label it bug, parser and assign it to @octocat and hubot.")
+		if len(actions) != 1 {
+			t.Fatalf("action count = %d, want 1", len(actions))
+		}
+		if actions[0].Action != "create_github_issue" {
+			t.Fatalf("action = %q, want create_github_issue", actions[0].Action)
+		}
+		if got := systemActionStringListParam(actions[0].Params, "labels"); strings.Join(got, ",") != "bug,parser" {
+			t.Fatalf("labels = %v, want [bug parser]", got)
+		}
+		if got := systemActionStringListParam(actions[0].Params, "assignees"); strings.Join(got, ",") != "octocat,hubot" {
+			t.Fatalf("assignees = %v, want [octocat hubot]", got)
+		}
+	})
+
+	t.Run("split into local items and github issue", func(t *testing.T) {
+		actions := parseInlineGitHubIssueActions("Split this into local items and a GitHub issue.")
+		if len(actions) != 2 {
+			t.Fatalf("action count = %d, want 2", len(actions))
+		}
+		if actions[0].Action != "split_items" {
+			t.Fatalf("first action = %q, want split_items", actions[0].Action)
+		}
+		if got := systemActionSplitCount(actions[0].Params); got != 0 {
+			t.Fatalf("split count = %d, want 0", got)
+		}
+		if actions[1].Action != "create_github_issue" {
+			t.Fatalf("second action = %q, want create_github_issue", actions[1].Action)
+		}
+	})
+}
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	initGitHubWorkspaceRepo(t, project.RootPath, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Parser panic when config file is missing\n\n1. Reproduce with an empty config.\n2. Observe the nil pointer panic."
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	_, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "make this an item")
+	if !handled {
+		t.Fatal("expected local item creation to be handled")
+	}
+	item := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+
+	var calls [][]string
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		calls = append(calls, append([]string{cwd}, args...))
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/owner/tabula/issues/77\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":77,"title":"Parser panic when config file is missing","url":"https://github.com/owner/tabula/issues/77","state":"OPEN","labels":[{"name":"bug"},{"name":"parser"}],"assignees":[{"login":"octocat"}]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "Create a GitHub issue from this and label it bug, parser and assign it to @octocat.")
+	if !handled {
+		t.Fatal("expected GitHub issue action to be handled")
+	}
+	if message != "Created GitHub issue #77: https://github.com/owner/tabula/issues/77" {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "github_issue_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strings.TrimSpace(strFromAny(payloads[0]["source_ref"])); got != "owner/tabula#77" {
+		t.Fatalf("source_ref payload = %q, want owner/tabula#77", got)
+	}
+
+	updated, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if updated.Source == nil || *updated.Source != "github" {
+		t.Fatalf("updated.Source = %v, want github", updated.Source)
+	}
+	if updated.SourceRef == nil || *updated.SourceRef != "owner/tabula#77" {
+		t.Fatalf("updated.SourceRef = %v, want owner/tabula#77", updated.SourceRef)
+	}
+	if updated.ArtifactID == nil {
+		t.Fatal("expected linked artifact")
+	}
+	artifact, err := app.store.GetArtifact(*updated.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindGitHubIssue {
+		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindGitHubIssue)
+	}
+	if artifact.RefURL == nil || *artifact.RefURL != "https://github.com/owner/tabula/issues/77" {
+		t.Fatalf("artifact.RefURL = %v, want issue URL", artifact.RefURL)
+	}
+	if artifact.MetaJSON == nil {
+		t.Fatal("expected artifact meta_json")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(*artifact.MetaJSON), &meta); err != nil {
+		t.Fatalf("unmarshal meta_json: %v", err)
+	}
+	if meta["owner_repo"] != "owner/tabula" {
+		t.Fatalf("owner_repo = %v, want owner/tabula", meta["owner_repo"])
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("gh call count = %d, want 2", len(calls))
+	}
+	createCall := strings.Join(calls[0][1:], " ")
+	if calls[0][0] != project.RootPath {
+		t.Fatalf("gh create cwd = %q, want %q", calls[0][0], project.RootPath)
+	}
+	for _, needle := range []string{
+		"issue create",
+		"--title Parser panic when config file is missing",
+		"--label bug",
+		"--label parser",
+		"--assignee octocat",
+	} {
+		if !strings.Contains(createCall, needle) {
+			t.Fatalf("create call = %q, missing %q", createCall, needle)
+		}
+	}
+	if !strings.Contains(createCall, "Reproduce with an empty config.") {
+		t.Fatalf("create call body = %q, want assistant text", createCall)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssueCreatesLinkedItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	initGitHubWorkspaceRepo(t, project.RootPath, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Document the workspace reassignment flow"
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/owner/tabula/issues/91\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":91,"title":"Document the workspace reassignment flow","url":"https://github.com/owner/tabula/issues/91","state":"OPEN","labels":[],"assignees":[]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "file this as an issue")
+	if !handled {
+		t.Fatal("expected GitHub issue creation to be handled")
+	}
+	if message != "Created GitHub issue #91: https://github.com/owner/tabula/issues/91" {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "github_issue_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.Source == nil || *item.Source != "github" {
+		t.Fatalf("item.Source = %v, want github", item.Source)
+	}
+	if item.SourceRef == nil || *item.SourceRef != "owner/tabula#91" {
+		t.Fatalf("item.SourceRef = %v, want owner/tabula#91", item.SourceRef)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssueRejectsMissingWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Follow up on the MCP control plane"
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create a GitHub issue from this")
+	if !handled {
+		t.Fatal("expected missing-workspace command to be handled")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != "I couldn't create the GitHub issue: no workspace is linked to this conversation" {
+		t.Fatalf("message = %q", message)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssueRejectsMissingRemote(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Write down the iPhone HTTPS capture steps"
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create a GitHub issue from this")
+	if !handled {
+		t.Fatal("expected missing-remote command to be handled")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != "I couldn't create the GitHub issue: workspace has no GitHub origin remote" {
+		t.Fatalf("message = %q", message)
+	}
+	items, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("inbox item count = %d, want 0", len(items))
+	}
+	if workspace.ID == 0 {
+		t.Fatal("expected workspace ID")
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssueSurfacesCreateFailure(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	initGitHubWorkspaceRepo(t, project.RootPath, "https://github.com/owner/tabula.git")
+	if _, err := app.store.CreateWorkspace("Default", project.RootPath); err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Ship the local intent classifier defaults"
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "", errors.New("gh issue create failed: permission denied")
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create a GitHub issue from this")
+	if !handled {
+		t.Fatal("expected create failure to be handled")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != "I couldn't create the GitHub issue: gh issue create failed: permission denied" {
+		t.Fatalf("message = %q", message)
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated chat-item GitHub issue promotion flow that parses direct dialogue commands, creates the issue through `gh`, and links or creates the local item with `source/source_ref`
- update linked artifacts to `github_issue` metadata and add store support for safely promoting an existing item to an external source without duplicating `source_ref`
- cover the new flow with focused store and web tests for success, labels/assignees, missing workspace, missing remote, and `gh` failure paths

## Verification
- Requirement: `"create a GitHub issue" creates GH issue and links item`
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem` and `TestClassifyAndExecuteSystemActionCreateGitHubIssueCreatesLinkedItem` in `internal/web/chat_items_github_test.go`
  Evidence: both assert `type=github_issue_created`, item `source=github`, and `source_ref=owner/tabula#<n>`
- Requirement: repo resolved from workspace git remote
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem` initializes `https://github.com/owner/tabula.git`, then asserts the mocked `gh` calls run in that workspace root and store `owner/tabula#77`
- Requirement: item updated with `source/source_ref`
  Evidence: `TestUpdateItemSource` in `internal/store/domain_test.go`
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem` verifies the pre-existing local item is updated in place
- Requirement: labels/assignees via dialogue
  Evidence: `TestParseInlineGitHubIssueActions` verifies `label it bug, parser` and `assign it to @octocat and hubot` parsing
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem` asserts `gh issue create` receives `--label bug --label parser --assignee octocat`
- Requirement: confirmation with issue number and URL
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssuePromotesExistingItem` and `...CreatesLinkedItem` assert `Created GitHub issue #77: https://github.com/owner/tabula/issues/77` and `#91: https://github.com/owner/tabula/issues/91`
- Requirement: edge cases for missing workspace, missing git remote, and creation failure
  Evidence: `TestClassifyAndExecuteSystemActionCreateGitHubIssueRejectsMissingWorkspace`, `...RejectsMissingRemote`, and `...SurfacesCreateFailure`
- Command
  Evidence: `go test ./internal/store ./internal/web -run 'Test(UpdateItemSource|ParseInlineGitHubIssueActions|ClassifyAndExecuteSystemActionCreateGitHubIssue.*|ClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext|ClassifyAndExecuteSystemActionSplitItemsCreatesMultipleItems)' 2>&1 | tee /tmp/issue187-go-test.log`
  Output excerpt:
  `ok   github.com/krystophny/tabura/internal/store`
  `ok   github.com/krystophny/tabura/internal/web`
