### PR TITLE
fix: Add print-to-PDF for items with artifacts (fixes #193)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, print_item, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
+	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -414,6 +414,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			"path":       canvasTitle,
 			"project_id": targetProject.ID,
 		}, nil
+	case "print_item":
+		return a.executePrintItemAction(sessionID, session, action)
 	default:
 		return "", nil, fmt.Errorf("unsupported action: %s", action.Action)
 	}

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -62,6 +62,8 @@ func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode st
 	switch normalized {
 	case "make this an item", "track this", "add to inbox":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
+	case "print this item", "print this for me":
+		return &SystemAction{Action: "print_item", Params: map[string]interface{}{}}
 	case "later", "remind me later":
 		visibleAfter := defaultReminderTime(now)
 		return &SystemAction{
@@ -216,7 +218,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item":
 		return true
 	default:
 		return false
@@ -229,6 +231,8 @@ func itemActionFailurePrefix(action string) string {
 		return "I couldn't create the GitHub issue: "
 	case "capture_idea":
 		return "I couldn't capture the idea: "
+	case "print_item":
+		return "I couldn't prepare the print view: "
 	}
 	if strings.EqualFold(strings.TrimSpace(action), "split_items") {
 		return "I couldn't create the items: "

--- a/internal/web/item_print.go
+++ b/internal/web/item_print.go
@@ -1,0 +1,406 @@
+package web
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const printableArtifactFileSizeLimit = 256 * 1024
+
+var itemPrintTemplate = template.Must(template.New("item-print").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.PageTitle}}</title>
+  <link rel="stylesheet" href="/static/print.css">
+</head>
+<body class="print-page">
+  <main class="print-shell">
+    <header class="print-cover">
+      <div class="print-kicker">Tabura Item Packet</div>
+      <h1>{{.Title}}</h1>
+      <p class="print-subtitle">{{.Subtitle}}</p>
+    </header>
+
+    <section class="print-section">
+      <h2>Cover Sheet</h2>
+      <dl class="print-facts">
+        {{range .Facts}}
+        <div class="print-fact">
+          <dt>{{.Label}}</dt>
+          <dd>{{.Value}}</dd>
+        </div>
+        {{end}}
+      </dl>
+    </section>
+
+    <section class="print-section">
+      <h2>Primary Artifact</h2>
+      {{if .Artifact}}
+        <div class="print-artifact-head">
+          <div>
+            <strong>{{.Artifact.Title}}</strong>
+            <span class="print-badge">{{.Artifact.Kind}}</span>
+          </div>
+          {{if .Artifact.RefURL}}
+          <a href="{{.Artifact.RefURL}}" class="print-link">{{.Artifact.RefURL}}</a>
+          {{end}}
+          {{if .Artifact.RefPath}}
+          <div class="print-muted">{{.Artifact.RefPath}}</div>
+          {{end}}
+        </div>
+        {{if .Artifact.Content}}
+        <pre class="print-content">{{.Artifact.Content}}</pre>
+        {{else}}
+        <p class="print-muted">No inline artifact text was available for print preview.</p>
+        {{end}}
+        {{if .Artifact.Metadata}}
+        <details class="print-details">
+          <summary>Artifact metadata</summary>
+          <pre class="print-content">{{.Artifact.Metadata}}</pre>
+        </details>
+        {{end}}
+      {{else}}
+      <p class="print-muted">No linked artifact.</p>
+      {{end}}
+    </section>
+  </main>
+  {{if .AutoPrint}}
+  <script>
+    window.addEventListener('load', function () {
+      window.focus();
+      window.print();
+    });
+  </script>
+  {{end}}
+</body>
+</html>
+`))
+
+type printFact struct {
+	Label string
+	Value string
+}
+
+type printArtifactView struct {
+	Kind     string
+	Title    string
+	RefPath  string
+	RefURL   string
+	Content  string
+	Metadata string
+}
+
+type itemPrintView struct {
+	PageTitle string
+	Title     string
+	Subtitle  string
+	AutoPrint bool
+	Facts     []printFact
+	Artifact  *printArtifactView
+}
+
+func (a *App) handleItemPrint(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	view, err := a.buildItemPrintView(item, !strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("format")), "html"))
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := itemPrintTemplate.Execute(w, view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (a *App) buildItemPrintView(item store.Item, autoPrint bool) (itemPrintView, error) {
+	facts := []printFact{
+		{Label: "State", Value: item.State},
+		{Label: "Created", Value: formatPrintableTimestamp(item.CreatedAt)},
+		{Label: "Updated", Value: formatPrintableTimestamp(item.UpdatedAt)},
+	}
+	if item.WorkspaceID != nil {
+		workspace, err := a.store.GetWorkspace(*item.WorkspaceID)
+		if err != nil {
+			return itemPrintView{}, err
+		}
+		facts = append(facts, printFact{Label: "Workspace", Value: workspace.Name})
+		facts = append(facts, printFact{Label: "Workspace Path", Value: workspace.DirPath})
+	}
+	if item.ActorID != nil {
+		actor, err := a.store.GetActor(*item.ActorID)
+		if err != nil {
+			return itemPrintView{}, err
+		}
+		facts = append(facts, printFact{Label: "Actor", Value: actor.Name})
+	}
+	if item.VisibleAfter != nil && strings.TrimSpace(*item.VisibleAfter) != "" {
+		facts = append(facts, printFact{Label: "Visible After", Value: formatPrintableTimestamp(*item.VisibleAfter)})
+	}
+	if item.FollowUpAt != nil && strings.TrimSpace(*item.FollowUpAt) != "" {
+		facts = append(facts, printFact{Label: "Follow Up", Value: formatPrintableTimestamp(*item.FollowUpAt)})
+	}
+	if item.Source != nil && strings.TrimSpace(*item.Source) != "" {
+		facts = append(facts, printFact{Label: "Source", Value: strings.TrimSpace(*item.Source)})
+	}
+	if item.SourceRef != nil && strings.TrimSpace(*item.SourceRef) != "" {
+		facts = append(facts, printFact{Label: "Source Ref", Value: strings.TrimSpace(*item.SourceRef)})
+	}
+
+	view := itemPrintView{
+		PageTitle: fmt.Sprintf("Print %s", item.Title),
+		Title:     item.Title,
+		Subtitle:  "Printable item review packet",
+		AutoPrint: autoPrint,
+		Facts:     facts,
+	}
+	if item.ArtifactID == nil {
+		return view, nil
+	}
+	artifact, err := a.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		return itemPrintView{}, err
+	}
+	view.Artifact = buildPrintArtifactView(artifact)
+	return view, nil
+}
+
+func buildPrintArtifactView(artifact store.Artifact) *printArtifactView {
+	metaText, metaPretty := printableArtifactMeta(artifact.MetaJSON)
+	content := printableArtifactContent(artifact, metaText)
+	return &printArtifactView{
+		Kind:     string(artifact.Kind),
+		Title:    firstPrintableValue(optionalStringValue(artifact.Title), optionalStringValue(artifact.RefPath), optionalStringValue(artifact.RefURL), string(artifact.Kind)),
+		RefPath:  optionalStringValue(artifact.RefPath),
+		RefURL:   optionalStringValue(artifact.RefURL),
+		Content:  content,
+		Metadata: metaPretty,
+	}
+}
+
+func printableArtifactContent(artifact store.Artifact, metaText string) string {
+	if path := strings.TrimSpace(optionalStringValue(artifact.RefPath)); path != "" {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Size() <= printableArtifactFileSizeLimit {
+			if data, readErr := os.ReadFile(path); readErr == nil && utf8.Valid(data) {
+				return string(data)
+			}
+		}
+	}
+	return strings.TrimSpace(metaText)
+}
+
+func printableArtifactMeta(raw *string) (string, string) {
+	text := strings.TrimSpace(optionalStringValue(raw))
+	if text == "" {
+		return "", ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+		return "", text
+	}
+	extracted := extractPrintableMetaText(decoded)
+	pretty, err := json.MarshalIndent(decoded, "", "  ")
+	if err != nil {
+		return extracted, text
+	}
+	return strings.TrimSpace(extracted), string(pretty)
+}
+
+func extractPrintableMetaText(decoded any) string {
+	obj, ok := decoded.(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"text", "transcript", "body", "content", "summary", "description"} {
+		value := strings.TrimSpace(fmt.Sprint(obj[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func optionalStringValue(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+	return strings.TrimSpace(*ptr)
+}
+
+func firstPrintableValue(values ...string) string {
+	for _, value := range values {
+		clean := strings.TrimSpace(value)
+		if clean != "" {
+			return clean
+		}
+	}
+	return ""
+}
+
+func formatPrintableTimestamp(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if ts, err := parseRFC3339OrSQLite(trimmed); err == nil {
+		return ts.UTC().Format("2006-01-02 15:04 UTC")
+	}
+	return trimmed
+}
+
+func parseRFC3339OrSQLite(raw string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, errors.New("invalid timestamp")
+}
+
+func systemActionItemID(params map[string]interface{}) int64 {
+	if params == nil {
+		return 0
+	}
+	switch value := params["item_id"].(type) {
+	case int:
+		return int64(value)
+	case int64:
+		return value
+	case float64:
+		return int64(value)
+	case string:
+		id, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		if err == nil {
+			return id
+		}
+	}
+	return 0
+}
+
+func itemPrintURL(itemID int64, htmlOnly bool) string {
+	path := fmt.Sprintf("/api/items/%d/print", itemID)
+	if htmlOnly {
+		return path + "?format=html"
+	}
+	return path
+}
+
+func (a *App) executePrintItemAction(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	item, err := a.resolvePrintItemTarget(session, action)
+	if err != nil {
+		return "", nil, err
+	}
+	return fmt.Sprintf("Opened print view for %q.", item.Title), map[string]interface{}{
+		"type":    "print_item",
+		"item_id": item.ID,
+		"title":   item.Title,
+		"url":     itemPrintURL(item.ID, false),
+	}, nil
+}
+
+func (a *App) resolvePrintItemTarget(session store.ChatSession, action *SystemAction) (store.Item, error) {
+	if action != nil {
+		if itemID := systemActionItemID(action.Params); itemID > 0 {
+			return a.store.GetItem(itemID)
+		}
+	}
+	project, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if item, err := a.resolveCanvasPrintItem(project); err == nil {
+		return item, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Item{}, err
+	}
+	if workspace, err := a.fallbackWorkspaceForProjectKey(session.ProjectKey); err != nil {
+		return store.Item{}, err
+	} else if workspace != nil {
+		items, listErr := a.listOpenWorkspaceItems(workspace.ID)
+		if listErr != nil {
+			return store.Item{}, listErr
+		}
+		if len(items) > 0 {
+			return items[0], nil
+		}
+	}
+	items, err := a.store.ListItems()
+	if err != nil {
+		return store.Item{}, err
+	}
+	if len(items) == 0 {
+		return store.Item{}, errors.New("no item is available to print")
+	}
+	return items[0], nil
+}
+
+func (a *App) resolveCanvasPrintItem(project store.Project) (store.Item, error) {
+	canvas := a.resolveConversationCanvasArtifact(project)
+	if canvas == nil {
+		return store.Item{}, sql.ErrNoRows
+	}
+	cwd := strings.TrimSpace(project.RootPath)
+	if cwd == "" {
+		cwd = strings.TrimSpace(a.cwdForProjectKey(project.ProjectKey))
+	}
+	resolvedPath := ""
+	if path := resolveConversationArtifactPath(cwd, canvas); path != nil {
+		resolvedPath = filepath.Clean(*path)
+	}
+	items, err := a.store.ListItems()
+	if err != nil {
+		return store.Item{}, err
+	}
+	for _, item := range items {
+		if item.ArtifactID == nil {
+			continue
+		}
+		artifact, getErr := a.store.GetArtifact(*item.ArtifactID)
+		if getErr != nil {
+			continue
+		}
+		if artifactMatchesCanvas(artifact, canvas, resolvedPath) {
+			return item, nil
+		}
+	}
+	return store.Item{}, sql.ErrNoRows
+}
+
+func artifactMatchesCanvas(artifact store.Artifact, canvas *conversationCanvasArtifact, resolvedPath string) bool {
+	if artifact.RefPath != nil && resolvedPath != "" && filepath.Clean(strings.TrimSpace(*artifact.RefPath)) == resolvedPath {
+		return true
+	}
+	canvasTitle := strings.TrimSpace(canvas.Title)
+	if artifact.Title != nil && canvasTitle != "" && strings.EqualFold(strings.TrimSpace(*artifact.Title), canvasTitle) {
+		return true
+	}
+	if artifact.RefPath != nil && canvasTitle != "" && strings.EqualFold(filepath.Base(strings.TrimSpace(*artifact.RefPath)), canvasTitle) {
+		return true
+	}
+	return false
+}

--- a/internal/web/item_print_test.go
+++ b/internal/web/item_print_test.go
@@ -1,0 +1,170 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func doAuthedRequest(t *testing.T, handler http.Handler, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookie, Value: testAuthToken})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Writer", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	actor, err := app.store.CreateActor("Alice", store.ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	artifactPath := filepath.Join(workspaceDir, "notes.md")
+	if err := os.WriteFile(artifactPath, []byte("# Review\n\n- tighten cover sheet\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	artifactTitle := "notes.md"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &artifactPath, nil, &artifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	source := "github"
+	sourceRef := "owner/tabura#193"
+	item, err := app.store.CreateItem("Print packet", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		ArtifactID:  &artifact.ID,
+		ActorID:     &actor.ID,
+		Source:      &source,
+		SourceRef:   &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	rr := doAuthedRequest(t, app.Router(), http.MethodGet, "/api/items/"+itoa(item.ID)+"/print?format=html")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("print html status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, snippet := range []string{
+		"Printable item review packet",
+		"Workspace",
+		"Writer",
+		"Alice",
+		"github",
+		"owner/tabura#193",
+		"# Review",
+		"- tighten cover sheet",
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("print body missing %q:\n%s", snippet, body)
+		}
+	}
+	if strings.Contains(body, "window.print()") {
+		t.Fatalf("html-only print response should not auto-print:\n%s", body)
+	}
+}
+
+func TestItemPrintDefaultIncludesAutoPrintAndArtifactMetadataFallback(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspace, err := app.store.CreateWorkspace("Default", filepath.Join(t.TempDir(), "workspace"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	metaJSON := `{"source":"assistant","text":"Capture all open review notes."}`
+	artifactTitle := "Review Notes"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindPlanNote, nil, nil, &artifactTitle, &metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Review packet", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		ArtifactID:  &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	rr := doAuthedRequest(t, app.Router(), http.MethodGet, "/api/items/"+itoa(item.ID)+"/print")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("print status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, snippet := range []string{
+		"window.print()",
+		"Capture all open review notes.",
+		"Artifact metadata",
+		`&#34;source&#34;: &#34;assistant&#34;`,
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("print body missing %q:\n%s", snippet, body)
+		}
+	}
+}
+
+func TestClassifyAndExecuteSystemActionPrintItemUsesActiveWorkspaceItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Print me", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "print this item")
+	if !handled {
+		t.Fatal("expected print command to be handled")
+	}
+	if message != `Opened print view for "Print me".` {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payloads len = %d, want 1", len(payloads))
+	}
+	payload := payloads[0]
+	if got := strFromAny(payload["type"]); got != "print_item" {
+		t.Fatalf("payload type = %q, want print_item", got)
+	}
+	if got := int64FromAny(payload["item_id"]); got != item.ID {
+		t.Fatalf("payload item_id = %d, want %d", got, item.ID)
+	}
+	if got := strFromAny(payload["url"]); got != "/api/items/"+itoa(item.ID)+"/print" {
+		t.Fatalf("payload url = %q", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -405,6 +405,7 @@ func (a *App) Router() http.Handler {
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)
 	r.Put("/api/items/{item_id}/state", a.handleItemStateUpdate)
 	r.Post("/api/items/{item_id}/triage", a.handleItemTriage)
+	r.Get("/api/items/{item_id}/print", a.handleItemPrint)
 	r.Get("/api/items/{item_id}", a.handleItemGet)
 	r.Put("/api/items/{item_id}", a.handleItemUpdate)
 	r.Delete("/api/items/{item_id}", a.handleItemDelete)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -1958,6 +1958,28 @@ function recordHarnessSTTAction(action, payload = {}) {
   window.__harnessLog.push({ type: 'stt', action, ...payload });
 }
 
+function recordHarnessPrintAction(action, payload = {}) {
+  if (!Array.isArray(window.__harnessLog)) return;
+  window.__harnessLog.push({ type: 'print', action, ...payload });
+}
+
+function openPrintView(url) {
+  const target = String(url || '').trim();
+  if (!target) return;
+  let frame = document.getElementById('print-frame');
+  if (!(frame instanceof HTMLIFrameElement)) {
+    frame = document.createElement('iframe');
+    frame.id = 'print-frame';
+    frame.style.display = 'none';
+    document.body.appendChild(frame);
+  }
+  const separator = target.includes('?') ? '&' : '?';
+  const nextURL = `${target}${separator}__tabura_print=${Date.now()}`;
+  frame.setAttribute('src', nextURL);
+  recordHarnessPrintAction('open', { url: nextURL });
+  showStatus('print view opened');
+}
+
 function sttStart(mimeType) {
   if (_sttAbortController) {
     try { _sttAbortController.abort(); } catch (_) {}
@@ -4979,6 +5001,8 @@ function handleChatEvent(payload) {
       }
     } else if (actionType === 'toggle_silent') {
       toggleTTSSilentMode();
+    } else if (actionType === 'print_item') {
+      openPrintView(String(action?.url || '').trim());
     } else if (actionType === 'toggle_live_dialogue' || actionType === 'toggle_conversation') {
       const next = state.liveSessionActive ? '' : LIVE_SESSION_MODE_DIALOGUE;
       const action = next

--- a/internal/web/static/print.css
+++ b/internal/web/static/print.css
@@ -1,0 +1,138 @@
+body.print-page {
+  margin: 0;
+  background: #f3efe5;
+  color: #1e1b16;
+  font: 15px/1.5 "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+}
+
+.print-shell {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 40px 24px 56px;
+}
+
+.print-cover,
+.print-section {
+  background: #fffdf8;
+  border: 1px solid #d8cfbc;
+  box-shadow: 0 10px 30px rgba(69, 53, 24, 0.08);
+}
+
+.print-cover {
+  padding: 28px 32px;
+  margin-bottom: 20px;
+}
+
+.print-cover h1,
+.print-section h2 {
+  margin: 0;
+  font-family: "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+  letter-spacing: 0.02em;
+}
+
+.print-cover h1 {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+  margin-top: 8px;
+}
+
+.print-subtitle,
+.print-muted,
+.print-link {
+  color: #5f5340;
+}
+
+.print-kicker,
+.print-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #efe5cf;
+  color: #7a5f20;
+  font: 700 0.8rem/1 "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.print-kicker {
+  padding: 6px 10px;
+}
+
+.print-section {
+  padding: 24px 28px;
+  margin-bottom: 18px;
+}
+
+.print-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px 18px;
+  margin: 18px 0 0;
+}
+
+.print-fact {
+  border-top: 1px solid #e8deca;
+  padding-top: 10px;
+}
+
+.print-fact dt {
+  font: 700 0.76rem/1.2 "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b7443;
+  margin-bottom: 6px;
+}
+
+.print-fact dd {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.print-artifact-head {
+  display: grid;
+  gap: 8px;
+  margin: 16px 0 18px;
+}
+
+.print-badge {
+  margin-left: 10px;
+  padding: 4px 8px;
+}
+
+.print-link {
+  text-decoration: none;
+}
+
+.print-content {
+  margin: 0;
+  padding: 18px;
+  background: #f8f3e7;
+  border: 1px solid #e2d8c3;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: 0.95rem/1.55 "IBM Plex Mono", "SFMono-Regular", monospace;
+}
+
+.print-details {
+  margin-top: 16px;
+}
+
+@media print {
+  body.print-page {
+    background: #fff;
+  }
+
+  .print-shell {
+    max-width: none;
+    padding: 0;
+  }
+
+  .print-cover,
+  .print-section {
+    border: 0;
+    box-shadow: none;
+    break-inside: avoid;
+  }
+}

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -807,6 +807,37 @@ test.describe('system_action model and project switching', () => {
   });
 });
 
+test.describe('system_action print item', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitReady(page);
+    await clearLog(page);
+  });
+
+  test('loads the print view into the hidden print iframe', async ({ page }) => {
+    await injectChatEvent(page, {
+      type: 'system_action',
+      action: {
+        type: 'print_item',
+        item_id: 42,
+        url: '/api/items/42/print',
+      },
+    });
+
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const frame = document.getElementById('print-frame');
+        if (!(frame instanceof HTMLIFrameElement)) return '';
+        return String(frame.getAttribute('src') || '');
+      });
+    }, { timeout: 5_000 }).toContain('/api/items/42/print');
+
+    const log = await getLog(page);
+    const printEntry = log.find((entry) => entry.type === 'print' && entry.action === 'open');
+    expect(String(printEntry?.url || '')).toContain('/api/items/42/print');
+    await expect(page.locator('#status-label')).toHaveText('print view opened');
+  });
+});
+
 
 // =============================================================================
 // Mic stream caching and invalidation


