### PR TITLE
fix: Add workspace-scoped dialogue context (fixes #182)

### DIFF
--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -147,6 +147,8 @@ func TestParseSystemAction(t *testing.T) {
 		wantAction string
 	}{
 		{name: "switch project", raw: `{"action":"switch_project","name":"docs"}`, wantAction: "switch_project"},
+		{name: "switch workspace", raw: `{"action":"switch_workspace","workspace":"tabula"}`, wantAction: "switch_workspace"},
+		{name: "list workspace items", raw: `{"action":"list_workspace_items","workspace":"tabula"}`, wantAction: "list_workspace_items"},
 		{name: "switch model", raw: `{"action":"switch_model","alias":"gpt","effort":"high"}`, wantAction: "switch_model"},
 		{name: "toggle silent", raw: `{"action":"toggle_silent"}`, wantAction: "toggle_silent"},
 		{name: "toggle live dialogue", raw: `{"action":"toggle_live_dialogue"}`, wantAction: "toggle_live_dialogue"},

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,7 +36,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, create_github_issue, create_github_issue_split, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, create_github_issue, create_github_issue_split, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -323,7 +323,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
+	case "switch_project", "switch_workspace", "list_workspace_items", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -773,6 +773,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return githubIssueActionFailurePrefix(enforced) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	if inlineWorkspaceAction := parseInlineWorkspaceIntent(trimmedText); inlineWorkspaceAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineWorkspaceAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return "I couldn't resolve the workspace request: " + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}
@@ -1320,6 +1331,44 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return fmt.Sprintf("Switched to %s.", activated.Name), map[string]interface{}{
 			"type":       "switch_project",
 			"project_id": activated.ID,
+		}, nil
+	case "switch_workspace":
+		workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		if err := a.store.SetActiveWorkspace(workspace.ID); err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Switched to workspace %s.", workspace.Name), map[string]interface{}{
+			"type":         "switch_workspace",
+			"workspace_id": workspace.ID,
+			"name":         workspace.Name,
+			"dir_path":     workspace.DirPath,
+		}, nil
+	case "list_workspace_items":
+		workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		items, err := a.listOpenWorkspaceItems(workspace.ID)
+		if err != nil {
+			return "", nil, err
+		}
+		itemIDs := make([]int64, 0, len(items))
+		titles := make([]string, 0, len(items))
+		for _, item := range items {
+			itemIDs = append(itemIDs, item.ID)
+			titles = append(titles, item.Title)
+		}
+		return summarizeWorkspaceItems(workspace, items), map[string]interface{}{
+			"type":         "list_workspace_items",
+			"workspace_id": workspace.ID,
+			"name":         workspace.Name,
+			"dir_path":     workspace.DirPath,
+			"item_ids":     itemIDs,
+			"item_titles":  titles,
+			"item_count":   len(items),
 		}, nil
 	case "switch_model":
 		targetProject, err := a.systemActionTargetProject(session)

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -68,6 +68,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
 	}
+	prompt = a.applyWorkspacePromptContext(session.ProjectKey, prompt)
 	prompt, err = a.applyPreAssistantPromptHook(context.Background(), sessionID, session.ProjectKey, outputMode, session.Mode, prompt)
 	if err != nil {
 		errText := err.Error()
@@ -316,6 +317,7 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
 	}
