### PR TITLE
fix: wire app-server approval policy to plan mode for interactiv (fixes #299)

### DIFF
--- a/internal/appserver/approval.go
+++ b/internal/appserver/approval.go
@@ -1,0 +1,94 @@
+package appserver
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ApprovalPolicyNever          = "never"
+	ApprovalPolicyOnRequest      = "on-request"
+	ApprovalPolicyUnlessTrusted  = "unlessTrusted"
+	ApprovalMethodCommandRequest = "item/commandExecution/requestApproval"
+	ApprovalMethodFileRequest    = "item/fileChange/requestApproval"
+)
+
+type ApprovalRequest struct {
+	ID        interface{}
+	Method    string
+	Kind      string
+	ItemID    string
+	Reason    string
+	GrantRoot string
+	Risk      map[string]interface{}
+}
+
+func applyDefaultApprovalPolicy(params map[string]interface{}) map[string]interface{} {
+	if params == nil {
+		params = map[string]interface{}{}
+	}
+	value, ok := params["approvalPolicy"]
+	if !ok || strings.TrimSpace(fmt.Sprint(value)) == "" || strings.EqualFold(strings.TrimSpace(fmt.Sprint(value)), "<nil>") {
+		params["approvalPolicy"] = ApprovalPolicyOnRequest
+	}
+	return params
+}
+
+func normalizeApprovalPolicy(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "default", "<nil>":
+		return ApprovalPolicyOnRequest
+	case ApprovalPolicyNever:
+		return ApprovalPolicyNever
+	case ApprovalPolicyOnRequest:
+		return ApprovalPolicyOnRequest
+	case "untrusted", "unless-trusted", "unlesstrusted", "unless_trusted", ApprovalPolicyUnlessTrusted:
+		return ApprovalPolicyUnlessTrusted
+	default:
+		return strings.TrimSpace(raw)
+	}
+}
+
+func parseApprovalRequest(msg map[string]interface{}) (*ApprovalRequest, bool) {
+	method := strings.TrimSpace(stringifyItemValue(msg["method"]))
+	switch method {
+	case ApprovalMethodCommandRequest, "execCommandApproval":
+		params, _ := msg["params"].(map[string]interface{})
+		req := &ApprovalRequest{
+			ID:     msg["id"],
+			Method: method,
+			Kind:   "command_execution",
+			ItemID: strings.TrimSpace(stringifyItemValue(params["item_id"])),
+			Reason: strings.TrimSpace(stringifyItemValue(params["reason"])),
+		}
+		if risk, _ := params["risk"].(map[string]interface{}); risk != nil {
+			req.Risk = risk
+		}
+		return req, true
+	case ApprovalMethodFileRequest, "fileChangeApproval":
+		params, _ := msg["params"].(map[string]interface{})
+		return &ApprovalRequest{
+			ID:        msg["id"],
+			Method:    method,
+			Kind:      "file_change",
+			ItemID:    strings.TrimSpace(stringifyItemValue(params["item_id"])),
+			Reason:    strings.TrimSpace(stringifyItemValue(params["reason"])),
+			GrantRoot: strings.TrimSpace(stringifyItemValue(params["grant_root"])),
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func normalizeApprovalDecision(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "cancel", "canceled", "cancelled":
+		return "cancel"
+	case "approve", "approved", "accept", "acceptforsession":
+		return "accept"
+	case "reject", "rejected", "decline", "denied", "deny":
+		return "decline"
+	default:
+		return "cancel"
+	}
+}

--- a/internal/appserver/approval_test.go
+++ b/internal/appserver/approval_test.go
@@ -1,0 +1,238 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestNormalizeApprovalPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "default", raw: "", want: ApprovalPolicyOnRequest},
+		{name: "never", raw: "never", want: ApprovalPolicyNever},
+		{name: "on request", raw: "on-request", want: ApprovalPolicyOnRequest},
+		{name: "untrusted alias", raw: "untrusted", want: ApprovalPolicyUnlessTrusted},
+		{name: "unless trusted alias", raw: "unless-trusted", want: ApprovalPolicyUnlessTrusted},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeApprovalPolicy(tc.raw); got != tc.want {
+				t.Fatalf("normalizeApprovalPolicy(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSendPromptStreamDefaultsToOnRequestApprovalPolicy(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	gotPolicy := ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			switch strings.TrimSpace(stringifyItemValue(msg["method"])) {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id":     msg["id"],
+					"result": map[string]interface{}{"userAgent": "test"},
+				})
+			case "thread/start":
+				params, _ := msg["params"].(map[string]interface{})
+				gotPolicy = strings.TrimSpace(stringifyItemValue(params["approvalPolicy"]))
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"thread": map[string]interface{}{"id": "thread-policy"},
+					},
+				})
+			case "turn/start":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-policy"},
+					},
+				})
+				_ = conn.WriteJSON(map[string]interface{}{
+					"method": "item/completed",
+					"params": map[string]interface{}{
+						"item": map[string]interface{}{
+							"type": "agentMessage",
+							"text": "done",
+						},
+					},
+				})
+				_ = conn.WriteJSON(map[string]interface{}{
+					"method": "turn/completed",
+					"params": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-policy", "status": "completed"},
+					},
+				})
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient("ws" + strings.TrimPrefix(srv.URL, "http"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.SendPromptStream(context.Background(), PromptRequest{
+		CWD:    "/tmp",
+		Prompt: "plan this",
+	}, nil)
+	if err != nil {
+		t.Fatalf("SendPromptStream: %v", err)
+	}
+	if gotPolicy != ApprovalPolicyOnRequest {
+		t.Fatalf("approvalPolicy = %q, want %q", gotPolicy, ApprovalPolicyOnRequest)
+	}
+}
+
+func TestSessionSendTurnHandlesApprovalRequests(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	gotPolicy := ""
+	gotDecision := ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			switch strings.TrimSpace(stringifyItemValue(msg["method"])) {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id":     msg["id"],
+					"result": map[string]interface{}{"userAgent": "test"},
+				})
+			case "thread/start":
+				params, _ := msg["params"].(map[string]interface{})
+				gotPolicy = strings.TrimSpace(stringifyItemValue(params["approvalPolicy"]))
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"thread": map[string]interface{}{"id": "thread-approval"},
+					},
+				})
+			case "turn/start":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-approval"},
+					},
+				})
+				_ = conn.WriteJSON(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      "approval-1",
+					"method":  ApprovalMethodCommandRequest,
+					"params": map[string]interface{}{
+						"item_id": "item-7",
+						"reason":  "run git status",
+					},
+				})
+			default:
+				if msg["id"] == "approval-1" {
+					result, _ := msg["result"].(map[string]interface{})
+					gotDecision = strings.TrimSpace(stringifyItemValue(result["decision"]))
+					_ = conn.WriteJSON(map[string]interface{}{
+						"method": "item/completed",
+						"params": map[string]interface{}{
+							"item": map[string]interface{}{
+								"type": "agentMessage",
+								"text": "approved and done",
+							},
+						},
+					})
+					_ = conn.WriteJSON(map[string]interface{}{
+						"method": "turn/completed",
+						"params": map[string]interface{}{
+							"turn": map[string]interface{}{"id": "turn-approval", "status": "completed"},
+						},
+					})
+					return
+				}
+			}
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient("ws" + strings.TrimPrefix(srv.URL, "http"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	sess, err := client.OpenSessionWithParams(context.Background(), "/tmp", "", map[string]interface{}{
+		"approvalPolicy": "untrusted",
+	})
+	if err != nil {
+		t.Fatalf("open session: %v", err)
+	}
+	defer sess.Close()
+
+	var approvalEvent *StreamEvent
+	resp, err := sess.SendTurn(context.Background(), "inspect repo", "", func(ev StreamEvent) {
+		if ev.Type != "approval_request" {
+			return
+		}
+		approvalEvent = &ev
+		if ev.Approval == nil {
+			t.Fatal("approval event missing request")
+		}
+		if err := ev.Respond("approve"); err != nil {
+			t.Fatalf("Respond: %v", err)
+		}
+	})
+	if err != nil {
+		t.Fatalf("SendTurn: %v", err)
+	}
+	if gotPolicy != ApprovalPolicyUnlessTrusted {
+		t.Fatalf("approvalPolicy = %q, want %q", gotPolicy, ApprovalPolicyUnlessTrusted)
+	}
+	if approvalEvent == nil {
+		t.Fatal("expected approval_request event")
+	}
+	if approvalEvent.Approval.Kind != "command_execution" {
+		t.Fatalf("approval kind = %q, want command_execution", approvalEvent.Approval.Kind)
+	}
+	if approvalEvent.Approval.Reason != "run git status" {
+		t.Fatalf("approval reason = %q, want %q", approvalEvent.Approval.Reason, "run git status")
+	}
+	if gotDecision != "accept" {
+		t.Fatalf("decision = %q, want %q", gotDecision, "accept")
+	}
+	if resp.Message != "approved and done" {
+		t.Fatalf("unexpected response message %q", resp.Message)
+	}
+}

--- a/internal/appserver/client.go
+++ b/internal/appserver/client.go
@@ -21,13 +21,13 @@ type Client struct {
 }
 
 type PromptRequest struct {
-	CWD       string
-	Prompt    string
-	Model     string        // thread-level default model
-	TurnModel string        // per-turn model override (sent in turn/start if set)
+	CWD          string
+	Prompt       string
+	Model        string                 // thread-level default model
+	TurnModel    string                 // per-turn model override (sent in turn/start if set)
 	ThreadParams map[string]interface{} // additional params for thread/start
-	TurnParams  map[string]interface{} // additional params for turn/start
-	Timeout   time.Duration
+	TurnParams   map[string]interface{} // additional params for turn/start
+	Timeout      time.Duration
 }
 
 type PromptResponse struct {
@@ -47,6 +47,8 @@ type StreamEvent struct {
 	Error       string
 	ContextUsed int64
 	ContextMax  int64
+	Approval    *ApprovalRequest
+	Respond     func(string) error
 }
 
 func NewClient(rawURL string) (*Client, error) {
@@ -175,24 +177,28 @@ func (c *Client) SendPromptStream(ctx context.Context, req PromptRequest, onEven
 		return nil, contextErr(ctx, err)
 	}
 
-	threadParams := map[string]interface{}{
+	threadParams := applyDefaultApprovalPolicy(map[string]interface{}{
 		"cwd":                    strings.TrimSpace(req.CWD),
-		"approvalPolicy":         "never",
 		"sandbox":                "danger-full-access",
 		"experimentalRawEvents":  false,
 		"persistExtendedHistory": true,
 		"ephemeral":              false,
-	}
+	})
 	if strings.TrimSpace(req.Model) != "" {
 		threadParams["model"] = strings.TrimSpace(req.Model)
 	}
 	if len(req.ThreadParams) > 0 {
 		for key, value := range req.ThreadParams {
 			if strings.TrimSpace(key) != "" {
+				if strings.EqualFold(strings.TrimSpace(key), "approvalPolicy") {
+					threadParams[key] = normalizeApprovalPolicy(fmt.Sprint(value))
+					continue
+				}
 				threadParams[key] = value
 			}
 		}
 	}
+	threadParams["approvalPolicy"] = normalizeApprovalPolicy(fmt.Sprint(threadParams["approvalPolicy"]))
 	if err := c.writeJSON(ctx, conn, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      2,
@@ -304,6 +310,30 @@ func (c *Client) readTurnUntilComplete(ctx context.Context, conn *websocket.Conn
 		msg, err := readJSON(ctx, conn)
 		if err != nil {
 			return "", "", nil, err
+		}
+
+		if approvalReq, ok := parseApprovalRequest(msg); ok {
+			ev := StreamEvent{
+				Type:     "approval_request",
+				ThreadID: threadID,
+				TurnID:   turnID,
+				Approval: approvalReq,
+			}
+			ev.Respond = func(decision string) error {
+				return c.writeJSON(ctx, conn, map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      approvalReq.ID,
+					"result": map[string]interface{}{
+						"decision": normalizeApprovalDecision(decision),
+					},
+				})
+			}
+			if onEvent != nil {
+				onEvent(ev)
+			} else {
+				_ = ev.Respond("cancel")
+			}
+			continue
 		}
 
 		if msgID, hasID := jsonRPCID(msg); hasID && msgID == 3 {

--- a/internal/appserver/session.go
+++ b/internal/appserver/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -14,15 +15,15 @@ import (
 // Session maintains a persistent WebSocket connection to the codex app server,
 // reusing a single thread across multiple turns.
 type Session struct {
-	client   *Client
-	conn     *websocket.Conn
-	threadID string
-	model    string
+	client       *Client
+	conn         *websocket.Conn
+	threadID     string
+	model        string
 	threadParams map[string]interface{}
-	cwd      string
-	mu       sync.Mutex
-	closed   bool
-	nextID   int
+	cwd          string
+	mu           sync.Mutex
+	closed       bool
+	nextID       int
 
 	// Context tracking (updated from turn/completed usage data).
 	ContextUsed int64
@@ -126,15 +127,15 @@ func (s *Session) handshake(ctx context.Context) error {
 
 func (s *Session) startThread(ctx context.Context, resumeThreadID string) (string, error) {
 	reqID := s.allocID()
-	params := map[string]interface{}{
+	params := applyDefaultApprovalPolicy(map[string]interface{}{
 		"cwd":                    s.cwd,
-		"approvalPolicy":         "never",
 		"sandbox":                "danger-full-access",
 		"experimentalRawEvents":  false,
 		"persistExtendedHistory": true,
 		"ephemeral":              false,
-	}
+	})
 	params = mergeStringInterfaceParams(params, s.threadParams)
+	params["approvalPolicy"] = normalizeApprovalPolicy(fmt.Sprint(params["approvalPolicy"]))
 	if s.model != "" {
 		params["model"] = s.model
 	}
@@ -162,6 +163,21 @@ func (s *Session) startThread(ctx context.Context, resumeThreadID string) (strin
 
 // ThreadID returns the app server thread ID for this session.
 func (s *Session) ThreadID() string { return s.threadID }
+
+func (s *Session) MatchesConfig(cwd, model string, threadParams map[string]interface{}) bool {
+	if s == nil {
+		return false
+	}
+	expected := cloneStringInterfaceMap(threadParams)
+	expected = applyDefaultApprovalPolicy(expected)
+	expected["approvalPolicy"] = normalizeApprovalPolicy(fmt.Sprint(expected["approvalPolicy"]))
+	actual := cloneStringInterfaceMap(s.threadParams)
+	actual = applyDefaultApprovalPolicy(actual)
+	actual["approvalPolicy"] = normalizeApprovalPolicy(fmt.Sprint(actual["approvalPolicy"]))
+	return strings.TrimSpace(s.cwd) == strings.TrimSpace(cwd) &&
+		strings.TrimSpace(s.model) == strings.TrimSpace(model) &&
+		reflect.DeepEqual(actual, expected)
+}
 
 // IsOpen returns true if the session connection is still usable.
 func (s *Session) IsOpen() bool {
@@ -251,6 +267,30 @@ func (s *Session) readTurnUntilComplete(ctx context.Context, turnRPCID int, onEv
 		msg, err := readJSON(ctx, s.conn)
 		if err != nil {
 			return "", "", nil, err
+		}
+
+		if approvalReq, ok := parseApprovalRequest(msg); ok {
+			ev := StreamEvent{
+				Type:     "approval_request",
+				ThreadID: s.threadID,
+				TurnID:   turnID,
+				Approval: approvalReq,
+			}
+			ev.Respond = func(decision string) error {
+				return s.writeJSON(ctx, map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      approvalReq.ID,
+					"result": map[string]interface{}{
+						"decision": normalizeApprovalDecision(decision),
+					},
+				})
+			}
+			if onEvent != nil {
+				onEvent(ev)
+			} else {
+				_ = ev.Respond("cancel")
+			}
+			continue
 		}
 
 		if msgID, hasID := jsonRPCID(msg); hasID && msgID == turnRPCID {

--- a/internal/web/chat_approval.go
+++ b/internal/web/chat_approval.go
@@ -1,0 +1,166 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/appserver"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type pendingAppServerApproval struct {
+	LocalID    string
+	Request    *appserver.ApprovalRequest
+	DecisionCh chan string
+	CreatedAt  time.Time
+}
+
+func approvalPolicyForSession(mode string, yoloMode bool) string {
+	if yoloMode {
+		return appserver.ApprovalPolicyNever
+	}
+	if strings.EqualFold(strings.TrimSpace(mode), "plan") {
+		return appserver.ApprovalPolicyUnlessTrusted
+	}
+	return appserver.ApprovalPolicyOnRequest
+}
+
+func mergeApprovalPolicyThreadParams(threadParams map[string]interface{}, mode string, yoloMode bool) map[string]interface{} {
+	merged := map[string]interface{}{}
+	for key, value := range threadParams {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		merged[key] = value
+	}
+	merged["approvalPolicy"] = approvalPolicyForSession(mode, yoloMode)
+	return merged
+}
+
+func (a *App) appServerProfileForChatSession(session store.ChatSession, profile appServerModelProfile) appServerModelProfile {
+	profile.ThreadParams = mergeApprovalPolicyThreadParams(profile.ThreadParams, session.Mode, a.yoloModeEnabled())
+	return profile
+}
+
+func formatApprovalRequestDescription(req *appserver.ApprovalRequest) string {
+	if req == nil {
+		return "Approval required"
+	}
+	reason := strings.TrimSpace(req.Reason)
+	switch req.Kind {
+	case "file_change":
+		if reason != "" {
+			return "Allow file changes: " + reason
+		}
+		if strings.TrimSpace(req.GrantRoot) != "" {
+			return "Allow file changes under " + req.GrantRoot
+		}
+		return "Allow file changes"
+	case "command_execution":
+		if reason != "" {
+			return "Allow command execution: " + reason
+		}
+		return "Allow command execution"
+	default:
+		if reason != "" {
+			return "Approval required: " + reason
+		}
+		return "Approval required"
+	}
+}
+
+func (a *App) storePendingAppServerApproval(sessionID string, pending *pendingAppServerApproval) {
+	if a == nil || strings.TrimSpace(sessionID) == "" || pending == nil || strings.TrimSpace(pending.LocalID) == "" {
+		return
+	}
+	a.approvalMu.Lock()
+	defer a.approvalMu.Unlock()
+	sessionApprovals := a.pendingApprovals[sessionID]
+	if sessionApprovals == nil {
+		sessionApprovals = map[string]*pendingAppServerApproval{}
+		a.pendingApprovals[sessionID] = sessionApprovals
+	}
+	sessionApprovals[pending.LocalID] = pending
+}
+
+func (a *App) removePendingAppServerApproval(sessionID, requestID string) {
+	if a == nil || strings.TrimSpace(sessionID) == "" || strings.TrimSpace(requestID) == "" {
+		return
+	}
+	a.approvalMu.Lock()
+	defer a.approvalMu.Unlock()
+	sessionApprovals := a.pendingApprovals[sessionID]
+	if sessionApprovals == nil {
+		return
+	}
+	delete(sessionApprovals, requestID)
+	if len(sessionApprovals) == 0 {
+		delete(a.pendingApprovals, sessionID)
+	}
+}
+
+func (a *App) resolvePendingAppServerApproval(sessionID, requestID, decision string) bool {
+	if a == nil || strings.TrimSpace(sessionID) == "" || strings.TrimSpace(requestID) == "" {
+		return false
+	}
+	normalizedDecision := strings.TrimSpace(decision)
+	if normalizedDecision == "" {
+		normalizedDecision = "cancel"
+	}
+	a.approvalMu.Lock()
+	sessionApprovals := a.pendingApprovals[sessionID]
+	pending := sessionApprovals[requestID]
+	if pending != nil {
+		delete(sessionApprovals, requestID)
+		if len(sessionApprovals) == 0 {
+			delete(a.pendingApprovals, sessionID)
+		}
+	}
+	a.approvalMu.Unlock()
+	if pending == nil {
+		return false
+	}
+	select {
+	case pending.DecisionCh <- normalizedDecision:
+	default:
+	}
+	return true
+}
+
+func (a *App) requestAppServerApproval(ctx context.Context, sessionID string, ev appserver.StreamEvent) (string, error) {
+	if a == nil || ev.Approval == nil {
+		return "", fmt.Errorf("approval request is unavailable")
+	}
+	requestID := randomToken()
+	pending := &pendingAppServerApproval{
+		LocalID:    requestID,
+		Request:    ev.Approval,
+		DecisionCh: make(chan string, 1),
+		CreatedAt:  time.Now().UTC(),
+	}
+	a.storePendingAppServerApproval(sessionID, pending)
+	a.broadcastChatEvent(sessionID, map[string]interface{}{
+		"type":         "approval_request",
+		"request_id":   requestID,
+		"action":       ev.Approval.Kind,
+		"description":  formatApprovalRequestDescription(ev.Approval),
+		"reason":       strings.TrimSpace(ev.Approval.Reason),
+		"grant_root":   strings.TrimSpace(ev.Approval.GrantRoot),
+		"item_id":      strings.TrimSpace(ev.Approval.ItemID),
+		"request_kind": ev.Approval.Kind,
+	})
+	select {
+	case <-ctx.Done():
+		a.removePendingAppServerApproval(sessionID, requestID)
+		return "", ctx.Err()
+	case decision := <-pending.DecisionCh:
+		a.broadcastChatEvent(sessionID, map[string]interface{}{
+			"type":       "approval_resolved",
+			"request_id": requestID,
+			"decision":   decision,
+		})
+		return decision, nil
+	}
+}

--- a/internal/web/chat_approval_test.go
+++ b/internal/web/chat_approval_test.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/appserver"
+)
+
+func TestApprovalPolicyForSession(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		yolo bool
+		want string
+	}{
+		{name: "yolo", mode: "chat", yolo: true, want: appserver.ApprovalPolicyNever},
+		{name: "plan", mode: "plan", yolo: false, want: appserver.ApprovalPolicyUnlessTrusted},
+		{name: "default", mode: "chat", yolo: false, want: appserver.ApprovalPolicyOnRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := approvalPolicyForSession(tc.mode, tc.yolo); got != tc.want {
+				t.Fatalf("approvalPolicyForSession(%q, %t) = %q, want %q", tc.mode, tc.yolo, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequestAppServerApprovalWaitsForDecision(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resultCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		decision, reqErr := app.requestAppServerApproval(ctx, session.ID, appserver.StreamEvent{
+			Approval: &appserver.ApprovalRequest{
+				Kind:   "command_execution",
+				Reason: "run git status",
+				ItemID: "item-42",
+			},
+		})
+		if reqErr != nil {
+			errCh <- reqErr
+			return
+		}
+		resultCh <- decision
+	}()
+
+	var requestID string
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		app.approvalMu.Lock()
+		for id := range app.pendingApprovals[session.ID] {
+			requestID = id
+		}
+		app.approvalMu.Unlock()
+		if requestID != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if requestID == "" {
+		t.Fatal("expected pending approval request")
+	}
+	if ok := app.resolvePendingAppServerApproval(session.ID, requestID, "decline"); !ok {
+		t.Fatal("expected approval resolution to succeed")
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("requestAppServerApproval error: %v", err)
+	case decision := <-resultCh:
+		if decision != "decline" {
+			t.Fatalf("decision = %q, want %q", decision, "decline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for approval resolution")
+	}
+}

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -193,6 +193,9 @@ func TestBuildPromptFromHistory_PlanMode(t *testing.T) {
 	if !strings.Contains(prompt, "plan mode") {
 		t.Error("prompt should mention plan mode")
 	}
+	if !strings.Contains(prompt, "wait for approval") {
+		t.Error("prompt should require approval in plan mode")
+	}
 }
 
 func TestBuildPromptFromHistoryForMode_SilentUsesToolOnlyPreamble(t *testing.T) {

--- a/internal/web/chat_prompt.go
+++ b/internal/web/chat_prompt.go
@@ -136,7 +136,9 @@ func buildPromptFromHistoryForModeWithCompanion(mode string, messages []store.Ch
 	}
 
 	if strings.EqualFold(strings.TrimSpace(mode), "plan") {
-		b.WriteString("You are in plan mode. Focus on analysis, design, and specification before implementation.\n\n")
+		b.WriteString("You are in plan mode. Propose actions step by step and wait for approval before executing risky or tool-driven work.\n")
+		b.WriteString("Explain what you intend to do and why, then continue once the approval decision is available.\n")
+		b.WriteString("For research tasks, propose each retrieval step clearly and present findings as artifacts or concise chat updates.\n\n")
 	}
 
 	appendCompanionPromptContext(&b, companion)

--- a/internal/web/chat_queue.go
+++ b/internal/web/chat_queue.go
@@ -408,8 +408,11 @@ func (a *App) getOrCreateAppSession(sessionID string, cwd string, profile appSer
 	a.mu.Lock()
 	s := a.chatAppSessions[sessionID]
 	a.mu.Unlock()
-	if s != nil && s.IsOpen() {
+	if s != nil && s.IsOpen() && s.MatchesConfig(cwd, profile.Model, profile.ThreadParams) {
 		return s, true, nil
+	}
+	if s != nil {
+		_ = s.Close()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/web/chat_stt.go
+++ b/internal/web/chat_stt.go
@@ -119,10 +119,12 @@ func handleSTTCancel(conn *chatWSConn) {
 
 func handleChatWSTextMessage(a *App, conn *chatWSConn, sessionID string, data []byte) {
 	var msg struct {
-		Type     string `json:"type"`
-		MimeType string `json:"mime_type"`
-		Text     string `json:"text"`
-		Lang     string `json:"lang"`
+		Type      string `json:"type"`
+		MimeType  string `json:"mime_type"`
+		Text      string `json:"text"`
+		Lang      string `json:"lang"`
+		RequestID string `json:"request_id"`
+		Decision  string `json:"decision"`
 	}
 	if err := json.Unmarshal(data, &msg); err != nil {
 		return
@@ -143,5 +145,13 @@ func handleChatWSTextMessage(a *App, conn *chatWSConn, sessionID string, data []
 		handleParticipantStart(a, conn, sessionID)
 	case "participant_stop":
 		handleParticipantStop(a, conn)
+	case "approval_response":
+		if !a.resolvePendingAppServerApproval(sessionID, msg.RequestID, msg.Decision) {
+			_ = conn.writeJSON(map[string]interface{}{
+				"type":       "approval_error",
+				"request_id": strings.TrimSpace(msg.RequestID),
+				"error":      "approval request not found",
+			})
+		}
 	}
 }

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -49,6 +49,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 			a.appServerSparkReasoningEffort,
 		)
 	}
+	profile = a.appServerProfileForChatSession(session, profile)
 	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
 		a.runAssistantTurnLegacy(sessionID, session, messages, outputMode, profile)
@@ -195,6 +196,23 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 			payload["context_max"] = ev.ContextMax
 		case "context_compact":
 			// pass through to frontend
+		case "approval_request":
+			decision, decisionErr := a.requestAppServerApproval(ctx, sessionID, ev)
+			if decisionErr != nil {
+				if ev.Respond != nil {
+					_ = ev.Respond("cancel")
+				}
+				shouldBroadcast = false
+				return
+			}
+			if ev.Respond != nil {
+				if respondErr := ev.Respond(decision); respondErr != nil {
+					shouldBroadcast = false
+					return
+				}
+			}
+			shouldBroadcast = false
+			return
 		case "error":
 			if strings.TrimSpace(ev.TurnID) != "" {
 				latestTurnID = ev.TurnID
@@ -311,6 +329,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 // runAssistantTurnLegacy is the single-shot fallback when persistent session
 // fails to connect. Each call creates a new WS + thread.
 func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, outputMode string, profile appServerModelProfile) {
+	profile = a.appServerProfileForChatSession(session, profile)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
 	prompt := buildPromptFromHistoryForMode(session.Mode, messages, canvasCtx, outputMode, profile.Alias)
 	if strings.TrimSpace(prompt) == "" {
@@ -443,6 +462,23 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 			if renderPlan.AutoCanvas {
 				payload["auto_canvas"] = true
 			}
+		case "approval_request":
+			decision, decisionErr := a.requestAppServerApproval(ctx, sessionID, ev)
+			if decisionErr != nil {
+				if ev.Respond != nil {
+					_ = ev.Respond("cancel")
+				}
+				shouldBroadcast = false
+				return
+			}
+			if ev.Respond != nil {
+				if respondErr := ev.Respond(decision); respondErr != nil {
+					shouldBroadcast = false
+					return
+				}
+			}
+			shouldBroadcast = false
+			return
 		case "error":
 			if strings.TrimSpace(ev.TurnID) != "" {
 				latestTurnID = ev.TurnID

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -93,6 +93,7 @@ type App struct {
 
 	mu               sync.Mutex
 	confirmMu        sync.Mutex
+	approvalMu       sync.Mutex
 	workerWG         sync.WaitGroup
 	hub              *wsHub
 	turns            *chatTurnTracker
@@ -103,6 +104,7 @@ type App struct {
 	tunnels          *tunnelRegistry
 	chatAppSessions  map[string]*appserver.Session
 	pendingDanger    map[string]*pendingDangerousAction
+	pendingApprovals map[string]map[string]*pendingAppServerApproval
 	ghCommandRunner  ghCommandRunner
 
 	shutdownCtx    context.Context
@@ -271,6 +273,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		tunnels:                       newTunnelRegistry(),
 		chatAppSessions:               map[string]*appserver.Session{},
 		pendingDanger:                 map[string]*pendingDangerousAction{},
+		pendingApprovals:              map[string]map[string]*pendingAppServerApproval{},
 		ghCommandRunner:               runGitHubCLI,
 		shutdownCtx:                   shutdownCtx,
 		shutdownCancel:                shutdownCancel,

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -71,6 +71,7 @@ const state = {
   disclaimerVersion: '',
   welcomeSurface: null,
   pendingByTurn: new Map(),
+  pendingApprovals: new Map(),
   pendingQueue: [],
   assistantActiveTurns: new Set(),
   assistantUnknownTurns: 0,
@@ -4321,6 +4322,108 @@ function appendPlainMessage(role, text, options = {}) {
   return row;
 }
 
+function approvalDecisionLabel(decision) {
+  const value = String(decision || '').trim().toLowerCase();
+  if (value === 'accept' || value === 'approve') return 'Approved';
+  if (value === 'decline' || value === 'reject') return 'Rejected';
+  return 'Cancelled';
+}
+
+function setApprovalButtonsDisabled(row, disabled) {
+  if (!(row instanceof HTMLElement)) return;
+  row.querySelectorAll('button[data-approval-decision]').forEach((button) => {
+    if (button instanceof HTMLButtonElement) {
+      button.disabled = disabled;
+    }
+  });
+}
+
+function renderApprovalRequestCard(payload) {
+  const requestID = String(payload?.request_id || '').trim();
+  if (!requestID) return null;
+  let row = state.pendingApprovals.get(requestID) || null;
+  if (!(row instanceof HTMLElement)) {
+    row = appendPlainMessage('system', '', { localId: requestID });
+    if (!(row instanceof HTMLElement)) return null;
+    row.classList.add('chat-approval-request');
+    state.pendingApprovals.set(requestID, row);
+  }
+  const bubble = row.querySelector('.chat-bubble');
+  if (!(bubble instanceof HTMLElement)) return row;
+  const description = String(payload?.description || 'Approval required').trim();
+  const action = String(payload?.action || payload?.request_kind || '').trim().replace(/_/g, ' ');
+  const reason = String(payload?.reason || '').trim();
+  const grantRoot = String(payload?.grant_root || '').trim();
+  bubble.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.className = 'chat-approval-title';
+  title.textContent = description;
+  bubble.appendChild(title);
+
+  if (action) {
+    const meta = document.createElement('div');
+    meta.className = 'chat-approval-meta';
+    meta.textContent = action;
+    bubble.appendChild(meta);
+  }
+  if (reason) {
+    const detail = document.createElement('div');
+    detail.className = 'chat-approval-detail';
+    detail.textContent = reason;
+    bubble.appendChild(detail);
+  }
+  if (grantRoot) {
+    const scope = document.createElement('div');
+    scope.className = 'chat-approval-detail';
+    scope.textContent = `scope: ${grantRoot}`;
+    bubble.appendChild(scope);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'chat-approval-actions';
+  [
+    ['Approve', 'accept'],
+    ['Reject', 'decline'],
+    ['Cancel', 'cancel'],
+  ].forEach(([label, decision]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'chat-approval-btn';
+    button.dataset.approvalDecision = decision;
+    button.textContent = label;
+    button.addEventListener('click', () => {
+      setApprovalButtonsDisabled(row, true);
+      if (!sendChatWsJSON({ type: 'approval_response', request_id: requestID, decision })) {
+        setApprovalButtonsDisabled(row, false);
+        showStatus('approval send failed');
+      }
+    });
+    actions.appendChild(button);
+  });
+  bubble.appendChild(actions);
+  syncChatScroll(chatHistoryEl());
+  return row;
+}
+
+function resolveApprovalRequestCard(requestID, decision) {
+  const key = String(requestID || '').trim();
+  if (!key) return;
+  const row = state.pendingApprovals.get(key);
+  if (!(row instanceof HTMLElement)) return;
+  setApprovalButtonsDisabled(row, true);
+  row.classList.add('is-resolved');
+  const bubble = row.querySelector('.chat-bubble');
+  if (!(bubble instanceof HTMLElement)) return;
+  let status = row.querySelector('.chat-approval-status');
+  if (!(status instanceof HTMLElement)) {
+    status = document.createElement('div');
+    status.className = 'chat-approval-status';
+    bubble.appendChild(status);
+  }
+  status.textContent = approvalDecisionLabel(decision);
+}
+
 function appendRenderedAssistant(markdownText, options = {}) {
   const host = chatHistoryEl();
   if (!host) return null;
@@ -4469,6 +4572,7 @@ function ensurePendingForTurn(turnID) {
 
 function resetAssistantTurnTracking({ clearError = false } = {}) {
   state.pendingByTurn.clear();
+  state.pendingApprovals.clear();
   state.pendingQueue = [];
   state.voiceTurns.clear();
   state.assistantActiveTurns.clear();
@@ -4488,6 +4592,7 @@ function resetAssistantTurnTracking({ clearError = false } = {}) {
 function clearChatHistory() {
   const host = chatHistoryEl();
   if (host) host.innerHTML = '';
+  state.pendingApprovals.clear();
 }
 
 function clearWelcomeSurface() {
@@ -5657,6 +5762,13 @@ function closeChatWs() {
   state.chatWs = null;
 }
 
+function sendChatWsJSON(payload) {
+  const ws = state.chatWs;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+  ws.send(JSON.stringify(payload));
+  return true;
+}
+
 function openChatWs() {
   if (!state.chatSessionId) return;
   const turnToken = state.chatWsToken + 1;
@@ -5869,6 +5981,25 @@ function handleChatEvent(payload) {
     if (summary) {
       showStatus('confirmation required');
       appendPlainMessage('system', `Confirmation required: ${summary}`);
+    }
+    return;
+  }
+
+  if (type === 'approval_request') {
+    renderApprovalRequestCard(payload);
+    showStatus('approval required');
+    return;
+  }
+
+  if (type === 'approval_resolved') {
+    resolveApprovalRequestCard(payload?.request_id, payload?.decision);
+    return;
+  }
+
+  if (type === 'approval_error') {
+    const message = String(payload?.error || 'approval failed').trim();
+    if (message) {
+      showStatus(message);
     }
     return;
   }

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -1934,6 +1934,56 @@ body.panel-motion-enabled {
   color: #78350f;
 }
 
+.chat-approval-request .chat-bubble {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.chat-approval-title {
+  font-weight: 600;
+}
+
+.chat-approval-meta {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.82;
+}
+
+.chat-approval-detail {
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.chat-approval-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-top: 0.15rem;
+}
+
+.chat-approval-btn {
+  border: 1px solid #b45309;
+  background: #fff7ed;
+  color: #78350f;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.chat-approval-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.chat-approval-status {
+  font-size: 0.78rem;
+  font-weight: 600;
+  margin-top: 0.2rem;
+}
+
 .chat-message.is-pending .chat-bubble {
   opacity: 0.82;
 }

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -378,6 +378,59 @@ test.describe('mode_changed event', () => {
   });
 });
 
+test.describe('approval_request event', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitReady(page);
+    await page.evaluate(() => {
+      document.getElementById('edge-right-tap')?.click();
+    });
+    await page.waitForTimeout(200);
+  });
+
+  test('renders approval card and sends approval response', async ({ page }) => {
+    await page.evaluate(() => {
+      const app = (window as any)._taburaApp;
+      const ws = app?.getState?.().chatWs;
+      (window as any).__approvalMessages = [];
+      if (!ws) return;
+      const originalSend = ws.send.bind(ws);
+      ws.send = (data: string) => {
+        try {
+          (window as any).__approvalMessages.push(JSON.parse(String(data)));
+        } catch (_) {}
+        originalSend(data);
+      };
+    });
+
+    await injectChatEvent(page, {
+      type: 'approval_request',
+      request_id: 'approval-1',
+      action: 'command_execution',
+      description: 'Allow command execution: run git status',
+      reason: 'run git status',
+    });
+
+    const card = page.locator('.chat-approval-request').last();
+    await expect(card.locator('.chat-approval-title')).toHaveText('Allow command execution: run git status');
+    await expect(card.locator('.chat-approval-detail')).toHaveText('run git status');
+
+    await card.getByRole('button', { name: 'Approve' }).click();
+
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as any).__approvalMessages || []);
+    }).toEqual([
+      {
+        type: 'approval_response',
+        request_id: 'approval-1',
+        decision: 'accept',
+      },
+    ]);
+
+    await injectChatEvent(page, { type: 'approval_resolved', request_id: 'approval-1', decision: 'accept' });
+    await expect(card.locator('.chat-approval-status')).toHaveText('Approved');
+  });
+});
+
 
 // =============================================================================
 // action: open_canvas event


### PR DESCRIPTION
## Summary
- wire chat session mode and yolo into app-server approvalPolicy values never, on-request, and unlessTrusted
- pause streamed turns on approval requests, forward them through the web client, and send the chosen decision back to the app-server
- render approval request cards with approve, reject, and cancel actions, and reopen app-server sessions when the approval policy changes

## Verification
- Requirement: plan mode and yolo map to app-server approval policies.
  Evidence: go test ./internal/appserver ./internal/web -run Test(NormalizeApprovalPolicy|SendPromptStreamDefaultsToOnRequestApprovalPolicy|SessionSendTurnHandlesApprovalRequests|ApprovalPolicyForSession|RequestAppServerApprovalWaitsForDecision|BuildPromptFromHistory_PlanMode) from /tmp/tabura-issue-299.log returned ok github.com/krystophny/tabura/internal/appserver 0.003s and ok github.com/krystophny/tabura/internal/web 0.019s. Those tests assert never, on-request, and unlessTrusted.
- Requirement: app-server approval requests are handled interactively and answered with a concrete decision.
  Evidence: the same go test run includes TestSessionSendTurnHandlesApprovalRequests, which exercises item/commandExecution/requestApproval and verifies the returned decision becomes accept.
- Requirement: plan mode prompts the agent to propose steps and wait for approval.
  Evidence: the same go test run includes TestBuildPromptFromHistory_PlanMode and passed.
- Requirement: the user-facing approval UI renders and submits a decision.
  Evidence: ./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep approval_request event from /tmp/tabura-issue-299.log returned 1 passed (1.6s); the spec asserts the approval card renders, the Approve button sends an approval_response payload for approval-1 with decision accept, and the resolved state shows Approved.
