### PR TITLE
fix: Add voice idea capture via STT pipeline (fixes #209)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -15,6 +15,7 @@ const (
 	ArtifactKindGitHubPR    ArtifactKind = "github_pr"
 	ArtifactKindTranscript  ArtifactKind = "transcript"
 	ArtifactKindPlanNote    ArtifactKind = "plan_note"
+	ArtifactKindIdeaNote    ArtifactKind = "idea_note"
 
 	ItemStateInbox   = "inbox"
 	ItemStateWaiting = "waiting"

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -71,6 +71,7 @@ When user asks to show/open an existing file, do NOT paste file body into chat; 
 type chatMessageRequest struct {
 	Text       string `json:"text"`
 	OutputMode string `json:"output_mode"`
+	InputMode  string `json:"input_mode,omitempty"`
 	LocalOnly  bool   `json:"local_only,omitempty"`
 }
 
@@ -345,6 +346,7 @@ func (a *App) handleChatSessionMessage(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	a.chatInputModes.set(sessionID, req.InputMode)
 	storedUser, err := a.store.AddChatMessage(sessionID, "user", text, text, "text")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/web/chat_input_mode.go
+++ b/internal/web/chat_input_mode.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"strings"
+	"sync"
+)
+
+const (
+	chatInputModeText  = "text"
+	chatInputModeVoice = "voice"
+)
+
+type chatInputModeTracker struct {
+	mu    sync.Mutex
+	modes map[string]string
+}
+
+func newChatInputModeTracker() *chatInputModeTracker {
+	return &chatInputModeTracker{
+		modes: map[string]string{},
+	}
+}
+
+func normalizeChatInputMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case chatInputModeVoice:
+		return chatInputModeVoice
+	default:
+		return chatInputModeText
+	}
+}
+
+func (t *chatInputModeTracker) set(sessionID, mode string) {
+	if t == nil {
+		return
+	}
+	cleanSessionID := sessionID
+	cleanMode := normalizeChatInputMode(mode)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if cleanSessionID == "" {
+		return
+	}
+	t.modes[cleanSessionID] = cleanMode
+}
+
+func (t *chatInputModeTracker) consume(sessionID string) string {
+	if t == nil {
+		return chatInputModeText
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if sessionID == "" {
+		return chatInputModeText
+	}
+	mode := normalizeChatInputMode(t.modes[sessionID])
+	delete(t.modes, sessionID)
+	return mode
+}

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,13 +36,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, create_github_issue, create_github_issue_split, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization requests use make_item, delegate_item, snooze_item, split_items, create_github_issue, or create_github_issue_split.
+For item materialization requests use make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, or create_github_issue_split.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -323,7 +323,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
+	case "switch_project", "switch_workspace", "list_workspace_items", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -451,6 +451,14 @@ func normalizeSystemActionForExecution(action *SystemAction, fallbackText string
 	}
 	if action.Params == nil {
 		action.Params = map[string]interface{}{}
+	}
+	if strings.EqualFold(strings.TrimSpace(action.Action), "capture_idea") {
+		if strings.TrimSpace(systemActionStringParam(action.Params, "text")) == "" {
+			action.Params["text"] = strings.TrimSpace(fallbackText)
+		}
+		if strings.TrimSpace(systemActionStringParam(action.Params, "input_mode")) == "" {
+			action.Params["input_mode"] = chatInputModeText
+		}
 	}
 	_ = fallbackText
 	return action
@@ -754,7 +762,8 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		}
 	}
 
