### PR TITLE
fix: Add PR review request to Item mapping (fixes #186)

### DIFF
--- a/internal/web/items_github_reviews.go
+++ b/internal/web/items_github_reviews.go
@@ -1,0 +1,235 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type itemGitHubPRReviewSyncResponse struct {
+	OK          bool   `json:"ok"`
+	WorkspaceID int64  `json:"workspace_id"`
+	Repo        string `json:"repo"`
+	Synced      int    `json:"synced"`
+	Requested   int    `json:"requested"`
+	Closed      int    `json:"closed"`
+}
+
+type ghPRReviewListItem struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	HeadRefName string `json:"headRefName"`
+	BaseRefName string `json:"baseRefName"`
+}
+
+func githubPRReviewSourceRef(ownerRepo string, number int) string {
+	return fmt.Sprintf("%s#PR-%d", strings.TrimSpace(ownerRepo), number)
+}
+
+func githubPRReviewDiffURL(raw string) string {
+	clean := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if clean == "" {
+		return ""
+	}
+	return clean + ".diff"
+}
+
+func githubPRArtifactMeta(ownerRepo string, pr ghPRReviewListItem) (*string, error) {
+	payload := map[string]any{
+		"owner_repo":    ownerRepo,
+		"number":        pr.Number,
+		"state":         "open",
+		"url":           strings.TrimSpace(pr.URL),
+		"diff_url":      githubPRReviewDiffURL(pr.URL),
+		"head_ref_name": strings.TrimSpace(pr.HeadRefName),
+		"base_ref_name": strings.TrimSpace(pr.BaseRefName),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func (a *App) listGitHubPRReviewRequests(cwd string) ([]ghPRReviewListItem, error) {
+	runner := a.ghCommandRunner
+	if runner == nil {
+		runner = runGitHubCLI
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), githubPRCommandTimeout)
+	defer cancel()
+
+	raw, err := runner(
+		ctx,
+		cwd,
+		"pr", "list",
+		"--search", "review-requested:@me",
+		"--state", "open",
+		"--limit", "500",
+		"--json", "number,title,url,headRefName,baseRefName",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var prs []ghPRReviewListItem
+	if err := json.Unmarshal([]byte(raw), &prs); err != nil {
+		return nil, fmt.Errorf("invalid github pr response: %w", err)
+	}
+	return prs, nil
+}
+
+func (a *App) syncGitHubPRReviewArtifact(item store.Item, ownerRepo string, pr ghPRReviewListItem) error {
+	kind := store.ArtifactKindGitHubPR
+	refURL := optionalTrimmedString(pr.URL)
+	title := optionalTrimmedString(fmt.Sprintf("PR #%d", pr.Number))
+	metaJSON, err := githubPRArtifactMeta(ownerRepo, pr)
+	if err != nil {
+		return err
+	}
+
+	createArtifact := func() (store.Artifact, error) {
+		return a.store.CreateArtifact(kind, nil, refURL, title, metaJSON)
+	}
+
+	if item.ArtifactID == nil {
+		artifact, err := createArtifact()
+		if err != nil {
+			return err
+		}
+		return a.store.UpdateItemArtifact(item.ID, &artifact.ID)
+	}
+
+	err = a.store.UpdateArtifact(*item.ArtifactID, store.ArtifactUpdate{
+		Kind:     &kind,
+		RefURL:   refURL,
+		Title:    title,
+		MetaJSON: metaJSON,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		artifact, createErr := createArtifact()
+		if createErr != nil {
+			return createErr
+		}
+		return a.store.UpdateItemArtifact(item.ID, &artifact.ID)
+	}
+	return err
+}
+
+func isGitHubPRReviewItem(item store.Item, ownerRepo string, workspaceID int64) bool {
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspaceID {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(stringFromPointer(item.Source)), "github") {
+		return false
+	}
+	sourceRef := strings.TrimSpace(stringFromPointer(item.SourceRef))
+	return strings.HasPrefix(sourceRef, strings.TrimSpace(ownerRepo)+"#PR-")
+}
+
+func (a *App) syncGitHubPRReviews(workspaceID int64) (itemGitHubPRReviewSyncResponse, error) {
+	workspace, err := a.store.GetWorkspace(workspaceID)
+	if err != nil {
+		return itemGitHubPRReviewSyncResponse{}, err
+	}
+	repo, err := a.store.GitHubRepoForWorkspace(workspaceID)
+	if err != nil {
+		return itemGitHubPRReviewSyncResponse{}, err
+	}
+	if strings.TrimSpace(repo) == "" {
+		return itemGitHubPRReviewSyncResponse{}, errors.New("workspace has no GitHub origin remote")
+	}
+
+	prs, err := a.listGitHubPRReviewRequests(workspace.DirPath)
+	if err != nil {
+		return itemGitHubPRReviewSyncResponse{}, err
+	}
+
+	result := itemGitHubPRReviewSyncResponse{
+		OK:          true,
+		WorkspaceID: workspace.ID,
+		Repo:        repo,
+		Synced:      len(prs),
+	}
+	activeRefs := make(map[string]struct{}, len(prs))
+	for _, pr := range prs {
+		if pr.Number <= 0 {
+			return itemGitHubPRReviewSyncResponse{}, errors.New("github pr number is required")
+		}
+		if strings.TrimSpace(pr.Title) == "" {
+			return itemGitHubPRReviewSyncResponse{}, fmt.Errorf("github pr #%d title is required", pr.Number)
+		}
+		sourceRef := githubPRReviewSourceRef(repo, pr.Number)
+		activeRefs[sourceRef] = struct{}{}
+
+		item, err := a.store.UpsertItemFromSource("github", sourceRef, pr.Title, &workspace.ID)
+		if err != nil {
+			return itemGitHubPRReviewSyncResponse{}, err
+		}
+		if err := a.syncGitHubPRReviewArtifact(item, repo, pr); err != nil {
+			return itemGitHubPRReviewSyncResponse{}, err
+		}
+		if item.State == store.ItemStateDone {
+			if err := a.store.SyncItemStateBySource("github", sourceRef, store.ItemStateInbox); err != nil {
+				return itemGitHubPRReviewSyncResponse{}, err
+			}
+		}
+		result.Requested++
+	}
+
+	items, err := a.store.ListItems()
+	if err != nil {
+		return itemGitHubPRReviewSyncResponse{}, err
+	}
+	for _, item := range items {
+		if !isGitHubPRReviewItem(item, repo, workspace.ID) {
+			continue
+		}
+		sourceRef := strings.TrimSpace(stringFromPointer(item.SourceRef))
+		if _, ok := activeRefs[sourceRef]; ok || item.State == store.ItemStateDone {
+			continue
+		}
+		if err := a.store.SyncItemStateBySource("github", sourceRef, store.ItemStateDone); err != nil {
+			return itemGitHubPRReviewSyncResponse{}, err
+		}
+		result.Closed++
+	}
+
+	return result, nil
+}
+
+func (a *App) handleGitHubPRReviewSync(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req itemGitHubSyncRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.WorkspaceID <= 0 {
+		http.Error(w, "workspace_id is required", http.StatusBadRequest)
+		return
+	}
+
+	result, err := a.syncGitHubPRReviews(req.WorkspaceID)
+	if err != nil {
+		switch {
+		case strings.Contains(strings.ToLower(err.Error()), "no github origin remote"):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, sql.ErrNoRows):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		default:
+			http.Error(w, err.Error(), http.StatusBadGateway)
+		}
+		return
+	}
+	writeJSON(w, result)
+}

--- a/internal/web/items_github_test.go
+++ b/internal/web/items_github_test.go
@@ -174,6 +174,162 @@ func TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote(t *testing.T) {
 	}
 }
 
+func TestGitHubPRReviewSyncAPI(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	repoDir := filepath.Join(t.TempDir(), "workspace")
+	initGitHubWorkspaceRepo(t, repoDir, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Repo", repoDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	var calls [][]string
+	var callCWDs []string
+	callCount := 0
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		callCWDs = append(callCWDs, cwd)
+		callCount++
+		switch callCount {
+		case 1:
+			return `[
+				{"number":21,"title":"Review sidebar opens PR mode","url":"https://github.com/owner/tabula/pull/21","headRefName":"fix/review-sidebar","baseRefName":"main"}
+			]`, nil
+		case 2:
+			return `[]`, nil
+		case 3:
+			return `[
+				{"number":21,"title":"Review sidebar opens PR mode v2","url":"https://github.com/owner/tabula/pull/21","headRefName":"fix/review-sidebar","baseRefName":"main"}
+			]`, nil
+		default:
+			t.Fatalf("unexpected gh invocation %d", callCount)
+			return "", nil
+		}
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github/reviews", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first review sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var first itemGitHubPRReviewSyncResponse
+	if err := json.NewDecoder(rr.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first review sync response: %v", err)
+	}
+	if first.Synced != 1 || first.Requested != 1 || first.Closed != 0 {
+		t.Fatalf("first review sync response = %+v, want synced=1 requested=1 closed=0", first)
+	}
+
+	reviewItem, err := app.store.GetItemBySource("github", "owner/tabula#PR-21")
+	if err != nil {
+		t.Fatalf("GetItemBySource(review) error: %v", err)
+	}
+	if reviewItem.State != store.ItemStateInbox {
+		t.Fatalf("review item state = %q, want %q", reviewItem.State, store.ItemStateInbox)
+	}
+	if reviewItem.WorkspaceID == nil || *reviewItem.WorkspaceID != workspace.ID {
+		t.Fatalf("review item workspace = %v, want %d", reviewItem.WorkspaceID, workspace.ID)
+	}
+	if reviewItem.ArtifactID == nil {
+		t.Fatal("expected review item artifact")
+	}
+	reviewArtifact, err := app.store.GetArtifact(*reviewItem.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact(review) error: %v", err)
+	}
+	if reviewArtifact.Kind != store.ArtifactKindGitHubPR {
+		t.Fatalf("review artifact kind = %q, want %q", reviewArtifact.Kind, store.ArtifactKindGitHubPR)
+	}
+	if reviewArtifact.RefURL == nil || *reviewArtifact.RefURL != "https://github.com/owner/tabula/pull/21" {
+		t.Fatalf("review artifact ref_url = %v, want PR URL", reviewArtifact.RefURL)
+	}
+	var reviewMeta map[string]any
+	if reviewArtifact.MetaJSON == nil {
+		t.Fatal("expected review artifact meta_json")
+	}
+	if err := json.Unmarshal([]byte(*reviewArtifact.MetaJSON), &reviewMeta); err != nil {
+		t.Fatalf("unmarshal review artifact meta_json: %v", err)
+	}
+	if reviewMeta["diff_url"] != "https://github.com/owner/tabula/pull/21.diff" {
+		t.Fatalf("review artifact diff_url = %v, want PR diff URL", reviewMeta["diff_url"])
+	}
+	if reviewMeta["head_ref_name"] != "fix/review-sidebar" || reviewMeta["base_ref_name"] != "main" {
+		t.Fatalf("review artifact refs = %#v, want head/base refs", reviewMeta)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github/reviews", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second review sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	closedItem, err := app.store.GetItem(reviewItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(closed review) error: %v", err)
+	}
+	if closedItem.State != store.ItemStateDone {
+		t.Fatalf("closed review state = %q, want %q", closedItem.State, store.ItemStateDone)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github/reviews", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("third review sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	reopenedItem, err := app.store.GetItemBySource("github", "owner/tabula#PR-21")
+	if err != nil {
+		t.Fatalf("GetItemBySource(reopened review) error: %v", err)
+	}
+	if reopenedItem.ID != reviewItem.ID {
+		t.Fatalf("reopened review ID = %d, want %d", reopenedItem.ID, reviewItem.ID)
+	}
+	if reopenedItem.State != store.ItemStateInbox {
+		t.Fatalf("reopened review state = %q, want %q", reopenedItem.State, store.ItemStateInbox)
+	}
+	if reopenedItem.Title != "Review sidebar opens PR mode v2" {
+		t.Fatalf("reopened review title = %q, want updated title", reopenedItem.Title)
+	}
+
+	if len(calls) != 3 {
+		t.Fatalf("gh call count = %d, want 3", len(calls))
+	}
+	for i, args := range calls {
+		if callCWDs[i] != repoDir {
+			t.Fatalf("gh cwd[%d] = %q, want %q", i, callCWDs[i], repoDir)
+		}
+		command := strings.Join(args, " ")
+		if !strings.Contains(command, "pr list --search review-requested:@me --state open --limit 500") {
+			t.Fatalf("gh args[%d] = %q, want review-requested pr list", i, command)
+		}
+		if !strings.Contains(command, "--json number,title,url,headRefName,baseRefName") {
+			t.Fatalf("gh args[%d] = %q, want expected review json fields", i, command)
+		}
+	}
+}
+
+func TestGitHubPRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "workspace")
+	if err := exec.Command("git", "init", workspaceDir).Run(); err != nil {
+		t.Fatalf("git init %s: %v", workspaceDir, err)
+	}
+	workspace, err := app.store.CreateWorkspace("Repo", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github/reviews", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("review sync without remote status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func initGitHubWorkspaceRepo(t *testing.T, dirPath, remoteURL string) {
 	t.Helper()
 	if err := exec.Command("git", "init", dirPath).Run(); err != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -405,6 +405,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/items/done", a.handleItemDone)
 	r.Get("/api/items/counts", a.handleItemCounts)
 	r.Post("/api/items/sync/github", a.handleGitHubIssueSync)
+	r.Post("/api/items/sync/github/reviews", a.handleGitHubPRReviewSync)
 	r.Put("/api/items/{item_id}/assign", a.handleItemAssign)
 	r.Put("/api/items/{item_id}/unassign", a.handleItemUnassign)
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -3072,6 +3072,58 @@ function itemSourceLabel(item) {
   return '';
 }
 
+function parsePullRequestNumberFromSourceRef(raw) {
+  const match = String(raw || '').trim().match(/#PR-(\d+)$/i);
+  if (!match) return 0;
+  const number = Number(match[1]);
+  return Number.isInteger(number) && number > 0 ? number : 0;
+}
+
+async function openSidebarPRReview(prNumber) {
+  if (!Number.isInteger(Number(prNumber)) || Number(prNumber) <= 0 || !state.chatSessionId) {
+    return false;
+  }
+  state.prReviewAwaitingArtifact = true;
+  try {
+    const resp = await fetch(apiURL(`chat/sessions/${encodeURIComponent(state.chatSessionId)}/commands`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: `/pr ${Number(prNumber)}` }),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    const commandName = String(payload?.result?.name || '').trim().toLowerCase();
+    if (payload?.kind === 'command' && commandName === 'pr') {
+      return true;
+    }
+    state.prReviewAwaitingArtifact = false;
+    throw new Error('unexpected PR review response');
+  } catch (err) {
+    state.prReviewAwaitingArtifact = false;
+    showStatus(`review open failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+async function openSidebarItem(item) {
+  state.itemSidebarActiveItemID = Number(item?.id || 0);
+  renderPrReviewFileList();
+  if (String(item?.artifact_kind || '').trim().toLowerCase() !== 'github_pr') {
+    return;
+  }
+  const prNumber = parsePullRequestNumberFromSourceRef(item?.source_ref);
+  if (prNumber <= 0) {
+    return;
+  }
+  const opened = await openSidebarPRReview(prNumber);
+  if (opened && isMobileViewport()) {
+    closeEdgePanels();
+  }
+}
+
 function itemKindLabel(item) {
   const artifactKind = String(item?.artifact_kind || '').trim().toLowerCase();
   if (artifactKind === 'idea_note') return 'idea';
@@ -3293,10 +3345,7 @@ function renderItemSidebarList(list) {
       badges: buildItemSidebarBadges(item),
       meta: formatSidebarAge(item?.updated_at || item?.created_at),
       active: Number(item?.id || 0) === Number(state.itemSidebarActiveItemID || 0),
-      onClick: () => {
-        state.itemSidebarActiveItemID = Number(item?.id || 0);
-        renderPrReviewFileList();
-      },
+      onClick: () => { void openSidebarItem(item); },
     }));
   });
 }

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -483,6 +483,15 @@
         },
       ],
     });
+    const mockPrDiff = (prNumber) => [
+      'diff --git a/src/review.js b/src/review.js',
+      'index 1111111..2222222 100644',
+      '--- a/src/review.js',
+      '+++ b/src/review.js',
+      `@@ -1 +1 @@`,
+      `-console.log("before ${prNumber}");`,
+      `+console.log("after ${prNumber}");`,
+    ].join('\n');
     window.__itemSidebarData = defaultItemSidebarData();
     window.__setItemSidebarData = (next) => {
       const incoming = next && typeof next === 'object' ? next : {};
@@ -994,6 +1003,49 @@
           payload: activityResponse,
         });
         return new Response(JSON.stringify(activityResponse), { status: 200 });
+      }
+      if (u.includes('/api/chat/sessions') && u.includes('/commands') && opts?.method === 'POST') {
+        let body = {};
+        try {
+          body = JSON.parse(String(opts?.body || '{}'));
+        } catch (_) {
+          body = {};
+        }
+        const command = String(body.command || '').trim();
+        window.__harnessLog.push({ type: 'command_sent', command });
+        const prMatch = command.match(/^\/?pr\s+(\d+)$/i);
+        if (prMatch) {
+          const prNumber = Number(prMatch[1]);
+          const app = window._taburaApp;
+          window.setTimeout(() => {
+            const canvasWs = app?.getState?.().canvasWs;
+            if (canvasWs && typeof canvasWs.injectEvent === 'function') {
+              canvasWs.injectEvent({
+                kind: 'text_artifact',
+                event_id: `evt-pr-command-${prNumber}`,
+                title: `.tabura/artifacts/pr/pr-${prNumber}.diff`,
+                text: mockPrDiff(prNumber),
+              });
+            }
+          }, 0);
+          return new Response(JSON.stringify({
+            ok: true,
+            kind: 'command',
+            result: {
+              name: 'pr',
+              pr_number: prNumber,
+              pr_title: `Harness PR ${prNumber}`,
+              pr_url: `https://github.com/owner/repo/pull/${prNumber}`,
+              files_changed: 1,
+              message: `Loaded PR #${prNumber}: Harness PR ${prNumber} (1 file).`,
+            },
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          ok: true,
+          kind: 'command',
+          result: { name: 'noop', message: 'Harness command' },
+        }), { status: 200 });
       }
       if (u.includes('/api/chat/') && u.includes('/messages') && opts?.method === 'POST') {
         const signal = opts?.signal;

--- a/tests/playwright/inbox.spec.ts
+++ b/tests/playwright/inbox.spec.ts
@@ -50,4 +50,39 @@ test.describe('item inbox sidebar', () => {
     await expect(page.locator('.sidebar-tab.is-active')).toContainText('Files');
     await expect(page.locator('#pr-file-list .pr-file-item .pr-file-name', { hasText: 'docs' })).toHaveCount(1);
   });
+
+  test('opening a PR review item enters PR review mode', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [{
+          id: 144,
+          title: 'Review sidebar PR mapping',
+          state: 'inbox',
+          source: 'github',
+          source_ref: 'owner/repo#PR-144',
+          artifact_title: 'PR #144',
+          artifact_kind: 'github_pr',
+          actor_name: 'Alice',
+          created_at: '2026-03-08 10:00:00',
+          updated_at: '2026-03-08 10:05:00',
+        }],
+        waiting: [],
+      });
+    });
+
+    await page.locator('#edge-left-tap').click();
+    await page.locator('.sidebar-tab', { hasText: 'Inbox' }).click();
+    await expect(page.locator('#pr-file-list')).toContainText('Review sidebar PR mapping');
+    await page.locator('#pr-file-list .pr-file-item').first().click();
+
+    await expect(page.locator('body')).toHaveClass(/pr-review-mode/);
+    await expect(page.locator('#canvas-text')).toContainText('src/review.js');
+    await expect(page.locator('#pr-file-list .pr-file-item')).toHaveCount(1);
+
+    const log = await page.evaluate(() => (window as any).__harnessLog || []);
+    expect(log.some((entry: any) => entry?.type === 'command_sent' && entry?.command === '/pr 144')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add `POST /api/items/sync/github/reviews` to map `gh pr list --search review-requested:@me` into inbox items with `github_pr` artifacts
- mark stale review-request items done and reopen the same item when review is requested again
- open PR review items from the inbox sidebar by issuing the existing `/pr <n>` command and entering PR review mode on the canvas

## Verification
- PR review requests appear as inbox items
  - `go test ./internal/web -run "TestGitHub(IssueSyncAPI|IssueSyncAPIRejectsWorkspaceWithoutGitHubRemote|PRReviewSyncAPI|PRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote)$"`
  - excerpt: `ok   github.com/krystophny/tabura/internal/web 0.052s`
  - coverage: `TestGitHubPRReviewSyncAPI` creates `owner/tabula#PR-21` in `inbox` from `/api/items/sync/github/reviews`
- Opening enters PR review mode on canvas
  - `./scripts/playwright.sh tests/playwright/inbox.spec.ts`
  - excerpt: `3 passed (2.5s)` and `opening a PR review item enters PR review mode`
  - artifact verification: the harness command path opens `.tabura/artifacts/pr/pr-144.diff`, and the spec asserts `body.pr-review-mode` plus `#canvas-text` containing `src/review.js`
- Submitted/merged/closed requests move to done
  - `go test ./internal/web -run "TestGitHub(IssueSyncAPI|IssueSyncAPIRejectsWorkspaceWithoutGitHubRemote|PRReviewSyncAPI|PRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote)$"`
  - coverage: `TestGitHubPRReviewSyncAPI` runs a second sync with an empty review-request list and asserts the existing PR review item moves to `done`, then a third sync reopens the same item id when the request returns
- Artifact includes diff URL and review metadata
  - `go test ./internal/web -run "TestGitHub(IssueSyncAPI|IssueSyncAPIRejectsWorkspaceWithoutGitHubRemote|PRReviewSyncAPI|PRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote)$"`
  - coverage: `TestGitHubPRReviewSyncAPI` asserts artifact kind `github_pr`, PR `ref_url`, `diff_url=https://github.com/owner/tabura/pull/21.diff`, and stored `head_ref_name` / `base_ref_name`
- HTTP surface stays in sync
  - `./scripts/sync-surface.sh --check`
  - excerpt: exit 0
