### PR TITLE
fix: Add swipe and gesture triage interactions for inbox items (fixes #184)

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -128,6 +128,7 @@ const state = {
   itemSidebarLoading: false,
   itemSidebarError: '',
   itemSidebarActiveItemID: 0,
+  itemSidebarMenuOpen: false,
   prReviewAwaitingArtifact: false,
   artifactEditMode: false,
   inkDraft: {
@@ -227,6 +228,11 @@ let localMessageSeq = 0;
 const CHAT_CTRL_LONG_PRESS_MS = 180;
 const ARTIFACT_EDIT_LONG_TAP_MS = 420;
 const ITEM_SIDEBAR_VIEWS = ['inbox', 'waiting', 'someday', 'done'];
+const ITEM_SIDEBAR_GESTURE_CANCEL_PX = 12;
+const ITEM_SIDEBAR_GESTURE_COMMIT_PX = 50;
+const ITEM_SIDEBAR_GESTURE_LONG_PX = 150;
+const ITEM_SIDEBAR_DEFAULT_LATER_HOUR_UTC = 9;
+const ITEM_SIDEBAR_MENU_ID = 'item-sidebar-menu';
 // Frontend end-of-utterance policy:
 // - start/end speech from local mic energy
 // - pure VAD commit (no semantic EOU sidecar)
@@ -3002,9 +3008,332 @@ async function refreshItemSidebarCounts() {
   return true;
 }
 
+function isEmailSidebarItem(item) {
+  return String(item?.artifact_kind || '').trim().toLowerCase() === 'email';
+}
+
+function itemSidebarActionLabel(action, item = null) {
+  const normalized = String(action || '').trim().toLowerCase();
+  if (normalized === 'done') {
+    return isEmailSidebarItem(item) ? 'Archive' : 'Done';
+  }
+  if (normalized === 'delete') return 'Delete';
+  if (normalized === 'delegate') return 'Delegate';
+  if (normalized === 'later') return 'Later';
+  return '';
+}
+
+function itemSidebarStatusText(action, item = null, actorName = '') {
+  const label = itemSidebarActionLabel(action, item).toLowerCase();
+  if (String(action || '').trim().toLowerCase() === 'delegate' && String(actorName || '').trim()) {
+    return `delegated to ${String(actorName || '').trim()}`;
+  }
+  if (!label) return 'updated';
+  if (label === 'later') return 'moved to later';
+  return `${label}d`;
+}
+
+function defaultItemSidebarLaterVisibleAfter(now = new Date()) {
+  const base = new Date(now);
+  base.setUTCDate(base.getUTCDate() + 1);
+  base.setUTCHours(ITEM_SIDEBAR_DEFAULT_LATER_HOUR_UTC, 0, 0, 0);
+  return base.toISOString();
+}
+
+function itemSidebarGestureAction(dx) {
+  const offset = Number(dx) || 0;
+  if (offset >= ITEM_SIDEBAR_GESTURE_LONG_PX) {
+    return { action: 'delete', label: 'Delete' };
+  }
+  if (offset >= ITEM_SIDEBAR_GESTURE_COMMIT_PX) {
+    return { action: 'done', label: 'Done' };
+  }
+  if (offset <= -ITEM_SIDEBAR_GESTURE_LONG_PX) {
+    return { action: 'later', label: 'Later' };
+  }
+  if (offset <= -ITEM_SIDEBAR_GESTURE_COMMIT_PX) {
+    return { action: 'delegate', label: 'Delegate' };
+  }
+  return null;
+}
+
+function itemSidebarMenuEl() {
+  let menu = document.getElementById(ITEM_SIDEBAR_MENU_ID);
+  if (menu instanceof HTMLElement) return menu;
+  menu = document.createElement('div');
+  menu.id = ITEM_SIDEBAR_MENU_ID;
+  menu.className = 'item-sidebar-menu';
+  menu.setAttribute('role', 'menu');
+  menu.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(menu);
+  return menu;
+}
+
+function hideItemSidebarMenu() {
+  const menu = document.getElementById(ITEM_SIDEBAR_MENU_ID);
+  if (!(menu instanceof HTMLElement)) return;
+  menu.innerHTML = '';
+  menu.classList.remove('is-open');
+  menu.setAttribute('aria-hidden', 'true');
+  state.itemSidebarMenuOpen = false;
+}
+
+function positionItemSidebarMenu(menu, x, y) {
+  if (!(menu instanceof HTMLElement)) return;
+  menu.style.left = '0px';
+  menu.style.top = '0px';
+  menu.style.maxHeight = `${Math.max(160, window.innerHeight - 24)}px`;
+  menu.classList.add('is-open');
+  menu.setAttribute('aria-hidden', 'false');
+  const rect = menu.getBoundingClientRect();
+  const maxLeft = Math.max(12, window.innerWidth - rect.width - 12);
+  const maxTop = Math.max(12, window.innerHeight - rect.height - 12);
+  const left = Math.min(Math.max(12, Number(x) || 12), maxLeft);
+  const top = Math.min(Math.max(12, Number(y) || 12), maxTop);
+  menu.style.left = `${left}px`;
+  menu.style.top = `${top}px`;
+  state.itemSidebarMenuOpen = true;
+}
+
+function showItemSidebarMenu(entries, x, y) {
+  const items = Array.isArray(entries) ? entries.filter((entry) => entry && entry.label) : [];
+  if (items.length === 0) {
+    hideItemSidebarMenu();
+    return;
+  }
+  const menu = itemSidebarMenuEl();
+  menu.innerHTML = '';
+  items.forEach((entry) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'item-sidebar-menu-item';
+    if (entry.action) {
+      button.dataset.action = String(entry.action);
+    }
+    button.textContent = String(entry.label || '');
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const handler = typeof entry.onClick === 'function' ? entry.onClick : null;
+      hideItemSidebarMenu();
+      if (handler) {
+        void Promise.resolve(handler());
+      }
+    });
+    menu.appendChild(button);
+  });
+  positionItemSidebarMenu(menu, x, y);
+}
+
+async function fetchItemSidebarActors() {
+  const resp = await fetch(apiURL('actors'), { cache: 'no-store' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const payload = await resp.json();
+  const actors = Array.isArray(payload?.actors) ? payload.actors : [];
+  return actors
+    .map((actor) => ({
+      id: Number(actor?.id || 0),
+      name: String(actor?.name || '').trim(),
+    }))
+    .filter((actor) => actor.id > 0 && actor.name);
+}
+
+async function performItemSidebarTriage(item, action, options = {}) {
+  const itemID = Number(item?.id || 0);
+  if (itemID <= 0) return false;
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) return false;
+  const body = { action: normalizedAction };
+  let actorName = '';
+  if (normalizedAction === 'later') {
+    body.visible_after = defaultItemSidebarLaterVisibleAfter(options.now || new Date());
+  } else if (normalizedAction === 'delegate') {
+    const actorID = Number(options.actorID || 0);
+    if (actorID <= 0) return false;
+    body.actor_id = actorID;
+    actorName = String(options.actorName || '').trim();
+  }
+  try {
+    const resp = await fetch(apiURL(`items/${encodeURIComponent(String(itemID))}/triage`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    if (normalizedAction === 'delete') {
+      if (state.itemSidebarActiveItemID === itemID) {
+        state.itemSidebarActiveItemID = 0;
+      }
+    } else {
+      state.itemSidebarActiveItemID = itemID;
+    }
+    await loadItemSidebarView(state.itemSidebarView);
+    showStatus(itemSidebarStatusText(normalizedAction, item, actorName));
+    return true;
+  } catch (err) {
+    showStatus(`item action failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+async function showItemSidebarDelegateMenu(item, x, y) {
+  try {
+    const actors = await fetchItemSidebarActors();
+    if (actors.length === 0) {
+      showStatus('no actors available');
+      return false;
+    }
+    showItemSidebarMenu(
+      actors.map((actor) => ({
+        label: actor.name,
+        action: 'delegate',
+        onClick: () => performItemSidebarTriage(item, 'delegate', {
+          actorID: actor.id,
+          actorName: actor.name,
+        }),
+      })),
+      x,
+      y,
+    );
+    return true;
+  } catch (err) {
+    showStatus(`delegate picker failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+function showItemSidebarActionMenu(item, x, y) {
+  const entries = [
+    {
+      label: itemSidebarActionLabel('done', item),
+      action: 'done',
+      onClick: () => performItemSidebarTriage(item, 'done'),
+    },
+    {
+      label: itemSidebarActionLabel('later', item),
+      action: 'later',
+      onClick: () => performItemSidebarTriage(item, 'later'),
+    },
+    {
+      label: itemSidebarActionLabel('delegate', item),
+      action: 'delegate',
+      onClick: () => showItemSidebarDelegateMenu(item, x, y),
+    },
+    {
+      label: itemSidebarActionLabel('delete', item),
+      action: 'delete',
+      onClick: () => performItemSidebarTriage(item, 'delete'),
+    },
+  ];
+  showItemSidebarMenu(entries, x, y);
+}
+
+function parseSidebarArtifactMeta(raw) {
+  const text = String(raw || '').trim();
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function buildSidebarItemFallbackText(item, artifact = null) {
+  const artifactMeta = parseSidebarArtifactMeta(artifact?.meta_json || '');
+  const title = String(artifact?.title || item?.artifact_title || item?.title || 'Item').trim() || 'Item';
+  const detail = [
+    `# ${title}`,
+    '',
+    `- Item: ${String(item?.title || title).trim() || title}`,
+    `- Kind: ${normalizeDisplayText(artifact?.kind || item?.artifact_kind || 'note') || 'note'}`,
+  ];
+  const sourceRef = String(item?.source_ref || '').trim();
+  if (sourceRef) detail.push(`- Source: ${sourceRef}`);
+  const refURL = String(artifact?.ref_url || '').trim();
+  if (refURL) detail.push(`- Link: ${refURL}`);
+  const body = String(
+    artifactMeta.transcript
+    || artifactMeta.text
+    || artifactMeta.body
+    || artifactMeta.summary
+    || artifactMeta.content
+    || '',
+  ).trim();
+  if (body) {
+    detail.push('', '## Details', '', body);
+  }
+  return detail.join('\n');
+}
+
+async function openSidebarArtifactItem(item) {
+  const artifactID = Number(item?.artifact_id || 0);
+  if (artifactID <= 0) {
+    applyCanvasArtifactEvent({
+      kind: 'text_artifact',
+      event_id: `sidebar-item-${Number(item?.id || 0)}-${Date.now()}`,
+      title: String(item?.title || 'Item'),
+      text: buildSidebarItemFallbackText(item),
+    });
+    return true;
+  }
+  const resp = await fetch(apiURL(`artifacts/${encodeURIComponent(String(artifactID))}`), { cache: 'no-store' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const payload = await resp.json();
+  const artifact = payload?.artifact || {};
+  const refPath = String(artifact?.ref_path || '').trim();
+  const artifactKind = String(artifact?.kind || item?.artifact_kind || '').trim().toLowerCase();
+  if (refPath && !refPath.startsWith('/')) {
+    if (artifactKind === 'pdf' || artifactKind === 'pdf_artifact' || refPath.toLowerCase().endsWith('.pdf')) {
+      applyCanvasArtifactEvent({
+        kind: 'pdf_artifact',
+        event_id: `sidebar-item-${artifactID}-${Date.now()}`,
+        title: String(artifact?.title || item?.artifact_title || item?.title || refPath),
+        path: refPath,
+      });
+      return true;
+    }
+    if (SIDEBAR_IMAGE_EXTENSIONS.has(`.${String(refPath.split('.').pop() || '').toLowerCase()}`)) {
+      applyCanvasArtifactEvent({
+        kind: 'image_artifact',
+        event_id: `sidebar-item-${artifactID}-${Date.now()}`,
+        title: String(artifact?.title || item?.artifact_title || item?.title || refPath),
+        path: refPath,
+      });
+      return true;
+    }
+  }
+  applyCanvasArtifactEvent({
+    kind: 'text_artifact',
+    event_id: `sidebar-item-${artifactID}-${Date.now()}`,
+    title: String(artifact?.title || item?.artifact_title || item?.title || 'Item'),
+    text: buildSidebarItemFallbackText(item, artifact),
+  });
+  return true;
+}
+
+function activeItemSidebarShortcutTarget() {
+  if (state.prReviewMode || state.fileSidebarMode !== 'items' || state.itemSidebarView !== 'inbox') {
+    return null;
+  }
+  const items = Array.isArray(state.itemSidebarItems) ? state.itemSidebarItems : [];
+  if (items.length === 0) return null;
+  const activeID = Number(state.itemSidebarActiveItemID || 0);
+  return items.find((item) => Number(item?.id || 0) === activeID) || items[0];
+}
+
 async function loadItemSidebarView(view = state.itemSidebarView) {
   const normalizedView = normalizeItemSidebarView(view);
   const projectID = String(state.activeProjectId || '').trim();
+  hideItemSidebarMenu();
   state.itemSidebarView = normalizedView;
   state.itemSidebarLoading = true;
   state.itemSidebarError = '';
@@ -3112,6 +3441,14 @@ async function openSidebarItem(item) {
   state.itemSidebarActiveItemID = Number(item?.id || 0);
   renderPrReviewFileList();
   if (String(item?.artifact_kind || '').trim().toLowerCase() !== 'github_pr') {
+    try {
+      const opened = await openSidebarArtifactItem(item);
+      if (opened && isMobileViewport()) {
+        closeEdgePanels();
+      }
+    } catch (err) {
+      showStatus(`item open failed: ${String(err?.message || err || 'unknown error')}`);
+    }
     return;
   }
   const prNumber = parsePullRequestNumberFromSourceRef(item?.source_ref);
@@ -3230,12 +3567,26 @@ function renderSidebarTabs(list) {
   list.appendChild(tabs);
 }
 
-function renderSidebarRow({ icon, iconText = '', label, active = false, meta = '', subtitle = '', badges = [], onClick }) {
+function renderSidebarRow({
+  icon,
+  iconText = '',
+  label,
+  active = false,
+  meta = '',
+  subtitle = '',
+  badges = [],
+  item = null,
+  triageEnabled = false,
+  onClick,
+}) {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'pr-file-item';
   if (active) {
     button.classList.add('is-active');
+  }
+  if (item && Number(item?.id || 0) > 0) {
+    button.dataset.itemId = String(Number(item.id));
   }
 
   const iconEl = document.createElement('span');
@@ -3281,20 +3632,108 @@ function renderSidebarRow({ icon, iconText = '', label, active = false, meta = '
     metaEl.textContent = String(meta);
     button.appendChild(metaEl);
   }
+
+  const resetSwipeUi = () => {
+    button.style.removeProperty('--swipe-offset');
+    delete button.dataset.triageAction;
+    delete button.dataset.triageLabel;
+  };
+
+  const applySwipeUi = (dx) => {
+    const limited = Math.max(-220, Math.min(220, Number(dx) || 0));
+    const action = itemSidebarGestureAction(limited);
+    button.style.setProperty('--swipe-offset', `${limited}px`);
+    if (action) {
+      button.dataset.triageAction = action.action;
+      button.dataset.triageLabel = itemSidebarActionLabel(action.action, item);
+    } else {
+      delete button.dataset.triageAction;
+      delete button.dataset.triageLabel;
+    }
+    return action;
+  };
+
   let lastTouchAt = 0;
-  let touchStartY = 0;
+  let touchState = null;
   button.addEventListener('touchstart', (ev) => {
     const t = ev.touches && ev.touches[0];
-    if (t) touchStartY = t.clientY;
+    if (!t) return;
+    hideItemSidebarMenu();
+    touchState = {
+      startX: t.clientX,
+      startY: t.clientY,
+      currentX: t.clientX,
+      currentY: t.clientY,
+      swiping: false,
+    };
+    resetSwipeUi();
   }, { passive: true });
+  if (triageEnabled && item) {
+    button.addEventListener('touchmove', (ev) => {
+      if (!touchState) return;
+      const t = ev.touches && ev.touches[0];
+      if (!t) return;
+      touchState.currentX = t.clientX;
+      touchState.currentY = t.clientY;
+      const dx = t.clientX - touchState.startX;
+      const dy = t.clientY - touchState.startY;
+      if (!touchState.swiping) {
+        if (Math.abs(dx) < ITEM_SIDEBAR_GESTURE_CANCEL_PX || Math.abs(dx) < Math.abs(dy)) {
+          return;
+        }
+        touchState.swiping = true;
+      }
+      ev.preventDefault();
+      applySwipeUi(dx);
+    }, { passive: false });
+    button.addEventListener('touchcancel', () => {
+      touchState = null;
+      resetSwipeUi();
+    });
+    button.addEventListener('contextmenu', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      state.itemSidebarActiveItemID = Number(item?.id || 0);
+      showItemSidebarActionMenu(item, ev.clientX, ev.clientY);
+    });
+  }
   button.addEventListener('touchend', (ev) => {
     const t = ev.changedTouches && ev.changedTouches[0];
-    if (t && Math.abs(t.clientY - touchStartY) > 10) return;
+    const current = touchState;
+    touchState = null;
+    if (!t || !current) {
+      return;
+    }
+    const dx = t.clientX - current.startX;
+    const dy = t.clientY - current.startY;
+    const gestureAction = triageEnabled ? itemSidebarGestureAction(dx) : null;
+    if (gestureAction && current.swiping) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      lastTouchAt = Date.now();
+      suppressSyntheticClick();
+      resetSwipeUi();
+      if (gestureAction.action === 'delegate') {
+        void showItemSidebarDelegateMenu(item, t.clientX, t.clientY);
+      } else {
+        void performItemSidebarTriage(item, gestureAction.action);
+      }
+      return;
+    }
+    resetSwipeUi();
+    if (Math.abs(dx) > ITEM_SIDEBAR_GESTURE_CANCEL_PX || Math.abs(dy) > 10) {
+      return;
+    }
     ev.preventDefault();
     ev.stopPropagation();
     lastTouchAt = Date.now();
     onClick(ev);
   }, { passive: false });
+  if (item) {
+    button.addEventListener('focus', () => {
+      state.itemSidebarActiveItemID = Number(item?.id || 0);
+    });
+  }
   button.addEventListener('click', (ev) => {
     if (Date.now() - lastTouchAt < 700) {
       ev.preventDefault();
@@ -3345,9 +3784,41 @@ function renderItemSidebarList(list) {
       badges: buildItemSidebarBadges(item),
       meta: formatSidebarAge(item?.updated_at || item?.created_at),
       active: Number(item?.id || 0) === Number(state.itemSidebarActiveItemID || 0),
+      item,
+      triageEnabled: state.itemSidebarView === 'inbox',
       onClick: () => { void openSidebarItem(item); },
     }));
   });
+}
+
+function handleItemSidebarKeyboardShortcut(ev) {
+  const sidebarTarget = activeItemSidebarShortcutTarget();
+  if (!sidebarTarget) return false;
+  if (!document.body.classList.contains('file-sidebar-open')) return false;
+  const key = String(ev.key || '');
+  let action = '';
+  if (key === 'Backspace') {
+    action = 'delete';
+  } else if (key === 'd' || key === 'D') {
+    action = 'done';
+  } else if (key === 'l' || key === 'L') {
+    action = 'later';
+  } else if (key === 'g' || key === 'G') {
+    action = 'delegate';
+  } else {
+    return false;
+  }
+  ev.preventDefault();
+  if (action === 'delegate') {
+    const row = document.querySelector(`#pr-file-list .pr-file-item[data-item-id="${Number(sidebarTarget.id)}"]`);
+    const rect = row instanceof HTMLElement ? row.getBoundingClientRect() : null;
+    const x = rect ? rect.right - 12 : 24;
+    const y = rect ? rect.top + Math.min(rect.height, 48) : 24;
+    void showItemSidebarDelegateMenu(sidebarTarget, x, y);
+    return true;
+  }
+  void performItemSidebarTriage(sidebarTarget, action);
+  return true;
 }
 
 function renderWorkspaceFileList(list) {
@@ -7077,6 +7548,10 @@ function bindUi() {
   // Click outside overlay/input -> dismiss
   document.addEventListener('mousedown', (ev) => {
     if (!(ev.target instanceof Element)) return;
+    const sidebarMenu = document.getElementById(ITEM_SIDEBAR_MENU_ID);
+    if (state.itemSidebarMenuOpen && sidebarMenu instanceof HTMLElement && !sidebarMenu.contains(ev.target)) {
+      hideItemSidebarMenu();
+    }
     // Dismiss overlay on click outside
     if (isOverlayVisible()) {
       const overlay = document.getElementById('overlay');
@@ -7113,6 +7588,10 @@ function bindUi() {
       }
       if (isTextInputVisible()) {
         hideTextInput();
+        return;
+      }
+      if (state.itemSidebarMenuOpen) {
+        hideItemSidebarMenu();
         return;
       }
       if (state.inkDraft.dirty) {
@@ -7175,6 +7654,7 @@ function bindUi() {
     if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
     if (isEditableTarget(ev.target)) return;
     if (state.artifactEditMode) return;
+    if (handleItemSidebarKeyboardShortcut(ev)) return;
 
     if (ev.key === 'ArrowRight') {
       if (stepCanvasFile(1)) {

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -182,6 +182,7 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
 }
 
 .pr-file-item {
+  position: relative;
   width: 100%;
   margin: 0;
   border: 0;
@@ -196,15 +197,104 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
   gap: 0.5rem;
   font-size: 1rem;
   line-height: 1.3;
+  transform: translateX(var(--swipe-offset, 0px));
+  transition: transform 140ms ease, background-color 140ms ease, color 140ms ease;
+  touch-action: pan-y;
+  overflow: hidden;
 }
 
 .pr-file-item:hover {
   background: #f3f4f6;
 }
 
+.pr-file-item::after {
+  content: attr(data-triage-label);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.pr-file-item[data-triage-action]::after {
+  opacity: 1;
+}
+
+.pr-file-item[data-triage-action="done"] {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+.pr-file-item[data-triage-action="done"]::after {
+  color: #166534;
+}
+
+.pr-file-item[data-triage-action="delete"] {
+  background: #fee2e2;
+  color: #7f1d1d;
+}
+
+.pr-file-item[data-triage-action="delete"]::after {
+  color: #991b1b;
+}
+
+.pr-file-item[data-triage-action="delegate"] {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.pr-file-item[data-triage-action="delegate"]::after {
+  color: #1d4ed8;
+}
+
+.pr-file-item[data-triage-action="later"] {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.pr-file-item[data-triage-action="later"]::after {
+  color: #c2410c;
+}
+
+.pr-file-item[data-triage-action] .pr-file-status,
+.pr-file-item[data-triage-action] .sidebar-row-subtitle {
+  color: currentColor;
+  opacity: 0.72;
+}
+
 .pr-file-item.is-active {
   background: #111827;
   color: #f9fafb;
+}
+
+.pr-file-item.is-active[data-triage-action="done"] {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+.pr-file-item.is-active[data-triage-action="delete"] {
+  background: #fee2e2;
+  color: #7f1d1d;
+}
+
+.pr-file-item.is-active[data-triage-action="delegate"] {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.pr-file-item.is-active[data-triage-action="later"] {
+  background: #ffedd5;
+  color: #9a3412;
 }
 
 .pr-file-status {
@@ -268,6 +358,44 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
   line-height: 1.1;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.item-sidebar-menu {
+  position: fixed;
+  z-index: 460;
+  min-width: 160px;
+  max-width: min(280px, calc(100vw - 24px));
+  display: none;
+  flex-direction: column;
+  border: 1px solid #111827;
+  background: #ffffff;
+  box-shadow: 0 12px 32px rgba(17, 24, 39, 0.18);
+  overflow: auto;
+}
+
+.item-sidebar-menu.is-open {
+  display: flex;
+}
+
+.item-sidebar-menu-item {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid #d1d5db;
+  border-radius: 0;
+  background: #ffffff;
+  color: #111827;
+  text-align: left;
+  padding: 0.62rem 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.item-sidebar-menu-item:last-child {
+  border-bottom: 0;
+}
+
+.item-sidebar-menu-item:hover {
+  background: #f3f4f6;
 }
 
 .chooser-icon {

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -413,12 +413,52 @@
       test: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
       hub: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
     };
+    const defaultItemSidebarActors = () => ([
+      { id: 1, name: 'Alice', kind: 'human' },
+      { id: 2, name: 'Bob', kind: 'human' },
+      { id: 3, name: 'Codex', kind: 'agent' },
+    ]);
+    const defaultItemSidebarArtifacts = () => ({
+      501: {
+        id: 501,
+        kind: 'idea_note',
+        title: 'Parser cleanup plan',
+        meta_json: JSON.stringify({
+          transcript: 'Break parser cleanup into a small refactor, a test pass, and one cleanup issue.',
+        }),
+      },
+      502: {
+        id: 502,
+        kind: 'email',
+        title: 'Re: triage follow-up',
+        meta_json: JSON.stringify({
+          body: 'Need a response before tomorrow morning. Confirm whether the review packet is ready.',
+        }),
+      },
+      503: {
+        id: 503,
+        kind: 'plan_note',
+        title: 'Gesture backlog',
+        meta_json: JSON.stringify({
+          text: 'Sketch quick triage affordances for small touch screens.',
+        }),
+      },
+      504: {
+        id: 504,
+        kind: 'github_issue',
+        title: 'Capture checklist',
+        meta_json: JSON.stringify({
+          text: 'Close the remaining capture tasks before cutting the release.',
+        }),
+      },
+    });
     const defaultItemSidebarData = () => ({
       inbox: [
         {
           id: 101,
           title: 'Review parser cleanup',
           state: 'inbox',
+          artifact_id: 501,
           source: 'github',
           source_ref: 'owner/repo#177',
           artifact_title: 'Parser cleanup plan',
@@ -431,6 +471,7 @@
           id: 102,
           title: 'Answer triage email',
           state: 'inbox',
+          artifact_id: 502,
           source: 'exchange',
           source_ref: 'msg-102',
           artifact_title: 'Re: triage follow-up',
@@ -445,6 +486,7 @@
           id: 201,
           title: 'Await review feedback',
           state: 'waiting',
+          artifact_id: 0,
           source: 'github',
           source_ref: 'owner/repo#144',
           artifact_title: 'PR 144',
@@ -459,6 +501,7 @@
           id: 301,
           title: 'Sketch mobile inbox gestures',
           state: 'someday',
+          artifact_id: 503,
           source: '',
           source_ref: '',
           artifact_title: 'Gesture backlog',
@@ -473,6 +516,7 @@
           id: 401,
           title: 'Ship capture flow',
           state: 'done',
+          artifact_id: 504,
           source: 'github',
           source_ref: 'owner/repo#90',
           artifact_title: 'Capture checklist',
@@ -493,6 +537,8 @@
       `+console.log("after ${prNumber}");`,
     ].join('\n');
     window.__itemSidebarData = defaultItemSidebarData();
+    window.__itemSidebarActors = defaultItemSidebarActors();
+    window.__itemSidebarArtifacts = defaultItemSidebarArtifacts();
     window.__setItemSidebarData = (next) => {
       const incoming = next && typeof next === 'object' ? next : {};
       window.__itemSidebarData = {
@@ -500,6 +546,62 @@
         ...incoming,
       };
     };
+    window.__setItemSidebarActors = (next) => {
+      window.__itemSidebarActors = Array.isArray(next)
+        ? next.map((actor) => ({ ...actor }))
+        : defaultItemSidebarActors();
+    };
+    window.__setItemSidebarArtifacts = (next) => {
+      const source = next && typeof next === 'object' ? next : {};
+      window.__itemSidebarArtifacts = Object.keys(source).reduce((acc, key) => {
+        acc[key] = { ...source[key] };
+        return acc;
+      }, {});
+    };
+    function cloneItemSidebarEntry(entry) {
+      return entry && typeof entry === 'object' ? { ...entry } : {};
+    }
+    function moveItemSidebarEntry(itemID, nextState, patch = {}) {
+      const data = window.__itemSidebarData || defaultItemSidebarData();
+      const states = ['inbox', 'waiting', 'someday', 'done'];
+      let found = null;
+      states.forEach((stateKey) => {
+        const rows = Array.isArray(data[stateKey]) ? data[stateKey] : [];
+        const index = rows.findIndex((entry) => Number(entry?.id || 0) === Number(itemID));
+        if (index >= 0) {
+          found = cloneItemSidebarEntry(rows[index]);
+          rows.splice(index, 1);
+          data[stateKey] = rows;
+        }
+      });
+      if (!found) return null;
+      const updated = {
+        ...found,
+        ...patch,
+        state: nextState,
+        updated_at: '2026-03-08 15:00:00',
+      };
+      if (!Array.isArray(data[nextState])) data[nextState] = [];
+      data[nextState] = [updated].concat(data[nextState]);
+      window.__itemSidebarData = data;
+      return updated;
+    }
+    function deleteItemSidebarEntry(itemID) {
+      const data = window.__itemSidebarData || defaultItemSidebarData();
+      const states = ['inbox', 'waiting', 'someday', 'done'];
+      let removed = null;
+      states.forEach((stateKey) => {
+        const rows = Array.isArray(data[stateKey]) ? data[stateKey] : [];
+        const index = rows.findIndex((entry) => Number(entry?.id || 0) === Number(itemID));
+        if (index >= 0) {
+          removed = cloneItemSidebarEntry(rows[index]);
+          rows.splice(index, 1);
+          data[stateKey] = rows;
+        }
+      });
+      window.__itemSidebarData = data;
+      return removed;
+    }
     window.__participantConfig = {
       companion_enabled: false,
       language: 'en',
@@ -907,6 +1009,57 @@
           done: Array.isArray(itemData.done) ? itemData.done.length : 0,
         };
         return new Response(JSON.stringify({ ok: true, counts }), { status: 200 });
+      }
+      if (/\/api\/items\/\d+\/triage(?:\?|$)/.test(u) && opts?.method === 'POST') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        const match = u.match(/\/api\/items\/(\d+)\/triage(?:\?|$)/);
+        const itemID = Number(match?.[1] || 0);
+        const action = String(body.action || '').trim().toLowerCase();
+        const actors = Array.isArray(window.__itemSidebarActors) ? window.__itemSidebarActors : [];
+        let item = null;
+        if (action === 'done') {
+          item = moveItemSidebarEntry(itemID, 'done');
+        } else if (action === 'later') {
+          item = moveItemSidebarEntry(itemID, 'waiting', { visible_after: String(body.visible_after || '') });
+        } else if (action === 'delegate') {
+          const actor = actors.find((entry) => Number(entry?.id || 0) === Number(body.actor_id || 0));
+          item = moveItemSidebarEntry(itemID, 'waiting', { actor_name: String(actor?.name || '') });
+        } else if (action === 'someday') {
+          item = moveItemSidebarEntry(itemID, 'someday');
+        } else if (action === 'delete') {
+          item = deleteItemSidebarEntry(itemID);
+        }
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'item_triage',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: body,
+        });
+        if (!item) {
+          return new Response('item not found', { status: 404 });
+        }
+        if (action === 'delete') {
+          return new Response(JSON.stringify({ ok: true, deleted: true, item_id: itemID }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ ok: true, item }), { status: 200 });
+      }
+      if (u.includes('/api/actors')) {
+        const actors = Array.isArray(window.__itemSidebarActors) ? window.__itemSidebarActors : [];
+        return new Response(JSON.stringify({ ok: true, actors }), { status: 200 });
+      }
+      if (/\/api\/artifacts\/\d+(?:\?|$)/.test(u)) {
+        const match = u.match(/\/api\/artifacts\/(\d+)(?:\?|$)/);
+        const artifactID = Number(match?.[1] || 0);
+        const artifacts = window.__itemSidebarArtifacts && typeof window.__itemSidebarArtifacts === 'object'
+          ? window.__itemSidebarArtifacts
+          : {};
+        const artifact = artifacts[String(artifactID)] || artifacts[artifactID];
+        if (!artifact) {
+          return new Response('artifact not found', { status: 404 });
+        }
+        return new Response(JSON.stringify({ ok: true, artifact }), { status: 200 });
       }
       if (u.includes('/api/items/inbox') || u.includes('/api/items/waiting') || u.includes('/api/items/someday') || u.includes('/api/items/done')) {
         const itemData = window.__itemSidebarData || defaultItemSidebarData();

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -1,0 +1,216 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    const wsOpen = (window as any).WebSocket.OPEN;
+    return s.chatWs?.readyState === wsOpen && s.canvasWs?.readyState === wsOpen;
+  }, null, { timeout: 8_000 });
+}
+
+async function openInbox(page: Page) {
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+  await page.locator('.sidebar-tab', { hasText: 'Inbox' }).click();
+  await expect(page.locator('.sidebar-tab.is-active')).toContainText('Inbox');
+}
+
+const parserInboxItem = {
+  id: 101,
+  title: 'Review parser cleanup',
+  state: 'inbox',
+  artifact_id: 501,
+  source: 'github',
+  source_ref: 'owner/repo#177',
+  artifact_title: 'Parser cleanup plan',
+  artifact_kind: 'idea_note',
+  actor_name: 'Alice',
+  created_at: '2026-03-08 09:40:00',
+  updated_at: '2026-03-08 09:58:00',
+};
+
+async function setInboxItems(page: Page, items: Array<Record<string, unknown>>) {
+  await page.evaluate((nextItems) => {
+    (window as any).__setItemSidebarData({ inbox: nextItems });
+  }, items);
+  await page.locator('.sidebar-tab', { hasText: 'Inbox' }).evaluate((el: HTMLElement) => {
+    el.click();
+  });
+  if (items.length > 0) {
+    await expect(page.locator('#pr-file-list')).toContainText(String(items[0].title || ''));
+  } else {
+    await expect(page.locator('#pr-file-list')).toContainText('No inbox items.');
+  }
+}
+
+async function touchPhase(page: Page, selector: string, phase: 'start' | 'move' | 'end', dx = 0, dy = 0) {
+  await page.locator(selector).evaluate((el, payload) => {
+    const rect = (el as HTMLElement).getBoundingClientRect();
+    const startX = rect.left + 24;
+    const startY = rect.top + rect.height / 2;
+    const currentX = startX + Number(payload.dx || 0);
+    const currentY = startY + Number(payload.dy || 0);
+    const target = el as HTMLElement;
+    const startTouch = new Touch({
+      identifier: 1,
+      target,
+      clientX: startX,
+      clientY: startY,
+      pageX: startX,
+      pageY: startY,
+      screenX: startX,
+      screenY: startY,
+    });
+    const moveTouch = new Touch({
+      identifier: 1,
+      target,
+      clientX: currentX,
+      clientY: currentY,
+      pageX: currentX,
+      pageY: currentY,
+      screenX: currentX,
+      screenY: currentY,
+    });
+    if (payload.phase === 'start') {
+      target.dispatchEvent(new TouchEvent('touchstart', {
+        bubbles: true,
+        cancelable: true,
+        touches: [startTouch],
+        changedTouches: [startTouch],
+        targetTouches: [startTouch],
+      }));
+      return;
+    }
+    if (payload.phase === 'move') {
+      target.dispatchEvent(new TouchEvent('touchmove', {
+        bubbles: true,
+        cancelable: true,
+        touches: [moveTouch],
+        changedTouches: [moveTouch],
+        targetTouches: [moveTouch],
+      }));
+      return;
+    }
+    target.dispatchEvent(new TouchEvent('touchend', {
+      bubbles: true,
+      cancelable: true,
+      touches: [],
+      changedTouches: [moveTouch],
+      targetTouches: [],
+    }));
+  }, { phase, dx, dy });
+}
+
+test.describe('inbox triage interactions', () => {
+  test('tap opens the linked artifact on canvas', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+
+    await page.locator('#pr-file-list .pr-file-item').first().click();
+
+    await expect(page.locator('#canvas-text')).toContainText('Parser cleanup plan');
+    await expect(page.locator('#canvas-text')).toContainText('Break parser cleanup into a small refactor');
+  });
+
+  test('touch gestures expose feedback and commit done, delete, delegate, and later', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+
+    const row = '#pr-file-list .pr-file-item[data-item-id="101"]';
+
+    await touchPhase(page, row, 'start');
+    await touchPhase(page, row, 'move', 90, 0);
+    await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'done');
+    await expect(page.locator(row)).toHaveAttribute('data-triage-label', 'Done');
+    await touchPhase(page, row, 'end', 90, 0);
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await touchPhase(page, row, 'start');
+    await touchPhase(page, row, 'move', 180, 0);
+    await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'delete');
+    await touchPhase(page, row, 'end', 180, 0);
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await touchPhase(page, row, 'start');
+    await touchPhase(page, row, 'move', -100, 0);
+    await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'delegate');
+    await touchPhase(page, row, 'end', -100, 0);
+    await expect(page.locator('#item-sidebar-menu')).toBeVisible();
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Alice');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Codex' }).click();
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await touchPhase(page, row, 'start');
+    await touchPhase(page, row, 'move', -185, 0);
+    await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'later');
+    await touchPhase(page, row, 'end', -185, 0);
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    const log = await page.evaluate(() => (window as any).__harnessLog || []);
+    const triageCalls = log.filter((entry: any) => entry?.action === 'item_triage');
+    expect(triageCalls.map((entry: any) => entry?.payload?.action)).toEqual(['done', 'delete', 'delegate', 'later']);
+  });
+
+  test('desktop context menu and keyboard shortcuts cover archive, delete, later, and delegate', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+    await openInbox(page);
+
+    const emailRow = page.locator('#pr-file-list .pr-file-item[data-item-id="102"]');
+    await emailRow.click();
+    await emailRow.click({ button: 'right' });
+    await expect(page.locator('#item-sidebar-menu')).toBeVisible();
+    await expect(page.locator('#item-sidebar-menu .item-sidebar-menu-item').first()).toContainText('Archive');
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Delete');
+    await page.mouse.click(10, 10);
+
+    await page.keyboard.press('KeyD');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Answer triage email');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await page.keyboard.press('KeyL');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await page.locator('#pr-file-list .pr-file-item[data-item-id="101"]').click();
+    await page.keyboard.press('KeyG');
+    await expect(page.locator('#item-sidebar-menu')).toBeVisible();
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Bob' }).click();
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+
+    await setInboxItems(page, [parserInboxItem]);
+    await page.keyboard.press('Backspace');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+  });
+
+  test('partial swipe cancels cleanly, rapid swipes remain stable, and empty inbox stays inert', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+
+    const rowA = '#pr-file-list .pr-file-item[data-item-id="101"]';
+    await touchPhase(page, rowA, 'start');
+    await touchPhase(page, rowA, 'move', 20, 0);
+    await touchPhase(page, rowA, 'end', 20, 0);
+    await expect(page.locator(rowA)).toBeVisible();
+
+    await touchPhase(page, rowA, 'start');
+    await touchPhase(page, rowA, 'move', 90, 0);
+    await touchPhase(page, rowA, 'end', 90, 0);
+    const rowB = '#pr-file-list .pr-file-item[data-item-id="102"]';
+    await touchPhase(page, rowB, 'start');
+    await touchPhase(page, rowB, 'move', 180, 0);
+    await touchPhase(page, rowB, 'end', 180, 0);
+
+    await setInboxItems(page, []);
+    await expect(page.locator('#item-sidebar-menu')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- add inbox-row swipe triage with visible action feedback and canvas opening on tap
- add desktop fallback actions through a context menu and keyboard shortcuts
- extend the Playwright harness and add focused coverage for gestures, keyboard paths, and edge cases

## Verification
- Tap opens artifact on canvas: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts`
  Output: `✓ ... tap opens the linked artifact on canvas`
- Right short swipe -> done, right long swipe -> delete, left short swipe -> delegate picker, left long swipe -> later, with visible feedback during swipe: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts`
  Output: `✓ ... touch gestures expose feedback and commit done, delete, delegate, and later`
- Desktop right-click and keyboard shortcuts (`d`, `l`, `g`, `Backspace`) work: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts`
  Output: `✓ ... desktop context menu and keyboard shortcuts cover archive, delete, later, and delegate`
- Partial swipes cancel cleanly, rapid swipes stay stable, and empty inbox remains inert: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts`
  Output: `✓ ... partial swipe cancels cleanly, rapid swipes remain stable, and empty inbox stays inert`
- Targeted UI suite result: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts`
  Output: `4 passed (3.5s)`