-	if inlineItemAction := parseInlineItemIntent(trimmedText, time.Now().UTC()); inlineItemAction != nil {
+	inputMode := a.chatInputModes.consume(sessionID)
+	if inlineItemAction := parseInlineItemIntentWithInputMode(trimmedText, time.Now().UTC(), inputMode); inlineItemAction != nil {
 		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineItemAction})
 		if len(enforced) == 0 {
 			return "", nil, false
@@ -808,6 +817,9 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 	localAction, localConfidence, localErr := a.classifyIntentLocally(ctx, trimmedText)
 	if localErr == nil && localAction != nil && localConfidence >= intentClassifierMinConfidence {
 		if normalized := normalizeSystemActionForExecution(localAction, trimmedText); normalized != nil {
+			if isItemSystemAction(normalized.Action) && strings.TrimSpace(systemActionStringParam(normalized.Params, "input_mode")) == "" {
+				normalized.Params["input_mode"] = inputMode
+			}
 			if isItemSystemAction(normalized.Action) {
 				enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{normalized})
 				if len(enforced) == 0 {
@@ -1408,6 +1420,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			return "", nil, err
 		}
 		return status, nil, nil
+	case "capture_idea":
+		return a.captureIdeaItem(session, action)
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
 	case "create_github_issue", "create_github_issue_split":

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -17,6 +17,8 @@ var (
 	itemTitlePrefixPattern = regexp.MustCompile(`^\s*(?:[#>*-]+|\d+[.)]|(?:\[[ xX]\]))\s*`)
 	itemDelegatePattern    = regexp.MustCompile(`(?i)^(?:delegate|assign)(?:\s+(?:this|it))?\s+to\s+(.+?)$`)
 	itemSplitPattern       = regexp.MustCompile(`(?i)^split\s+(?:this|it)\s+into\s+(.+?)\s+items?$`)
+	ideaPrefixPattern      = regexp.MustCompile(`(?i)^\s*(?:new\s+idea|idea|i\s+have\s+an\s+idea|capture)\s*:\s*(.+?)\s*$`)
+	ideaSentencePattern    = regexp.MustCompile(`^.*?[.!?](?:\s|$)`)
 )
 
 type conversationCanvasArtifact struct {
@@ -42,7 +44,21 @@ func normalizeItemCommandText(raw string) string {
 }
 
 func parseInlineItemIntent(text string, now time.Time) *SystemAction {
+	return parseInlineItemIntentWithInputMode(text, now, chatInputModeText)
+}
+
+func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode string) *SystemAction {
 	normalized := normalizeItemCommandText(text)
+	if ideaText, ok := extractIdeaCaptureText(text); ok {
+		return &SystemAction{
+			Action: "capture_idea",
+			Params: map[string]interface{}{
+				"text":       text,
+				"idea_text":  ideaText,
+				"input_mode": normalizeChatInputMode(inputMode),
+			},
+		}
+	}
 	switch normalized {
 	case "make this an item", "track this", "add to inbox":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
@@ -80,6 +96,47 @@ func parseInlineItemIntent(text string, now time.Time) *SystemAction {
 		}
 	}
 	return nil
+}
+
+func extractIdeaCaptureText(raw string) (string, bool) {
+	match := ideaPrefixPattern.FindStringSubmatch(raw)
+	if len(match) != 2 {
+		return "", false
+	}
+	clean := normalizeIdeaText(match[1])
+	if clean == "" {
+		return "", false
+	}
+	return clean, true
+}
+
+func normalizeIdeaText(raw string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+}
+
+func deriveIdeaTitle(raw string) string {
+	clean := normalizeIdeaText(raw)
+	if clean == "" {
+		return ""
+	}
+	sentenceMatch := ideaSentencePattern.FindString(clean)
+	title := clean
+	if strings.TrimSpace(sentenceMatch) != "" {
+		title = normalizeIdeaText(sentenceMatch)
+	}
+	runes := []rune(title)
+	if len(runes) > 80 {
+		title = strings.TrimSpace(string(runes[:77])) + "..."
+	}
+	runes = []rune(title)
+	if len(runes) == 0 {
+		return ""
+	}
+	first := strings.ToUpper(string(runes[0]))
+	if len(runes) == 1 {
+		return first
+	}
+	return first + string(runes[1:])
 }
 
 func cleanActorReference(raw string) string {
@@ -159,7 +216,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "create_github_issue", "create_github_issue_split":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
 		return true
 	default:
 		return false
@@ -170,6 +227,8 @@ func itemActionFailurePrefix(action string) string {
 	switch strings.ToLower(strings.TrimSpace(action)) {
 	case "create_github_issue", "create_github_issue_split":
 		return "I couldn't create the GitHub issue: "
+	case "capture_idea":
+		return "I couldn't capture the idea: "
 	}
 	if strings.EqualFold(strings.TrimSpace(action), "split_items") {
 		return "I couldn't create the items: "
@@ -542,6 +601,85 @@ func (a *App) resolveActorByName(name string) (store.Actor, error) {
 	default:
 		return store.Actor{}, fmt.Errorf("actor %q not found", cleanName)
 	}
+}
+
+func ideaArtifactMeta(title, transcript, inputMode string, capturedAt time.Time) (*string, error) {
+	payload := map[string]string{
+		"title":        title,
+		"transcript":   transcript,
+		"capture_mode": normalizeChatInputMode(inputMode),
+		"captured_at":  capturedAt.UTC().Format(time.RFC3339),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	meta := string(raw)
+	return &meta, nil
+}
+
+func ideaCaptureConfirmation(title string) string {
+	clean := strings.TrimSpace(title)
+	if clean == "" {
+		return "Captured idea."
+	}
+	if strings.HasSuffix(clean, ".") || strings.HasSuffix(clean, "!") || strings.HasSuffix(clean, "?") {
+		return "Captured idea: " + clean
+	}
+	return "Captured idea: " + clean + "."
+}
+
+func (a *App) captureIdeaItem(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	rawText := strings.TrimSpace(systemActionStringParam(action.Params, "text"))
+	ideaText, ok := extractIdeaCaptureText(rawText)
+	if !ok {
+		ideaText = normalizeIdeaText(systemActionStringParam(action.Params, "idea_text"))
+	}
+	if ideaText == "" {
+		return "", nil, errors.New("idea text is required after the prefix")
+	}
+	title := deriveIdeaTitle(ideaText)
+	if title == "" {
+		return "", nil, errors.New("idea title is required")
+	}
+
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	workspaceID, err := a.resolveConversationWorkspaceID(targetProject, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	inputMode := normalizeChatInputMode(systemActionStringParam(action.Params, "input_mode"))
+	capturedAt := time.Now().UTC()
+	metaJSON, err := ideaArtifactMeta(title, ideaText, inputMode, capturedAt)
+	if err != nil {
+		return "", nil, err
+	}
+	artifact, err := a.store.CreateArtifact(store.ArtifactKindIdeaNote, nil, nil, &title, metaJSON)
+	if err != nil {
+		return "", nil, err
+	}
+	source := "idea"
+	item, err := a.store.CreateItem(title, store.ItemOptions{
+		WorkspaceID: workspaceID,
+		ArtifactID:  &artifact.ID,
+		Source:      &source,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	payload := map[string]interface{}{
+		"type":         "item_created",
+		"item_id":      item.ID,
+		"state":        item.State,
+		"title":        item.Title,
+		"artifact_id":  artifact.ID,
+		"source":       source,
+		"capture_mode": inputMode,
+	}
+	return ideaCaptureConfirmation(item.Title), payload, nil
 }
 
 func (a *App) createConversationItem(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {

--- a/internal/web/chat_items_test.go
+++ b/internal/web/chat_items_test.go
@@ -34,6 +34,8 @@ func TestParseInlineItemIntent(t *testing.T) {
 		wantWhen   string
 		wantCount  int
 	}{
+		{text: "idea: better swipe triage", wantAction: "capture_idea"},
+		{text: "new idea: add a review inbox", wantAction: "capture_idea"},
 		{text: "make this an item", wantAction: "make_item"},
 		{text: "delegate this to Codex", wantAction: "delegate_item", wantActor: "Codex"},
 		{text: "remind me tomorrow", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
@@ -224,6 +226,113 @@ func TestClassifyAndExecuteSystemActionSnoozeItemCreatesWaitingItem(t *testing.T
 	item := mustFirstItemByState(t, app, store.ItemStateWaiting)
 	if item.VisibleAfter == nil || *item.VisibleAfter != "2026-03-09T09:00:00Z" {
 		t.Fatalf("visible_after = %v", item.VisibleAfter)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	app.chatInputModes.set(session.ID, chatInputModeVoice)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(
+		context.Background(),
+		session.ID,
+		session,
+		"idea: better swipe triage for waiting items. Capture the blockers too.",
+	)
+	if !handled {
+		t.Fatal("expected idea capture to be handled")
+	}
+	if message != "Captured idea: Better swipe triage for waiting items." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "item_created" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if strFromAny(payloads[0]["capture_mode"]) != chatInputModeVoice {
+		t.Fatalf("capture_mode payload = %#v", payloads[0])
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if item.Title != "Better swipe triage for waiting items." {
+		t.Fatalf("item title = %q", item.Title)
+	}
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.Source == nil || *item.Source != "idea" {
+		t.Fatalf("item source = %v, want idea", item.Source)
+	}
+	if item.ArtifactID == nil {
+		t.Fatal("expected idea artifact to be linked")
+	}
+	artifact, err := app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindIdeaNote {
+		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindIdeaNote)
+	}
+	if artifact.MetaJSON == nil || !containsAll(
+		*artifact.MetaJSON,
+		`"capture_mode":"voice"`,
+		`"transcript":"better swipe triage for waiting items. Capture the blockers too."`,
+		`"title":"Better swipe triage for waiting items."`,
+	) {
+		t.Fatalf("artifact meta_json = %v", artifact.MetaJSON)
+	}
+}
+
+func TestRunAssistantTurnCaptureIdeaPersistsAssistantConfirmation(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	if _, err := app.store.CreateWorkspace("Default", project.RootPath); err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "idea: support batched inbox review", "idea: support batched inbox review", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+	app.chatInputModes.set(session.ID, chatInputModeText)
+
+	app.runAssistantTurn(session.ID, turnOutputModeVoice, false)
+
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages() error: %v", err)
+	}
+	foundAssistant := false
+	for _, msg := range messages {
+		if msg.Role == "assistant" && msg.ContentPlain == "Captured idea: Support batched inbox review." {
+			foundAssistant = true
+			break
+		}
+	}
+	if !foundAssistant {
+		t.Fatalf("expected assistant confirmation in chat history, got %#v", messages)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -98,6 +98,7 @@ type App struct {
 	turns            *chatTurnTracker
 	companionTurns   *companionPendingTurnTracker
 	companionRuntime *companionRuntimeTracker
+	chatInputModes   *chatInputModeTracker
 	projectAttention *projectAttentionTracker
 	tunnels          *tunnelRegistry
 	chatAppSessions  map[string]*appserver.Session
@@ -265,6 +266,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		turns:                         newChatTurnTracker(),
 		companionTurns:                newCompanionPendingTurnTracker(),
 		companionRuntime:              newCompanionRuntimeTracker(),
+		chatInputModes:                newChatInputModeTracker(),
 		projectAttention:              newProjectAttentionTracker(),
 		tunnels:                       newTunnelRegistry(),
 		chatAppSessions:               map[string]*appserver.Session{},

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -5322,6 +5322,7 @@ async function submitMessage(text, options = {}) {
   const body = {
     text: finalText,
     output_mode: state.ttsSilent ? 'silent' : 'voice',
+    input_mode: submitKind === 'voice_transcript' ? 'voice' : 'text',
   };
   try {
     if (submitKind === 'voice_transcript' && submitController) {

--- a/tests/playwright/chat-voice-send.spec.ts
+++ b/tests/playwright/chat-voice-send.spec.ts
@@ -311,6 +311,35 @@ test('click on canvas starts voice recording', async ({ page }) => {
   expect(sttActions).toContain('stop');
 });
 
+test('typed idea capture sends the idea prefix unchanged', async ({ page }) => {
+  await clearLog(page);
+
+  const input = page.locator('#chat-pane-input');
+  await input.fill('idea: better swipe triage');
+  await input.press('Enter');
+
+  await waitForLogEntry(page, 'message_sent');
+
+  const log = await getLog(page);
+  const sent = log.find((entry) => entry.type === 'message_sent');
+  expect(sent?.text).toBe('idea: better swipe triage');
+});
+
+test('voice idea capture sends the transcript unchanged', async ({ page }) => {
+  await setHarnessSTTTranscribeResponse(page, { text: 'idea: better swipe triage' }, 200);
+  await clearLog(page);
+
+  await page.mouse.click(400, 400);
+  await waitForLogEntry(page, 'recorder', 'start');
+  await page.mouse.click(400, 400);
+
+  await waitForLogEntry(page, 'message_sent');
+
+  const log = await getLog(page);
+  const sent = log.find((entry) => entry.type === 'message_sent');
+  expect(sent?.text).toBe('idea: better swipe triage');
+});
+
 test('sequential recordings reuse cached mic stream', async ({ page }) => {
   await clearLog(page);
 


### PR DESCRIPTION
## Summary
Add inline `idea:` capture for chat and voice transcripts, persist the idea as an `idea_note` artifact plus inbox item, and tag the capture mode so voice and typed flows are distinguishable end-to-end.

## Verification
- Requirement: `"idea: ..."` via voice creates an inbox idea item.
  Evidence: `go test ./internal/web ./internal/store`
  Evidence excerpt: `ok   github.com/krystophny/tabura/internal/web	4.056s`
  Covered by: `TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput` asserts inbox item creation, `source=idea` in the current Item model, and `capture_mode=voice`.
- Requirement: `"idea: ..."` via text input works the same way.
  Evidence: `go test ./internal/web ./internal/store`
  Covered by: `TestParseInlineItemIntent` includes `idea:` and `new idea:` parsing; `TestRunAssistantTurnCaptureIdeaPersistsAssistantConfirmation` runs the normal assistant turn path from a typed user message.
- Requirement: transcript stored as an `idea_note` artifact.
  Evidence: `go test ./internal/web ./internal/store`
  Covered by: `TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput` asserts `artifact.Kind == idea_note` and checks the stored transcript/title metadata.
- Requirement: active workspace inherited.
  Evidence: `go test ./internal/web ./internal/store`
  Covered by: `TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput` asserts the created item inherits the workspace mapped from the active project root.
- Requirement: confirmation shown in chat.
  Evidence: `go test ./internal/web ./internal/store`
  Covered by: `TestRunAssistantTurnCaptureIdeaPersistsAssistantConfirmation` asserts the persisted assistant reply `Captured idea: ...`.
- Requirement: works in dialogue mode and tap-to-talk.
  Evidence: `./scripts/playwright.sh tests/playwright/chat-voice-send.spec.ts`
  Evidence excerpts:
  - `✓   3 [chromium] › tests/playwright/chat-voice-send.spec.ts:314:5 › typed idea capture sends the idea prefix unchanged`
  - `✓   4 [chromium] › tests/playwright/chat-voice-send.spec.ts:328:5 › voice idea capture sends the transcript unchanged`
  - `35 passed (45.1s)`
