### PR TITLE
fix: Add meeting summary to Items generation (fixes #181)

### DIFF
--- a/internal/web/chat_meeting_items.go
+++ b/internal/web/chat_meeting_items.go
@@ -1,0 +1,386 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const meetingSummaryItemSource = "meeting_summary"
+
+var (
+	meetingItemExplicitPrefixPattern = regexp.MustCompile(`(?i)^(?:action(?:\s+item)?|todo|follow[- ]?up|next\s+step|owner)\s*[:\-]\s*(.+)$`)
+	meetingItemActorActionPattern    = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s+(?:will|should|can|must|needs?\s+to|is\s+going\s+to|to)\s+(.+)$`)
+	meetingItemActorLabelPattern     = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s*[:\-]\s*(.+)$`)
+)
+
+type proposedMeetingItem struct {
+	Index     int    `json:"index"`
+	Title     string `json:"title"`
+	ActorName string `json:"actor_name,omitempty"`
+	Evidence  string `json:"evidence,omitempty"`
+}
+
+type projectMeetingItemsResponse struct {
+	OK            bool                       `json:"ok"`
+	ProjectID     string                     `json:"project_id"`
+	ProjectKey    string                     `json:"project_key"`
+	Sessions      []store.ParticipantSession `json:"sessions"`
+	Session       *store.ParticipantSession  `json:"session,omitempty"`
+	SummaryText   string                     `json:"summary_text"`
+	ProposedItems []proposedMeetingItem      `json:"proposed_items"`
+}
+
+type createdMeetingItem struct {
+	ID        int64  `json:"id"`
+	Title     string `json:"title"`
+	State     string `json:"state"`
+	ActorName string `json:"actor_name,omitempty"`
+}
+
+type createMeetingItemsRequest struct {
+	Selected []int `json:"selected"`
+}
+
+type createMeetingItemsResponse struct {
+	OK            bool                      `json:"ok"`
+	ProjectID     string                    `json:"project_id"`
+	ProjectKey    string                    `json:"project_key"`
+	Session       *store.ParticipantSession `json:"session,omitempty"`
+	CreatedItems  []createdMeetingItem      `json:"created_items"`
+	ProposedItems []proposedMeetingItem     `json:"proposed_items"`
+}
+
+func meetingItemActionVerbs() []string {
+	return []string{
+		"add", "book", "clean", "close", "collect", "confirm", "contact", "coordinate",
+		"create", "decide", "deliver", "document", "draft", "follow up", "follow-up",
+		"fix", "implement", "investigate", "move", "open", "plan", "prepare", "publish",
+		"review", "schedule", "send", "set up", "setup", "share", "summarize",
+		"sync", "test", "triage", "update", "write",
+	}
+}
+
+func splitMeetingSummaryCandidates(summary string) []string {
+	text := strings.ReplaceAll(summary, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+		start := 0
+		for i, r := range line {
+			switch r {
+			case '.', '!', '?', ';':
+				segment := strings.TrimSpace(line[start : i+1])
+				if segment != "" {
+					out = append(out, segment)
+				}
+				start = i + 1
+			}
+		}
+		if tail := strings.TrimSpace(line[start:]); tail != "" {
+			out = append(out, tail)
+		}
+	}
+	return out
+}
+
+func normalizeMeetingItemTitle(raw string) string {
+	title := strings.TrimSpace(raw)
+	title = strings.Trim(title, " \t\r\n-:;,.!?")
+	if strings.HasPrefix(strings.ToLower(title), "to ") {
+		title = strings.TrimSpace(title[3:])
+	}
+	title = strings.Join(strings.Fields(title), " ")
+	if title == "" {
+		return ""
+	}
+	runes := []rune(title)
+	first := strings.ToUpper(string(runes[0]))
+	if len(runes) == 1 {
+		return first
+	}
+	return first + string(runes[1:])
+}
+
+func looksLikeMeetingAction(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	for _, prefix := range []string{
+		"meeting summary", "summary", "decisions", "decision", "references",
+		"agenda", "notes", "discussion", "context",
+	} {
+		if lower == prefix {
+			return false
+		}
+	}
+	for _, verb := range meetingItemActionVerbs() {
+		if strings.HasPrefix(lower, verb+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func parseMeetingItemCandidate(raw string) (proposedMeetingItem, bool) {
+	evidence := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	if evidence == "" || strings.HasPrefix(evidence, "#") {
+		return proposedMeetingItem{}, false
+	}
+	text := strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(evidence, ""))
+	if text == "" {
+		return proposedMeetingItem{}, false
+	}
+	explicit := false
+	if match := meetingItemExplicitPrefixPattern.FindStringSubmatch(text); len(match) == 2 {
+		text = strings.TrimSpace(match[1])
+		explicit = true
+	}
+
+	actorName := ""
+	if match := meetingItemActorActionPattern.FindStringSubmatch(text); len(match) == 3 {
+		actorName = strings.TrimSpace(match[1])
+		text = strings.TrimSpace(match[2])
+	} else if match := meetingItemActorLabelPattern.FindStringSubmatch(text); len(match) == 3 && looksLikeMeetingAction(match[2]) {
+		actorName = strings.TrimSpace(match[1])
+		text = strings.TrimSpace(match[2])
+	}
+
+	if !explicit && !looksLikeMeetingAction(text) {
+		return proposedMeetingItem{}, false
+	}
+
+	title := normalizeMeetingItemTitle(text)
+	if title == "" {
+		return proposedMeetingItem{}, false
+	}
+	return proposedMeetingItem{
+		Title:     title,
+		ActorName: actorName,
+		Evidence:  evidence,
+	}, true
+}
+
+func (a *App) extractMeetingItems(summary string) []proposedMeetingItem {
+	candidates := splitMeetingSummaryCandidates(summary)
+	if len(candidates) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]proposedMeetingItem, 0, len(candidates))
+	for _, candidate := range candidates {
+		item, ok := parseMeetingItemCandidate(candidate)
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(item.Title) + "\n" + strings.ToLower(item.ActorName)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		item.Index = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func (a *App) loadProjectMeetingItems(w http.ResponseWriter, r *http.Request) (store.Project, []store.ParticipantSession, *store.ParticipantSession, string, []proposedMeetingItem, bool) {
+	project, sessions, session, ok := a.resolveProjectCompanionArtifact(w, r)
+	if !ok {
+		return store.Project{}, nil, nil, "", nil, false
+	}
+	summaryText := ""
+	if session != nil {
+		memory, err := a.loadCompanionRoomMemory(session.ID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return store.Project{}, nil, nil, "", nil, false
+		}
+		summaryText = strings.TrimSpace(memory.SummaryText)
+	}
+	return project, sessions, session, summaryText, a.extractMeetingItems(summaryText), true
+}
+
+func (a *App) handleProjectMeetingItemsGet(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	project, sessions, session, summaryText, proposed, ok := a.loadProjectMeetingItems(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, projectMeetingItemsResponse{
+		OK:            true,
+		ProjectID:     project.ID,
+		ProjectKey:    project.ProjectKey,
+		Sessions:      sessions,
+		Session:       session,
+		SummaryText:   summaryText,
+		ProposedItems: proposed,
+	})
+}
+
+func (a *App) ensureMeetingSummaryArtifact(project store.Project, session *store.ParticipantSession, summaryText string) (store.Artifact, error) {
+	if session == nil {
+		return store.Artifact{}, errors.New("meeting session is required")
+	}
+	if err := a.syncProjectCompanionArtifacts(project, session); err != nil {
+		return store.Artifact{}, err
+	}
+	summaryPath := filepath.Join(companionArtifactDir(project, session), "summary.md")
+	title := "Meeting Summary"
+	metaPayload := map[string]any{
+		"source":      meetingSummaryItemSource,
+		"summary":     strings.TrimSpace(summaryText),
+		"session_id":  session.ID,
+		"project_id":  project.ID,
+		"project_key": project.ProjectKey,
+	}
+	raw, err := json.Marshal(metaPayload)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	metaJSON := string(raw)
+	return a.store.CreateArtifact(store.ArtifactKindMarkdown, &summaryPath, nil, &title, &metaJSON)
+}
+
+func (a *App) resolveMeetingItemActor(name string) (*store.Actor, error) {
+	cleanName := strings.TrimSpace(name)
+	if cleanName == "" {
+		return nil, nil
+	}
+	actors, err := a.store.ListActors()
+	if err != nil {
+		return nil, err
+	}
+	var exact *store.Actor
+	for i := range actors {
+		if strings.EqualFold(actors[i].Name, cleanName) {
+			if exact != nil {
+				return nil, nil
+			}
+			actor := actors[i]
+			exact = &actor
+		}
+	}
+	if exact != nil {
+		return exact, nil
+	}
+	created, err := a.store.CreateActor(cleanName, store.ActorKindHuman)
+	if err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+func normalizeSelectedMeetingItems(selected []int, limit int) []int {
+	seen := map[int]struct{}{}
+	out := make([]int, 0, len(selected))
+	for _, index := range selected {
+		if index < 0 || index >= limit {
+			continue
+		}
+		if _, exists := seen[index]; exists {
+			continue
+		}
+		seen[index] = struct{}{}
+		out = append(out, index)
+	}
+	return out
+}
+
+func (a *App) handleCreateMeetingItems(project store.Project, session *store.ParticipantSession, summaryText string, proposed []proposedMeetingItem, selected []int) ([]createdMeetingItem, error) {
+	chosen := normalizeSelectedMeetingItems(selected, len(proposed))
+	if len(chosen) == 0 {
+		return nil, errors.New("at least one proposed item must be selected")
+	}
+	artifact, err := a.ensureMeetingSummaryArtifact(project, session, summaryText)
+	if err != nil {
+		return nil, err
+	}
+	workspaceID, err := a.resolveConversationWorkspaceID(project, &artifact)
+	if err != nil {
+		return nil, err
+	}
+	created := make([]createdMeetingItem, 0, len(chosen))
+	for _, index := range chosen {
+		proposal := proposed[index]
+		opts := store.ItemOptions{
+			WorkspaceID: workspaceID,
+			ArtifactID:  &artifact.ID,
+		}
+		if actor, err := a.resolveMeetingItemActor(proposal.ActorName); err != nil {
+			return nil, err
+		} else if actor != nil {
+			opts.ActorID = &actor.ID
+		}
+		sourceRef := fmt.Sprintf("%s:%d", session.ID, index)
+		opts.Source = stringPtr(meetingSummaryItemSource)
+		opts.SourceRef = &sourceRef
+		item, err := a.store.CreateItem(proposal.Title, opts)
+		if err != nil {
+			return nil, err
+		}
+		createdItem := createdMeetingItem{
+			ID:    item.ID,
+			Title: item.Title,
+			State: item.State,
+		}
+		if proposal.ActorName != "" {
+			createdItem.ActorName = proposal.ActorName
+		}
+		created = append(created, createdItem)
+	}
+	return created, nil
+}
+
+func (a *App) handleProjectMeetingItemsCreate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	project, _, session, summaryText, proposed, ok := a.loadProjectMeetingItems(w, r)
+	if !ok {
+		return
+	}
+	if session == nil || strings.TrimSpace(summaryText) == "" {
+		http.Error(w, "meeting summary not available", http.StatusBadRequest)
+		return
+	}
+	var req createMeetingItemsRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	created, err := a.handleCreateMeetingItems(project, session, summaryText, proposed, req.Selected)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, createMeetingItemsResponse{
+		OK:            true,
+		ProjectID:     project.ID,
+		ProjectKey:    project.ProjectKey,
+		Session:       session,
+		CreatedItems:  created,
+		ProposedItems: proposed,
+	})
+}
+
+func stringPtr(value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	clean := strings.TrimSpace(value)
+	return &clean
+}

--- a/internal/web/chat_meeting_items_test.go
+++ b/internal/web/chat_meeting_items_test.go
@@ -1,0 +1,159 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestExtractMeetingItemsSupportsMixedSummaryFormats(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	summary := strings.Join([]string{
+		"# Meeting Summary",
+		"",
+		"- ACTION: Alice will draft the revised agenda.",
+		"1. TODO: review the budget appendix.",
+		"Bob: send the follow-up email.",
+		"Discussion: the budget is tight.",
+	}, "\n")
+
+	proposed := app.extractMeetingItems(summary)
+	if len(proposed) != 3 {
+		t.Fatalf("extractMeetingItems() len = %d, want 3", len(proposed))
+	}
+
+	if proposed[0].Title != "Draft the revised agenda" || proposed[0].ActorName != "Alice" {
+		t.Fatalf("first proposal = %#v", proposed[0])
+	}
+	if proposed[1].Title != "Review the budget appendix" || proposed[1].ActorName != "" {
+		t.Fatalf("second proposal = %#v", proposed[1])
+	}
+	if proposed[2].Title != "Send the follow-up email" || proposed[2].ActorName != "Bob" {
+		t.Fatalf("third proposal = %#v", proposed[2])
+	}
+
+	if got := app.extractMeetingItems("The meeting covered current status only."); len(got) != 0 {
+		t.Fatalf("extractMeetingItems(no actions) len = %d, want 0", len(got))
+	}
+}
+
+func TestProjectMeetingItemsAPIAndCreation(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, session := seedProjectCompanionSession(t, app)
+
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.UpsertParticipantRoomState(session.ID, strings.Join([]string{
+		"Meeting summary",
+		"",
+		"- ACTION: Alice will draft the revised agenda.",
+		"- TODO: review the budget appendix.",
+	}, "\n"), `["Alice"]`, `[]`); err != nil {
+		t.Fatalf("UpsertParticipantRoomState() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects/"+project.ID+"/meeting-items", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET meeting-items status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var proposals projectMeetingItemsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &proposals); err != nil {
+		t.Fatalf("decode meeting-items response: %v", err)
+	}
+	if proposals.Session == nil || proposals.Session.ID != session.ID {
+		t.Fatalf("selected session = %#v, want %q", proposals.Session, session.ID)
+	}
+	if len(proposals.ProposedItems) != 2 {
+		t.Fatalf("proposed_items len = %d, want 2", len(proposals.ProposedItems))
+	}
+	if proposals.ProposedItems[0].ActorName != "Alice" {
+		t.Fatalf("first proposed actor = %q, want Alice", proposals.ProposedItems[0].ActorName)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/projects/"+project.ID+"/meeting-items", map[string]any{
+		"selected": []int{0, 1},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST meeting-items status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var created createMeetingItemsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created response: %v", err)
+	}
+	if len(created.CreatedItems) != 2 {
+		t.Fatalf("created_items len = %d, want 2", len(created.CreatedItems))
+	}
+
+	items, err := app.store.ListInboxItems(time.Now())
+	if err != nil {
+		t.Fatalf("ListInboxItems() error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListInboxItems() len = %d, want 2", len(items))
+	}
+
+	var draftItem, reviewItem store.ItemSummary
+	for _, item := range items {
+		switch item.Title {
+		case "Draft the revised agenda":
+			draftItem = item
+		case "Review the budget appendix":
+			reviewItem = item
+		}
+	}
+	if draftItem.ID == 0 || reviewItem.ID == 0 {
+		t.Fatalf("created inbox items = %#v", items)
+	}
+	if draftItem.WorkspaceID == nil || *draftItem.WorkspaceID != workspace.ID {
+		t.Fatalf("draft workspace_id = %v, want %d", draftItem.WorkspaceID, workspace.ID)
+	}
+	if reviewItem.WorkspaceID == nil || *reviewItem.WorkspaceID != workspace.ID {
+		t.Fatalf("review workspace_id = %v, want %d", reviewItem.WorkspaceID, workspace.ID)
+	}
+	if draftItem.ActorName == nil || *draftItem.ActorName != "Alice" {
+		t.Fatalf("draft actor_name = %v, want Alice", draftItem.ActorName)
+	}
+	if reviewItem.ActorName != nil && *reviewItem.ActorName != "" {
+		t.Fatalf("review actor_name = %v, want nil/empty", reviewItem.ActorName)
+	}
+	if draftItem.ArtifactID == nil || reviewItem.ArtifactID == nil || *draftItem.ArtifactID != *reviewItem.ArtifactID {
+		t.Fatalf("artifact ids = %v and %v, want shared summary artifact", draftItem.ArtifactID, reviewItem.ArtifactID)
+	}
+
+	artifact, err := app.store.GetArtifact(*draftItem.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.RefPath == nil || !strings.HasSuffix(*artifact.RefPath, "/summary.md") {
+		t.Fatalf("artifact ref_path = %v, want summary.md", artifact.RefPath)
+	}
+	if artifact.MetaJSON == nil || !strings.Contains(*artifact.MetaJSON, `"source":"meeting_summary"`) {
+		t.Fatalf("artifact meta_json = %v, want meeting_summary source", artifact.MetaJSON)
+	}
+	if artifact.MetaJSON == nil || !strings.Contains(*artifact.MetaJSON, `"summary":"Meeting summary`) {
+		t.Fatalf("artifact meta_json = %v, want summary text", artifact.MetaJSON)
+	}
+}
+
+func TestProjectMeetingItemsCreateRejectsEmptySelection(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, session := seedProjectCompanionSession(t, app)
+
+	if err := app.store.UpsertParticipantRoomState(session.ID, "- ACTION: Alice will draft the revised agenda.", `["Alice"]`, `[]`); err != nil {
+		t.Fatalf("UpsertParticipantRoomState() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/projects/"+project.ID+"/meeting-items", map[string]any{
+		"selected": []int{},
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("POST meeting-items empty selection status = %d, want 400", rr.Code)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -379,6 +379,8 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/projects/{project_id}/transcript", a.handleProjectCompanionTranscript)
 	r.Get("/api/projects/{project_id}/summary", a.handleProjectCompanionSummary)
 	r.Get("/api/projects/{project_id}/references", a.handleProjectCompanionReferences)
+	r.Get("/api/projects/{project_id}/meeting-items", a.handleProjectMeetingItemsGet)
+	r.Post("/api/projects/{project_id}/meeting-items", a.handleProjectMeetingItemsCreate)
 	r.Post("/api/ink/submit", a.handleInkSubmit)
 	r.Post("/api/review/submit", a.handleReviewSubmit)
 	r.Get("/api/workspaces", a.handleWorkspaceList)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -227,6 +227,7 @@ const COMPANION_REFERENCES_VIEW_PATH = `${COMPANION_VIEW_PATH_PREFIX}/references
 const MEETING_TRANSCRIPT_LABEL = 'Meeting Transcript';
 const MEETING_SUMMARY_LABEL = 'Meeting Summary';
 const MEETING_REFERENCES_LABEL = 'Meeting References';
+const MEETING_SUMMARY_ITEMS_PANEL_ID = 'meeting-summary-items';
 let localMessageSeq = 0;
 const CHAT_CTRL_LONG_PRESS_MS = 180;
 const ARTIFACT_EDIT_LONG_TAP_MS = 420;
@@ -4228,11 +4229,217 @@ async function openCompanionWorkspaceView(viewKind, filePath) {
       title: titles[viewKind] || filePath,
       text,
     });
+    if (viewKind === 'summary') {
+      void renderMeetingSummaryItems(projectID, filePath);
+    }
     showCanvasColumn('canvas-text');
     if (isMobileViewport()) { setPrReviewDrawerOpen(false); closeEdgePanels(); }
     return true;
   } catch (err) {
     appendPlainMessage('system', `${titles[viewKind] || 'Meeting view'} failed: ${String(err?.message || err)}`);
+    return false;
+  }
+}
+
+function clearMeetingSummaryItemsPanel() {
+  const existing = document.getElementById(MEETING_SUMMARY_ITEMS_PANEL_ID);
+  if (existing instanceof HTMLElement) {
+    existing.remove();
+  }
+}
+
+function isCurrentMeetingSummaryView(projectID, filePath) {
+  return String(state.activeProjectId || '').trim() === String(projectID || '').trim()
+    && normalizeWorkspaceBrowserPath(state.workspaceOpenFilePath) === normalizeWorkspaceBrowserPath(filePath);
+}
+
+function meetingSummaryItemsButtonLabel(count) {
+  return count === 1 ? 'Create 1 inbox item' : `Create ${count} inbox items`;
+}
+
+function setMeetingSummaryItemsBusy(panel, busy, label = '') {
+  if (!(panel instanceof HTMLElement)) return;
+  panel.dataset.busy = busy ? 'true' : 'false';
+  panel.querySelectorAll('input,button').forEach((node) => {
+    if (node instanceof HTMLInputElement || node instanceof HTMLButtonElement) {
+      node.disabled = busy;
+    }
+  });
+  const submit = panel.querySelector('.meeting-summary-items-submit');
+  if (submit instanceof HTMLButtonElement && label) {
+    submit.textContent = label;
+  }
+}
+
+function countSelectedMeetingSummaryItems(panel) {
+  if (!(panel instanceof HTMLElement)) return 0;
+  return panel.querySelectorAll('.meeting-summary-items-list input[type="checkbox"]:checked').length;
+}
+
+function updateMeetingSummaryItemsSelection(panel) {
+  if (!(panel instanceof HTMLElement)) return;
+  const count = countSelectedMeetingSummaryItems(panel);
+  const submit = panel.querySelector('.meeting-summary-items-submit');
+  if (submit instanceof HTMLButtonElement) {
+    submit.disabled = count === 0 || panel.dataset.busy === 'true';
+    submit.textContent = meetingSummaryItemsButtonLabel(count);
+  }
+}
+
+async function submitMeetingSummaryItems(projectID, panel) {
+  if (!(panel instanceof HTMLElement)) return false;
+  const selected = Array.from(panel.querySelectorAll('.meeting-summary-items-list input[type="checkbox"]:checked'))
+    .map((node) => Number(node.value || '-1'))
+    .filter((value) => Number.isInteger(value) && value >= 0);
+  if (selected.length === 0) {
+    showStatus('select at least one action item');
+    return false;
+  }
+  setMeetingSummaryItemsBusy(panel, true, 'Creating inbox items...');
+  try {
+    const resp = await fetch(apiURL(`projects/${encodeURIComponent(projectID)}/meeting-items`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ selected }),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    const createdItems = Array.isArray(payload?.created_items) ? payload.created_items : [];
+    const createdCount = createdItems.length;
+    const createdSet = new Set(selected);
+    panel.querySelectorAll('.meeting-summary-items-list input[type="checkbox"]').forEach((node) => {
+      if (!(node instanceof HTMLInputElement)) return;
+      if (!createdSet.has(Number(node.value || '-1'))) return;
+      node.checked = false;
+      node.disabled = true;
+      const row = node.closest('.meeting-summary-items-row');
+      if (row instanceof HTMLElement) {
+        row.classList.add('is-created');
+      }
+    });
+    const status = panel.querySelector('.meeting-summary-items-status');
+    if (status instanceof HTMLElement) {
+      status.textContent = createdCount === 1
+        ? '1 inbox item created from this summary.'
+        : `${createdCount} inbox items created from this summary.`;
+    }
+    await loadItemSidebarView('inbox');
+    setMeetingSummaryItemsBusy(panel, false);
+    panel.querySelectorAll('.meeting-summary-items-list input[type="checkbox"]').forEach((node) => {
+      if (!(node instanceof HTMLInputElement)) return;
+      if (createdSet.has(Number(node.value || '-1'))) {
+        node.disabled = true;
+      }
+    });
+    updateMeetingSummaryItemsSelection(panel);
+    showStatus(createdCount === 1 ? 'meeting item added to inbox' : 'meeting items added to inbox');
+    return true;
+  } catch (err) {
+    setMeetingSummaryItemsBusy(panel, false);
+    updateMeetingSummaryItemsSelection(panel);
+    showStatus(`meeting item create failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+async function renderMeetingSummaryItems(projectID, filePath) {
+  clearMeetingSummaryItemsPanel();
+  const pane = document.getElementById('canvas-text');
+  if (!(pane instanceof HTMLElement) || !isCurrentMeetingSummaryView(projectID, filePath)) return false;
+
+  const panel = document.createElement('section');
+  panel.id = MEETING_SUMMARY_ITEMS_PANEL_ID;
+  panel.className = 'meeting-summary-items';
+
+  const heading = document.createElement('h2');
+  heading.textContent = 'Proposed Inbox Items';
+  panel.appendChild(heading);
+
+  const intro = document.createElement('p');
+  intro.className = 'meeting-summary-items-copy';
+  intro.textContent = 'Select the action items you want to turn into inbox items.';
+  panel.appendChild(intro);
+
+  const status = document.createElement('p');
+  status.className = 'meeting-summary-items-status';
+  status.textContent = 'Loading action items...';
+  panel.appendChild(status);
+
+  pane.appendChild(panel);
+
+  try {
+    const resp = await fetch(apiURL(`projects/${encodeURIComponent(projectID)}/meeting-items`), { cache: 'no-store' });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    if (!panel.isConnected || !isCurrentMeetingSummaryView(projectID, filePath)) return false;
+    const proposedItems = Array.isArray(payload?.proposed_items) ? payload.proposed_items : [];
+    if (proposedItems.length === 0) {
+      status.textContent = 'No action items detected in this summary yet.';
+      return true;
+    }
+    status.textContent = 'Choose the actions you want to keep.';
+
+    const list = document.createElement('div');
+    list.className = 'meeting-summary-items-list';
+    proposedItems.forEach((proposal) => {
+      const index = Number(proposal?.index || 0);
+      const title = String(proposal?.title || '').trim();
+      if (!title) return;
+      const row = document.createElement('label');
+      row.className = 'meeting-summary-items-row';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = String(index);
+      checkbox.checked = true;
+      checkbox.addEventListener('change', () => {
+        updateMeetingSummaryItemsSelection(panel);
+      });
+
+      const body = document.createElement('span');
+      body.className = 'meeting-summary-items-body';
+
+      const titleNode = document.createElement('span');
+      titleNode.className = 'meeting-summary-items-title';
+      titleNode.textContent = title;
+      body.appendChild(titleNode);
+
+      const metaParts = [];
+      const actorName = String(proposal?.actor_name || '').trim();
+      const evidence = String(proposal?.evidence || '').trim();
+      if (actorName) metaParts.push(actorName);
+      if (evidence) metaParts.push(evidence);
+      if (metaParts.length > 0) {
+        const meta = document.createElement('span');
+        meta.className = 'meeting-summary-items-meta';
+        meta.textContent = metaParts.join(' | ');
+        body.appendChild(meta);
+      }
+
+      row.appendChild(checkbox);
+      row.appendChild(body);
+      list.appendChild(row);
+    });
+    panel.appendChild(list);
+
+    const submit = document.createElement('button');
+    submit.type = 'button';
+    submit.className = 'meeting-summary-items-submit';
+    submit.addEventListener('click', () => {
+      void submitMeetingSummaryItems(projectID, panel);
+    });
+    panel.appendChild(submit);
+    updateMeetingSummaryItemsSelection(panel);
+    return true;
+  } catch (err) {
+    if (!panel.isConnected || !isCurrentMeetingSummaryView(projectID, filePath)) return false;
+    status.textContent = `Action items unavailable: ${String(err?.message || err || 'unknown error')}`;
     return false;
   }
 }

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -2085,6 +2085,86 @@ body.panel-motion-enabled {
   padding-left: 0.35rem;
 }
 
+.meeting-summary-items {
+  margin-top: 1.5rem;
+  padding: 1rem 1rem 1.1rem;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 16px;
+  background: rgba(247, 248, 250, 0.92);
+}
+
+.meeting-summary-items h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.meeting-summary-items-copy,
+.meeting-summary-items-status {
+  margin: 0;
+  color: rgba(17, 24, 39, 0.72);
+  font-size: 0.95rem;
+}
+
+.meeting-summary-items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  margin-top: 0.9rem;
+}
+
+.meeting-summary-items-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.7rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  cursor: pointer;
+}
+
+.meeting-summary-items-row.is-created {
+  opacity: 0.65;
+}
+
+.meeting-summary-items-row input[type="checkbox"] {
+  margin-top: 0.2rem;
+}
+
+.meeting-summary-items-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.meeting-summary-items-title {
+  font-weight: 600;
+  color: #111827;
+}
+
+.meeting-summary-items-meta {
+  font-size: 0.9rem;
+  color: rgba(17, 24, 39, 0.68);
+}
+
+.meeting-summary-items-submit {
+  margin-top: 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.68rem 1rem;
+  background: #111827;
+  color: #f9fafb;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.meeting-summary-items-submit:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .chat-bubble.markdown ul,
 .chat-bubble.markdown ol {
   margin: 0.4rem 0 0.4rem 1.25rem;

--- a/tests/playwright/companion-mode.spec.ts
+++ b/tests/playwright/companion-mode.spec.ts
@@ -186,6 +186,57 @@ test('workspace sidebar exposes companion transcript, summary, and references vi
   await expect(page.locator('#canvas-text')).toContainText('Budget');
 });
 
+test('meeting summary proposes selectable inbox items and creates the chosen ones', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+
+  await page.evaluate(() => {
+    (window as any).__setItemSidebarData({
+      inbox: [],
+      waiting: [],
+      someday: [],
+      done: [],
+    });
+    (window as any).__setMeetingSummaryProposals([
+      {
+        title: 'Draft the revised agenda',
+        actor_name: 'Alice',
+        evidence: 'ACTION: Alice will draft the revised agenda.',
+      },
+      {
+        title: 'Review the budget appendix',
+        actor_name: '',
+        evidence: 'TODO: review the budget appendix.',
+      },
+    ]);
+  });
+
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+  await switchSidebarToFiles(page);
+  await page.getByRole('button', { name: 'Meeting Summary' }).click();
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).not.toHaveClass(/is-open/);
+
+  await expect(page.locator('#meeting-summary-items')).toContainText('Draft the revised agenda');
+  await expect(page.locator('#meeting-summary-items')).toContainText('Review the budget appendix');
+
+  await page.getByLabel(/Review the budget appendix/).uncheck();
+  await page.getByRole('button', { name: 'Create 1 inbox item' }).click();
+
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+  await expect(page.locator('#pr-file-list')).toContainText('Draft the revised agenda');
+  await expect(page.locator('#pr-file-list')).toContainText('Alice');
+  await expect(page.locator('#pr-file-list')).not.toContainText('Review the budget appendix');
+
+  const log = await page.evaluate(() => (window as any).__harnessLog);
+  expect(log.some((entry: any) => entry?.action === 'meeting_items_create'
+    && Array.isArray(entry?.payload?.selected)
+    && entry.payload.selected.length === 1
+    && Number(entry.payload.selected[0]) === 0)).toBe(true);
+});
+
 test('companion idle surface tracks runtime state and hides behind open artifacts', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await waitReady(page);

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -527,6 +527,20 @@
         },
       ],
     });
+    const defaultMeetingSummaryProposals = () => ([
+      {
+        index: 0,
+        title: 'Draft the revised agenda',
+        actor_name: 'Alice',
+        evidence: 'ACTION: Alice will draft the revised agenda.',
+      },
+      {
+        index: 1,
+        title: 'Review the budget appendix',
+        actor_name: '',
+        evidence: 'TODO: review the budget appendix.',
+      },
+    ]);
     const mockPrDiff = (prNumber) => [
       'diff --git a/src/review.js b/src/review.js',
       'index 1111111..2222222 100644',
@@ -539,6 +553,7 @@
     window.__itemSidebarData = defaultItemSidebarData();
     window.__itemSidebarActors = defaultItemSidebarActors();
     window.__itemSidebarArtifacts = defaultItemSidebarArtifacts();
+    window.__meetingSummaryProposals = defaultMeetingSummaryProposals();
     window.__itemSidebarResponseDelays = {
       inbox: [],
       waiting: [],
@@ -564,6 +579,11 @@
         acc[key] = { ...source[key] };
         return acc;
       }, {});
+    };
+    window.__setMeetingSummaryProposals = (next) => {
+      window.__meetingSummaryProposals = Array.isArray(next)
+        ? next.map((entry, index) => ({ index, ...entry }))
+        : defaultMeetingSummaryProposals();
     };
     window.__queueItemSidebarResponseDelay = (view, delayMs) => {
       const key = String(view || '').trim().toLowerCase();
@@ -633,6 +653,13 @@
       });
       window.__itemSidebarData = data;
       return removed;
