### PR TITLE
fix: add Go test coverage audit and fill gaps (fixes #303)

### DIFF
--- a/internal/store/store_auth_host_test.go
+++ b/internal/store/store_auth_host_test.go
@@ -1,0 +1,58 @@
+package store
+
+import "testing"
+
+func TestStoreAuthHelpersHandleMissingAndDeletedSessions(t *testing.T) {
+	s := newTestStore(t)
+
+	if s.VerifyAdminPassword("anything") {
+		t.Fatal("VerifyAdminPassword() = true, want false before password is set")
+	}
+	if s.HasAuthSession("") {
+		t.Fatal("HasAuthSession(\"\") = true, want false")
+	}
+	if s.HasAuthSession("missing") {
+		t.Fatal("HasAuthSession(missing) = true, want false")
+	}
+	if err := s.AddAuthSession("tok-edge"); err != nil {
+		t.Fatalf("AddAuthSession() error: %v", err)
+	}
+	if err := s.DeleteAuthSession("tok-edge"); err != nil {
+		t.Fatalf("DeleteAuthSession() error: %v", err)
+	}
+	if s.HasAuthSession("tok-edge") {
+		t.Fatal("HasAuthSession(tok-edge) = true, want false after delete")
+	}
+}
+
+func TestStoreUpdateHostNoopAndUnknownFieldsKeepExistingRecord(t *testing.T) {
+	s := newTestStore(t)
+
+	original, err := s.AddHost(HostConfig{
+		Name:       "alpha",
+		Hostname:   "alpha.local",
+		Port:       2202,
+		Username:   "u1",
+		KeyPath:    "/tmp/key1",
+		ProjectDir: "/tmp/p1",
+	})
+	if err != nil {
+		t.Fatalf("AddHost() error: %v", err)
+	}
+
+	unchanged, err := s.UpdateHost(original.ID, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("UpdateHost(empty) error: %v", err)
+	}
+	if unchanged != original {
+		t.Fatalf("UpdateHost(empty) = %+v, want %+v", unchanged, original)
+	}
+
+	ignored, err := s.UpdateHost(original.ID, map[string]interface{}{"unsupported": "value"})
+	if err != nil {
+		t.Fatalf("UpdateHost(unsupported) error: %v", err)
+	}
+	if ignored != original {
+		t.Fatalf("UpdateHost(unsupported) = %+v, want %+v", ignored, original)
+	}
+}

--- a/internal/web/chat_model_test.go
+++ b/internal/web/chat_model_test.go
@@ -1,0 +1,58 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/krystophny/tabura/internal/modelprofile"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestEffectiveProjectChatModelFallsBackToConfiguredAppServerModel(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.appServerModel = modelprofile.ModelCodex
+
+	project := store.Project{}
+	if got := app.effectiveProjectChatModelAlias(project); got != modelprofile.AliasCodex {
+		t.Fatalf("effectiveProjectChatModelAlias() = %q, want %q", got, modelprofile.AliasCodex)
+	}
+	if got := app.effectiveProjectChatModelReasoningEffort(project); got != modelprofile.ReasoningHigh {
+		t.Fatalf("effectiveProjectChatModelReasoningEffort() = %q, want %q", got, modelprofile.ReasoningHigh)
+	}
+}
+
+func TestAppServerModelProfileForProjectNormalizesReasoning(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	profile := app.appServerModelProfileForProject(store.Project{
+		ChatModel:                modelprofile.AliasGPT,
+		ChatModelReasoningEffort: "minimal",
+	})
+	if profile.Alias != modelprofile.AliasGPT {
+		t.Fatalf("profile.Alias = %q, want %q", profile.Alias, modelprofile.AliasGPT)
+	}
+	if profile.Model != modelprofile.ModelGPT {
+		t.Fatalf("profile.Model = %q, want %q", profile.Model, modelprofile.ModelGPT)
+	}
+	if profile.ThreadParams != nil {
+		t.Fatalf("profile.ThreadParams = %#v, want nil", profile.ThreadParams)
+	}
+	if got := profile.TurnParams["effort"]; got != modelprofile.ReasoningHigh {
+		t.Fatalf("profile.TurnParams[effort] = %#v, want %q", got, modelprofile.ReasoningHigh)
+	}
+}
+
+func TestAppServerModelProfileForProjectKeyFallsBackWhenProjectMissing(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.appServerModel = modelprofile.ModelCodex
+
+	profile := app.appServerModelProfileForProjectKey("missing-project")
+	if profile.Alias != modelprofile.AliasCodex {
+		t.Fatalf("profile.Alias = %q, want %q", profile.Alias, modelprofile.AliasCodex)
+	}
+	if profile.Model != modelprofile.ModelCodex {
+		t.Fatalf("profile.Model = %q, want %q", profile.Model, modelprofile.ModelCodex)
+	}
+	if got := profile.TurnParams["effort"]; got != modelprofile.ReasoningHigh {
+		t.Fatalf("profile.TurnParams[effort] = %#v, want %q", got, modelprofile.ReasoningHigh)
+	}
+}

