### PR TITLE
fix: Harden mobile/iPhone capture for HTTPS, permissions, and upload (fixes #226)

### DIFF
--- a/internal/web/static/capture.css
+++ b/internal/web/static/capture.css
@@ -85,6 +85,23 @@ body::before {
   color: var(--capture-muted);
 }
 
+.capture-alert {
+  margin: 18px 0 0;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(166, 63, 31, 0.18);
+  background: rgba(166, 63, 31, 0.08);
+  color: var(--capture-accent-strong);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.capture-alert[data-tone="info"] {
+  border-color: rgba(29, 122, 82, 0.16);
+  background: rgba(29, 122, 82, 0.08);
+  color: var(--capture-ink);
+}
+
 .capture-record {
   width: 100%;
   margin-top: 24px;
@@ -105,6 +122,7 @@ body::before {
 .capture-record:focus-visible,
 .capture-save:focus-visible,
 .capture-retry:focus-visible,
+.capture-fallback:focus-visible,
 .capture-reset:focus-visible,
 #capture-note:focus-visible {
   outline: 3px solid rgba(29, 122, 82, 0.24);
@@ -170,6 +188,7 @@ body::before {
 
 .capture-save,
 .capture-retry,
+.capture-fallback,
 .capture-reset {
   min-height: 52px;
   border-radius: 999px;
@@ -205,7 +224,18 @@ body::before {
   color: var(--capture-accent-strong);
 }
 
+.capture-fallback {
+  padding: 0 20px;
+  border: 1px solid rgba(29, 122, 82, 0.2);
+  background: rgba(29, 122, 82, 0.08);
+  color: #155843;
+}
+
 .capture-retry[hidden] {
+  display: none;
+}
+
+.capture-fallback[hidden] {
   display: none;
 }
 
@@ -248,6 +278,16 @@ body[data-capture-state="saving"] .capture-card {
 
 body[data-capture-state="transcribing"] .capture-card {
   box-shadow: 0 28px 80px rgba(166, 63, 31, 0.18);
+}
+
+body[data-capture-state="success"] .capture-card {
+  box-shadow: 0 28px 80px rgba(29, 122, 82, 0.22);
+  border-color: rgba(29, 122, 82, 0.2);
+}
+
+body[data-capture-state="failed"] .capture-card,
+body[data-capture-state="offline"] .capture-card {
+  border-color: rgba(166, 63, 31, 0.22);
 }
 
 @keyframes capturePulse {

--- a/internal/web/static/capture.html
+++ b/internal/web/static/capture.html
@@ -14,6 +14,7 @@
       <p class="capture-kicker">Quick Capture</p>
       <h1 id="capture-title">Catch the thought before it drifts.</h1>
       <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+      <p id="capture-alert" class="capture-alert" hidden></p>
 
       <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
         <span class="capture-record-ring" aria-hidden="true"></span>
@@ -35,6 +36,7 @@
       <div class="capture-actions">
         <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
         <button id="capture-retry" class="capture-retry" type="button" hidden>Retry voice memo</button>
+        <button id="capture-fallback" class="capture-fallback" type="button" hidden>Save as text note instead</button>
         <button id="capture-reset" class="capture-reset" type="button">Clear</button>
       </div>
 

--- a/internal/web/static/capture.js
+++ b/internal/web/static/capture.js
@@ -1,35 +1,67 @@
 (function () {
   const page = document.getElementById('capture-page');
+  const alertNode = document.getElementById('capture-alert');
   const noteInput = document.getElementById('capture-note');
   const recordButton = document.getElementById('capture-record');
   const recordLabel = recordButton ? recordButton.querySelector('.capture-record-label') : null;
   const recordHint = recordButton ? recordButton.querySelector('.capture-record-hint') : null;
   const saveButton = document.getElementById('capture-save');
   const retryButton = document.getElementById('capture-retry');
+  const fallbackButton = document.getElementById('capture-fallback');
   const resetButton = document.getElementById('capture-reset');
   const statusNode = document.getElementById('capture-status');
 
-  if (!page || !noteInput || !recordButton || !recordLabel || !recordHint || !saveButton || !retryButton || !resetButton || !statusNode) {
+  if (!page || !alertNode || !noteInput || !recordButton || !recordLabel || !recordHint || !saveButton || !retryButton || !fallbackButton || !resetButton || !statusNode) {
     return;
   }
 
+  const testEnv = window.__taburaCaptureTestEnv || {};
+  const microphonePermissionCacheKey = 'tabura.capture.microphone_permission';
+  const queueDatabaseName = String(testEnv.queueDatabaseName || 'tabura-capture');
+  const queueStoreName = 'voice-memos';
+  const maxVoiceRetries = 3;
+
   const state = {
     statusTimer: 0,
+    captureStateTimer: 0,
     recording: false,
     saving: false,
     transcribing: false,
+    drainingQueue: false,
     discardRecording: false,
     mediaStream: null,
     mediaRecorder: null,
     audioChunks: [],
     audioBlob: null,
     pendingTranscript: '',
+    voiceRetryCount: 0,
+    fallbackVisible: false,
+    microphonePermission: readCachedMicrophonePermission(),
+    voiceCaptureDisabled: false,
   };
 
   function clearStatusTimer() {
     if (state.statusTimer) {
       window.clearTimeout(state.statusTimer);
       state.statusTimer = 0;
+    }
+  }
+
+  function clearCaptureStateTimer() {
+    if (state.captureStateTimer) {
+      window.clearTimeout(state.captureStateTimer);
+      state.captureStateTimer = 0;
+    }
+  }
+
+  function setAlert(message, tone) {
+    const text = String(message || '').trim();
+    alertNode.textContent = text;
+    alertNode.hidden = text === '';
+    if (tone) {
+      alertNode.dataset.tone = tone;
+    } else {
+      delete alertNode.dataset.tone;
     }
   }
 
@@ -50,6 +82,16 @@
     }, delayMS);
   }
 
+  function scheduleCaptureStateReset(delayMS) {
+    clearCaptureStateTimer();
+    state.captureStateTimer = window.setTimeout(() => {
+      state.captureStateTimer = 0;
+      if (!state.recording && !state.saving && !state.transcribing) {
+        setCaptureState('idle');
+      }
+    }, delayMS);
+  }
+
   function setCaptureState(nextState) {
     const cleanState = String(nextState || 'idle').trim() || 'idle';
     document.body.dataset.captureState = cleanState;
@@ -63,6 +105,28 @@
     if (cleanState === 'transcribing') {
       recordLabel.textContent = 'Transcribing';
       recordHint.textContent = 'Saving the voice memo into your inbox.';
+      return;
+    }
+    if (cleanState === 'saving') {
+      recordLabel.textContent = 'Saving';
+      recordHint.textContent = 'Sending the capture into your inbox.';
+      return;
+    }
+    if (cleanState === 'offline') {
+      recordLabel.textContent = 'Queued';
+      recordHint.textContent = 'Saved locally. It will upload when you are back online.';
+      return;
+    }
+    if (cleanState === 'success') {
+      recordLabel.textContent = 'Saved';
+      recordHint.textContent = 'Your memo is in the inbox.';
+      return;
+    }
+    if (cleanState === 'failed') {
+      recordLabel.textContent = 'Retry';
+      recordHint.textContent = state.fallbackVisible
+        ? 'Retry the memo or save it as text instead.'
+        : 'Retry the memo or clear to discard.';
       return;
     }
     recordLabel.textContent = 'Record';
@@ -96,11 +160,87 @@
     const hasNote = normalizeNote(noteInput.value) !== '';
     const busy = state.saving || state.transcribing;
     noteInput.disabled = busy;
-    recordButton.disabled = busy;
+    recordButton.disabled = busy || state.voiceCaptureDisabled;
     retryButton.hidden = !(state.audioBlob && !state.recording && !state.transcribing);
     retryButton.disabled = busy || !state.audioBlob;
+    fallbackButton.hidden = !state.fallbackVisible;
+    fallbackButton.disabled = busy;
     resetButton.disabled = busy;
     saveButton.disabled = busy || !hasNote;
+  }
+
+  function readCachedMicrophonePermission() {
+    try {
+      return String(window.localStorage.getItem(microphonePermissionCacheKey) || '').trim();
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function writeCachedMicrophonePermission(value) {
+    const clean = String(value || '').trim();
+    state.microphonePermission = clean;
+    try {
+      if (clean) {
+        window.localStorage.setItem(microphonePermissionCacheKey, clean);
+      } else {
+        window.localStorage.removeItem(microphonePermissionCacheKey);
+      }
+    } catch (_) {}
+  }
+
+  function currentProtocol() {
+    return String(testEnv.protocol || window.location.protocol || '').trim().toLowerCase();
+  }
+
+  function currentHostname() {
+    return String(testEnv.hostname || window.location.hostname || '').trim().toLowerCase();
+  }
+
+  function currentHost() {
+    const rawHost = String(window.location.host || '').trim();
+    const envHost = String(testEnv.hostname || '').trim();
+    if (envHost.includes(':')) {
+      return envHost;
+    }
+    if (rawHost) {
+      return rawHost;
+    }
+    return envHost;
+  }
+
+  function isLoopbackHost(hostname) {
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  }
+
+  function isCaptureSecureContext() {
+    if (typeof testEnv.isSecureContext === 'boolean') {
+      return testEnv.isSecureContext;
+    }
+    return window.isSecureContext;
+  }
+
+  function isOnline() {
+    if (typeof testEnv.online === 'boolean') {
+      return testEnv.online;
+    }
+    if (typeof navigator.onLine === 'boolean') {
+      return navigator.onLine;
+    }
+    return true;
+  }
+
+  function applyCaptureAvailability() {
+    const hostname = currentHostname();
+    const secure = isCaptureSecureContext();
+    const blockedByProtocol = currentProtocol() !== 'https:' && !isLoopbackHost(hostname) && !secure;
+    state.voiceCaptureDisabled = blockedByProtocol;
+    if (blockedByProtocol) {
+      setAlert(`Voice capture requires HTTPS. Visit https://${currentHost()}${window.location.pathname}`, '');
+    } else if (alertNode.textContent.includes('Voice capture requires HTTPS')) {
+      setAlert('', '');
+    }
+    updateSaveState();
   }
 
   function releaseMediaStream() {
@@ -128,6 +268,8 @@
     state.audioChunks = [];
     state.audioBlob = null;
     state.pendingTranscript = '';
+    state.voiceRetryCount = 0;
+    state.fallbackVisible = false;
   }
 
   function voiceMemoErrorMessage(reason) {
@@ -212,11 +354,159 @@
     return title;
   }
 
+  function isNetworkFailure(error) {
+    const message = String(error && error.message ? error.message : error).toLowerCase();
+    return !isOnline() || message.includes('failed to fetch') || message.includes('networkerror');
+  }
+
+  function queueUnsupported() {
+    return !window.indexedDB;
+  }
+
+  function openQueueDB() {
+    return new Promise((resolve, reject) => {
+      if (queueUnsupported()) {
+        reject(new Error('IndexedDB unavailable'));
+        return;
+      }
+      const request = window.indexedDB.open(queueDatabaseName, 1);
+      request.onerror = () => {
+        reject(request.error || new Error('capture queue unavailable'));
+      };
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(queueStoreName)) {
+          db.createObjectStore(queueStoreName, { keyPath: 'id', autoIncrement: true });
+        }
+      };
+      request.onsuccess = () => {
+        resolve(request.result);
+      };
+    });
+  }
+
+  function runQueueRequest(mode, action) {
+    return openQueueDB().then((db) => new Promise((resolve, reject) => {
+      const tx = db.transaction(queueStoreName, mode);
+      const store = tx.objectStore(queueStoreName);
+      let request;
+      try {
+        request = action(store);
+      } catch (error) {
+        db.close();
+        reject(error);
+        return;
+      }
+      tx.oncomplete = () => {
+        db.close();
+      };
+      tx.onerror = () => {
+        db.close();
+        reject(tx.error || new Error('capture queue transaction failed'));
+      };
+      request.onsuccess = () => {
+        resolve(request.result);
+      };
+      request.onerror = () => {
+        reject(request.error || new Error('capture queue request failed'));
+      };
+    }));
+  }
+
+  function enqueueVoiceMemo(blob, transcript) {
+    return runQueueRequest('readwrite', (store) => store.add({
+      createdAt: new Date().toISOString(),
+      blob,
+      transcript: String(transcript || '').trim(),
+    }));
+  }
+
+  function listQueuedVoiceMemos() {
+    return runQueueRequest('readonly', (store) => store.getAll()).then((items) => {
+      const out = Array.isArray(items) ? items : [];
+      out.sort((left, right) => Number(left.id || 0) - Number(right.id || 0));
+      return out;
+    });
+  }
+
+  function deleteQueuedVoiceMemo(id) {
+    return runQueueRequest('readwrite', (store) => store.delete(id));
+  }
+
+  async function queueCurrentVoiceMemo() {
+    if (!state.audioBlob) {
+      return false;
+    }
+    await enqueueVoiceMemo(state.audioBlob, state.pendingTranscript);
+    clearVoiceMemoState();
+    setCaptureState('offline');
+    setStatus('Saved locally. It will upload when online.', '');
+    return true;
+  }
+
+  async function drainQueuedVoiceMemos() {
+    if (state.drainingQueue || !isOnline()) {
+      return;
+    }
+    state.drainingQueue = true;
+    try {
+      const queued = await listQueuedVoiceMemos();
+      for (const entry of queued) {
+        if (!isOnline()) {
+          break;
+        }
+        const transcript = normalizeNote(entry && entry.transcript)
+          || await transcribeVoiceMemo(entry && entry.blob ? entry.blob : null);
+        await saveVoiceMemo(transcript);
+        await deleteQueuedVoiceMemo(entry.id);
+        setCaptureState('success');
+        setStatus(`Saved: ${deriveItemTitle(transcript)}`, 'success');
+        scheduleStatusClear(1800);
+        scheduleCaptureStateReset(1800);
+      }
+    } catch (error) {
+      if (!isNetworkFailure(error)) {
+        setStatus(`Queued memo failed: ${String(error && error.message ? error.message : error)}`, 'error');
+      }
+    } finally {
+      state.drainingQueue = false;
+      updateSaveState();
+    }
+  }
+
+  async function readMicrophonePermission() {
+    if (!navigator.permissions || typeof navigator.permissions.query !== 'function') {
+      return state.microphonePermission || '';
+    }
+    try {
+      const status = await navigator.permissions.query({ name: 'microphone' });
+      const clean = String(status && status.state ? status.state : '').trim();
+      if (clean) {
+        writeCachedMicrophonePermission(clean);
+      }
+      return clean;
+    } catch (_) {
+      return state.microphonePermission || '';
+    }
+  }
+
+  function microphonePermissionMessage(permissionState, error) {
+    const name = String(error && error.name ? error.name : '').trim();
+    if (permissionState === 'denied') {
+      return 'Microphone access denied. Check Settings > Safari > Microphone.';
+    }
+    if (name === 'NotAllowedError') {
+      return 'Tap record again to allow microphone access.';
+    }
+    return `Voice capture failed: ${String(error && error.message ? error.message : error)}`;
+  }
+
   async function processVoiceMemo() {
     if (!state.audioBlob || state.saving || state.transcribing) {
       return;
     }
     clearStatusTimer();
+    clearCaptureStateTimer();
     state.transcribing = true;
     updateSaveState();
     setCaptureState('transcribing');
@@ -226,17 +516,36 @@
       state.pendingTranscript = transcript;
       const title = await saveVoiceMemo(transcript);
       clearVoiceMemoState();
-      setCaptureState('idle');
+      setCaptureState('success');
       setStatus(`Saved: ${title}`, 'success');
       scheduleStatusClear(1800);
+      scheduleCaptureStateReset(1800);
     } catch (error) {
-      setCaptureState('idle');
       const message = String(error && error.message ? error.message : error);
-      if (message === 'transcription_http_error') {
-        setStatus('Transcription failed. Retry this memo.', 'error');
+      if (isNetworkFailure(error)) {
+        try {
+          const queued = await queueCurrentVoiceMemo();
+          if (!queued) {
+            throw new Error('queue_unavailable');
+          }
+        } catch (queueError) {
+          setCaptureState('failed');
+          setStatus(`Upload failed: ${String(queueError && queueError.message ? queueError.message : queueError)}`, 'error');
+        }
+      } else if (message === 'transcription_http_error') {
+        state.voiceRetryCount += 1;
+        state.fallbackVisible = state.voiceRetryCount >= maxVoiceRetries;
+        setCaptureState('failed');
+        setStatus(state.fallbackVisible ? 'Transcription failed. Retry this memo or save it as text instead.' : 'Transcription failed. Retry this memo.', 'error');
       } else if (message === 'artifact_create_failed' || /^HTTP \d+$/.test(message)) {
-        setStatus('Saving voice memo failed. Retry this memo.', 'error');
+        state.voiceRetryCount += 1;
+        state.fallbackVisible = state.voiceRetryCount >= maxVoiceRetries;
+        setCaptureState('failed');
+        setStatus(state.fallbackVisible ? 'Saving voice memo failed. Retry it or save it as text instead.' : 'Saving voice memo failed. Retry this memo.', 'error');
       } else {
+        state.voiceRetryCount += 1;
+        state.fallbackVisible = state.voiceRetryCount >= maxVoiceRetries;
+        setCaptureState('failed');
         setStatus(message, 'error');
       }
     } finally {
@@ -246,6 +555,10 @@
   }
 
   async function startRecording() {
+    applyCaptureAvailability();
+    if (state.voiceCaptureDisabled) {
+      return;
+    }
     if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
       setStatus('Voice capture is not available in this browser.', 'error');
       return;
@@ -255,8 +568,19 @@
       return;
     }
     clearStatusTimer();
+    clearCaptureStateTimer();
+    const permissionState = await readMicrophonePermission();
+    if (permissionState === 'denied') {
+      writeCachedMicrophonePermission('denied');
+      setAlert('Microphone access denied. Check Settings > Safari > Microphone.', '');
+      setStatus('Microphone access is currently denied.', 'error');
+      updateSaveState();
+      return;
+    }
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      writeCachedMicrophonePermission('granted');
+      setAlert('', '');
       const recorder = new window.MediaRecorder(stream);
       state.recording = true;
       clearVoiceMemoState();
@@ -276,6 +600,14 @@
         state.discardRecording = false;
         finishRecording();
         if (state.audioBlob) {
+          if (!isOnline()) {
+            void queueCurrentVoiceMemo().catch((error) => {
+              setCaptureState('failed');
+              setStatus(`Queue failed: ${String(error && error.message ? error.message : error)}`, 'error');
+              updateSaveState();
+            });
+            return;
+          }
           void processVoiceMemo();
         }
       });
@@ -287,8 +619,11 @@
       releaseMediaStream();
       state.recording = false;
       state.mediaRecorder = null;
-      setCaptureState('idle');
-      setStatus(`Voice capture failed: ${String(error && error.message ? error.message : error)}`, 'error');
+      setCaptureState('failed');
+      const nextPermission = permissionState === 'prompt' ? 'dismissed' : permissionState || 'denied';
+      writeCachedMicrophonePermission(nextPermission);
+      setAlert(microphonePermissionMessage(permissionState, error), '');
+      setStatus(microphonePermissionMessage(permissionState, error), 'error');
       updateSaveState();
     }
   }
@@ -307,6 +642,7 @@
 
   function resetCapture() {
     clearStatusTimer();
+    clearCaptureStateTimer();
     if (state.mediaRecorder && state.mediaRecorder.state !== 'inactive') {
       state.discardRecording = true;
       state.mediaRecorder.stop();
@@ -318,6 +654,19 @@
     noteInput.value = '';
     setCaptureState('idle');
     setStatus('', '');
+    updateSaveState();
+  }
+
+  function offerTextFallback() {
+    const transcript = normalizeNote(state.pendingTranscript);
+    if (transcript && normalizeNote(noteInput.value) === '') {
+      noteInput.value = transcript;
+    }
+    noteInput.focus();
+    setCaptureState('failed');
+    setStatus(transcript
+      ? 'Transcript copied into the note field. Edit it if needed, then save as text.'
+      : 'Type the memo while it is fresh, then save it as a text note.', '');
     updateSaveState();
   }
 
@@ -342,11 +691,12 @@
       });
       noteInput.value = '';
       clearVoiceMemoState();
-      setCaptureState('idle');
+      setCaptureState('success');
       setStatus(`Saved: ${title}`, 'success');
       scheduleStatusClear(1800);
+      scheduleCaptureStateReset(1800);
     } catch (error) {
-      setCaptureState(state.recording ? 'recording' : 'idle');
+      setCaptureState(state.recording ? 'recording' : 'failed');
       setStatus(`Save failed: ${String(error && error.message ? error.message : error)}`, 'error');
     } finally {
       state.saving = false;
@@ -368,10 +718,26 @@
   retryButton.addEventListener('click', () => {
     void processVoiceMemo();
   });
+  fallbackButton.addEventListener('click', offerTextFallback);
   resetButton.addEventListener('click', resetCapture);
+  window.addEventListener('online', () => {
+    if (!state.recording && !state.saving && !state.transcribing) {
+      void drainQueuedVoiceMemos();
+    }
+  });
+  window.addEventListener('offline', () => {
+    if (!state.recording && !state.audioBlob) {
+      setCaptureState('offline');
+      setStatus('Offline. New voice memos will queue until you reconnect.', '');
+    }
+  });
 
   updateSaveState();
+  applyCaptureAvailability();
   setCaptureState('idle');
+  if (isOnline()) {
+    void drainQueuedVoiceMemos();
+  }
   window.__taburaCapture = {
     deriveItemTitle,
     voiceMemoErrorMessage,

--- a/tests/playwright/capture-harness.html
+++ b/tests/playwright/capture-harness.html
@@ -12,6 +12,7 @@
       <p class="capture-kicker">Quick Capture</p>
       <h1 id="capture-title">Catch the thought before it drifts.</h1>
       <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+      <p id="capture-alert" class="capture-alert" hidden></p>
 
       <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
         <span class="capture-record-ring" aria-hidden="true"></span>
@@ -33,6 +34,7 @@
       <div class="capture-actions">
         <button id="capture-save" class="capture-save" type="button" disabled>Save</button>
         <button id="capture-retry" class="capture-retry" type="button" hidden>Retry voice memo</button>
+        <button id="capture-fallback" class="capture-fallback" type="button" hidden>Save as text note instead</button>
         <button id="capture-reset" class="capture-reset" type="button">Clear</button>
       </div>
 
@@ -46,14 +48,31 @@
       const artifactRequests = [];
       const transcribeRequests = [];
       const fetchRequests = [];
+      const searchParams = new URLSearchParams(window.location.search);
+      let online = searchParams.get('online') !== '0';
+      let permissionMode = searchParams.get('permission') || 'granted';
       let transcribeResponses = [
         { status: 200, body: { text: 'Voice memo from capture harness. Follow up tomorrow morning.' } },
       ];
+
+      window.__taburaCaptureTestEnv = {
+        isSecureContext: searchParams.get('secure') !== '0',
+        protocol: searchParams.get('protocol') || window.location.protocol,
+        hostname: searchParams.get('host') || window.location.hostname,
+        queueDatabaseName: `tabura-capture-${Math.random().toString(16).slice(2)}`,
+      };
 
       window.__captureRequests = itemRequests;
       window.__captureArtifactRequests = artifactRequests;
       window.__captureTranscribeRequests = transcribeRequests;
       window.__captureFetchRequests = fetchRequests;
+      window.__setCaptureOnline = (value) => {
+        online = Boolean(value);
+        window.dispatchEvent(new Event(online ? 'online' : 'offline'));
+      };
+      window.__setCapturePermissionMode = (value) => {
+        permissionMode = String(value || 'granted');
+      };
       window.__setCaptureTranscribeResponses = (responses) => {
         if (!Array.isArray(responses) || responses.length === 0) {
           transcribeResponses = [
@@ -79,6 +98,9 @@
           url: String(url),
           method: options.method || 'GET',
         });
+        if (!online) {
+          throw new TypeError('Failed to fetch');
+        }
         if (String(url).includes('/api/stt/transcribe')) {
           transcribeRequests.push({
             method: options.method || 'GET',
@@ -124,7 +146,38 @@
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,
         value: {
-          getUserMedia: async () => new FakeStream(),
+          getUserMedia: async () => {
+            if (permissionMode === 'denied') {
+              const error = new Error('Permission denied');
+              error.name = 'NotAllowedError';
+              throw error;
+            }
+            if (permissionMode === 'dismissed') {
+              const error = new Error('Permission dismissed');
+              error.name = 'NotAllowedError';
+              throw error;
+            }
+            return new FakeStream();
+          },
+        },
+      });
+
+      Object.defineProperty(navigator, 'onLine', {
+        configurable: true,
+        get() {
+          return online;
+        },
+      });
+
+      Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: {
+          query: async ({ name }) => ({
+            name,
+            state: permissionMode === 'granted' ? 'granted' : permissionMode === 'denied' ? 'denied' : 'prompt',
+            addEventListener() {},
+            removeEventListener() {},
+          }),
         },
       });
 

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -84,6 +84,74 @@ test.describe('capture page', () => {
     expect(itemRequests[0].title).toBe('Retry worked after the STT sidecar came back.');
   });
 
+  test('shows an actionable HTTPS warning on insecure non-loopback origins', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html?secure=0&protocol=http:&host=tabura.local:8420');
+
+    await expect(page.locator('#capture-alert')).toContainText('Voice capture requires HTTPS.');
+    await expect(page.locator('#capture-alert')).toContainText('https://tabura.local:8420/tests/playwright/capture-harness.html');
+    await expect(page.locator('#capture-record')).toBeDisabled();
+  });
+
+  test('shows Safari recovery guidance when microphone access is denied', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html?permission=denied');
+
+    await page.locator('#capture-record').click({ force: true });
+
+    await expect(page.locator('#capture-alert')).toContainText('Check Settings > Safari > Microphone');
+    await expect(page.locator('#capture-status')).toContainText('Microphone access is currently denied.');
+  });
+
+  test('queues voice memos offline and uploads them on reconnect', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html?online=0');
+
+    await page.locator('#capture-record').click({ force: true });
+    await page.locator('#capture-record').click({ force: true });
+
+    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'offline');
+    await expect(page.locator('#capture-status')).toContainText('Saved locally');
+
+    const transcribeRequestsBefore = await page.evaluate(() => (window as any).__captureTranscribeRequests);
+    expect(transcribeRequestsBefore).toHaveLength(0);
+
+    await page.evaluate(() => {
+      (window as any).__setCaptureOnline(true);
+    });
+
+    await expect(page.locator('#capture-status')).toContainText('Saved: Voice memo from capture harness.');
+    const transcribeRequestsAfter = await page.evaluate(() => (window as any).__captureTranscribeRequests);
+    expect(transcribeRequestsAfter).toHaveLength(1);
+    const itemRequests = await page.evaluate(() => (window as any).__captureRequests);
+    expect(itemRequests).toHaveLength(1);
+  });
+
+  test('offers a text fallback after repeated voice save failures', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tests/playwright/capture-harness.html');
+
+    await page.evaluate(() => {
+      (window as any).__setCaptureTranscribeResponses([
+        { status: 502, body: { error: 'sidecar unavailable' } },
+        { status: 502, body: { error: 'sidecar unavailable' } },
+        { status: 502, body: { error: 'sidecar unavailable' } },
+      ]);
+    });
+
+    await page.locator('#capture-record').click({ force: true });
+    await page.locator('#capture-record').click({ force: true });
+
+    await expect(page.locator('#capture-retry')).toBeVisible();
+    await page.locator('#capture-retry').click();
+    await page.locator('#capture-retry').click();
+
+    await expect(page.locator('#capture-fallback')).toBeVisible();
+    await page.locator('#capture-fallback').click();
+    await expect(page.locator('#capture-note')).toBeFocused();
+    await expect(page.locator('#capture-status')).toContainText('Type the memo');
+  });
+
   test('toggles record state with the large capture button', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/tests/playwright/capture-harness.html');
@@ -94,7 +162,7 @@ test.describe('capture page', () => {
     await expect(page.locator('#capture-record')).toHaveAttribute('aria-pressed', 'true');
 
     await page.locator('#capture-record').click({ force: true });
-    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'idle');
+    await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'success');
     await expect(page.locator('#capture-record')).toHaveAttribute('aria-pressed', 'false');
     await expect(page.locator('#capture-status')).toContainText('Saved: Voice memo from capture harness.');
   });


