### PR TITLE
fix: Define audio retention policy for captured voice memos (fixes #225)

### DIFF
--- a/docs/meeting-notes-privacy.md
+++ b/docs/meeting-notes-privacy.md
@@ -2,9 +2,16 @@
 
 > **Legal notice:** Tabura is provided "as is" and "as available" without warranties, and to the maximum extent permitted by applicable law the authors/contributors accept no liability for damages, data loss, or misuse. You are solely responsible for backups, verification, and safe operation. See [`DISCLAIMER.md`](/DISCLAIMER.md).
 
-This document formalizes the audio privacy guarantees for Tabura's speech-to-text pipeline.
+This document formalizes the audio privacy guarantees for Tabura's speech-to-text pipeline, including meeting capture, tap-to-talk transcription, and capture-mode voice memos.
 
 **Key invariant: audio exists only in RAM during processing and is never persisted to disk or database.**
+
+## Capture Retention Policy
+
+- Captured voice memos follow the same RAM-only policy as meeting capture.
+- Uploaded audio is normalized and transcribed in memory, then discarded immediately.
+- Only transcript text may persist as an artifact or chat message. The original recording must not be stored for replay.
+- Oversized or invalid uploads must be rejected without creating multipart temp files on disk.
 
 ## Meeting Consent Boundary
 

--- a/internal/web/chat_stt_http.go
+++ b/internal/web/chat_stt_http.go
@@ -5,10 +5,24 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"strings"
 
 	"github.com/krystophny/tabura/internal/stt"
+)
+
+const (
+	sttMultipartOverheadBytes = 1 * 1024 * 1024
+	sttMultipartFieldLimit    = 4 * 1024
+)
+
+var (
+	errInvalidMultipartPayload = errors.New("invalid multipart payload")
+	errMissingAudioFile        = errors.New("missing audio file")
+	errDuplicateAudioFile      = errors.New("multiple audio files are not supported")
+	errAudioPayloadTooLarge    = errors.New("audio payload exceeds max size")
 )
 
 func (a *App) handleSTTTranscribe(w http.ResponseWriter, r *http.Request) {
@@ -19,35 +33,24 @@ func (a *App) handleSTTTranscribe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "stt sidecar is not configured", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseMultipartForm(stt.MaxAudioBytes + (1 * 1024 * 1024)); err != nil {
-		http.Error(w, "invalid multipart payload", http.StatusBadRequest)
-		return
-	}
-	file, header, err := r.FormFile("file")
+	data, mimeType, err := readSTTMultipartAudio(w, r)
 	if err != nil {
-		http.Error(w, "missing audio file", http.StatusBadRequest)
+		switch {
+		case errors.Is(err, errAudioPayloadTooLarge):
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		case errors.Is(err, errMissingAudioFile), errors.Is(err, errDuplicateAudioFile), errors.Is(err, errInvalidMultipartPayload):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, "failed to read audio payload", http.StatusBadRequest)
+		}
 		return
 	}
-	defer file.Close()
-
-	data, err := io.ReadAll(io.LimitReader(file, stt.MaxAudioBytes+1))
-	if err != nil {
-		http.Error(w, "failed to read audio payload", http.StatusBadRequest)
-		return
-	}
-	if len(data) > stt.MaxAudioBytes {
-		http.Error(w, "audio payload exceeds max size", http.StatusRequestEntityTooLarge)
-		return
-	}
+	defer zeroBytes(data)
 	if len(data) < 1024 {
 		writeJSON(w, map[string]string{"text": "", "reason": "recording_too_short"})
 		return
 	}
 
-	mimeType := strings.TrimSpace(r.FormValue("mime_type"))
-	if mimeType == "" && header != nil {
-		mimeType = strings.TrimSpace(header.Header.Get("Content-Type"))
-	}
 	mimeType = stt.NormalizeMimeType(mimeType)
 	if !stt.IsAllowedMimeType(mimeType) {
 		http.Error(w, "mime_type must be audio/* or application/octet-stream", http.StatusBadRequest)
@@ -58,6 +61,7 @@ func (a *App) handleSTTTranscribe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("audio normalization failed: %v", normalizeErr), http.StatusBadRequest)
 		return
 	}
+	defer zeroBytes(normalizedData)
 
 	replacements := a.loadSTTReplacements()
 	options := a.sttTranscribeOptions()
