### PR TITLE
fix: add workspace creation from git repo URL via hub dialogue (fixes #282)

### DIFF
--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -149,6 +149,7 @@ func TestParseSystemAction(t *testing.T) {
 		{name: "switch project", raw: `{"action":"switch_project","name":"docs"}`, wantAction: "switch_project"},
 		{name: "switch workspace", raw: `{"action":"switch_workspace","workspace":"tabula"}`, wantAction: "switch_workspace"},
 		{name: "list workspace items", raw: `{"action":"list_workspace_items","workspace":"tabula"}`, wantAction: "list_workspace_items"},
+		{name: "create workspace from git", raw: `{"action":"create_workspace_from_git","repo_url":"git@github.com:user/repo.git"}`, wantAction: "create_workspace_from_git"},
 		{name: "switch model", raw: `{"action":"switch_model","alias":"gpt","effort":"high"}`, wantAction: "switch_model"},
 		{name: "toggle silent", raw: `{"action":"toggle_silent"}`, wantAction: "toggle_silent"},
 		{name: "toggle live dialogue", raw: `{"action":"toggle_live_dialogue"}`, wantAction: "toggle_live_dialogue"},

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -36,7 +36,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -323,7 +323,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
+	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -1381,6 +1381,18 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			"item_ids":     itemIDs,
 			"item_titles":  titles,
 			"item_count":   len(items),
+		}, nil
+	case "create_workspace_from_git":
+		workspace, repoURL, err := a.createWorkspaceFromGit(systemActionGitRepoURL(action.Params), systemActionGitTargetPath(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Created workspace %s at %s.", workspace.Name, workspace.DirPath), map[string]interface{}{
+			"type":         "create_workspace_from_git",
+			"workspace_id": workspace.ID,
+			"name":         workspace.Name,
+			"dir_path":     workspace.DirPath,
+			"repo_url":     repoURL,
 		}, nil
 	case "switch_model":
 		targetProject, err := a.systemActionTargetProject(session)

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -16,6 +16,9 @@ func parseInlineWorkspaceIntent(text string) *SystemAction {
 	if trimmed == "" {
 		return nil
 	}
+	if action := parseCreateWorkspaceFromGitIntent(trimmed); action != nil {
+		return action
+	}
 	lower := normalizeItemCommandText(trimmed)
 	switch lower {
 	case "show items here", "show open items here", "show items for this workspace", "what's open", "what is open", "what's open here", "what is open here":

--- a/internal/web/chat_workspace_git.go
+++ b/internal/web/chat_workspace_git.go
@@ -1,0 +1,206 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/protocol"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const workspaceCloneTimeout = 45 * time.Second
+
+func parseCreateWorkspaceFromGitIntent(text string) *SystemAction {
+	repoURL, targetPath, ok := parseWorkspaceCreateFromGitRequest(text)
+	if !ok {
+		return nil
+	}
+	params := map[string]interface{}{"repo_url": repoURL}
+	if targetPath != "" {
+		params["target_path"] = targetPath
+	}
+	return &SystemAction{Action: "create_workspace_from_git", Params: params}
+}
+
+func parseWorkspaceCreateFromGitRequest(raw string) (string, string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	lower := strings.ToLower(trimmed)
+	prefix := ""
+	switch {
+	case strings.HasPrefix(lower, "create workspace from "):
+		prefix = "create workspace from "
+	case strings.HasPrefix(lower, "add workspace from "):
+		prefix = "add workspace from "
+	default:
+		return "", "", false
+	}
+
+	rest := strings.TrimSpace(trimmed[len(prefix):])
+	rest = strings.TrimRight(rest, " \t\r\n!?,:;.")
+	if strings.HasPrefix(strings.ToLower(rest), "git ") {
+		rest = strings.TrimSpace(rest[len("git "):])
+	}
+	if rest == "" {
+		return "", "", false
+	}
+
+	targetPath := ""
+	for _, marker := range []string{" clone to ", " to "} {
+		idx := strings.LastIndex(strings.ToLower(rest), marker)
+		if idx <= 0 {
+			continue
+		}
+		repoURL := strings.TrimSpace(rest[:idx])
+		target := strings.TrimSpace(rest[idx+len(marker):])
+		if looksLikeGitRepoURL(repoURL) && target != "" {
+			return repoURL, target, true
+		}
+	}
+	if !looksLikeGitRepoURL(rest) {
+		return "", "", false
+	}
+	return rest, targetPath, true
+}
+
+func looksLikeGitRepoURL(raw string) bool {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return false
+	}
+	for _, prefix := range []string{"git@", "ssh://", "https://", "http://", "file://", "/", "./", "../", "~/"} {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(value, ".git")
+}
+
+func systemActionGitRepoURL(params map[string]interface{}) string {
+	for _, key := range []string{"repo_url", "url", "repo", "remote"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func systemActionGitTargetPath(params map[string]interface{}) string {
+	for _, key := range []string{"target_path", "path", "clone_to", "target"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func workspaceRepoNameFromURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" {
+		value = parsed.Path
+	} else if strings.HasPrefix(value, "git@") {
+		if idx := strings.Index(value, ":"); idx >= 0 && idx+1 < len(value) {
+			value = value[idx+1:]
+		}
+	}
+	value = strings.TrimRight(value, "/")
+	base := path.Base(strings.ReplaceAll(value, "\\", "/"))
+	base = strings.TrimSuffix(base, ".git")
+	return strings.TrimSpace(base)
+}
+
+func workspaceCloneRootDir() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("TABURA_WORKSPACE_CLONE_ROOT")); configured != "" {
+		return filepath.Abs(filepath.Clean(expandWorkspacePathReference(configured)))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "code"), nil
+}
+
+func resolveWorkspaceCloneTarget(repoURL, targetPath string) (string, string, error) {
+	if cleanTarget := strings.TrimSpace(targetPath); cleanTarget != "" {
+		expanded := expandWorkspacePathReference(cleanTarget)
+		absTarget, err := filepath.Abs(filepath.Clean(expanded))
+		if err != nil {
+			return "", "", err
+		}
+		return absTarget, filepath.Base(absTarget), nil
+	}
+	repoName := workspaceRepoNameFromURL(repoURL)
+	if repoName == "" {
+		return "", "", fmt.Errorf("unable to determine repository name from %q", repoURL)
+	}
+	rootDir, err := workspaceCloneRootDir()
+	if err != nil {
+		return "", "", err
+	}
+	absRoot, err := filepath.Abs(filepath.Clean(rootDir))
+	if err != nil {
+		return "", "", err
+	}
+	target := filepath.Join(absRoot, repoName)
+	return target, repoName, nil
+}
+
+func cloneWorkspaceRepo(ctx context.Context, repoURL, targetDir string) error {
+	cmd := exec.CommandContext(ctx, "git", "clone", "--", repoURL, targetDir)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	message := strings.TrimSpace(string(output))
+	if message == "" {
+		return err
+	}
+	return fmt.Errorf("git clone failed: %s", message)
+}
+
+func (a *App) createWorkspaceFromGit(repoURL, targetPath string) (store.Workspace, string, error) {
+	cleanRepoURL := strings.TrimSpace(repoURL)
+	if cleanRepoURL == "" {
+		return store.Workspace{}, "", fmt.Errorf("git repository URL is required")
+	}
+	targetDir, workspaceName, err := resolveWorkspaceCloneTarget(cleanRepoURL, targetPath)
+	if err != nil {
+		return store.Workspace{}, "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
+		return store.Workspace{}, "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), workspaceCloneTimeout)
+	defer cancel()
+	if err := cloneWorkspaceRepo(ctx, cleanRepoURL, targetDir); err != nil {
+		return store.Workspace{}, "", err
+	}
+	if _, err := protocol.BootstrapProject(targetDir); err != nil {
+		return store.Workspace{}, "", err
+	}
+
+	workspace, err := a.store.CreateWorkspace(workspaceName, targetDir)
+	if err != nil {
+		return store.Workspace{}, "", err
+	}
+	if err := a.store.SetActiveWorkspace(workspace.ID); err != nil {
+		return store.Workspace{}, "", err
+	}
+	workspace, err = a.store.GetWorkspace(workspace.ID)
+	if err != nil {
+		return store.Workspace{}, "", err
+	}
+	return workspace, cleanRepoURL, nil
+}

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,12 +16,16 @@ func TestParseInlineWorkspaceIntent(t *testing.T) {
 		text          string
 		wantAction    string
 		wantWorkspace string
+		wantRepoURL   string
+		wantTarget    string
 	}{
 		{text: "open workspace Alpha", wantAction: "switch_workspace", wantWorkspace: "Alpha"},
 		{text: "switch to workspace Beta", wantAction: "switch_workspace", wantWorkspace: "Beta"},
 		{text: "switch to ./repo", wantAction: "switch_workspace", wantWorkspace: "./repo"},
 		{text: "show items here", wantAction: "list_workspace_items"},
 		{text: "what's open", wantAction: "list_workspace_items"},
+		{text: "create workspace from git@github.com:user/repo.git", wantAction: "create_workspace_from_git", wantRepoURL: "git@github.com:user/repo.git"},
+		{text: "create workspace from https://gitlab.example.com/user/data-repo.git to ~/write/proposal", wantAction: "create_workspace_from_git", wantRepoURL: "https://gitlab.example.com/user/data-repo.git", wantTarget: "~/write/proposal"},
 	}
 
 	for _, tc := range cases {
@@ -34,6 +40,12 @@ func TestParseInlineWorkspaceIntent(t *testing.T) {
 			}
 			if got := systemActionWorkspaceRef(action.Params); got != tc.wantWorkspace {
 				t.Fatalf("workspace ref = %q, want %q", got, tc.wantWorkspace)
+			}
+			if got := systemActionGitRepoURL(action.Params); got != tc.wantRepoURL {
+				t.Fatalf("repo_url = %q, want %q", got, tc.wantRepoURL)
+			}
+			if got := systemActionGitTargetPath(action.Params); got != tc.wantTarget {
+				t.Fatalf("target_path = %q, want %q", got, tc.wantTarget)
 			}
 		})
 	}
@@ -153,6 +165,75 @@ func TestClassifyAndExecuteSystemActionListWorkspaceItemsUsesActiveWorkspace(t *
 	}
 }
 
+func TestClassifyAndExecuteSystemActionCreateWorkspaceFromGit(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	cloneRoot := filepath.Join(t.TempDir(), "code")
+	t.Setenv("TABURA_WORKSPACE_CLONE_ROOT", cloneRoot)
+
+	sourceRepo := initGitTestRepo(t, "example-workspace")
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	command := "create workspace from file://" + filepath.ToSlash(sourceRepo)
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, command)
+	if !handled {
+		t.Fatal("expected create workspace from git command to be handled")
+	}
+	targetDir := filepath.Join(cloneRoot, "example-workspace")
+	if message != "Created workspace example-workspace at "+targetDir+"." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "create_workspace_from_git" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strFromAny(payloads[0]["dir_path"]); got != targetDir {
+		t.Fatalf("dir_path = %q, want %q", got, targetDir)
+	}
+
+	workspace, err := app.store.GetWorkspace(int64FromAny(payloads[0]["workspace_id"]))
+	if err != nil {
+		t.Fatalf("GetWorkspace() error: %v", err)
+	}
+	if workspace.Name != "example-workspace" {
+		t.Fatalf("workspace name = %q, want %q", workspace.Name, "example-workspace")
+	}
+	if !workspace.IsActive {
+		t.Fatal("expected cloned workspace to be active")
+	}
+	if workspace.DirPath != targetDir {
+		t.Fatalf("workspace dir_path = %q, want %q", workspace.DirPath, targetDir)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, ".git")); err != nil {
+		t.Fatalf("clone missing .git directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, ".tabura", "codex-mcp.toml")); err != nil {
+		t.Fatalf("bootstrap missing codex-mcp.toml: %v", err)
+	}
+	gitignoreBody, err := os.ReadFile(filepath.Join(targetDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignoreBody), ".tabura/artifacts/") {
+		t.Fatalf(".gitignore = %q, want .tabura/artifacts entry", string(gitignoreBody))
+	}
+	readmeBody, err := os.ReadFile(filepath.Join(targetDir, "README.md"))
+	if err != nil {
+		t.Fatalf("read cloned README: %v", err)
+	}
+	if strings.TrimSpace(string(readmeBody)) != "# example-workspace" {
+		t.Fatalf("README = %q", string(readmeBody))
+	}
+}
+
 func TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary(t *testing.T) {
 	app := newAuthedTestApp(t)
 	project, err := app.ensureDefaultProjectRecord()
@@ -188,5 +269,41 @@ func TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary(t *testing.T)
 	}
 	if !strings.Contains(prompt, "Conversation transcript:\nUSER:\nhello") {
 		t.Fatalf("prompt missing original content: %q", prompt)
+	}
+}
+
+func initGitTestRepo(t *testing.T, name string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, string(output))
+		}
+	}
+	runGit("init", root)
+	runGit("-C", root, "add", "README.md")
+	runGit("-C", root, "-c", "user.name=Tabura Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	return root
+}
+
+func int64FromAny(v any) int64 {
+	switch value := v.(type) {
+	case float64:
+		return int64(value)
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	default:
+		return 0
 	}
 }


