### PR TITLE
fix: add Bitwarden CLI as optional credential backend for exter (fixes #281)

### DIFF
--- a/internal/store/external_account_credentials.go
+++ b/internal/store/external_account_credentials.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	externalAccountCredentialSourceEnv       = "env"
+	externalAccountCredentialSourceBitwarden = "bitwarden"
+)
+
+var errExternalAccountPasswordUnavailable = errors.New("external account password is not configured")
+
+type externalAccountCommandRunner func(context.Context, string, ...string) (string, error)
+
+type cachedExternalAccountCredential struct {
+	value  string
+	source string
+}
+
+func runExternalAccountCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+				return "", errors.New(stderr)
+			}
+		}
+		return "", err
+	}
+	return string(output), nil
+}
+
+func decodeExternalAccountConfigJSON(raw string) (map[string]any, error) {
+	clean := strings.TrimSpace(raw)
+	if clean == "" {
+		return map[string]any{}, nil
+	}
+	var config map[string]any
+	if err := json.Unmarshal([]byte(clean), &config); err != nil {
+		return nil, fmt.Errorf("decode external account config: %w", err)
+	}
+	if config == nil {
+		config = map[string]any{}
+	}
+	return config, nil
+}
+
+func externalAccountCredentialRef(config map[string]any) string {
+	raw, _ := config["credential_ref"].(string)
+	return strings.TrimSpace(raw)
+}
+
+func bitwardenItemNameFromCredentialRef(ref string) (string, error) {
+	clean := strings.TrimSpace(ref)
+	if clean == "" {
+		return "", errors.New("credential_ref is required")
+	}
+	if !strings.HasPrefix(strings.ToLower(clean), "bw://") {
+		return "", fmt.Errorf("unsupported credential_ref %q", clean)
+	}
+	itemName := strings.TrimLeft(clean[len("bw://"):], "/")
+	itemName = strings.TrimSpace(itemName)
+	if itemName == "" {
+		return "", errors.New("bitwarden credential_ref must include an item name")
+	}
+	return itemName, nil
+}
+
+func trimSecretOutput(raw string) string {
+	return strings.TrimRight(raw, "\r\n")
+}
+
+func externalAccountCredentialCacheKey(account ExternalAccount, credentialRef string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(account.Provider),
+		strings.TrimSpace(account.Label),
+		strings.TrimSpace(credentialRef),
+	}, "\x00")
+}
+
+func (s *Store) cachedExternalAccountPassword(key string) (cachedExternalAccountCredential, bool) {
+	s.externalAccountCredentialMu.Lock()
+	defer s.externalAccountCredentialMu.Unlock()
+	entry, ok := s.externalAccountCredentialCache[key]
+	return entry, ok
+}
+
+func (s *Store) cacheExternalAccountPassword(key, source, value string) {
+	if key == "" || value == "" {
+		return
+	}
+	s.externalAccountCredentialMu.Lock()
+	defer s.externalAccountCredentialMu.Unlock()
+	if s.externalAccountCredentialCache == nil {
+		s.externalAccountCredentialCache = map[string]cachedExternalAccountCredential{}
+	}
+	s.externalAccountCredentialCache[key] = cachedExternalAccountCredential{
+		value:  value,
+		source: source,
+	}
+}
+
+func (s *Store) lookupExternalAccountEnv(key string) (string, bool) {
+	if s.externalAccountLookupEnv != nil {
+		return s.externalAccountLookupEnv(key)
+	}
+	return os.LookupEnv(key)
+}
+
+func (s *Store) runExternalAccountCredentialCommand(ctx context.Context, name string, args ...string) (string, error) {
+	if s.externalAccountCommandRunner != nil {
+		return s.externalAccountCommandRunner(ctx, name, args...)
+	}
+	return runExternalAccountCommand(ctx, name, args...)
+}
+
+func (s *Store) resolveBitwardenPassword(ctx context.Context, credentialRef string) (string, error) {
+	itemName, err := bitwardenItemNameFromCredentialRef(credentialRef)
+	if err != nil {
+		return "", err
+	}
+	output, err := s.runExternalAccountCredentialCommand(ctx, "bw", "get", "password", itemName)
+	if err != nil {
+		return "", fmt.Errorf("resolve bitwarden credential %q: %w", itemName, err)
+	}
+	password := trimSecretOutput(output)
+	if password == "" {
+		return "", fmt.Errorf("resolve bitwarden credential %q: empty password", itemName)
+	}
+	return password, nil
+}
+
+func (s *Store) ResolveExternalAccountPassword(ctx context.Context, accountID int64) (string, string, error) {
+	account, err := s.GetExternalAccount(accountID)
+	if err != nil {
+		return "", "", err
+	}
+	return s.ResolveExternalAccountPasswordForAccount(ctx, account)
+}
+
+func (s *Store) ResolveExternalAccountPasswordForAccount(ctx context.Context, account ExternalAccount) (string, string, error) {
+	envVar := ExternalAccountPasswordEnvVar(account.Provider, account.Label)
+	config, err := decodeExternalAccountConfigJSON(account.ConfigJSON)
+	if err != nil {
+		return "", "", err
+	}
+	credentialRef := externalAccountCredentialRef(config)
+	cacheKey := externalAccountCredentialCacheKey(account, credentialRef)
+
+	if value, ok := s.lookupExternalAccountEnv(envVar); ok && value != "" {
+		s.cacheExternalAccountPassword(cacheKey, externalAccountCredentialSourceEnv, value)
+		return value, externalAccountCredentialSourceEnv, nil
+	}
+	if cached, ok := s.cachedExternalAccountPassword(cacheKey); ok {
+		return cached.value, cached.source, nil
+	}
+	if credentialRef == "" {
+		return "", "", errExternalAccountPasswordUnavailable
+	}
+	password, err := s.resolveBitwardenPassword(ctx, credentialRef)
+	if err != nil {
+		return "", "", err
+	}
+	s.cacheExternalAccountPassword(cacheKey, externalAccountCredentialSourceBitwarden, password)
+	return password, externalAccountCredentialSourceBitwarden, nil
+}