@@ -82,4 +86,89 @@ func (a *App) handleSTTTranscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]string{"text": trimmed})
+}
+
+func readSTTMultipartAudio(w http.ResponseWriter, r *http.Request) ([]byte, string, error) {
+	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "multipart/form-data" {
+		return nil, "", errInvalidMultipartPayload
+	}
+	boundary := strings.TrimSpace(params["boundary"])
+	if boundary == "" {
+		return nil, "", errInvalidMultipartPayload
+	}
+
+	limitedBody := http.MaxBytesReader(w, r.Body, stt.MaxAudioBytes+sttMultipartOverheadBytes)
+	defer limitedBody.Close()
+
+	reader := multipart.NewReader(limitedBody, boundary)
+	var (
+		audioData []byte
+		mimeType  string
+	)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if isBodyTooLarge(err) {
+				return nil, "", errAudioPayloadTooLarge
+			}
+			return nil, "", errInvalidMultipartPayload
+		}
+
+		name := strings.TrimSpace(part.FormName())
+		switch name {
+		case "file":
+			if audioData != nil {
+				return nil, "", errDuplicateAudioFile
+			}
+			audioData, err = io.ReadAll(io.LimitReader(part, stt.MaxAudioBytes+1))
+			if err != nil {
+				if isBodyTooLarge(err) {
+					return nil, "", errAudioPayloadTooLarge
+				}
+				return nil, "", errInvalidMultipartPayload
+			}
+			if len(audioData) > stt.MaxAudioBytes {
+				return nil, "", errAudioPayloadTooLarge
+			}
+			if mimeType == "" {
+				mimeType = strings.TrimSpace(part.Header.Get("Content-Type"))
+			}
+		case "mime_type":
+			value, err := io.ReadAll(io.LimitReader(part, sttMultipartFieldLimit))
+			if err != nil {
+				if isBodyTooLarge(err) {
+					return nil, "", errAudioPayloadTooLarge
+				}
+				return nil, "", errInvalidMultipartPayload
+			}
+			mimeType = strings.TrimSpace(string(value))
+		default:
+			if _, err := io.Copy(io.Discard, part); err != nil {
+				if isBodyTooLarge(err) {
+					return nil, "", errAudioPayloadTooLarge
+				}
+				return nil, "", errInvalidMultipartPayload
+			}
+		}
+	}
+	if audioData == nil {
+		return nil, "", errMissingAudioFile
+	}
+	return audioData, mimeType, nil
+}
+
+func isBodyTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
+
+func zeroBytes(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
 }

--- a/internal/web/server_security_test.go
+++ b/internal/web/server_security_test.go
@@ -1,9 +1,15 @@
 package web
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"math"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -223,6 +229,79 @@ func TestPrivacySTTResultContainsOnlyText(t *testing.T) {
 	}
 }
 
+func TestPrivacySTTHTTPCaptureRejectsOversizedUploadWithoutTempFiles(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.sttURL = "http://127.0.0.1:1"
+
+	scopedTmp := t.TempDir()
+	t.Setenv("TMPDIR", scopedTmp)
+
+	before, err := listScopedEntries(scopedTmp)
+	if err != nil {
+		t.Fatalf("list temp dir before: %v", err)
+	}
+
+	tooLarge := bytes.Repeat([]byte("a"), stt.MaxAudioBytes+(2*1024*1024))
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.webm", "audio/webm", tooLarge)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want %d: %s", rr.Code, http.StatusRequestEntityTooLarge, rr.Body.String())
+	}
+
+	after, err := listScopedEntries(scopedTmp)
+	if err != nil {
+		t.Fatalf("list temp dir after: %v", err)
+	}
+	for _, path := range diffScopedEntries(before, after) {
+		t.Errorf("oversized upload created unexpected temp file: %s", path)
+	}
+}
+
+func TestPrivacySTTHTTPCaptureReturnsOnlyTextWithoutTempFiles(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"text": "  captured idea  "}); err != nil {
+			t.Fatalf("encode stt response: %v", err)
+		}
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	scopedTmp := t.TempDir()
+	t.Setenv("TMPDIR", scopedTmp)
+
+	before, err := listScopedEntries(scopedTmp)
+	if err != nil {
+		t.Fatalf("list temp dir before: %v", err)
+	}
+
+	audio := buildSpeechLikeWAV(16000, 240, 0.75)
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.wav", "audio/wav", audio)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode STT response: %v", err)
+	}
+	if len(payload) != 1 {
+		t.Fatalf("STT response fields = %v, want only text", payload)
+	}
+	if payload["text"] != "captured idea" {
+		t.Fatalf("STT response text = %q, want %q", payload["text"], "captured idea")
+	}
+
+	after, err := listScopedEntries(scopedTmp)
+	if err != nil {
+		t.Fatalf("list temp dir after: %v", err)
+	}
+	for _, path := range diffScopedEntries(before, after) {
+		t.Errorf("capture upload created unexpected temp file: %s", path)
+	}
+}
+
 func TestPrivacyNoChatMessageAudioContent(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -254,4 +333,96 @@ func TestPrivacyNoChatMessageAudioContent(t *testing.T) {
 			}
 		}
 	}