### PR DESCRIPTION
## Summary
- harden `/capture` for insecure origins, denied microphone access, offline recording, and repeated upload failures
- persist queued voice memos in IndexedDB and auto-drain them on reconnect
- extend the Playwright harness/spec to cover HTTPS, denial recovery, offline queueing, retry, and text fallback flows

## Verification
- Non-HTTPS warning: `./scripts/playwright.sh tests/playwright/capture.spec.ts --grep "actionable HTTPS warning|microphone access is denied|queues voice memos offline"` -> `3 passed (1.2s)`; the HTTPS test asserts the warning text includes the exact `https://.../capture` URL and that the record button is disabled.
- Microphone denial recovery: same targeted Playwright run -> `shows Safari recovery guidance when microphone access is denied` passed; it asserts the recovery message points to `Settings > Safari > Microphone` and that the page reports microphone access is denied.
- Retry after failed upload/transcription: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `7 passed (2.1s)`; `keeps the memo available for retry after transcription failure` passed and asserts the retry button stays visible until the retry succeeds.
- Text fallback after repeated failures: same Playwright run -> `offers a text fallback after repeated voice save failures` passed; it asserts the fallback button appears after the third failed attempt and focuses the note field.
- Offline queue + reconnect: targeted Playwright run -> `queues voice memos offline and uploads them on reconnect` passed; it asserts `data-capture-state="offline"`, zero STT requests while offline, then a successful upload after reconnect.
- Visual state coverage: full Playwright run -> `toggles record state with the large capture button` passed; together with the offline/success tests it exercises `recording`, `offline`, and `success` capture states.
- One-handed mobile layout evidence: `internal/web/static/capture.css` keeps safe-area padding via `env(safe-area-inset-*)`, a full-width primary record control, and 52px minimum action targets.
- IndexedDB persistence evidence: `internal/web/static/capture.js` now opens `indexedDB` store `voice-memos`, queues captured blobs when offline/network-failed, and drains them from the `online` listener.