### PR DESCRIPTION
## Summary
Adds a printable item packet route with cover-sheet metadata, artifact rendering, a print stylesheet, and a local `print_item` dialogue action that loads the print view from the UI.

## Verification
- Printable document + cover sheet + artifact file content:
  - Command: `go test ./internal/web -run "TestItemPrint|TestClassifyAndExecuteSystemActionPrintItemUsesActiveWorkspaceItem"`
  - Evidence: `TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent` passed and the command output was `ok   github.com/krystophny/tabura/internal/web  0.024s`.
  - Artifact path: `/api/items/{id}/print?format=html` with stylesheet `/static/print.css`.
- Auto-print route for browser PDF flow:
  - Command: `go test ./internal/web -run "TestItemPrint|TestClassifyAndExecuteSystemActionPrintItemUsesActiveWorkspaceItem"`
  - Evidence: `TestItemPrintDefaultIncludesAutoPrintAndArtifactMetadataFallback` passed, covering `/api/items/{id}/print` and verifying the response contains `window.print()` plus artifact metadata fallback text.
- Dialogue-triggered print flow:
  - Command: `go test ./internal/web -run "TestItemPrint|TestClassifyAndExecuteSystemActionPrintItemUsesActiveWorkspaceItem"`
  - Evidence: `TestClassifyAndExecuteSystemActionPrintItemUsesActiveWorkspaceItem` passed, proving `print this item` resolves an item and returns the `print_item` action payload.
- UI handling for the print action:
  - Command: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts -g "system_action print item"`
  - Evidence: `1 passed (1.3s)` from `tests/playwright/ui-system.spec.ts`, which verifies the hidden print iframe loads `/api/items/42/print` and updates the UI status.