+}
+
+func doAuthedMultipartAudioRequest(t *testing.T, handler http.Handler, path, filename, mimeType string, audio []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(audio); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	if err := writer.WriteField("mime_type", mimeType); err != nil {
+		t.Fatalf("WriteField(mime_type): %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.AddCookie(&http.Cookie{Name: SessionCookie, Value: testAuthToken})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func buildSpeechLikeWAV(sampleRate, durationMS int, amplitude float64) []byte {
+	if sampleRate <= 0 {
+		sampleRate = 16000
+	}
+	if durationMS <= 0 {
+		durationMS = 240
+	}
+	if amplitude <= 0 {
+		amplitude = 0.75
+	}
+	if amplitude > 1 {
+		amplitude = 1
+	}
+
+	totalSamples := sampleRate * durationMS / 1000
+	dataSize := totalSamples * 2
+	out := make([]byte, 44+dataSize)
+
+	copy(out[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(out[4:8], uint32(36+dataSize))
+	copy(out[8:12], "WAVE")
+	copy(out[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(out[16:20], 16)
+	binary.LittleEndian.PutUint16(out[20:22], 1)
+	binary.LittleEndian.PutUint16(out[22:24], 1)
+	binary.LittleEndian.PutUint32(out[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(out[28:32], uint32(sampleRate*2))
+	binary.LittleEndian.PutUint16(out[32:34], 2)
+	binary.LittleEndian.PutUint16(out[34:36], 16)
+	copy(out[36:40], "data")
+	binary.LittleEndian.PutUint32(out[40:44], uint32(dataSize))
+
+	pos := 44
+	for i := 0; i < totalSamples; i++ {
+		t := float64(i) / float64(sampleRate)
+		sample := int16(amplitude * 32767.0 * math.Sin(2*math.Pi*220*t))
+		binary.LittleEndian.PutUint16(out[pos:pos+2], uint16(sample))
+		pos += 2
+	}
+	return out
+}
+
+func listScopedEntries(dir string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		out[filepath.Join(dir, entry.Name())] = struct{}{}
+	}
+	return out, nil
+}
+
+func diffScopedEntries(before, after map[string]struct{}) []string {
+	var added []string
+	for path := range after {
+		if _, ok := before[path]; !ok {
+			added = append(added, path)
+		}
+	}
+	return added
 }


### PR DESCRIPTION
## Summary
- switch `/api/stt/transcribe` from `ParseMultipartForm` to streaming multipart parsing so capture uploads stay RAM-only and oversized payloads are rejected without temp-file spill
- zero HTTP STT audio buffers after use and keep the HTTP response surface text-only
- document the capture memo retention decision and add HTTP privacy regression coverage

## Verification
- Requirement: audio retention policy explicitly decided and documented.
  Evidence: `docs/meeting-notes-privacy.md:5` and `docs/meeting-notes-privacy.md:9` now state that capture-mode voice memos follow the RAM-only policy and that oversized or invalid uploads must not create temp files.
- Requirement: implementation matches the documented RAM-only policy.
  Evidence: `internal/web/chat_stt_http.go:36` routes uploads through `readSTTMultipartAudio`; `internal/web/chat_stt_http.go:102` enforces an in-memory body limit with `http.MaxBytesReader`; `internal/web/chat_stt_http.go:128` rejects oversized file parts before persistence; `internal/web/chat_stt_http.go:48` and `internal/web/chat_stt_http.go:64` zero the request and normalized audio buffers after use.
- Requirement: capture uploads do not create temp files and the HTTP surface persists only transcript text.
  Evidence: `TestPrivacySTTHTTPCaptureRejectsOversizedUploadWithoutTempFiles` at `internal/web/server_security_test.go:232` and `TestPrivacySTTHTTPCaptureReturnsOnlyTextWithoutTempFiles` at `internal/web/server_security_test.go:259` cover oversized rejection, no temp files, and text-only response behavior.
- Requirement: existing privacy tests still pass.
  Evidence: `go test ./internal/web ./internal/stt 2>&1 | tee /tmp/tabura-issue-225-test.log` produced `ok   github.com/krystophny/tabura/internal/web 3.989s` and `ok   github.com/krystophny/tabura/internal/stt 0.057s`.