+    }
+    function prependInboxItem(entry) {
+      const data = window.__itemSidebarData || defaultItemSidebarData();
+      const inbox = Array.isArray(data.inbox) ? data.inbox : [];
+      data.inbox = [cloneItemSidebarEntry(entry)].concat(inbox);
+      window.__itemSidebarData = data;
+      return entry;
     }
     window.__participantConfig = {
       companion_enabled: false,
@@ -967,6 +994,67 @@
           session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
           summary_text: 'Harness companion summary',
           updated_at: 101,
+        }), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/meeting-items') && opts?.method === 'POST') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        const proposals = Array.isArray(window.__meetingSummaryProposals) ? window.__meetingSummaryProposals : defaultMeetingSummaryProposals();
+        const selected = Array.isArray(body.selected) ? body.selected : [];
+        const nextIDBase = 900 + (Array.isArray((window.__itemSidebarData || {}).inbox) ? window.__itemSidebarData.inbox.length : 0);
+        const createdItems = selected
+          .map((index) => Number(index))
+          .filter((index, position, all) => Number.isInteger(index) && index >= 0 && all.indexOf(index) === position)
+          .map((index) => proposals.find((entry) => Number(entry?.index ?? -1) === index))
+          .filter(Boolean)
+          .map((proposal, offset) => prependInboxItem({
+            id: nextIDBase + offset,
+            title: String(proposal.title || ''),
+            state: 'inbox',
+            artifact_id: 701,
+            source: 'meeting_summary',
+            source_ref: `psess-harness-001:${Number(proposal.index || 0)}`,
+            artifact_title: 'Meeting Summary',
+            artifact_kind: 'markdown',
+            actor_name: String(proposal.actor_name || ''),
+            created_at: '2026-03-08 15:00:00',
+            updated_at: '2026-03-08 15:00:00',
+          }));
+        window.__itemSidebarArtifacts = {
+          ...(window.__itemSidebarArtifacts || {}),
+          701: {
+            id: 701,
+            kind: 'markdown',
+            title: 'Meeting Summary',
+            meta_json: JSON.stringify({ summary: 'Harness companion summary' }),
+          },
+        };
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'meeting_items_create',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: body,
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          project_id: activeProjectId,
+          project_key: '/tmp/test',
+          session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
+          proposed_items: proposals,
+          created_items: createdItems,
+        }), { status: 200 });
+      }
+      if (u.includes('/api/projects/') && u.includes('/meeting-items')) {
+        const proposals = Array.isArray(window.__meetingSummaryProposals) ? window.__meetingSummaryProposals : defaultMeetingSummaryProposals();
+        return new Response(JSON.stringify({
+          ok: true,
+          project_id: activeProjectId,
+          project_key: '/tmp/test',
+          sessions: [{ id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' }],
+          session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
+          summary_text: 'Harness companion summary',
+          proposed_items: proposals,
         }), { status: 200 });
       }
       if (u.includes('/api/projects/') && u.includes('/references')) {


### PR DESCRIPTION
## Summary
- add `GET/POST /api/projects/{project_id}/meeting-items` to derive action items from the latest meeting summary and create inbox items from a selected subset
- link created items to a shared meeting summary artifact and infer/create human actors from `Alice will ...` ownership lines
- render a selectable picker in the Meeting Summary canvas view and cover the flow with a Playwright harness test

## Verification
- Meeting summary generates proposed items:
  `go test ./internal/web -run 'Test(ExtractMeetingItemsSupportsMixedSummaryFormats|ProjectMeetingItemsAPIAndCreation|ProjectMeetingItemsCreateRejectsEmptySelection)$'
  Output: `ok   github.com/krystophny/tabura/internal/web	0.025s`
  Evidence: `TestExtractMeetingItemsSupportsMixedSummaryFormats` covers bullet/action/TODO/actor extraction and the no-action edge case.
- User selects which items to create:
  `./scripts/playwright.sh tests/playwright/companion-mode.spec.ts --grep 'meeting summary proposes selectable inbox items'
  Output: `1 passed (1.6s)`
  Evidence: the spec opens Meeting Summary, unchecks one proposal, submits the remaining selection, and verifies only the chosen item is created.
- Items link to the summary artifact:
  `go test ./internal/web -run 'Test(ExtractMeetingItemsSupportsMixedSummaryFormats|ProjectMeetingItemsAPIAndCreation|ProjectMeetingItemsCreateRejectsEmptySelection)$'
  Evidence: `TestProjectMeetingItemsAPIAndCreation` asserts both created items share one artifact with ref path `.tabura/artifacts/companion/<session>/summary.md` and summary text persisted in artifact metadata.
- Actor inferred from participant names:
  `go test ./internal/web -run 'Test(ExtractMeetingItemsSupportsMixedSummaryFormats|ProjectMeetingItemsAPIAndCreation|ProjectMeetingItemsCreateRejectsEmptySelection)$'
  Evidence: `"Alice will draft ..."` is extracted as `actor_name=Alice`, and the created inbox item is assigned to `Alice`.
- Items appear in inbox:
  `./scripts/playwright.sh tests/playwright/companion-mode.spec.ts --grep 'meeting summary proposes selectable inbox items'
  Output: `1 passed (1.6s)`
  Evidence: the spec reopens the sidebar after creation and verifies the inbox row `Draft the revised agenda` plus `Alice`.
- Surface inventory stays in sync:
  `./scripts/sync-surface.sh --check`
  Output: exit 0
