### PR TITLE
fix: add external_bindings table for sync tracking (fixes #251)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -94,6 +94,19 @@ type ExternalAccountUpdate struct {
 	Enabled  *bool          `json:"enabled,omitempty"`
 }
 
+type ExternalBinding struct {
+	ID              int64   `json:"id"`
+	AccountID       int64   `json:"account_id"`
+	Provider        string  `json:"provider"`
+	ObjectType      string  `json:"object_type"`
+	RemoteID        string  `json:"remote_id"`
+	ItemID          *int64  `json:"item_id,omitempty"`
+	ArtifactID      *int64  `json:"artifact_id,omitempty"`
+	ContainerRef    *string `json:"container_ref,omitempty"`
+	RemoteUpdatedAt *string `json:"remote_updated_at,omitempty"`
+	LastSyncedAt    string  `json:"last_synced_at"`
+}
+
 type Actor struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -34,6 +34,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"actors":            {"id", "name", "kind", "created_at"},
 		"artifacts":         {"id", "kind", "ref_path", "ref_url", "title", "meta_json", "created_at", "updated_at"},
 		"external_accounts": {"id", "sphere", "provider", "label", "config_json", "enabled", "created_at", "updated_at"},
+		"external_bindings": {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
 		"items":             {"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
 	} {
 		got := make(map[string]bool, len(columns[table]))
@@ -120,7 +121,7 @@ CREATE TABLE chat_messages (
 	if err != nil {
 		t.Fatalf("TableColumns() error: %v", err)
 	}
-	for _, table := range []string{"workspaces", "actors", "artifacts", "external_accounts", "items"} {
+	for _, table := range []string{"workspaces", "actors", "artifacts", "external_accounts", "external_bindings", "items"} {
 		if _, ok := columns[table]; !ok {
 			t.Fatalf("expected migrated table %s to exist", table)
 		}

--- a/internal/store/external_binding_test.go
+++ b/internal/store/external_binding_test.go
@@ -1,0 +1,228 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExternalBindingStoreCRUDAndQueries(t *testing.T) {
+	s := newTestStore(t)
+
+	account, err := s.CreateExternalAccount(SphereWork, ExternalProviderGmail, "Work Gmail", map[string]any{
+		"username":   "alice@example.com",
+		"token_file": "gmail-work.json",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(work) error: %v", err)
+	}
+	otherAccount, err := s.CreateExternalAccount(SpherePrivate, ExternalProviderTodoist, "Personal Todoist", map[string]any{
+		"username": "alice",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(todoist) error: %v", err)
+	}
+	item, err := s.CreateItem("Follow up", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	title := "Imported thread"
+	artifact, err := s.CreateArtifact(ArtifactKindEmail, nil, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	containerRef := "INBOX/Work"
+	remoteUpdatedAt := "2026-03-08T12:00:00Z"
+	created, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        " GMAIL ",
+		ObjectType:      " Email ",
+		RemoteID:        " msg-1 ",
+		ItemID:          &item.ID,
+		ArtifactID:      &artifact.ID,
+		ContainerRef:    &containerRef,
+		RemoteUpdatedAt: &remoteUpdatedAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding(create) error: %v", err)
+	}
+	if created.ID == 0 {
+		t.Fatal("expected created binding ID")
+	}
+	if created.Provider != ExternalProviderGmail {
+		t.Fatalf("binding provider = %q, want %q", created.Provider, ExternalProviderGmail)
+	}
+	if created.ObjectType != "email" {
+		t.Fatalf("binding object_type = %q, want email", created.ObjectType)
+	}
+	if created.RemoteID != "msg-1" {
+		t.Fatalf("binding remote_id = %q, want msg-1", created.RemoteID)
+	}
+	if created.ItemID == nil || *created.ItemID != item.ID {
+		t.Fatalf("binding item_id = %v, want %d", created.ItemID, item.ID)
+	}
+	if created.ArtifactID == nil || *created.ArtifactID != artifact.ID {
+		t.Fatalf("binding artifact_id = %v, want %d", created.ArtifactID, artifact.ID)
+	}
+	if created.ContainerRef == nil || *created.ContainerRef != containerRef {
+		t.Fatalf("binding container_ref = %v, want %q", created.ContainerRef, containerRef)
+	}
+	if created.RemoteUpdatedAt == nil || *created.RemoteUpdatedAt != "2026-03-08T12:00:00Z" {
+		t.Fatalf("binding remote_updated_at = %v, want normalized timestamp", created.RemoteUpdatedAt)
+	}
+	if created.LastSyncedAt == "" {
+		t.Fatal("expected last_synced_at")
+	}
+
+	got, err := s.GetBindingByRemote(account.ID, ExternalProviderGmail, "email", "msg-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote() error: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("GetBindingByRemote() id = %d, want %d", got.ID, created.ID)
+	}
+
+	updatedRemoteAt := "2026-03-08T13:15:00Z"
+	updated, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        ExternalProviderGmail,
+		ObjectType:      "email",
+		RemoteID:        "msg-1",
+		ItemID:          &item.ID,
+		ContainerRef:    &containerRef,
+		RemoteUpdatedAt: &updatedRemoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding(update) error: %v", err)
+	}
+	if updated.ID != created.ID {
+		t.Fatalf("updated binding ID = %d, want %d", updated.ID, created.ID)
+	}
+	if updated.ArtifactID != nil {
+		t.Fatalf("updated binding artifact_id = %v, want nil after update", updated.ArtifactID)
+	}
+	if updated.RemoteUpdatedAt == nil || *updated.RemoteUpdatedAt != updatedRemoteAt {
+		t.Fatalf("updated remote_updated_at = %v, want %q", updated.RemoteUpdatedAt, updatedRemoteAt)
+	}
+	if updated.LastSyncedAt == "" {
+		t.Fatal("expected updated last_synced_at")
+	}
+
+	otherRemoteAt := "2026-03-08T08:30:00Z"
+	second, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:       otherAccount.ID,
+		Provider:        ExternalProviderTodoist,
+		ObjectType:      "task",
+		RemoteID:        "task-7",
+		ItemID:          &item.ID,
+		ArtifactID:      &artifact.ID,
+		RemoteUpdatedAt: &otherRemoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding(second) error: %v", err)
+	}
+
+	itemBindings, err := s.GetBindingsByItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetBindingsByItem() error: %v", err)
+	}
+	if len(itemBindings) != 2 {
+		t.Fatalf("GetBindingsByItem() len = %d, want 2", len(itemBindings))
+	}
+	if itemBindings[0].ID != updated.ID || itemBindings[1].ID != second.ID {
+		t.Fatalf("GetBindingsByItem() order = %+v", itemBindings)
+	}
+
+	artifactBindings, err := s.GetBindingsByArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetBindingsByArtifact() error: %v", err)
+	}
+	if len(artifactBindings) != 1 || artifactBindings[0].ID != second.ID {
+		t.Fatalf("GetBindingsByArtifact() = %+v, want only second binding", artifactBindings)
+	}
+
+	oldSync := "2026-03-08T09:00:00Z"
+	if _, err := s.db.Exec(`UPDATE external_bindings SET last_synced_at = ? WHERE id = ?`, oldSync, updated.ID); err != nil {
+		t.Fatalf("seed old last_synced_at: %v", err)
+	}
+	stale, err := s.ListStaleBindings(ExternalProviderGmail, time.Date(2026, time.March, 8, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListStaleBindings() error: %v", err)
+	}
+	if len(stale) != 1 || stale[0].ID != updated.ID {
+		t.Fatalf("ListStaleBindings() = %+v, want updated binding only", stale)
+	}
+
+	if err := s.DeleteBinding(updated.ID); err != nil {
+		t.Fatalf("DeleteBinding() error: %v", err)
+	}
+	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderGmail, "email", "msg-1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetBindingByRemote(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestExternalBindingStoreRejectsInvalidInput(t *testing.T) {
+	s := newTestStore(t)
+
+	account, err := s.CreateExternalAccount(SphereWork, ExternalProviderIMAP, "Work IMAP", map[string]any{
+		"host":     "imap.example.com",
+		"port":     993,
+		"username": "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	if _, err := s.UpsertExternalBinding(ExternalBinding{}); err == nil {
+		t.Fatal("expected missing account error")
+	}
+	if _, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:  account.ID,
+		Provider:   ExternalProviderGmail,
+		ObjectType: "email",
+		RemoteID:   "msg-1",
+	}); err == nil {
+		t.Fatal("expected provider mismatch error")
+	}
+	if _, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID: account.ID,
+		Provider:  ExternalProviderIMAP,
+		RemoteID:  "msg-1",
+	}); err == nil {
+		t.Fatal("expected missing object_type error")
+	}
+	if _, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:  account.ID,
+		Provider:   ExternalProviderIMAP,
+		ObjectType: "email",
+	}); err == nil {
+		t.Fatal("expected missing remote_id error")
+	}
+	badRemoteUpdatedAt := "tomorrow morning"
+	if _, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        ExternalProviderIMAP,
+		ObjectType:      "email",
+		RemoteID:        "msg-1",
+		RemoteUpdatedAt: &badRemoteUpdatedAt,
+	}); err == nil {
+		t.Fatal("expected invalid remote_updated_at error")
+	}
+	if _, err := s.GetBindingByRemote(account.ID, "", "email", "msg-1"); err == nil {
+		t.Fatal("expected missing provider lookup error")
+	}
+	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderIMAP, "", "msg-1"); err == nil {
+		t.Fatal("expected missing object_type lookup error")
+	}
+	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderIMAP, "email", ""); err == nil {
+		t.Fatal("expected missing remote_id lookup error")
+	}
+	if _, err := s.ListStaleBindings("smtp", time.Now()); err == nil {
+		t.Fatal("expected invalid stale provider error")
+	}
+	if err := s.DeleteBinding(999999); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("DeleteBinding(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -66,6 +66,22 @@ CREATE TABLE IF NOT EXISTS external_accounts (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_external_accounts_identity
   ON external_accounts(lower(sphere), lower(provider), lower(label));
+CREATE TABLE IF NOT EXISTS external_bindings (
+  id INTEGER PRIMARY KEY,
+  account_id INTEGER NOT NULL REFERENCES external_accounts(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  object_type TEXT NOT NULL,
+  remote_id TEXT NOT NULL,
+  item_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
+  artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
+  container_ref TEXT,
+  remote_updated_at TEXT,
+  last_synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_bindings_identity
+  ON external_bindings(account_id, provider, object_type, remote_id);
+CREATE INDEX IF NOT EXISTS idx_external_bindings_stale
+  ON external_bindings(provider, last_synced_at);
 `
 	if _, err := s.db.Exec(schema); err != nil {
 		return err

--- a/internal/store/store_external_binding.go
+++ b/internal/store/store_external_binding.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+func normalizeExternalBindingObjectType(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func normalizeExternalBindingRemoteID(raw string) string {
+	return strings.TrimSpace(raw)
+}
+
+func scanExternalBinding(
+	row interface {
+		Scan(dest ...any) error
+	},
+) (ExternalBinding, error) {
+	var (
+		out                           ExternalBinding
+		itemID, artifactID            sql.NullInt64
+		containerRef, remoteUpdatedAt sql.NullString
+	)
+	if err := row.Scan(
+		&out.ID,
+		&out.AccountID,
+		&out.Provider,
+		&out.ObjectType,
+		&out.RemoteID,
+		&itemID,
+		&artifactID,
+		&containerRef,
+		&remoteUpdatedAt,
+		&out.LastSyncedAt,
+	); err != nil {
+		return ExternalBinding{}, err
+	}
+	out.Provider = normalizeExternalAccountProvider(out.Provider)
+	out.ObjectType = normalizeExternalBindingObjectType(out.ObjectType)
+	out.RemoteID = normalizeExternalBindingRemoteID(out.RemoteID)
+	out.ItemID = nullInt64Pointer(itemID)
+	out.ArtifactID = nullInt64Pointer(artifactID)
+	out.ContainerRef = nullStringPointer(containerRef)
+	out.RemoteUpdatedAt = nullStringPointer(remoteUpdatedAt)
+	out.LastSyncedAt = strings.TrimSpace(out.LastSyncedAt)
+	return out, nil
+}
+
+func (s *Store) validateExternalBindingAccount(accountID int64, provider string) (ExternalAccount, error) {
+	if accountID <= 0 {
+		return ExternalAccount{}, errors.New("external binding account_id is required")
+	}
+	cleanProvider := normalizeExternalAccountProvider(provider)
+	if cleanProvider == "" {
+		return ExternalAccount{}, errors.New("external binding provider is required")
+	}
+	account, err := s.GetExternalAccount(accountID)
+	if err != nil {
+		return ExternalAccount{}, err
+	}
+	if account.Provider != cleanProvider {
+		return ExternalAccount{}, errors.New("external binding provider must match account provider")
+	}
+	return account, nil
+}
+
+func (s *Store) UpsertExternalBinding(binding ExternalBinding) (ExternalBinding, error) {
+	account, err := s.validateExternalBindingAccount(binding.AccountID, binding.Provider)
+	if err != nil {
+		return ExternalBinding{}, err
+	}
+	objectType := normalizeExternalBindingObjectType(binding.ObjectType)
+	if objectType == "" {
+		return ExternalBinding{}, errors.New("external binding object_type is required")
+	}
+	remoteID := normalizeExternalBindingRemoteID(binding.RemoteID)
+	if remoteID == "" {
+		return ExternalBinding{}, errors.New("external binding remote_id is required")
+	}
+	remoteUpdatedAt, err := normalizeOptionalRFC3339String(binding.RemoteUpdatedAt)
+	if err != nil {
+		return ExternalBinding{}, errors.New("external binding remote_updated_at must be a valid RFC3339 timestamp")
+	}
+	lastSyncedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := s.db.Exec(
+		`INSERT INTO external_bindings (
+			account_id, provider, object_type, remote_id, item_id, artifact_id, container_ref, remote_updated_at, last_synced_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, provider, object_type, remote_id) DO UPDATE SET
+			item_id = excluded.item_id,
+			artifact_id = excluded.artifact_id,
+			container_ref = excluded.container_ref,
+			remote_updated_at = excluded.remote_updated_at,
+			last_synced_at = excluded.last_synced_at`,
+		account.ID,
+		account.Provider,
+		objectType,
+		remoteID,
+		nullablePositiveID(valueOrZero(binding.ItemID)),
+		nullablePositiveID(valueOrZero(binding.ArtifactID)),
+		normalizeOptionalString(binding.ContainerRef),
+		remoteUpdatedAt,
+		lastSyncedAt,
+	); err != nil {
+		return ExternalBinding{}, err
+	}
+	return s.GetBindingByRemote(account.ID, account.Provider, objectType, remoteID)
+}
+
+func (s *Store) GetBindingByRemote(accountID int64, provider, objectType, remoteID string) (ExternalBinding, error) {
+	if _, err := s.validateExternalBindingAccount(accountID, provider); err != nil {
+		return ExternalBinding{}, err
+	}
+	cleanObjectType := normalizeExternalBindingObjectType(objectType)
+	if cleanObjectType == "" {
+		return ExternalBinding{}, errors.New("external binding object_type is required")
+	}
+	cleanRemoteID := normalizeExternalBindingRemoteID(remoteID)
+	if cleanRemoteID == "" {
+		return ExternalBinding{}, errors.New("external binding remote_id is required")
+	}
+	return scanExternalBinding(s.db.QueryRow(
+		`SELECT id, account_id, provider, object_type, remote_id, item_id, artifact_id, container_ref, remote_updated_at, last_synced_at
+		 FROM external_bindings
+		 WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_id = ?`,
+		accountID,
+		normalizeExternalAccountProvider(provider),
+		cleanObjectType,
+		cleanRemoteID,
+	))
+}
+
+func (s *Store) GetBindingsByItem(itemID int64) ([]ExternalBinding, error) {
+	rows, err := s.db.Query(
+		`SELECT id, account_id, provider, object_type, remote_id, item_id, artifact_id, container_ref, remote_updated_at, last_synced_at
+		 FROM external_bindings
+		 WHERE item_id = ?
+		 ORDER BY lower(provider), lower(object_type), remote_id, id`,
+		itemID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanExternalBindingRows(rows)
+}
+
+func (s *Store) GetBindingsByArtifact(artifactID int64) ([]ExternalBinding, error) {
+	rows, err := s.db.Query(
+		`SELECT id, account_id, provider, object_type, remote_id, item_id, artifact_id, container_ref, remote_updated_at, last_synced_at
+		 FROM external_bindings
+		 WHERE artifact_id = ?
+		 ORDER BY lower(provider), lower(object_type), remote_id, id`,
+		artifactID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanExternalBindingRows(rows)
+}
+
+func (s *Store) ListStaleBindings(provider string, olderThan time.Time) ([]ExternalBinding, error) {
+	cleanProvider := normalizeExternalAccountProvider(provider)
+	if cleanProvider == "" {
+		return nil, errors.New("external binding provider is required")
+	}
+	rows, err := s.db.Query(
+		`SELECT id, account_id, provider, object_type, remote_id, item_id, artifact_id, container_ref, remote_updated_at, last_synced_at
+		 FROM external_bindings
+		 WHERE provider = ? AND datetime(last_synced_at) < datetime(?)
+		 ORDER BY datetime(last_synced_at) ASC, id ASC`,
+		cleanProvider,
+		olderThan.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanExternalBindingRows(rows)
+}
+
+func (s *Store) DeleteBinding(id int64) error {
+	res, err := s.db.Exec(`DELETE FROM external_bindings WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func scanExternalBindingRows(rows *sql.Rows) ([]ExternalBinding, error) {
+	var out []ExternalBinding
+	for rows.Next() {
+		binding, err := scanExternalBinding(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, binding)
+	}
+	return out, rows.Err()
+}
+
+func valueOrZero(id *int64) int64 {
+	if id == nil {
+		return 0
+	}
+	return *id
+}


### PR DESCRIPTION
## Summary
- add the `external_bindings` schema, identity/stale indexes, and a first-class `ExternalBinding` store model
- implement idempotent binding upsert, reverse lookups by remote/item/artifact, stale-binding queries, and delete support
- add focused store tests for schema migration, lifecycle coverage, and invalid-input rejection

## Verification
- Schema created on fresh and legacy databases: `go test ./internal/store`
  - `TestStoreMigratesDomainTablesOnFreshDatabase` asserts the `external_bindings` columns are present.
  - `TestStoreMigratesDomainTablesOnExistingDatabase` asserts legacy DBs gain the table during migration.
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/store	1.338s`
- `UpsertExternalBinding` is idempotent and updates tracked metadata: `go test ./internal/store`
  - `TestExternalBindingStoreCRUDAndQueries` creates a binding, re-upserts the same remote object, and confirms the same binding row is updated.
- `GetBindingByRemote`, `GetBindingsByItem`, `GetBindingsByArtifact`, `ListStaleBindings`, and `DeleteBinding` work end-to-end: `go test ./internal/store`
  - `TestExternalBindingStoreCRUDAndQueries` exercises each query path plus stale filtering and delete behavior.
- Invalid binding input is rejected: `go test ./internal/store`
  - `TestExternalBindingStoreRejectsInvalidInput` covers missing account/provider/object type/remote ID, provider mismatch, invalid RFC3339 timestamps, invalid stale-provider filters, and missing-row deletion.
