### PR TITLE
fix: extract tool palette as floating icon bar (fixes #242)

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -139,6 +139,24 @@ const state = {
   companionProjectKey: '',
 };
 
+const TOOL_PALETTE_MODES = [
+  {
+    id: 'voice',
+    label: 'Voice mode',
+    icon: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v8"/><path d="M8.5 8.5a3.5 3.5 0 0 1 7 0V12a3.5 3.5 0 0 1-7 0Z"/><path d="M6 11.5a6 6 0 0 0 12 0"/><path d="M12 17.5V21"/><path d="M9 21h6"/></svg>',
+  },
+  {
+    id: 'pen',
+    label: 'Pen mode',
+    icon: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m4 20 4.5-1 9-9a2.1 2.1 0 0 0-3-3l-9 9Z"/><path d="m13 7 4 4"/><path d="M4 20h5"/></svg>',
+  },
+  {
+    id: 'keyboard',
+    label: 'Keyboard mode',
+    icon: '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="6" width="18" height="12" rx="2"/><path d="M6 10h.01"/><path d="M9 10h.01"/><path d="M12 10h.01"/><path d="M15 10h.01"/><path d="M18 10h.01"/><path d="M6 14h12"/></svg>',
+  },
+];
+
 export function getState() {
   return state;
 }
@@ -1105,6 +1123,41 @@ function isPenInputMode() {
 
 function isKeyboardInputMode() {
   return state.inputMode === 'keyboard' || state.inputMode === 'typing';
+}
+
+function renderToolPalette() {
+  const host = document.getElementById('tool-palette');
+  if (!(host instanceof HTMLElement)) return;
+  host.replaceChildren();
+  const disabled = state.projectSwitchInFlight || state.projectModelSwitchInFlight;
+  for (const mode of TOOL_PALETTE_MODES) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tool-palette-btn';
+    button.dataset.mode = mode.id;
+    button.setAttribute('aria-label', mode.label);
+    button.setAttribute('title', mode.label);
+    button.setAttribute('aria-pressed', state.inputMode === mode.id ? 'true' : 'false');
+    if (state.inputMode === mode.id) {
+      button.classList.add('is-active');
+    }
+    button.disabled = disabled;
+    button.innerHTML = mode.icon;
+    button.addEventListener('click', () => {
+      updateRuntimePreferences({ input_mode: mode.id })
+        .then(() => {
+          if (mode.id !== 'pen') {
+            clearInkDraft();
+          }
+          renderInkControls();
+          showStatus(`${mode.id} mode on`);
+        })
+        .catch((err) => {
+          showStatus(`input mode failed: ${String(err?.message || err || 'unknown error')}`);
+        });
+    });
+    host.appendChild(button);
+  }
 }
 
 async function fetchRuntimeMeta() {
@@ -4211,7 +4264,7 @@ function renderEdgeTopModelButtons() {
   } else {
     const dialogueButton = document.createElement('button');
     dialogueButton.type = 'button';
-    dialogueButton.className = 'edge-project-btn edge-model-btn edge-live-dialogue-btn edge-conv-btn';
+    dialogueButton.className = 'edge-project-btn edge-model-btn edge-live-dialogue-btn';
     dialogueButton.textContent = 'Dialogue';
     dialogueButton.disabled = liveDisabled || !ttsEnabled;
     dialogueButton.addEventListener('click', () => {
@@ -4295,37 +4348,6 @@ function renderEdgeTopModelButtons() {
   });
   host.appendChild(blackButton);
 
-  const inputModes = [
-    { id: 'voice', label: 'voice' },
-    { id: 'pen', label: 'pen' },
-    { id: 'keyboard', label: 'kbd' },
-  ];
-  for (const mode of inputModes) {
-    const inputButton = document.createElement('button');
-    inputButton.type = 'button';
-    inputButton.className = 'edge-project-btn edge-model-btn';
-    inputButton.textContent = mode.label;
-    inputButton.setAttribute('aria-pressed', state.inputMode === mode.id ? 'true' : 'false');
-    if (state.inputMode === mode.id) {
-      inputButton.classList.add('is-active');
-    }
-    inputButton.disabled = state.projectSwitchInFlight || state.projectModelSwitchInFlight;
-    inputButton.addEventListener('click', () => {
-      updateRuntimePreferences({ input_mode: mode.id })
-        .then(() => {
-          if (mode.id !== 'pen') {
-            clearInkDraft();
-          }
-          renderInkControls();
-          showStatus(`${mode.id} mode on`);
-        })
-        .catch((err) => {
-          showStatus(`input mode failed: ${String(err?.message || err || 'unknown error')}`);
-      });
-    });
-    host.appendChild(inputButton);
-  }
-
   const temporarySourceProjectID = project && !isHubProject(project) ? String(project.id || '').trim() : '';
   const temporaryButtons = isTemporaryProjectKind(project?.kind)
     ? [
@@ -4361,6 +4383,7 @@ function renderEdgeTopModelButtons() {
     button.addEventListener('click', action.onClick);
     host.appendChild(button);
   }
+  renderToolPalette();
 }
 
 async function switchProjectChatModel(modelAlias, reasoningEffort = '') {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -77,6 +77,8 @@
         <div class="overlay-content"></div>
       </div>
 
+      <div id="tool-palette" class="tool-palette" aria-label="Interaction tools"></div>
+
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
       <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
 

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -328,6 +328,67 @@ body.file-sidebar-enabled #pr-file-drawer-backdrop.is-open {
   font-weight: 600;
 }
 
+.tool-palette {
+  position: fixed;
+  left: 50%;
+  bottom: calc(1rem + var(--safe-area-bottom));
+  transform: translateX(-50%);
+  z-index: 395;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid rgba(17, 24, 39, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(10px);
+}
+
+.tool-palette-btn {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: #334155;
+  padding: 0;
+  cursor: pointer;
+}
+
+.tool-palette-btn:hover,
+.tool-palette-btn:focus-visible {
+  border-color: rgba(15, 23, 42, 0.16);
+  background: rgba(241, 245, 249, 0.96);
+  color: #0f172a;
+}
+
+.tool-palette-btn.is-active {
+  border-color: #0f172a;
+  background: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.22);
+}
+
+.tool-palette-btn:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.tool-palette-btn svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .companion-idle-surface {
   --companion-bg: radial-gradient(circle at top, #f5f1e8 0%, #e7e1d5 42%, #d8d0c1 100%);
   --companion-panel: rgba(255, 252, 246, 0.78);
@@ -1401,8 +1462,9 @@ body.panel-motion-enabled {
   display: flex;
   gap: 0.35rem;
   align-items: center;
-  flex-wrap: nowrap;
-  overflow-x: auto;
+  flex-wrap: wrap;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .edge-model-btn {
@@ -1438,10 +1500,6 @@ body.panel-motion-enabled {
 }
 
 .edge-silent-btn {
-  margin-left: 0.35rem;
-}
-
-.edge-conv-btn {
   margin-left: 0.35rem;
 }
 
@@ -1702,6 +1760,13 @@ body.panel-motion-enabled {
 
   .edge-top {
     height: calc(200px + var(--safe-area-top));
+  }
+
+  .tool-palette {
+    left: auto;
+    right: calc(0.75rem + var(--safe-area-right));
+    bottom: calc(0.75rem + var(--safe-area-bottom));
+    transform: none;
   }
 }
 

--- a/tests/playwright/chat-harness.html
+++ b/tests/playwright/chat-harness.html
@@ -34,6 +34,8 @@
         <div class="overlay-content"></div>
       </div>
 
+      <div id="tool-palette" class="tool-palette" aria-label="Interaction tools"></div>
+
       <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
 
       <div id="edge-top" class="edge-panel edge-top">

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -63,6 +63,8 @@
         <div class="overlay-content"></div>
       </div>
 
+      <div id="tool-palette" class="tool-palette" aria-label="Interaction tools"></div>
+
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
       <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
 

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -198,6 +198,56 @@ test.describe('tabula rasa button', () => {
   });
 });
 
+test.describe('floating tool palette', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitReady(page);
+  });
+
+  test('renders icon-only interaction controls outside the top panel', async ({ page }) => {
+    await expect(page.locator('#tool-palette')).toBeVisible();
+
+    const snapshot = await page.evaluate(() => {
+      const paletteButtons = Array.from(document.querySelectorAll('#tool-palette .tool-palette-btn')).map((button) => ({
+        mode: button.getAttribute('data-mode'),
+        label: button.getAttribute('aria-label'),
+        text: String(button.textContent || '').trim(),
+      }));
+      const topButtonTexts = Array.from(document.querySelectorAll('#edge-top-models button')).map((button) => String(button.textContent || '').trim());
+      const topModels = document.getElementById('edge-top-models');
+      return {
+        paletteButtons,
+        topButtonTexts,
+        dialogueButtons: document.querySelectorAll('#edge-top-models .edge-live-dialogue-btn').length,
+        topOverflows: topModels ? (topModels.scrollWidth > topModels.clientWidth + 1) : null,
+      };
+    });
+
+    expect(snapshot.paletteButtons.map((button) => button.mode)).toEqual(['voice', 'pen', 'keyboard']);
+    expect(snapshot.paletteButtons.every((button) => button.text === '')).toBe(true);
+    expect(snapshot.topButtonTexts).not.toContain('voice');
+    expect(snapshot.topButtonTexts).not.toContain('pen');
+    expect(snapshot.topButtonTexts).not.toContain('kbd');
+    expect(snapshot.dialogueButtons).toBe(1);
+    expect(snapshot.topOverflows).toBe(false);
+  });
+
+  test('palette clicks switch the active interaction mode', async ({ page }) => {
+    await clearLog(page);
+
+    const keyboardButton = page.locator('#tool-palette .tool-palette-btn[data-mode="keyboard"]');
+    const penButton = page.locator('#tool-palette .tool-palette-btn[data-mode="pen"]');
+
+    await keyboardButton.click();
+    await waitForLogEntry(page, 'api_fetch', 'runtime_preferences');
+
+    await expect(keyboardButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(penButton).toHaveAttribute('aria-pressed', 'false');
+
+    const inputMode = await page.evaluate(() => (window as any)._taburaApp?.getState?.().inputMode);
+    expect(inputMode).toBe('keyboard');
+  });
+});
+
 
 // =============================================================================
 // Image artifact rendering


### PR DESCRIPTION
## Summary

Moves the current interaction-mode controls out of `#edge-top` into a floating `#tool-palette`, keeps the top edge panel focused on project/model/session controls, and adds focused Playwright coverage for the new layout contract.

## Verification

- Extract palette from `#edge-top`
  Evidence: `internal/web/static/app.js` now renders `voice`/`pen`/`keyboard` only through `renderToolPalette()`, and `tests/playwright/ui-system.spec.ts` test `renders icon-only interaction controls outside the top panel` asserts `#edge-top-models` no longer contains `voice`, `pen`, or `kbd` buttons.
- Create floating `#tool-palette`
  Evidence: `internal/web/static/index.html`, `tests/playwright/harness.html`, and `tests/playwright/chat-harness.html` now include `<div id="tool-palette">`; `internal/web/static/style.css` positions it as a fixed floating bar over the canvas.
- Icons not text
  Evidence: `renderToolPalette()` renders SVG-only buttons with `aria-label`/`title`; the new Playwright test asserts every palette button has empty visible text.
- Fix Dialogue duplication
  Evidence: `internal/web/static/app.js` drops the extra `edge-conv-btn` treatment and the new Playwright test asserts exactly one `.edge-live-dialogue-btn` remains in `#edge-top-models`.
- Slim down `#edge-top` / remove horizontal overflow
  Evidence: `internal/web/static/style.css` switches `#edge-top-models` to wrapping layout with hidden horizontal overflow; the new Playwright test asserts `scrollWidth <= clientWidth` for `#edge-top-models`.
- Regression coverage for adjacent controls
  Evidence: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts tests/playwright/conversation-mode.spec.ts tests/playwright/companion-mode.spec.ts tests/playwright/hub-mode.spec.ts`
  Output excerpt: `75 passed (50.7s)`