--- a/internal/store/external_account_test.go
+++ b/internal/store/external_account_test.go
@@ -1,8 +1,11 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -134,5 +137,149 @@ func TestExternalAccountCredentialHelpers(t *testing.T) {
 	wantPath := filepath.Join("/home/test/.config/tabura", "tokens", "gmail_work_gmail.json")
 	if tokenPath != wantPath {
 		t.Fatalf("ExternalAccountTokenPath() = %q, want %q", tokenPath, wantPath)
+	}
+}
+
+func TestResolveExternalAccountPasswordUsesEnvFirstAndCaches(t *testing.T) {
+	s := newTestStore(t)
+
+	account, err := s.CreateExternalAccount(SphereWork, ExternalProviderIMAP, "Work Mail", map[string]any{
+		"host":           "imap.example.com",
+		"username":       "alice@example.com",
+		"credential_ref": "bw://work-email-imap",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	envVar := ExternalAccountPasswordEnvVar(account.Provider, account.Label)
+	s.externalAccountLookupEnv = func(key string) (string, bool) {
+		if key != envVar {
+			t.Fatalf("env lookup key = %q, want %q", key, envVar)
+		}
+		return "env-secret", true
+	}
+	commandCalls := 0
+	s.externalAccountCommandRunner = func(_ context.Context, name string, args ...string) (string, error) {
+		commandCalls++
+		t.Fatalf("unexpected credential command: %s %v", name, args)
+		return "", nil
+	}
+
+	password, source, err := s.ResolveExternalAccountPassword(context.Background(), account.ID)
+	if err != nil {
+		t.Fatalf("ResolveExternalAccountPassword() error: %v", err)
+	}
+	if password != "env-secret" {
+		t.Fatalf("ResolveExternalAccountPassword() password = %q, want env-secret", password)
+	}
+	if source != externalAccountCredentialSourceEnv {
+		t.Fatalf("ResolveExternalAccountPassword() source = %q, want %q", source, externalAccountCredentialSourceEnv)
+	}
+	if commandCalls != 0 {
+		t.Fatalf("credential command calls = %d, want 0", commandCalls)
+	}
+
+	s.externalAccountLookupEnv = func(string) (string, bool) {
+		return "", false
+	}
+	password, source, err = s.ResolveExternalAccountPassword(context.Background(), account.ID)
+	if err != nil {
+		t.Fatalf("ResolveExternalAccountPassword() cached error: %v", err)
+	}
+	if password != "env-secret" {
+		t.Fatalf("cached password = %q, want env-secret", password)
+	}
+	if source != externalAccountCredentialSourceEnv {
+		t.Fatalf("cached source = %q, want %q", source, externalAccountCredentialSourceEnv)
+	}
+	if commandCalls != 0 {
+		t.Fatalf("credential command calls after cache = %d, want 0", commandCalls)
+	}
+}
+
+func TestResolveExternalAccountPasswordFallsBackToBitwardenAndCaches(t *testing.T) {
+	s := newTestStore(t)
+
+	account, err := s.CreateExternalAccount(SphereWork, ExternalProviderIMAP, "Work Mail", map[string]any{
+		"host":           "imap.example.com",
+		"username":       "alice@example.com",
+		"credential_ref": "bw://work-email-imap",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	s.externalAccountLookupEnv = func(string) (string, bool) {
+		return "", false
+	}
+	commandCalls := 0
+	s.externalAccountCommandRunner = func(_ context.Context, name string, args ...string) (string, error) {
+		commandCalls++
+		if name != "bw" {
+			t.Fatalf("command name = %q, want bw", name)
+		}
+		if len(args) != 3 || args[0] != "get" || args[1] != "password" || args[2] != "work-email-imap" {
+			t.Fatalf("command args = %#v, want bw get password work-email-imap", args)
+		}
+		return "bitwarden-secret\n", nil
+	}
+
+	password, source, err := s.ResolveExternalAccountPasswordForAccount(context.Background(), account)
+	if err != nil {
+		t.Fatalf("ResolveExternalAccountPasswordForAccount() error: %v", err)
+	}
+	if password != "bitwarden-secret" {
+		t.Fatalf("password = %q, want bitwarden-secret", password)
+	}
+	if source != externalAccountCredentialSourceBitwarden {
+		t.Fatalf("source = %q, want %q", source, externalAccountCredentialSourceBitwarden)
+	}
+	if commandCalls != 1 {
+		t.Fatalf("credential command calls = %d, want 1", commandCalls)
+	}
+
+	password, source, err = s.ResolveExternalAccountPasswordForAccount(context.Background(), account)
+	if err != nil {
+		t.Fatalf("ResolveExternalAccountPasswordForAccount() cached error: %v", err)
+	}
+	if password != "bitwarden-secret" {
+		t.Fatalf("cached password = %q, want bitwarden-secret", password)
+	}
+	if source != externalAccountCredentialSourceBitwarden {
+		t.Fatalf("cached source = %q, want %q", source, externalAccountCredentialSourceBitwarden)
+	}
+	if commandCalls != 1 {
+		t.Fatalf("credential command calls after cache = %d, want 1", commandCalls)
+	}
+}
+
+func TestResolveExternalAccountPasswordRejectsMissingOrUnsupportedCredentialConfig(t *testing.T) {
+	s := newTestStore(t)
+	s.externalAccountLookupEnv = func(string) (string, bool) {
+		return "", false
+	}
+
+	missingAccount, err := s.CreateExternalAccount(SphereWork, ExternalProviderIMAP, "Work Mail", map[string]any{
+		"host":     "imap.example.com",
+		"username": "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(missing) error: %v", err)
+	}
+	if _, _, err := s.ResolveExternalAccountPassword(context.Background(), missingAccount.ID); !errors.Is(err, errExternalAccountPasswordUnavailable) {
+		t.Fatalf("ResolveExternalAccountPassword(missing) error = %v, want %v", err, errExternalAccountPasswordUnavailable)
+	}
+
+	unsupportedAccount, err := s.CreateExternalAccount(SphereWork, ExternalProviderIMAP, "Other Mail", map[string]any{
+		"host":           "imap.example.com",
+		"username":       "bob@example.com",
+		"credential_ref": "vault://other-mail",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(unsupported) error: %v", err)
+	}
+	if _, _, err := s.ResolveExternalAccountPassword(context.Background(), unsupportedAccount.ID); err == nil || !strings.Contains(err.Error(), `unsupported credential_ref "vault://other-mail"`) {
+		t.Fatalf("ResolveExternalAccountPassword(unsupported) error = %v, want unsupported credential_ref", err)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -26,6 +27,11 @@ type HostConfig struct {
 
 type Store struct {
 	db *sql.DB
+
+	externalAccountLookupEnv       func(string) (string, bool)
+	externalAccountCommandRunner   externalAccountCommandRunner
+	externalAccountCredentialMu    sync.Mutex
+	externalAccountCredentialCache map[string]cachedExternalAccountCredential
 }
 
 type ChatSession struct {
@@ -78,7 +84,12 @@ func New(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	s := &Store{db: db}
+	s := &Store{
+		db:                             db,
+		externalAccountLookupEnv:       os.LookupEnv,
+		externalAccountCommandRunner:   runExternalAccountCommand,
+		externalAccountCredentialCache: map[string]cachedExternalAccountCredential{},
+	}
 	if err := s.migrate(); err != nil {
 		_ = db.Close()
 		return nil, err


### PR DESCRIPTION
## Summary
- add env-first external account password resolution with optional `bw://...` credential references
- cache resolved credentials in memory for the current store session so `bw` is not re-run on repeated lookups
- cover env precedence, Bitwarden fallback, caching, and invalid credential refs with focused store tests

## Verification
- Env var wins over Bitwarden and remains available from the in-memory cache: `go test ./internal/store -run 'TestExternalAccount|TestResolveExternalAccountPassword' 2>&1 | tee /tmp/tabura-issue-281-test.log` via `TestResolveExternalAccountPasswordUsesEnvFirstAndCaches`
- Bitwarden fallback is used when the env var is absent, and repeated lookups reuse the cached password instead of rerunning `bw`: same command via `TestResolveExternalAccountPasswordFallsBackToBitwardenAndCaches`
- Missing or unsupported `credential_ref` values fail cleanly, and raw passwords still remain forbidden in persisted external account config: same command via `TestResolveExternalAccountPasswordRejectsMissingOrUnsupportedCredentialConfig` and `TestExternalAccountStoreRejectsInvalidConfigAndIdentity`
- Output excerpt: `ok   github.com/krystophny/tabura/internal/store 0.026s`
