### PR TITLE
fix: Add capture-mode STT flow for short voice memos (fixes #224)

### DIFF
--- a/internal/web/static/capture.css
+++ b/internal/web/static/capture.css
@@ -104,6 +104,7 @@ body::before {
 
 .capture-record:focus-visible,
 .capture-save:focus-visible,
+.capture-retry:focus-visible,
 .capture-reset:focus-visible,
 #capture-note:focus-visible {
   outline: 3px solid rgba(29, 122, 82, 0.24);
@@ -168,6 +169,7 @@ body::before {
 }
 
 .capture-save,
+.capture-retry,
 .capture-reset {
   min-height: 52px;
   border-radius: 999px;
@@ -194,6 +196,17 @@ body::before {
   border: 1px solid var(--capture-line);
   background: rgba(255, 255, 255, 0.58);
   color: var(--capture-ink);
+}
+
+.capture-retry {
+  padding: 0 20px;
+  border: 1px solid rgba(210, 95, 55, 0.28);
+  background: rgba(210, 95, 55, 0.08);
+  color: var(--capture-accent-strong);
+}
+
+.capture-retry[hidden] {
+  display: none;
 }
 
 .capture-status {
@@ -231,6 +244,10 @@ body[data-capture-state="recording"] .capture-card {
 
 body[data-capture-state="saving"] .capture-card {
   box-shadow: 0 28px 80px rgba(21, 88, 67, 0.18);
+}
+
+body[data-capture-state="transcribing"] .capture-card {
+  box-shadow: 0 28px 80px rgba(166, 63, 31, 0.18);
 }
 
 @keyframes capturePulse {

--- a/internal/web/static/capture.html
+++ b/internal/web/static/capture.html
@@ -34,6 +34,7 @@
 
       <div class="capture-actions">
         <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
+        <button id="capture-retry" class="capture-retry" type="button" hidden>Retry voice memo</button>
         <button id="capture-reset" class="capture-reset" type="button">Clear</button>
       </div>
 

--- a/internal/web/static/capture.js
+++ b/internal/web/static/capture.js
@@ -5,10 +5,11 @@
   const recordLabel = recordButton ? recordButton.querySelector('.capture-record-label') : null;
   const recordHint = recordButton ? recordButton.querySelector('.capture-record-hint') : null;
   const saveButton = document.getElementById('capture-save');
+  const retryButton = document.getElementById('capture-retry');
   const resetButton = document.getElementById('capture-reset');
   const statusNode = document.getElementById('capture-status');
 
-  if (!page || !noteInput || !recordButton || !recordLabel || !recordHint || !saveButton || !resetButton || !statusNode) {
+  if (!page || !noteInput || !recordButton || !recordLabel || !recordHint || !saveButton || !retryButton || !resetButton || !statusNode) {
     return;
   }
 
@@ -16,11 +17,13 @@
     statusTimer: 0,
     recording: false,
     saving: false,
+    transcribing: false,
     discardRecording: false,
     mediaStream: null,
     mediaRecorder: null,
     audioChunks: [],
     audioBlob: null,
+    pendingTranscript: '',
   };
 
   function clearStatusTimer() {
@@ -57,8 +60,19 @@
       recordHint.textContent = 'Tap again to stop.';
       return;
     }
+    if (cleanState === 'transcribing') {
+      recordLabel.textContent = 'Transcribing';
+      recordHint.textContent = 'Saving the voice memo into your inbox.';
+      return;
+    }
     recordLabel.textContent = 'Record';
-    recordHint.textContent = state.audioBlob ? 'Recording captured. Type a note or clear to reset.' : 'Tap once to start, again to stop.';
+    if (state.audioBlob) {
+      recordHint.textContent = state.pendingTranscript
+        ? 'Memo captured. Retry save or clear to discard.'
+        : 'Memo captured. Retry transcription or clear to discard.';
+      return;
+    }
+    recordHint.textContent = 'Tap once to start, again to stop.';
   }
 
   function normalizeNote(raw) {
@@ -80,7 +94,13 @@
 
   function updateSaveState() {
     const hasNote = normalizeNote(noteInput.value) !== '';
-    saveButton.disabled = state.saving || !hasNote;
+    const busy = state.saving || state.transcribing;
+    noteInput.disabled = busy;
+    recordButton.disabled = busy;
+    retryButton.hidden = !(state.audioBlob && !state.recording && !state.transcribing);
+    retryButton.disabled = busy || !state.audioBlob;
+    resetButton.disabled = busy;
+    saveButton.disabled = busy || !hasNote;
   }
 
   function releaseMediaStream() {
@@ -101,9 +121,127 @@
     state.mediaRecorder = null;
     releaseMediaStream();
     setCaptureState('idle');
-    if (state.audioBlob) {
-      setStatus('Recording captured.', 'success');
+    updateSaveState();
+  }
+
+  function clearVoiceMemoState() {
+    state.audioChunks = [];
+    state.audioBlob = null;
+    state.pendingTranscript = '';
+  }
+
+  function voiceMemoErrorMessage(reason) {
+    switch (String(reason || '').trim()) {
+      case 'recording_too_short':
+        return 'Recording too short. Retry this memo.';
+      case 'likely_noise':
+      case 'no_speech_detected':
+      case 'empty_transcript':
+        return 'No speech was detected. Retry this memo.';
+      default:
+        return 'Transcription failed. Retry this memo.';
+    }
+  }
+
+  async function postJSON(url, payload) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (_) {
+      data = {};
+    }
+    if (!response.ok) {
+      throw new Error(String(data && data.error ? data.error : `HTTP ${response.status}`));
+    }
+    return data;
+  }
+
+  async function transcribeVoiceMemo(blob) {
+    const mimeType = String(blob && blob.type ? blob.type : 'audio/webm').trim() || 'audio/webm';
+    const payload = new FormData();
+    payload.append('file', blob, `capture${mimeType.startsWith('audio/') ? '' : '.bin'}`);
+    payload.append('mime_type', mimeType);
+    const response = await fetch('./api/stt/transcribe', {
+      method: 'POST',
+      body: payload,
+    });
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (_) {
+      data = {};
+    }
+    if (!response.ok) {
+      throw new Error('transcription_http_error');
+    }
+    const transcript = normalizeNote(data && data.text);
+    if (!transcript) {
+      throw new Error(voiceMemoErrorMessage(data && data.reason));
+    }
+    return transcript;
+  }
+
+  async function saveVoiceMemo(transcript) {
+    const title = deriveItemTitle(transcript);
+    if (!title) {
+      throw new Error('Transcription was empty after cleanup. Retry this memo.');
+    }
+    const artifactPayload = await postJSON('./api/artifacts', {
+      kind: 'idea_note',
+      title,
+      meta_json: JSON.stringify({
+        transcript,
+        source: 'capture_stt',
+      }),
+    });
+    const artifactID = Number(artifactPayload && artifactPayload.artifact && artifactPayload.artifact.id);
+    if (!Number.isFinite(artifactID) || artifactID <= 0) {
+      throw new Error('artifact_create_failed');
+    }
+    await postJSON('./api/items', {
+      title,
+      artifact_id: artifactID,
+    });
+    return title;
+  }
+
+  async function processVoiceMemo() {
+    if (!state.audioBlob || state.saving || state.transcribing) {
+      return;
+    }
+    clearStatusTimer();
+    state.transcribing = true;
+    updateSaveState();
+    setCaptureState('transcribing');
+    setStatus(state.pendingTranscript ? 'Saving voice memo...' : 'Transcribing...', '');
+    try {
+      const transcript = state.pendingTranscript || await transcribeVoiceMemo(state.audioBlob);
+      state.pendingTranscript = transcript;
+      const title = await saveVoiceMemo(transcript);
+      clearVoiceMemoState();
+      setCaptureState('idle');
+      setStatus(`Saved: ${title}`, 'success');
       scheduleStatusClear(1800);
+    } catch (error) {
+      setCaptureState('idle');
+      const message = String(error && error.message ? error.message : error);
+      if (message === 'transcription_http_error') {
+        setStatus('Transcription failed. Retry this memo.', 'error');
+      } else if (message === 'artifact_create_failed' || /^HTTP \d+$/.test(message)) {
+        setStatus('Saving voice memo failed. Retry this memo.', 'error');
+      } else {
+        setStatus(message, 'error');
+      }
+    } finally {
+      state.transcribing = false;
+      updateSaveState();
     }
   }
 
@@ -121,10 +259,10 @@
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const recorder = new window.MediaRecorder(stream);
       state.recording = true;
+      clearVoiceMemoState();
       state.mediaStream = stream;
       state.mediaRecorder = recorder;
       state.audioChunks = [];
-      state.audioBlob = null;
       recorder.addEventListener('dataavailable', (event) => {
         if (event.data) {
           state.audioChunks.push(event.data);
@@ -137,16 +275,21 @@
         }
         state.discardRecording = false;
         finishRecording();
+        if (state.audioBlob) {
+          void processVoiceMemo();
+        }
       });
       recorder.start();
       setStatus('', '');
       setCaptureState('recording');
+      updateSaveState();
     } catch (error) {
       releaseMediaStream();
       state.recording = false;
       state.mediaRecorder = null;
       setCaptureState('idle');
       setStatus(`Voice capture failed: ${String(error && error.message ? error.message : error)}`, 'error');
+      updateSaveState();
     }
   }
 
@@ -170,8 +313,7 @@
     }
     state.recording = false;
     state.mediaRecorder = null;
-    state.audioChunks = [];
-    state.audioBlob = null;
+    clearVoiceMemoState();
     releaseMediaStream();
     noteInput.value = '';
     setCaptureState('idle');
@@ -195,20 +337,11 @@
     setCaptureState('saving');
     setStatus('Saving...', '');
     try {
-      const response = await fetch('./api/items', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          title,
-        }),
+      await postJSON('./api/items', {
+        title,
       });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
       noteInput.value = '';
-      state.audioBlob = null;
+      clearVoiceMemoState();
       setCaptureState('idle');
       setStatus(`Saved: ${title}`, 'success');
       scheduleStatusClear(1800);
@@ -232,12 +365,16 @@
   saveButton.addEventListener('click', () => {
     void saveCapture();
   });
+  retryButton.addEventListener('click', () => {
+    void processVoiceMemo();
+  });
   resetButton.addEventListener('click', resetCapture);
 
   updateSaveState();
   setCaptureState('idle');
   window.__taburaCapture = {
     deriveItemTitle,
+    voiceMemoErrorMessage,
     resetCapture,
   };
 })();

--- a/tests/playwright/capture-harness.html
+++ b/tests/playwright/capture-harness.html
@@ -32,6 +32,7 @@
 
       <div class="capture-actions">
         <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
+        <button id="capture-retry" class="capture-retry" type="button" hidden>Retry voice memo</button>
         <button id="capture-reset" class="capture-reset" type="button">Clear</button>
       </div>
 
@@ -41,24 +42,73 @@
 
   <script>
     (() => {
-      const savedRequests = [];
-      window.__captureRequests = savedRequests;
+      const itemRequests = [];
+      const artifactRequests = [];
+      const transcribeRequests = [];
+      const fetchRequests = [];
+      let transcribeResponses = [
+        { status: 200, body: { text: 'Voice memo from capture harness. Follow up tomorrow morning.' } },
+      ];
+
+      window.__captureRequests = itemRequests;
+      window.__captureArtifactRequests = artifactRequests;
+      window.__captureTranscribeRequests = transcribeRequests;
+      window.__captureFetchRequests = fetchRequests;
+      window.__setCaptureTranscribeResponses = (responses) => {
+        if (!Array.isArray(responses) || responses.length === 0) {
+          transcribeResponses = [
+            { status: 200, body: { text: 'Voice memo from capture harness. Follow up tomorrow morning.' } },
+          ];
+          return;
+        }
+        transcribeResponses = responses.map((entry) => ({
+          status: Number(entry && entry.status) || 200,
+          body: entry && typeof entry.body === 'object' ? entry.body : {},
+        }));
+      };
+
+      function nextTranscribeResponse() {
+        if (transcribeResponses.length > 1) {
+          return transcribeResponses.shift();
+        }
+        return transcribeResponses[0];
+      }
 
       window.fetch = async (url, options = {}) => {
+        fetchRequests.push({
+          url: String(url),
+          method: options.method || 'GET',
+        });
+        if (String(url).includes('/api/stt/transcribe')) {
+          transcribeRequests.push({
+            method: options.method || 'GET',
+          });
+          const next = nextTranscribeResponse();
+          return new Response(JSON.stringify(next.body), {
+            status: next.status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (String(url).includes('/api/artifacts')) {
+          const payload = options && options.body ? JSON.parse(String(options.body)) : {};
+          artifactRequests.push(payload);
+          return new Response(JSON.stringify({
+            ok: true,
+            artifact: { id: artifactRequests.length, title: payload.title || '', kind: payload.kind || '' },
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
         if (String(url).includes('/api/items')) {
           const payload = options && options.body ? JSON.parse(String(options.body)) : {};
-          savedRequests.push(payload);
-          return {
+          itemRequests.push(payload);
+          return new Response(JSON.stringify({
             ok: true,
-            status: 200,
-            json: async () => ({ ok: true, item: { id: savedRequests.length, title: payload.title || '' } }),
-          };
+            item: { id: itemRequests.length, title: payload.title || '' },
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
         }
-        return {
-          ok: true,
+        return new Response(JSON.stringify({ ok: true }), {
           status: 200,
-          json: async () => ({ ok: true }),
-        };
+          headers: { 'Content-Type': 'application/json' },
+        });
       };
 
       class FakeTrack {

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -23,6 +23,67 @@ test.describe('capture page', () => {
     expect(requests[0].title).toBe('Follow up with the review queue tomorrow morning.');
   });
 
+  test('transcribes a voice memo and saves an artifact-backed inbox item', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html');
+
+    await page.locator('#capture-record').click({ force: true });
+    await page.locator('#capture-record').click({ force: true });
+
+    await expect(page.locator('#capture-status')).toContainText('Saved: Voice memo from capture harness.');
+    await expect(page.locator('#capture-retry')).toBeHidden();
+
+    const transcribeRequests = await page.evaluate(() => (window as any).__captureTranscribeRequests);
+    expect(transcribeRequests).toHaveLength(1);
+
+    const artifactRequests = await page.evaluate(() => (window as any).__captureArtifactRequests);
+    expect(artifactRequests).toHaveLength(1);
+    expect(artifactRequests[0].kind).toBe('idea_note');
+    expect(artifactRequests[0].title).toBe('Voice memo from capture harness.');
+    expect(JSON.parse(String(artifactRequests[0].meta_json)).transcript).toBe(
+      'Voice memo from capture harness. Follow up tomorrow morning.',
+    );
+
+    const itemRequests = await page.evaluate(() => (window as any).__captureRequests);
+    expect(itemRequests).toHaveLength(1);
+    expect(itemRequests[0].title).toBe('Voice memo from capture harness.');
+    expect(itemRequests[0].artifact_id).toBe(1);
+
+    const fetchRequests = await page.evaluate(() => (window as any).__captureFetchRequests);
+    expect(fetchRequests).toHaveLength(3);
+    expect(fetchRequests.some((request: { url: string }) => request.url.includes('/api/chat/'))).toBe(false);
+  });
+
+  test('keeps the memo available for retry after transcription failure', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html');
+
+    await page.evaluate(() => {
+      (window as any).__setCaptureTranscribeResponses([
+        { status: 502, body: { error: 'sidecar unavailable' } },
+        { status: 200, body: { text: 'Retry worked after the STT sidecar came back.' } },
+      ]);
+    });
+
+    await page.locator('#capture-record').click({ force: true });
+    await page.locator('#capture-record').click({ force: true });
+
+    await expect(page.locator('#capture-status')).toContainText('Transcription failed. Retry this memo.');
+    await expect(page.locator('#capture-retry')).toBeVisible();
+
+    await page.locator('#capture-retry').click();
+
+    await expect(page.locator('#capture-status')).toContainText('Saved: Retry worked after the STT sidecar came back.');
+    await expect(page.locator('#capture-retry')).toBeHidden();
+
+    const transcribeRequests = await page.evaluate(() => (window as any).__captureTranscribeRequests);
+    expect(transcribeRequests).toHaveLength(2);
+
+    const itemRequests = await page.evaluate(() => (window as any).__captureRequests);
+    expect(itemRequests).toHaveLength(1);
+    expect(itemRequests[0].title).toBe('Retry worked after the STT sidecar came back.');
+  });
+
   test('toggles record state with the large capture button', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/tests/playwright/capture-harness.html');
@@ -35,6 +96,6 @@ test.describe('capture page', () => {
     await page.locator('#capture-record').click({ force: true });
     await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'idle');
     await expect(page.locator('#capture-record')).toHaveAttribute('aria-pressed', 'false');
-    await expect(page.locator('#capture-status')).toContainText('Recording captured.');
+    await expect(page.locator('#capture-status')).toContainText('Saved: Voice memo from capture harness.');
   });
 });


### PR DESCRIPTION
## Summary
- wire `/capture` voice memos through `/api/stt/transcribe`, then persist an `idea_note` artifact plus inbox item from the derived title
- add retryable failure handling and explicit transcribing/success states without touching chat or assistant turn flows
- extend the capture harness/spec to verify artifact payloads, retry behavior, and the absence of chat endpoint usage

## Verification
- [x] Voice memo recorded and transcribed on `/capture`
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: `✓  [chromium] › tests/playwright/capture.spec.ts:26:7 › capture page › transcribes a voice memo and saves an artifact-backed inbox item`
- [x] Transcript becomes item title + `idea_note` artifact
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: the same spec asserts `artifactRequests[0].kind === 'idea_note'`, stores the full transcript in `meta_json`, and verifies `itemRequests[0].artifact_id === 1`
- [x] No chat/dialogue session created
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: the same spec asserts exactly 3 fetches for the voice memo flow and none hit `/api/chat/`
- [x] No assistant response triggered
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: the voice memo flow only exercises `/api/stt/transcribe`, `/api/artifacts`, and `/api/items`; no chat fetch is observed in the harness
- [x] Transcription failure shows clear error with retry option
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: `✓  [chromium] › tests/playwright/capture.spec.ts:57:7 › capture page › keeps the memo available for retry after transcription failure`
- [x] Success shows brief confirmation then resets
  Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts`
  Evidence: `✓  [chromium] › tests/playwright/capture.spec.ts:87:7 › capture page › toggles record state with the large capture button`
- [x] Existing item/artifact API path still passes
  Command: `go test ./internal/web -run 'TestArtifactCRUDAPI|TestItemCRUDAndStateAPI'`
  Evidence: `ok   github.com/krystophny/tabura/internal/web	0.019s`