--- a/internal/web/chat_stt_http_test.go
+++ b/internal/web/chat_stt_http_test.go
@@ -1,0 +1,256 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/stt"
+)
+
+func multipartRequestForTest(t *testing.T, path string, build func(*multipart.Writer)) (*httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	build(writer)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return httptest.NewRecorder(), req
+}
+
+func authedMultipartRequestForTest(t *testing.T, handler http.Handler, path string, build func(*multipart.Writer)) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rr, req := multipartRequestForTest(t, path, build)
+	req.AddCookie(&http.Cookie{Name: SessionCookie, Value: testAuthToken})
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func addMultipartAudioPart(t *testing.T, writer *multipart.Writer, filename, mimeType string, audio []byte) {
+	t.Helper()
+
+	header := textproto.MIMEHeader{}
+	header.Set("Content-Disposition", `form-data; name="file"; filename="`+filename+`"`)
+	if strings.TrimSpace(mimeType) != "" {
+		header.Set("Content-Type", mimeType)
+	}
+	part, err := writer.CreatePart(header)
+	if err != nil {
+		t.Fatalf("create multipart audio part: %v", err)
+	}
+	if _, err := part.Write(audio); err != nil {
+		t.Fatalf("write multipart audio: %v", err)
+	}
+}
+
+func TestReadSTTMultipartAudioRejectsInvalidPayloads(t *testing.T) {
+	t.Run("invalid content type", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/stt/transcribe", strings.NewReader("nope"))
+		req.Header.Set("Content-Type", "text/plain")
+
+		_, _, err := readSTTMultipartAudio(rr, req)
+		if !errors.Is(err, errInvalidMultipartPayload) {
+			t.Fatalf("readSTTMultipartAudio() error = %v, want %v", err, errInvalidMultipartPayload)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		rr, req := multipartRequestForTest(t, "/api/stt/transcribe", func(writer *multipart.Writer) {
+			if err := writer.WriteField("mime_type", "audio/webm"); err != nil {
+				t.Fatalf("WriteField(mime_type): %v", err)
+			}
+		})
+
+		_, _, err := readSTTMultipartAudio(rr, req)
+		if !errors.Is(err, errMissingAudioFile) {
+			t.Fatalf("readSTTMultipartAudio() error = %v, want %v", err, errMissingAudioFile)
+		}
+	})
+
+	t.Run("duplicate file", func(t *testing.T) {
+		rr, req := multipartRequestForTest(t, "/api/stt/transcribe", func(writer *multipart.Writer) {
+			addMultipartAudioPart(t, writer, "one.webm", "audio/webm", []byte("first"))
+			addMultipartAudioPart(t, writer, "two.webm", "audio/webm", []byte("second"))
+		})
+
+		_, _, err := readSTTMultipartAudio(rr, req)
+		if !errors.Is(err, errDuplicateAudioFile) {
+			t.Fatalf("readSTTMultipartAudio() error = %v, want %v", err, errDuplicateAudioFile)
+		}
+	})
+
+	t.Run("oversized file", func(t *testing.T) {
+		rr, req := multipartRequestForTest(t, "/api/stt/transcribe", func(writer *multipart.Writer) {
+			addMultipartAudioPart(t, writer, "large.webm", "audio/webm", bytes.Repeat([]byte("a"), stt.MaxAudioBytes+1))
+		})
+
+		_, _, err := readSTTMultipartAudio(rr, req)
+		if !errors.Is(err, errAudioPayloadTooLarge) {
+			t.Fatalf("readSTTMultipartAudio() error = %v, want %v", err, errAudioPayloadTooLarge)
+		}
+	})
+}
+
+func TestReadSTTMultipartAudioUsesMimeTypeFieldOverride(t *testing.T) {
+	rr, req := multipartRequestForTest(t, "/api/stt/transcribe", func(writer *multipart.Writer) {
+		addMultipartAudioPart(t, writer, "audio.bin", "application/octet-stream", []byte("audio-data"))
+		if err := writer.WriteField("mime_type", "audio/wav"); err != nil {
+			t.Fatalf("WriteField(mime_type): %v", err)
+		}
+	})
+
+	audio, mimeType, err := readSTTMultipartAudio(rr, req)
+	if err != nil {
+		t.Fatalf("readSTTMultipartAudio() error: %v", err)
+	}
+	if string(audio) != "audio-data" {
+		t.Fatalf("audio = %q, want %q", string(audio), "audio-data")
+	}
+	if mimeType != "audio/wav" {
+		t.Fatalf("mimeType = %q, want %q", mimeType, "audio/wav")
+	}
+}
+
+func TestHandleSTTTranscribeReturnsServiceUnavailableWhenDisabled(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.sttURL = ""
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.webm", "audio/webm", []byte("short"))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want %d: %s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+}
+
+func TestHandleSTTTranscribeReturnsShortRecordingReason(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.sttURL = "http://127.0.0.1:1"
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.webm", "audio/webm", bytes.Repeat([]byte("a"), 512))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["text"] != "" {
+		t.Fatalf("text = %q, want empty", payload["text"])
+	}
+	if payload["reason"] != "recording_too_short" {
+		t.Fatalf("reason = %q, want %q", payload["reason"], "recording_too_short")
+	}
+}
+
+func TestHandleSTTTranscribeRejectsInvalidMimeType(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.sttURL = "http://127.0.0.1:1"
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.txt", "text/plain", bytes.Repeat([]byte("a"), 2048))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want %d: %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "mime_type must be audio/*") {
+		t.Fatalf("response body = %q, want mime_type validation error", rr.Body.String())
+	}
+}
+
+func TestHandleSTTTranscribeRejectsMultipartWithoutFile(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.sttURL = "http://127.0.0.1:1"
+
+	rr := authedMultipartRequestForTest(t, app.Router(), "/api/stt/transcribe", func(writer *multipart.Writer) {
+		if err := writer.WriteField("mime_type", "audio/webm"); err != nil {
+			t.Fatalf("WriteField(mime_type): %v", err)
+		}
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want %d: %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), errMissingAudioFile.Error()) {
+		t.Fatalf("response body = %q, want %q", rr.Body.String(), errMissingAudioFile.Error())
+	}
+}
+
+func TestHandleSTTTranscribeReturnsLikelyNoiseReason(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"text": "okay"}); err != nil {
+			t.Fatalf("encode stt response: %v", err)
+		}
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.wav", "audio/wav", buildSpeechLikeWAV(16000, 240, 0.75))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["reason"] != "likely_noise" {
+		t.Fatalf("reason = %q, want %q", payload["reason"], "likely_noise")
+	}
+}
+
+func TestHandleSTTTranscribeReturnsNoSpeechDetectedForEmptyTranscript(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"text": "   "}); err != nil {
+			t.Fatalf("encode stt response: %v", err)
+		}
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.wav", "audio/wav", buildSpeechLikeWAV(16000, 240, 0.75))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["reason"] != "no_speech_detected" {
+		t.Fatalf("reason = %q, want %q", payload["reason"], "no_speech_detected")
+	}
+}
+
+func TestHandleSTTTranscribeReturnsBadGatewayForUpstreamFailure(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	rr := doAuthedMultipartAudioRequest(t, app.Router(), "/api/stt/transcribe", "audio.wav", "audio/wav", buildSpeechLikeWAV(16000, 240, 0.75))
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("POST /api/stt/transcribe status = %d, want %d: %s", rr.Code, http.StatusBadGateway, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "transcription failed: stt HTTP 502") {
+		t.Fatalf("response body = %q, want upstream transcription failure", rr.Body.String())
+	}
+}

--- a/internal/web/chat_tts_test.go
+++ b/internal/web/chat_tts_test.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSynthesizeTTSAudioRejectsEmptyTextAndMissingService(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	if audio, errMsg := app.synthesizeTTSAudio("session-1", 1, "   ", "en"); errMsg != "text is required" || audio != nil {
+		t.Fatalf("empty text result = (%v, %q), want (nil, %q)", audio, errMsg, "text is required")
+	}
+
+	app.ttsURL = ""
+	if audio, errMsg := app.synthesizeTTSAudio("session-1", 2, "hello", "en"); errMsg != "TTS service not configured" || audio != nil {
+		t.Fatalf("missing service result = (%v, %q), want (nil, %q)", audio, errMsg, "TTS service not configured")
+	}
+}
+
+func TestSynthesizeTTSAudioHandlesUpstreamHTTPError(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	ttsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer ttsSrv.Close()
+	app.ttsURL = ttsSrv.URL
+
+	audio, errMsg := app.synthesizeTTSAudio("session-1", 3, "hello", "de")
+	if audio != nil {
+		t.Fatalf("audio = %v, want nil", audio)
+	}
+	if errMsg != "TTS error: HTTP 502" {
+		t.Fatalf("errMsg = %q, want %q", errMsg, "TTS error: HTTP 502")
+	}
+}
+
+func TestSynthesizeTTSAudioUsesDefaultLanguageAndReturnsAudio(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	var gotPayload map[string]any
+	ttsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/audio/speech" {
+			t.Fatalf("path = %s, want /v1/audio/speech", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write([]byte("RIFFtest"))
+	}))
+	defer ttsSrv.Close()
+	app.ttsURL = ttsSrv.URL
+
+	audio, errMsg := app.synthesizeTTSAudio("session-1", 4, "  hello world  ", "")
+	if errMsg != "" {
+		t.Fatalf("errMsg = %q, want empty", errMsg)
+	}
+	if string(audio) != "RIFFtest" {
+		t.Fatalf("audio = %q, want %q", string(audio), "RIFFtest")
+	}
+	if gotPayload["input"] != "hello world" {
+		t.Fatalf("input = %#v, want %q", gotPayload["input"], "hello world")
+	}
+	if gotPayload["voice"] != "en" {
+		t.Fatalf("voice = %#v, want %q", gotPayload["voice"], "en")
+	}
+	if gotPayload["response_format"] != "wav" {
+		t.Fatalf("response_format = %#v, want %q", gotPayload["response_format"], "wav")
+	}
+}


### PR DESCRIPTION
## Summary
- add focused coverage tests for store auth/session handling and host CRUD no-op paths
- add focused coverage tests for STT multipart/HTTP error handling, TTS request handling, and project model-profile fallback logic

## Verification
- Coverage audit across internal packages: `go test -coverprofile=cover.out ./... 2>&1 | tee /tmp/tabula-issue-303-test.log`
  - package excerpts from the captured run: `internal/store` 75.4%, `internal/web` 68.7%
  - environment blocker outside this change: `tests/services` failed because `http://127.0.0.1:8426` refused connections in `TestLLMHealth`, `TestLLMChatCompletion`, `TestLLMIntentClassification`, and `TestLLMLatency`
- Identify/fill low-coverage functions in the touched areas: `go test -coverprofile=/tmp/tabula-issue-303-web-store.cover ./internal/store ./internal/web 2>&1 | tee /tmp/tabula-issue-303-targeted.log`
  - targeted rerun passed: `internal/store` 75.4%, `internal/web` 68.8%
  - `go tool cover -func=/tmp/tabula-issue-303-web-store.cover | rg 'store_auth.go|store_host.go|chat_model.go|chat_stt_http.go|chat_tts.go|total:'`
  - excerpts: `store_auth.go` `SetAdminPassword` 73.3%, `VerifyAdminPassword`/`HasAuthSession`/`DeleteAuthSession` 100%; `store_host.go` `UpdateHost` 93.3%; `chat_model.go` 71.4%-87.5%; `chat_stt_http.go` `handleSTTTranscribe` 86.4%; `chat_tts.go` `synthesizeTTSAudio` 82.4%; combined targeted total 70.0%
- Added test coverage for the requested reliability areas
  - store operations and edge cases: [internal/store/store_auth_host_test.go](/home/ert/code/assi/tabula/internal/store/store_auth_host_test.go)
  - STT multipart parsing and HTTP response branches: [internal/web/chat_stt_http_test.go](/home/ert/code/assi/tabula/internal/web/chat_stt_http_test.go)
  - TTS request construction and upstream failure handling: [internal/web/chat_tts_test.go](/home/ert/code/assi/tabula/internal/web/chat_tts_test.go)
  - project model-profile fallback and reasoning normalization: [internal/web/chat_model_test.go](/home/ert/code/assi/tabula/internal/web/chat_model_test.go)