+	prompt = a.applyWorkspacePromptContext(session.ProjectKey, prompt)
 	var err error
 	prompt, err = a.applyPreAssistantPromptHook(context.Background(), sessionID, session.ProjectKey, outputMode, session.Mode, prompt)
 	if err != nil {

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -1,0 +1,247 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func parseInlineWorkspaceIntent(text string) *SystemAction {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	lower := normalizeItemCommandText(trimmed)
+	switch lower {
+	case "show items here", "show open items here", "show items for this workspace", "what's open", "what is open", "what's open here", "what is open here":
+		return &SystemAction{Action: "list_workspace_items", Params: map[string]interface{}{}}
+	}
+
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "open workspace "); ok {
+		return &SystemAction{Action: "switch_workspace", Params: map[string]interface{}{"workspace": name}}
+	}
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "switch to workspace "); ok {
+		return &SystemAction{Action: "switch_workspace", Params: map[string]interface{}{"workspace": name}}
+	}
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "switch workspace to "); ok {
+		return &SystemAction{Action: "switch_workspace", Params: map[string]interface{}{"workspace": name}}
+	}
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "show items for workspace "); ok {
+		return &SystemAction{Action: "list_workspace_items", Params: map[string]interface{}{"workspace": name}}
+	}
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "show items for "); ok && looksLikeWorkspaceReference(name) {
+		return &SystemAction{Action: "list_workspace_items", Params: map[string]interface{}{"workspace": name}}
+	}
+	if name, ok := cutPrefixedWorkspaceReference(trimmed, "switch to "); ok && looksLikeWorkspaceReference(name) {
+		return &SystemAction{Action: "switch_workspace", Params: map[string]interface{}{"workspace": name}}
+	}
+	return nil
+}
+
+func cutPrefixedWorkspaceReference(text, prefix string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+		return "", false
+	}
+	value := strings.TrimSpace(trimmed[len(prefix):])
+	value = strings.TrimRight(value, " \t\r\n!?,:;.")
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func looksLikeWorkspaceReference(raw string) bool {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return false
+	}
+	if strings.ContainsAny(value, `/\~.`) {
+		return true
+	}
+	if strings.EqualFold(value, "here") || strings.EqualFold(value, "this workspace") {
+		return true
+	}
+	return false
+}
+
+func systemActionWorkspaceRef(params map[string]interface{}) string {
+	for _, key := range []string{"workspace", "name", "path", "target"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func expandWorkspacePathReference(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	if value == "~" || strings.HasPrefix(value, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return value
+		}
+		if value == "~" {
+			return home
+		}
+		return filepath.Join(home, strings.TrimPrefix(value, "~/"))
+	}
+	return value
+}
+
+func (a *App) fallbackWorkspaceForProjectKey(projectKey string) (*store.Workspace, error) {
+	workspaces, err := a.store.ListWorkspaces()
+	if err != nil {
+		return nil, err
+	}
+	for i := range workspaces {
+		if workspaces[i].IsActive {
+			return &workspaces[i], nil
+		}
+	}
+	key := strings.TrimSpace(projectKey)
+	if key == "" {
+		return nil, nil
+	}
+	project, err := a.store.GetProjectByProjectKey(key)
+	if err != nil {
+		return nil, nil
+	}
+	workspaceID, err := a.store.FindWorkspaceContainingPath(project.RootPath)
+	if err != nil || workspaceID == nil {
+		return nil, err
+	}
+	workspace, err := a.store.GetWorkspace(*workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return &workspace, nil
+}
+
+func (a *App) resolveWorkspaceReference(projectKey string, raw string) (store.Workspace, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" || strings.EqualFold(ref, "here") || strings.EqualFold(ref, "this workspace") {
+		workspace, err := a.fallbackWorkspaceForProjectKey(projectKey)
+		if err != nil {
+			return store.Workspace{}, err
+		}
+		if workspace == nil {
+			return store.Workspace{}, errors.New("no active workspace")
+		}
+		return *workspace, nil
+	}
+
+	expanded := expandWorkspacePathReference(ref)
+	if strings.ContainsAny(expanded, `/\~.`) {
+		if workspace, err := a.store.GetWorkspaceByPath(expanded); err == nil {
+			return workspace, nil
+		}
+		if workspaceID, err := a.store.FindWorkspaceContainingPath(expanded); err == nil && workspaceID != nil {
+			return a.store.GetWorkspace(*workspaceID)
+		}
+	}
+
+	workspaces, err := a.store.ListWorkspaces()
+	if err != nil {
+		return store.Workspace{}, err
+	}
+	var matches []store.Workspace
+	for _, workspace := range workspaces {
+		switch {
+		case strings.EqualFold(workspace.Name, ref):
+			matches = append(matches, workspace)
+		case strings.EqualFold(filepath.Base(workspace.DirPath), ref):
+			matches = append(matches, workspace)
+		case strings.EqualFold(workspace.DirPath, expanded):
+			matches = append(matches, workspace)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		sort.Slice(matches, func(i, j int) bool {
+			if matches[i].IsActive != matches[j].IsActive {
+				return matches[i].IsActive
+			}
+			return strings.ToLower(matches[i].Name) < strings.ToLower(matches[j].Name)
+		})
+		return store.Workspace{}, fmt.Errorf("workspace %q is ambiguous", ref)
+	}
+	return store.Workspace{}, fmt.Errorf("workspace %q not found", ref)
+}
+
+func (a *App) listOpenWorkspaceItems(workspaceID int64) ([]store.Item, error) {
+	items, err := a.store.ListItems()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]store.Item, 0, len(items))
+	for _, item := range items {
+		if item.WorkspaceID == nil || *item.WorkspaceID != workspaceID {
+			continue
+		}
+		if item.State == store.ItemStateDone {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func summarizeWorkspaceItems(workspace store.Workspace, items []store.Item) string {
+	if len(items) == 0 {
+		return fmt.Sprintf("No open items for workspace %s.", workspace.Name)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Open items for workspace %s:\n", workspace.Name)
+	for _, item := range items {
+		fmt.Fprintf(&b, "- %s [%s]\n", item.Title, item.State)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+type workspacePromptContext struct {
+	Workspace     store.Workspace
+	OpenItemCount int
+}
+
+func (a *App) loadWorkspacePromptContext(projectKey string) *workspacePromptContext {
+	workspace, err := a.fallbackWorkspaceForProjectKey(projectKey)
+	if err != nil || workspace == nil {
+		return nil
+	}
+	items, err := a.listOpenWorkspaceItems(workspace.ID)
+	if err != nil {
+		return nil
+	}
+	return &workspacePromptContext{
+		Workspace:     *workspace,
+		OpenItemCount: len(items),
+	}
+}
+
+func prependWorkspacePromptContext(prompt string, ctx *workspacePromptContext) string {
+	if ctx == nil || strings.TrimSpace(prompt) == "" {
+		return prompt
+	}
+	var b strings.Builder
+	b.WriteString("## Workspace Context\n")
+	fmt.Fprintf(&b, "Active workspace: %s (%s)\n", ctx.Workspace.Name, ctx.Workspace.DirPath)
+	fmt.Fprintf(&b, "Open items in this workspace: %d\n\n", ctx.OpenItemCount)
+	b.WriteString(prompt)
+	return b.String()
+}
+
+func (a *App) applyWorkspacePromptContext(projectKey, prompt string) string {
+	return prependWorkspacePromptContext(prompt, a.loadWorkspacePromptContext(projectKey))
+}

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -1,0 +1,192 @@
+package web
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineWorkspaceIntent(t *testing.T) {
+	cases := []struct {
+		text          string
+		wantAction    string
+		wantWorkspace string
+	}{
+		{text: "open workspace Alpha", wantAction: "switch_workspace", wantWorkspace: "Alpha"},
+		{text: "switch to workspace Beta", wantAction: "switch_workspace", wantWorkspace: "Beta"},
+		{text: "switch to ./repo", wantAction: "switch_workspace", wantWorkspace: "./repo"},
+		{text: "show items here", wantAction: "list_workspace_items"},
+		{text: "what's open", wantAction: "list_workspace_items"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineWorkspaceIntent(tc.text)
+			if action == nil {
+				t.Fatal("expected workspace action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if got := systemActionWorkspaceRef(action.Params); got != tc.wantWorkspace {
+				t.Fatalf("workspace ref = %q, want %q", got, tc.wantWorkspace)
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSwitchWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	alphaPath := filepath.Join(t.TempDir(), "alpha")
+	betaPath := filepath.Join(t.TempDir(), "beta")
+	alpha, err := app.store.CreateWorkspace("Alpha", alphaPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha) error: %v", err)
+	}
+	beta, err := app.store.CreateWorkspace("Beta", betaPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(alpha.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(alpha) error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "switch to "+betaPath)
+	if !handled {
+		t.Fatal("expected switch workspace command to be handled")
+	}
+	if message != "Switched to workspace Beta." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "switch_workspace" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	updated, err := app.store.GetWorkspace(beta.ID)
+	if err != nil {
+		t.Fatalf("GetWorkspace(beta) error: %v", err)
+	}
+	if !updated.IsActive {
+		t.Fatal("expected beta workspace to be active")
+	}
+}
+
+func TestClassifyAndExecuteSystemActionListWorkspaceItemsUsesActiveWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	alpha, err := app.store.CreateWorkspace("Alpha", filepath.Join(t.TempDir(), "alpha"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha) error: %v", err)
+	}
+	beta, err := app.store.CreateWorkspace("Beta", filepath.Join(t.TempDir(), "beta"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(beta.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(beta) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Review parser plan", store.ItemOptions{WorkspaceID: &beta.ID}); err != nil {
+		t.Fatalf("CreateItem(beta inbox) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Follow up on review", store.ItemOptions{
+		WorkspaceID: &beta.ID,
+		State:       store.ItemStateWaiting,
+	}); err != nil {
+		t.Fatalf("CreateItem(beta waiting) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Closed beta item", store.ItemOptions{
+		WorkspaceID: &beta.ID,
+		State:       store.ItemStateDone,
+	}); err != nil {
+		t.Fatalf("CreateItem(beta done) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Alpha stray item", store.ItemOptions{WorkspaceID: &alpha.ID}); err != nil {
+		t.Fatalf("CreateItem(alpha) error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show items here")
+	if !handled {
+		t.Fatal("expected list workspace items command to be handled")
+	}
+	if !strings.Contains(message, "Open items for workspace Beta:") {
+		t.Fatalf("message = %q", message)
+	}
+	if !strings.Contains(message, "Review parser plan [inbox]") {
+		t.Fatalf("message missing inbox item: %q", message)
+	}
+	if !strings.Contains(message, "Follow up on review [waiting]") {
+		t.Fatalf("message missing waiting item: %q", message)
+	}
+	if strings.Contains(message, "Closed beta item") || strings.Contains(message, "Alpha stray item") {
+		t.Fatalf("message should exclude non-open or other-workspace items: %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "list_workspace_items" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := intFromAny(payloads[0]["item_count"], 0); got != 2 {
+		t.Fatalf("item_count = %d, want 2", got)
+	}
+}
+
+func TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Visible item", store.ItemOptions{WorkspaceID: &workspace.ID}); err != nil {
+		t.Fatalf("CreateItem(visible) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Done item", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		State:       store.ItemStateDone,
+	}); err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+
+	prompt := app.applyWorkspacePromptContext(project.ProjectKey, "Conversation transcript:\nUSER:\nhello")
+	if !strings.Contains(prompt, "## Workspace Context") {
+		t.Fatalf("prompt missing workspace section: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Active workspace: Default ("+project.RootPath+")") {
+		t.Fatalf("prompt missing active workspace line: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Open items in this workspace: 1") {
+		t.Fatalf("prompt missing open item count: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Conversation transcript:\nUSER:\nhello") {
+		t.Fatalf("prompt missing original content: %q", prompt)
+	}
+}


### PR DESCRIPTION
## Summary
- add workspace-specific dialogue actions for switching the active workspace and listing open items in the current workspace
- inject active workspace name/path plus open-item count into assistant prompts before execution
- cover parsing, switching, item filtering, prompt context, and existing active-workspace item-link behavior with targeted tests

## Verification
- Items auto-link to the active workspace: `go test ./internal/web -run 'Test(ParseSystemAction|ParseInlineWorkspaceIntent|ClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext|ClassifyAndExecuteSystemActionSwitchWorkspace|ClassifyAndExecuteSystemActionListWorkspaceItemsUsesActiveWorkspace|ApplyWorkspacePromptContextIncludesActiveWorkspaceSummary)$' 2>&1 | tee /tmp/tabula-issue-182-test.log` -> `ok   github.com/krystophny/tabura/internal/web 0.027s`; covered by `TestClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext`.
- `open workspace X` / path-like `switch to ...` switches the active workspace: same command/output; covered by `TestParseInlineWorkspaceIntent` and `TestClassifyAndExecuteSystemActionSwitchWorkspace`.
- `show items here` filters to the active workspace and excludes done/other-workspace items: same command/output; covered by `TestClassifyAndExecuteSystemActionListWorkspaceItemsUsesActiveWorkspace`.
- Prompt includes workspace context with open-item count: same command/output; covered by `TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary`.
- Switch persistence across turns is inferred from the active-workspace store update in `TestClassifyAndExecuteSystemActionSwitchWorkspace` plus prompt lookup of the active workspace in `TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary`.
