### PR TITLE
fix: Add dedicated /capture route with mobile-first intake UI (fixes #223)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -18,6 +18,11 @@ Routes in `internal/serve/app.go`:
 
 ## Web Runtime HTTP APIs
 
+Public pages:
+- `GET /`
+- `GET /canvas`
+- `GET /capture`
+
 Auth and setup:
 - `GET /api/setup`
 - `POST /api/setup`

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -91,6 +91,14 @@ var MCPDaemonRoutes = []string{
 
 var WebRouteSections = []RouteSection{
 	{
+		Title: "Public pages",
+		Routes: []string{
+			"GET /",
+			"GET /canvas",
+			"GET /capture",
+		},
+	},
+	{
 		Title: "Auth and setup",
 		Routes: []string{
 			"GET /api/setup",

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -432,6 +432,7 @@ func (a *App) Router() http.Handler {
 	// static
 	r.Get("/", a.serveIndex)
 	r.Get("/canvas", a.serveCanvas)
+	r.Get("/capture", a.serveCapture)
 	if a.devRuntime {
 		diskDir := filepath.Join(a.localProjectDir, "internal", "web", "static")
 		r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir(diskDir))))
@@ -537,6 +538,33 @@ func (a *App) serveIndex(w http.ResponseWriter, r *http.Request) {
 func (a *App) serveCanvas(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Location", "./?desktop=1")
 	w.WriteHeader(http.StatusTemporaryRedirect)
+}
+
+func (a *App) serveCapture(w http.ResponseWriter, r *http.Request) {
+	var data []byte
+	var err error
+	if a.devRuntime {
+		data, err = os.ReadFile(filepath.Join(a.localProjectDir, "internal", "web", "static", "capture.html"))
+	} else {
+		data, err = staticFiles.ReadFile("static/capture.html")
+	}
+	if err != nil {
+		http.Error(w, "capture client not found", http.StatusNotFound)
+		return
+	}
+	page := string(data)
+	boot := strings.TrimSpace(a.bootID)
+	if boot != "" {
+		styleTag := `href="./static/capture.css"`
+		styleTagVer := fmt.Sprintf(`href="./static/capture.css?v=%s"`, url.QueryEscape(boot))
+		scriptTag := `src="./static/capture.js"`
+		scriptTagVer := fmt.Sprintf(`src="./static/capture.js?v=%s"`, url.QueryEscape(boot))
+		page = strings.Replace(page, styleTag, styleTagVer, 1)
+		page = strings.Replace(page, scriptTag, scriptTagVer, 1)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(page))
 }
 
 func decodeJSON(r *http.Request, out interface{}) error {

--- a/internal/web/server_security_test.go
+++ b/internal/web/server_security_test.go
@@ -89,6 +89,35 @@ func TestServeCanvasRedirectIsRelative(t *testing.T) {
 	}
 }
 
+func TestServeCaptureUsesStandaloneAssets(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/capture", nil)
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /capture status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, fragment := range []string{
+		`id="capture-page"`,
+		`href="./static/capture.css`,
+		`src="./static/capture.js`,
+		`id="capture-record"`,
+		`id="capture-note"`,
+	} {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("GET /capture body missing %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{`id="workspace"`, `id="edge-left-tap"`, `src="./static/app.js"`} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("GET /capture body unexpectedly contained %q", forbidden)
+		}
+	}
+}
+
 // newTestWSConn creates a chatWSConn backed by a real websocket for testing.
 // The returned cleanup function closes both ends.
 func newTestWSConn(t *testing.T) (*chatWSConn, func()) {

--- a/internal/web/static/capture.css
+++ b/internal/web/static/capture.css
@@ -1,0 +1,269 @@
+:root {
+  --capture-bg: #f3efe4;
+  --capture-panel: rgba(255, 252, 245, 0.94);
+  --capture-ink: #1d2b28;
+  --capture-muted: #60706c;
+  --capture-line: rgba(29, 43, 40, 0.12);
+  --capture-accent: #d25f37;
+  --capture-accent-strong: #a63f1f;
+  --capture-accent-soft: rgba(210, 95, 55, 0.12);
+  --capture-success: #1d7a52;
+  --capture-shadow: 0 28px 80px rgba(39, 29, 20, 0.12);
+  --capture-font: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--capture-font);
+  color: var(--capture-ink);
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.72), transparent 42%),
+    linear-gradient(160deg, #f8f3e7 0%, var(--capture-bg) 58%, #efe3d1 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(135deg, rgba(210, 95, 55, 0.08), transparent 30%),
+    radial-gradient(circle at 85% 15%, rgba(34, 119, 99, 0.08), transparent 24%);
+}
+
+.capture-shell {
+  min-height: 100vh;
+  padding:
+    max(24px, env(safe-area-inset-top))
+    20px
+    max(24px, env(safe-area-inset-bottom))
+    20px;
+  display: grid;
+  place-items: center;
+}
+
+.capture-card {
+  width: min(100%, 32rem);
+  padding: 24px;
+  border: 1px solid var(--capture-line);
+  border-radius: 28px;
+  background: var(--capture-panel);
+  box-shadow: var(--capture-shadow);
+  backdrop-filter: blur(10px);
+}
+
+.capture-kicker {
+  margin: 0 0 10px;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--capture-accent-strong);
+}
+
+.capture-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 8vw, 3.2rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.capture-copy {
+  margin: 14px 0 0;
+  max-width: 30ch;
+  font-size: 0.98rem;
+  line-height: 1.5;
+  color: var(--capture-muted);
+}
+
+.capture-record {
+  width: 100%;
+  margin-top: 24px;
+  padding: 24px 20px;
+  border: 0;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(210, 95, 55, 0.96), rgba(166, 63, 31, 0.98));
+  color: #fffaf4;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  text-align: center;
+  box-shadow: 0 18px 36px rgba(166, 63, 31, 0.22);
+  cursor: pointer;
+}
+
+.capture-record:focus-visible,
+.capture-save:focus-visible,
+.capture-reset:focus-visible,
+#capture-note:focus-visible {
+  outline: 3px solid rgba(29, 122, 82, 0.24);
+  outline-offset: 2px;
+}
+
+.capture-record-ring {
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  border: 10px solid rgba(255, 250, 244, 0.24);
+  box-shadow: inset 0 0 0 16px rgba(255, 250, 244, 0.88);
+}
+
+.capture-record-label {
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.capture-record-hint {
+  font-size: 0.92rem;
+  color: rgba(255, 250, 244, 0.86);
+}
+
+.capture-field {
+  display: grid;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.capture-field-label {
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--capture-muted);
+}
+
+#capture-note {
+  width: 100%;
+  resize: vertical;
+  min-height: 8.5rem;
+  padding: 16px 18px;
+  border: 1px solid var(--capture-line);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.78);
+  font: inherit;
+  color: var(--capture-ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+#capture-note::placeholder {
+  color: rgba(96, 112, 108, 0.72);
+}
+
+.capture-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.capture-save,
+.capture-reset {
+  min-height: 52px;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.capture-save {
+  border: 0;
+  background: linear-gradient(180deg, #1f7a63, #155843);
+  color: #f8f5ef;
+  box-shadow: 0 16px 30px rgba(21, 88, 67, 0.18);
+}
+
+.capture-save[disabled] {
+  opacity: 0.45;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.capture-reset {
+  padding: 0 20px;
+  border: 1px solid var(--capture-line);
+  background: rgba(255, 255, 255, 0.58);
+  color: var(--capture-ink);
+}
+
+.capture-status {
+  min-height: 1.4em;
+  margin: 14px 0 0;
+  font-size: 0.95rem;
+  color: var(--capture-muted);
+}
+
+.capture-status[data-tone="success"] {
+  color: var(--capture-success);
+}
+
+.capture-status[data-tone="error"] {
+  color: var(--capture-accent-strong);
+}
+
+body[data-capture-state="recording"] .capture-record {
+  animation: capturePulse 1.3s ease-in-out infinite;
+}
+
+body[data-capture-state="recording"] .capture-record-ring {
+  box-shadow:
+    inset 0 0 0 16px rgba(255, 250, 244, 0.9),
+    0 0 0 18px rgba(255, 250, 244, 0.12);
+}
+
+body[data-capture-state="recording"] .capture-record-hint {
+  color: #fff;
+}
+
+body[data-capture-state="recording"] .capture-card {
+  border-color: rgba(210, 95, 55, 0.28);
+}
+
+body[data-capture-state="saving"] .capture-card {
+  box-shadow: 0 28px 80px rgba(21, 88, 67, 0.18);
+}
+
+@keyframes capturePulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.015);
+  }
+}
+
+@media (max-width: 480px) {
+  .capture-shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .capture-card {
+    width: 100%;
+    padding: 22px 18px 20px;
+    border-radius: 24px;
+  }
+
+  .capture-record {
+    min-height: 196px;
+  }
+
+  .capture-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .capture-reset {
+    width: 100%;
+  }
+}

--- a/internal/web/static/capture.html
+++ b/internal/web/static/capture.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <title>Capture | Tabura</title>
+  <link rel="stylesheet" href="./static/capture.css">
+</head>
+<body data-capture-state="idle">
+  <main id="capture-page" class="capture-shell" data-state="idle">
+    <section class="capture-card" aria-labelledby="capture-title">
+      <p class="capture-kicker">Quick Capture</p>
+      <h1 id="capture-title">Catch the thought before it drifts.</h1>
+      <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+
+      <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
+        <span class="capture-record-ring" aria-hidden="true"></span>
+        <span class="capture-record-label">Record</span>
+        <span class="capture-record-hint">Tap once to start, again to stop.</span>
+      </button>
+
+      <label class="capture-field" for="capture-note">
+        <span class="capture-field-label">Type a note</span>
+        <textarea
+          id="capture-note"
+          rows="5"
+          maxlength="4000"
+          placeholder="Idea, reminder, fragment, next step..."
+          autocomplete="off"
+        ></textarea>
+      </label>
+
+      <div class="capture-actions">
+        <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
+        <button id="capture-reset" class="capture-reset" type="button">Clear</button>
+      </div>
+
+      <p id="capture-status" class="capture-status" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <script src="./static/capture.js"></script>
+</body>
+</html>

--- a/internal/web/static/capture.js
+++ b/internal/web/static/capture.js
@@ -1,0 +1,243 @@
+(function () {
+  const page = document.getElementById('capture-page');
+  const noteInput = document.getElementById('capture-note');
+  const recordButton = document.getElementById('capture-record');
+  const recordLabel = recordButton ? recordButton.querySelector('.capture-record-label') : null;
+  const recordHint = recordButton ? recordButton.querySelector('.capture-record-hint') : null;
+  const saveButton = document.getElementById('capture-save');
+  const resetButton = document.getElementById('capture-reset');
+  const statusNode = document.getElementById('capture-status');
+
+  if (!page || !noteInput || !recordButton || !recordLabel || !recordHint || !saveButton || !resetButton || !statusNode) {
+    return;
+  }
+
+  const state = {
+    statusTimer: 0,
+    recording: false,
+    saving: false,
+    discardRecording: false,
+    mediaStream: null,
+    mediaRecorder: null,
+    audioChunks: [],
+    audioBlob: null,
+  };
+
+  function clearStatusTimer() {
+    if (state.statusTimer) {
+      window.clearTimeout(state.statusTimer);
+      state.statusTimer = 0;
+    }
+  }
+
+  function setStatus(message, tone) {
+    statusNode.textContent = String(message || '');
+    if (tone) {
+      statusNode.dataset.tone = tone;
+    } else {
+      delete statusNode.dataset.tone;
+    }
+  }
+
+  function scheduleStatusClear(delayMS) {
+    clearStatusTimer();
+    state.statusTimer = window.setTimeout(() => {
+      setStatus('', '');
+      state.statusTimer = 0;
+    }, delayMS);
+  }
+
+  function setCaptureState(nextState) {
+    const cleanState = String(nextState || 'idle').trim() || 'idle';
+    document.body.dataset.captureState = cleanState;
+    page.dataset.state = cleanState;
+    recordButton.setAttribute('aria-pressed', cleanState === 'recording' ? 'true' : 'false');
+    if (cleanState === 'recording') {
+      recordLabel.textContent = 'Recording';
+      recordHint.textContent = 'Tap again to stop.';
+      return;
+    }
+    recordLabel.textContent = 'Record';
+    recordHint.textContent = state.audioBlob ? 'Recording captured. Type a note or clear to reset.' : 'Tap once to start, again to stop.';
+  }
+
+  function normalizeNote(raw) {
+    return String(raw || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function deriveItemTitle(raw) {
+    const clean = normalizeNote(raw);
+    if (!clean) {
+      return '';
+    }
+    const sentenceMatch = clean.match(/^.*?[.!?](?:\s|$)/);
+    const firstSentence = normalizeNote(sentenceMatch ? sentenceMatch[0] : clean);
+    if (firstSentence.length <= 80) {
+      return firstSentence;
+    }
+    return `${firstSentence.slice(0, 77).trimEnd()}...`;
+  }
+
+  function updateSaveState() {
+    const hasNote = normalizeNote(noteInput.value) !== '';
+    saveButton.disabled = state.saving || !hasNote;
+  }
+
+  function releaseMediaStream() {
+    if (!state.mediaStream || typeof state.mediaStream.getTracks !== 'function') {
+      state.mediaStream = null;
+      return;
+    }
+    for (const track of state.mediaStream.getTracks()) {
+      if (track && typeof track.stop === 'function') {
+        track.stop();
+      }
+    }
+    state.mediaStream = null;
+  }
+
+  function finishRecording() {
+    state.recording = false;
+    state.mediaRecorder = null;
+    releaseMediaStream();
+    setCaptureState('idle');
+    if (state.audioBlob) {
+      setStatus('Recording captured.', 'success');
+      scheduleStatusClear(1800);
+    }
+  }
+
+  async function startRecording() {
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+      setStatus('Voice capture is not available in this browser.', 'error');
+      return;
+    }
+    if (typeof window.MediaRecorder !== 'function') {
+      setStatus('MediaRecorder is unavailable in this browser.', 'error');
+      return;
+    }
+    clearStatusTimer();
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new window.MediaRecorder(stream);
+      state.recording = true;
+      state.mediaStream = stream;
+      state.mediaRecorder = recorder;
+      state.audioChunks = [];
+      state.audioBlob = null;
+      recorder.addEventListener('dataavailable', (event) => {
+        if (event.data) {
+          state.audioChunks.push(event.data);
+        }
+      });
+      recorder.addEventListener('stop', () => {
+        const mimeType = String(recorder.mimeType || 'audio/webm').trim() || 'audio/webm';
+        if (!state.discardRecording && state.audioChunks.length > 0) {
+          state.audioBlob = new Blob(state.audioChunks, { type: mimeType });
+        }
+        state.discardRecording = false;
+        finishRecording();
+      });
+      recorder.start();
+      setStatus('', '');
+      setCaptureState('recording');
+    } catch (error) {
+      releaseMediaStream();
+      state.recording = false;
+      state.mediaRecorder = null;
+      setCaptureState('idle');
+      setStatus(`Voice capture failed: ${String(error && error.message ? error.message : error)}`, 'error');
+    }
+  }
+
+  function stopRecording() {
+    if (!state.recording || !state.mediaRecorder) {
+      finishRecording();
+      return;
+    }
+    if (state.mediaRecorder.state !== 'inactive') {
+      state.mediaRecorder.stop();
+      return;
+    }
+    finishRecording();
+  }
+
+  function resetCapture() {
+    clearStatusTimer();
+    if (state.mediaRecorder && state.mediaRecorder.state !== 'inactive') {
+      state.discardRecording = true;
+      state.mediaRecorder.stop();
+    }
+    state.recording = false;
+    state.mediaRecorder = null;
+    state.audioChunks = [];
+    state.audioBlob = null;
+    releaseMediaStream();
+    noteInput.value = '';
+    setCaptureState('idle');
+    setStatus('', '');
+    updateSaveState();
+  }
+
+  async function saveCapture() {
+    const note = normalizeNote(noteInput.value);
+    if (!note || state.saving) {
+      updateSaveState();
+      return;
+    }
+    const title = deriveItemTitle(note);
+    if (!title) {
+      updateSaveState();
+      return;
+    }
+    state.saving = true;
+    updateSaveState();
+    setCaptureState('saving');
+    setStatus('Saving...', '');
+    try {
+      const response = await fetch('./api/items', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      noteInput.value = '';
+      state.audioBlob = null;
+      setCaptureState('idle');
+      setStatus(`Saved: ${title}`, 'success');
+      scheduleStatusClear(1800);
+    } catch (error) {
+      setCaptureState(state.recording ? 'recording' : 'idle');
+      setStatus(`Save failed: ${String(error && error.message ? error.message : error)}`, 'error');
+    } finally {
+      state.saving = false;
+      updateSaveState();
+    }
+  }
+
+  recordButton.addEventListener('click', () => {
+    if (state.recording) {
+      stopRecording();
+      return;
+    }
+    void startRecording();
+  });
+  noteInput.addEventListener('input', updateSaveState);
+  saveButton.addEventListener('click', () => {
+    void saveCapture();
+  });
+  resetButton.addEventListener('click', resetCapture);
+
+  updateSaveState();
+  setCaptureState('idle');
+  window.__taburaCapture = {
+    deriveItemTitle,
+    resetCapture,
+  };
+})();

--- a/tests/playwright/capture-harness.html
+++ b/tests/playwright/capture-harness.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>Capture Harness</title>
+  <link rel="stylesheet" href="/internal/web/static/capture.css">
+</head>
+<body data-capture-state="idle">
+  <main id="capture-page" class="capture-shell" data-state="idle">
+    <section class="capture-card" aria-labelledby="capture-title">
+      <p class="capture-kicker">Quick Capture</p>
+      <h1 id="capture-title">Catch the thought before it drifts.</h1>
+      <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+
+      <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
+        <span class="capture-record-ring" aria-hidden="true"></span>
+        <span class="capture-record-label">Record</span>
+        <span class="capture-record-hint">Tap once to start, again to stop.</span>
+      </button>
+
+      <label class="capture-field" for="capture-note">
+        <span class="capture-field-label">Type a note</span>
+        <textarea
+          id="capture-note"
+          rows="5"
+          maxlength="4000"
+          placeholder="Idea, reminder, fragment, next step..."
+          autocomplete="off"
+        ></textarea>
+      </label>
+
+      <div class="capture-actions">
+        <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
+        <button id="capture-reset" class="capture-reset" type="button">Clear</button>
+      </div>
+
+      <p id="capture-status" class="capture-status" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <script>
+    (() => {
+      const savedRequests = [];
+      window.__captureRequests = savedRequests;
+
+      window.fetch = async (url, options = {}) => {
+        if (String(url).includes('/api/items')) {
+          const payload = options && options.body ? JSON.parse(String(options.body)) : {};
+          savedRequests.push(payload);
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true, item: { id: savedRequests.length, title: payload.title || '' } }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true }),
+        };
+      };
+
+      class FakeTrack {
+        stop() {}
+      }
+
+      class FakeStream {
+        getTracks() {
+          return [new FakeTrack()];
+        }
+      }
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: {
+          getUserMedia: async () => new FakeStream(),
+        },
+      });
+
+      class FakeMediaRecorder {
+        constructor(stream) {
+          this.stream = stream;
+          this.state = 'inactive';
+          this.mimeType = 'audio/webm';
+          this.listeners = {};
+        }
+
+        addEventListener(type, listener) {
+          if (!this.listeners[type]) {
+            this.listeners[type] = [];
+          }
+          this.listeners[type].push(listener);
+        }
+
+        _emit(type, event) {
+          const handlers = this.listeners[type] || [];
+          handlers.forEach((handler) => handler(event));
+        }
+
+        start() {
+          this.state = 'recording';
+        }
+
+        stop() {
+          this.state = 'inactive';
+          this._emit('dataavailable', { data: new Blob(['recorded memo'], { type: this.mimeType }) });
+          this._emit('stop', {});
+        }
+      }
+
+      window.MediaRecorder = FakeMediaRecorder;
+    })();
+  </script>
+  <script src="/internal/web/static/capture.js"></script>
+</body>
+</html>

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('capture page', () => {
+  test('saves a typed note and stays outside the canvas shell', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html');
+
+    await expect(page.locator('#capture-page')).toBeVisible();
+    await expect(page.locator('#workspace')).toHaveCount(0);
+    await expect(page.locator('#edge-left-tap')).toHaveCount(0);
+    await expect(page.locator('#capture-save')).toBeDisabled();
+
+    await page.locator('#capture-note').fill('Follow up with the review queue tomorrow morning. Capture the blockers too.');
+    await expect(page.locator('#capture-save')).toBeEnabled();
+
+    await page.locator('#capture-save').click();
+    await expect(page.locator('#capture-note')).toHaveValue('');
+    await expect(page.locator('#capture-status')).toContainText('Saved:');
+    await expect(page.locator('#capture-save')).toBeDisabled();
+
+    const requests = await page.evaluate(() => (window as any).__captureRequests);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].title).toBe('Follow up with the review queue tomorrow morning.');
+  });
+
+  test('toggles record state with the large capture button', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html');
+
+    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'idle');
+    await page.locator('#capture-record').click({ force: true });
+    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'recording');
+    await expect(page.locator('#capture-record')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.locator('#capture-record').click({ force: true });
+    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'idle');
+    await expect(page.locator('#capture-record')).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('#capture-status')).toContainText('Recording captured.');
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone `/capture` page with dedicated HTML, CSS, and JS instead of loading the full canvas runtime
- support typed note capture into inbox items and wire the record button through start/stop capture state for follow-on STT work
- cover the new route, surface inventory, and UI flow with Go tests plus a dedicated Playwright harness

## Verification
- `/capture` serves a capture-only page and excludes the canvas shell: `go test ./internal/web ./internal/surface`
  - `ok github.com/krystophny/tabura/internal/web 4.024s`
  - `ok github.com/krystophny/tabura/internal/surface 0.001s`
  - `TestServeCaptureUsesStandaloneAssets` asserts `capture.css` and `capture.js` are present while `app.js`, `#workspace`, and `#edge-left-tap` are absent.
- The public route inventory includes the new page: `./scripts/sync-surface.sh --check`
- Typing a note saves an inbox item and resets the page: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  - `2 passed (1.1s)`
  - `capture page › saves a typed note and stays outside the canvas shell` verifies the save button posts `/api/items`, clears the note, and shows `Saved: ...`.
- The record button starts and stops capture state on the dedicated page: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  - `capture page › toggles record state with the large capture button` verifies `data-capture-state` transitions `idle -> recording -> idle` and surfaces `Recording captured.`.
- No inbox, review, or canvas chrome leaks onto `/capture`: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  - `capture page › saves a typed note and stays outside the canvas shell` asserts `#workspace` and `#edge-left-tap` are not present.