### PR DESCRIPTION
## Summary
- add a `create_workspace_from_git` hub/dialogue action and inline parser for git/https/file remotes plus optional `to <path>` targets
- clone the repository, run `protocol.BootstrapProject`, then register and activate the workspace
- cover the new action with parser, JSON routing, and end-to-end hub-session tests

## Verification
- Dialogue parsing and routed execution:
  - `go test ./internal/web -run 'Test(ParseInlineWorkspaceIntent|ClassifyAndExecuteSystemActionCreateWorkspaceFromGit|ParseSystemAction)$' 2>&1 | tee /tmp/tabura-issue-282-test.log`
  - Output: `ok   github.com/krystophny/tabura/internal/web  0.025s`
- `create workspace from <git-url>` command:
  - `TestParseInlineWorkspaceIntent` verifies `create workspace from git@github.com:user/repo.git`
- Optional target path extraction:
  - `TestParseInlineWorkspaceIntent` verifies `create workspace from https://gitlab.example.com/user/data-repo.git to ~/write/proposal`
- Clone into the workspace root and bootstrap the clone:
  - `TestClassifyAndExecuteSystemActionCreateWorkspaceFromGit` clones into `<temp>/code/example-workspace`, asserts `<clone>/.tabura/codex-mcp.toml`, and checks `.gitignore` contains `.tabura/artifacts/`
- Hub dialogue registration and activation:
  - `TestClassifyAndExecuteSystemActionCreateWorkspaceFromGit` runs through a hub chat session, then verifies the workspace record, active flag, cloned `.git/`, and cloned `README.md`
- LLM/local-router JSON action parsing:
  - `TestParseSystemAction` accepts `{"action":"create_workspace_from_git","repo_url":"git@github.com:user/repo.git"}`
