### PR TITLE
fix: add cross-workspace artifact linking via dialogue (fixes #284)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -117,6 +117,12 @@ type ExternalContainerMapping struct {
 	Sphere        *string `json:"sphere,omitempty"`
 }
 
+type ArtifactWorkspaceLink struct {
+	WorkspaceID int64  `json:"workspace_id"`
+	ArtifactID  int64  `json:"artifact_id"`
+	CreatedAt   string `json:"created_at"`
+}
+
 type Actor struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -35,6 +36,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"artifacts":                   {"id", "kind", "ref_path", "ref_url", "title", "meta_json", "created_at", "updated_at"},
 		"external_accounts":           {"id", "sphere", "provider", "label", "config_json", "enabled", "created_at", "updated_at"},
 		"external_container_mappings": {"id", "provider", "container_type", "container_ref", "workspace_id", "project_id", "sphere"},
+		"workspace_artifact_links":    {"workspace_id", "artifact_id", "created_at"},
 		"external_bindings":           {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
 		"items":                       {"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
 	} {
@@ -122,7 +124,7 @@ CREATE TABLE chat_messages (
 	if err != nil {
 		t.Fatalf("TableColumns() error: %v", err)
 	}
-	for _, table := range []string{"workspaces", "actors", "artifacts", "external_accounts", "external_container_mappings", "external_bindings", "items"} {
+	for _, table := range []string{"workspaces", "actors", "artifacts", "external_accounts", "external_container_mappings", "workspace_artifact_links", "external_bindings", "items"} {
 		if _, ok := columns[table]; !ok {
 			t.Fatalf("expected migrated table %s to exist", table)
 		}
@@ -237,6 +239,7 @@ func TestDomainTypesExposeJSONTags(t *testing.T) {
 		{name: "Workspace", typ: reflect.TypeOf(Workspace{})},
 		{name: "Actor", typ: reflect.TypeOf(Actor{})},
 		{name: "Artifact", typ: reflect.TypeOf(Artifact{})},
+		{name: "ArtifactWorkspaceLink", typ: reflect.TypeOf(ArtifactWorkspaceLink{})},
 		{name: "Item", typ: reflect.TypeOf(Item{})},
 	} {
 		for i := 0; i < tc.typ.NumField(); i++ {
@@ -1283,6 +1286,117 @@ func TestInferWorkspaceForArtifact(t *testing.T) {
 	}
 	if inferredUnknown != nil {
 		t.Fatalf("InferWorkspaceForArtifact(unknown github) = %v, want nil", *inferredUnknown)
+	}
+}
+
+func TestWorkspaceArtifactLinksIncludeLinkedArtifactsInWorkspaceListings(t *testing.T) {
+	s := newTestStore(t)
+
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	targetDir := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	sourceWorkspace, err := s.CreateWorkspace("Source", sourceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(source) error: %v", err)
+	}
+	targetWorkspace, err := s.CreateWorkspace("Target", targetDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(target) error: %v", err)
+	}
+	sourcePath := filepath.Join(sourceDir, "results.pdf")
+	if err := os.WriteFile(sourcePath, []byte("pdf"), 0o644); err != nil {
+		t.Fatalf("write results.pdf: %v", err)
+	}
+	sourceTitle := "results.pdf"
+	sourceArtifact, err := s.CreateArtifact(ArtifactKindPDF, &sourcePath, nil, &sourceTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(source) error: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "notes.md")
+	if err := os.WriteFile(targetPath, []byte("# notes\n"), 0o644); err != nil {
+		t.Fatalf("write notes.md: %v", err)
+	}
+	targetTitle := "notes.md"
+	targetArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, &targetPath, nil, &targetTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(target) error: %v", err)
+	}
+
+	if err := s.LinkArtifactToWorkspace(targetWorkspace.ID, sourceArtifact.ID); err != nil {
+		t.Fatalf("LinkArtifactToWorkspace() error: %v", err)
+	}
+	if err := s.LinkArtifactToWorkspace(targetWorkspace.ID, sourceArtifact.ID); err != nil {
+		t.Fatalf("LinkArtifactToWorkspace(duplicate) error: %v", err)
+	}
+
+	links, err := s.ListArtifactWorkspaceLinks(targetWorkspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactWorkspaceLinks() error: %v", err)
+	}
+	if len(links) != 1 || links[0].ArtifactID != sourceArtifact.ID {
+		t.Fatalf("ListArtifactWorkspaceLinks() = %+v, want source artifact %d", links, sourceArtifact.ID)
+	}
+
+	linked, err := s.ListLinkedArtifacts(targetWorkspace.ID)
+	if err != nil {
+		t.Fatalf("ListLinkedArtifacts() error: %v", err)
+	}
+	if len(linked) != 1 || linked[0].ID != sourceArtifact.ID {
+		t.Fatalf("ListLinkedArtifacts() = %+v, want source artifact %d", linked, sourceArtifact.ID)
+	}
+
+	targetArtifacts, err := s.ListArtifactsForWorkspace(targetWorkspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactsForWorkspace(target) error: %v", err)
+	}
+	if len(targetArtifacts) != 2 {
+		t.Fatalf("ListArtifactsForWorkspace(target) len = %d, want 2", len(targetArtifacts))
+	}
+	targetSeen := map[int64]bool{}
+	for _, artifact := range targetArtifacts {
+		targetSeen[artifact.ID] = true
+	}
+	if !targetSeen[sourceArtifact.ID] || !targetSeen[targetArtifact.ID] {
+		t.Fatalf("ListArtifactsForWorkspace(target) ids = %#v", targetSeen)
+	}
+
+	sourceArtifacts, err := s.ListArtifactsForWorkspace(sourceWorkspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactsForWorkspace(source) error: %v", err)
+	}
+	if len(sourceArtifacts) != 1 || sourceArtifacts[0].ID != sourceArtifact.ID {
+		t.Fatalf("ListArtifactsForWorkspace(source) = %+v, want source artifact only", sourceArtifacts)
+	}
+}
+
+func TestLinkArtifactToWorkspaceRejectsHomeWorkspace(t *testing.T) {
+	s := newTestStore(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "alpha")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatalf("mkdir alpha: %v", err)
+	}
+	workspace, err := s.CreateWorkspace("Alpha", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	refPath := filepath.Join(workspaceDir, "spec.md")
+	if err := os.WriteFile(refPath, []byte("# spec\n"), 0o644); err != nil {
+		t.Fatalf("write spec.md: %v", err)
+	}
+	title := "spec.md"
+	artifact, err := s.CreateArtifact(ArtifactKindMarkdown, &refPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	if err := s.LinkArtifactToWorkspace(workspace.ID, artifact.ID); err == nil || err.Error() != "artifact already belongs to workspace" {
+		t.Fatalf("LinkArtifactToWorkspace(home) error = %v, want home-workspace rejection", err)
 	}
 }
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -77,6 +77,12 @@ CREATE TABLE IF NOT EXISTS external_container_mappings (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_external_container_mappings_identity
   ON external_container_mappings(lower(provider), lower(container_type), lower(container_ref));
+CREATE TABLE IF NOT EXISTS workspace_artifact_links (
+  workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  artifact_id INTEGER NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (workspace_id, artifact_id)
+);
 CREATE TABLE IF NOT EXISTS external_bindings (
   id INTEGER PRIMARY KEY,
   account_id INTEGER NOT NULL REFERENCES external_accounts(id) ON DELETE CASCADE,
@@ -726,6 +732,15 @@ func (s *Store) GetArtifact(id int64) (Artifact, error) {
 	))
 }
 
+func sortArtifactsNewestFirst(artifacts []Artifact) {
+	sort.Slice(artifacts, func(i, j int) bool {
+		if artifacts[i].UpdatedAt == artifacts[j].UpdatedAt {
+			return artifacts[i].ID < artifacts[j].ID
+		}
+		return artifacts[i].UpdatedAt > artifacts[j].UpdatedAt
+	})
+}
+
 func (s *Store) ListArtifactsByKind(kind ArtifactKind) ([]Artifact, error) {
 	cleanKind := normalizeArtifactKind(kind)
 	if cleanKind == "" {
@@ -752,12 +767,7 @@ func (s *Store) ListArtifactsByKind(kind ArtifactKind) ([]Artifact, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].UpdatedAt == out[j].UpdatedAt {
-			return out[i].ID < out[j].ID
-		}
-		return out[i].UpdatedAt > out[j].UpdatedAt
-	})
+	sortArtifactsNewestFirst(out)
 	return out, nil
 }
 
@@ -781,12 +791,111 @@ func (s *Store) ListArtifacts() ([]Artifact, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].UpdatedAt == out[j].UpdatedAt {
-			return out[i].ID < out[j].ID
+	sortArtifactsNewestFirst(out)
+	return out, nil
+}
+
+func (s *Store) LinkArtifactToWorkspace(workspaceID, artifactID int64) error {
+	if _, err := s.GetWorkspace(workspaceID); err != nil {
+		return err
+	}
+	artifact, err := s.GetArtifact(artifactID)
+	if err != nil {
+		return err
+	}
+	if homeWorkspaceID, err := s.InferWorkspaceForArtifact(artifact); err != nil {
+		return err
+	} else if homeWorkspaceID != nil && *homeWorkspaceID == workspaceID {
+		return errors.New("artifact already belongs to workspace")
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO workspace_artifact_links (workspace_id, artifact_id)
+		 VALUES (?, ?)
+		 ON CONFLICT(workspace_id, artifact_id) DO NOTHING`,
+		workspaceID,
+		artifactID,
+	)
+	return err
+}
+
+func (s *Store) ListArtifactWorkspaceLinks(workspaceID int64) ([]ArtifactWorkspaceLink, error) {
+	if _, err := s.GetWorkspace(workspaceID); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.Query(
+		`SELECT workspace_id, artifact_id, created_at
+		 FROM workspace_artifact_links
+		 WHERE workspace_id = ?
+		 ORDER BY created_at DESC, artifact_id ASC`,
+		workspaceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ArtifactWorkspaceLink{}
+	for rows.Next() {
+		var link ArtifactWorkspaceLink
+		if err := rows.Scan(&link.WorkspaceID, &link.ArtifactID, &link.CreatedAt); err != nil {
+			return nil, err
 		}
-		return out[i].UpdatedAt > out[j].UpdatedAt
-	})
+		out = append(out, link)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ListLinkedArtifacts(workspaceID int64) ([]Artifact, error) {
+	links, err := s.ListArtifactWorkspaceLinks(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Artifact, 0, len(links))
+	for _, link := range links {
+		artifact, err := s.GetArtifact(link.ArtifactID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+		out = append(out, artifact)
+	}
+	sortArtifactsNewestFirst(out)
+	return out, nil
+}
+
+func (s *Store) ListArtifactsForWorkspace(workspaceID int64) ([]Artifact, error) {
+	if _, err := s.GetWorkspace(workspaceID); err != nil {
+		return nil, err
+	}
+	artifacts, err := s.ListArtifacts()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Artifact, 0, len(artifacts))
+	seen := map[int64]struct{}{}
+	for _, artifact := range artifacts {
+		homeWorkspaceID, err := s.InferWorkspaceForArtifact(artifact)
+		if err != nil {
+			return nil, err
+		}
+		if homeWorkspaceID == nil || *homeWorkspaceID != workspaceID {
+			continue
+		}
+		out = append(out, artifact)
+		seen[artifact.ID] = struct{}{}
+	}
+	linked, err := s.ListLinkedArtifacts(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	for _, artifact := range linked {
+		if _, ok := seen[artifact.ID]; ok {
+			continue
+		}
+		out = append(out, artifact)
+	}
+	sortArtifactsNewestFirst(out)
 	return out, nil
 }
 

--- a/internal/web/artifacts.go
+++ b/internal/web/artifacts.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/krystophny/tabura/internal/store"
@@ -20,13 +21,27 @@ func (a *App) handleArtifactList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	kind := store.ArtifactKind(strings.TrimSpace(r.URL.Query().Get("kind")))
+	workspaceIDText := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+	linkedOnly := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("linked")), "true")
 	var (
 		artifacts []store.Artifact
 		err       error
 	)
-	if kind != "" {
+	switch {
+	case workspaceIDText != "":
+		workspaceID, parseErr := strconv.ParseInt(workspaceIDText, 10, 64)
+		if parseErr != nil || workspaceID <= 0 {
+			http.Error(w, "workspace_id must be a positive integer", http.StatusBadRequest)
+			return
+		}
+		if linkedOnly {
+			artifacts, err = a.store.ListLinkedArtifacts(workspaceID)
+		} else {
+			artifacts, err = a.store.ListArtifactsForWorkspace(workspaceID)
+		}
+	case kind != "":
 		artifacts, err = a.store.ListArtifactsByKind(kind)
-	} else {
+	default:
 		artifacts, err = a.store.ListArtifacts()
 	}
 	if err != nil {

--- a/internal/web/artifacts_test.go
+++ b/internal/web/artifacts_test.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/krystophny/tabura/internal/store"
@@ -54,5 +56,94 @@ func TestArtifactCRUDAPI(t *testing.T) {
 	rrMissing := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts/"+itoa(artifactID), nil)
 	if rrMissing.Code != http.StatusNotFound {
 		t.Fatalf("deleted artifact status = %d, want 404: %s", rrMissing.Code, rrMissing.Body.String())
+	}
+}
+
+func TestArtifactListAPIIncludesLinkedArtifactsForWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	targetDir := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	sourceWorkspace, err := app.store.CreateWorkspace("Source", sourceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(source) error: %v", err)
+	}
+	targetWorkspace, err := app.store.CreateWorkspace("Target", targetDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(target) error: %v", err)
+	}
+
+	sourcePath := filepath.Join(sourceDir, "results.pdf")
+	if err := os.WriteFile(sourcePath, []byte("pdf"), 0o644); err != nil {
+		t.Fatalf("write source artifact: %v", err)
+	}
+	sourceTitle := "results.pdf"
+	sourceArtifact, err := app.store.CreateArtifact(store.ArtifactKindPDF, &sourcePath, nil, &sourceTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(source) error: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "notes.md")
+	if err := os.WriteFile(targetPath, []byte("# notes\n"), 0o644); err != nil {
+		t.Fatalf("write target artifact: %v", err)
+	}
+	targetTitle := "notes.md"
+	targetArtifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &targetPath, nil, &targetTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(target) error: %v", err)
+	}
+	if err := app.store.LinkArtifactToWorkspace(targetWorkspace.ID, sourceArtifact.ID); err != nil {
+		t.Fatalf("LinkArtifactToWorkspace() error: %v", err)
+	}
+
+	rrWorkspaceList := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?workspace_id="+itoa(targetWorkspace.ID), nil)
+	if rrWorkspaceList.Code != http.StatusOK {
+		t.Fatalf("workspace list status = %d, want 200: %s", rrWorkspaceList.Code, rrWorkspaceList.Body.String())
+	}
+	workspacePayload := decodeJSONResponse(t, rrWorkspaceList)
+	workspaceArtifacts, ok := workspacePayload["artifacts"].([]any)
+	if !ok || len(workspaceArtifacts) != 2 {
+		t.Fatalf("workspace artifacts payload = %#v", workspacePayload)
+	}
+	seen := map[int64]bool{}
+	for _, raw := range workspaceArtifacts {
+		entry, _ := raw.(map[string]any)
+		seen[int64(entry["id"].(float64))] = true
+	}
+	if !seen[sourceArtifact.ID] || !seen[targetArtifact.ID] {
+		t.Fatalf("workspace artifact ids = %#v", seen)
+	}
+
+	rrLinkedList := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?workspace_id="+itoa(targetWorkspace.ID)+"&linked=true", nil)
+	if rrLinkedList.Code != http.StatusOK {
+		t.Fatalf("linked list status = %d, want 200: %s", rrLinkedList.Code, rrLinkedList.Body.String())
+	}
+	linkedPayload := decodeJSONResponse(t, rrLinkedList)
+	linkedArtifacts, ok := linkedPayload["artifacts"].([]any)
+	if !ok || len(linkedArtifacts) != 1 {
+		t.Fatalf("linked artifacts payload = %#v", linkedPayload)
+	}
+	if got := int64(linkedArtifacts[0].(map[string]any)["id"].(float64)); got != sourceArtifact.ID {
+		t.Fatalf("linked artifact id = %d, want %d", got, sourceArtifact.ID)
+	}
+
+	rrBadWorkspace := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?workspace_id=bad", nil)
+	if rrBadWorkspace.Code != http.StatusBadRequest {
+		t.Fatalf("bad workspace_id status = %d, want 400: %s", rrBadWorkspace.Code, rrBadWorkspace.Body.String())
+	}
+
+	rrSourceLinked := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?workspace_id="+itoa(sourceWorkspace.ID)+"&linked=true", nil)
+	if rrSourceLinked.Code != http.StatusOK {
+		t.Fatalf("source linked list status = %d, want 200: %s", rrSourceLinked.Code, rrSourceLinked.Body.String())
+	}
+	sourceLinkedPayload := decodeJSONResponse(t, rrSourceLinked)
+	sourceLinkedArtifacts, ok := sourceLinkedPayload["artifacts"].([]any)
+	if !ok || len(sourceLinkedArtifacts) != 0 {
+		t.Fatalf("source linked artifacts payload = %#v", sourceLinkedPayload)
 	}
 }

--- a/internal/web/chat_artifact_links.go
+++ b/internal/web/chat_artifact_links.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+var (
+	artifactLinkPattern        = regexp.MustCompile(`(?i)^link\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)$`)
+	showLinkedArtifactsPattern = regexp.MustCompile(`(?i)^(?:show|list)\s+linked\s+artifacts(?:\s+for\s+(.+?))?$`)
+)
+
+func parseInlineArtifactLinkIntent(text string) *SystemAction {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	if match := artifactLinkPattern.FindStringSubmatch(trimmed); len(match) == 4 {
+		artifactRef := cleanArtifactReference(match[1])
+		sourceWorkspace := cleanArtifactReference(match[2])
+		targetWorkspace := cleanArtifactReference(match[3])
+		if artifactRef != "" && sourceWorkspace != "" && targetWorkspace != "" {
+			return &SystemAction{
+				Action: "link_workspace_artifact",
+				Params: map[string]interface{}{
+					"artifact":         artifactRef,
+					"source_workspace": sourceWorkspace,
+					"target_workspace": targetWorkspace,
+				},
+			}
+		}
+	}
+	if match := showLinkedArtifactsPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		params := map[string]interface{}{}
+		if workspaceRef := cleanArtifactReference(match[1]); workspaceRef != "" {
+			params["workspace"] = workspaceRef
+		}
+		return &SystemAction{Action: "list_linked_artifacts", Params: params}
+	}
+	return nil
+}
+
+func cleanArtifactReference(raw string) string {
+	text := strings.TrimSpace(raw)
+	text = strings.Trim(text, " \t\r\n!?,:;.")
+	text = strings.Trim(text, `"'`)
+	return strings.TrimSpace(text)
+}
+
+func systemActionArtifactRef(params map[string]interface{}) string {
+	for _, key := range []string{"artifact", "title", "path", "name"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func optionalArtifactString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func artifactMatchesReference(artifact store.Artifact, ref string) bool {
+	if strings.EqualFold(optionalArtifactString(artifact.Title), ref) {
+		return true
+	}
+	if strings.EqualFold(optionalArtifactString(artifact.RefPath), ref) {
+		return true
+	}
+	if strings.EqualFold(filepath.Base(optionalArtifactString(artifact.RefPath)), ref) {
+		return true
+	}
+	if strings.EqualFold(optionalArtifactString(artifact.RefURL), ref) {
+		return true
+	}
+	return false
+}
+
+func (a *App) resolveWorkspaceArtifactReference(workspaceID int64, raw string) (store.Artifact, error) {
+	ref := cleanArtifactReference(raw)
+	if ref == "" {
+		return store.Artifact{}, fmt.Errorf("artifact reference is required")
+	}
+	artifacts, err := a.store.ListArtifactsForWorkspace(workspaceID)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	matches := make([]store.Artifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifactMatchesReference(artifact, ref) {
+			matches = append(matches, artifact)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return store.Artifact{}, fmt.Errorf("artifact %q is ambiguous", ref)
+	}
+	return store.Artifact{}, fmt.Errorf("artifact %q not found", ref)
+}
+
+func (a *App) linkWorkspaceArtifact(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	sourceWorkspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionStringParam(action.Params, "source_workspace"))
+	if err != nil {
+		return "", nil, err
+	}
+	targetWorkspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionStringParam(action.Params, "target_workspace"))
+	if err != nil {
+		return "", nil, err
+	}
+	artifact, err := a.resolveWorkspaceArtifactReference(sourceWorkspace.ID, systemActionArtifactRef(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	if err := a.store.LinkArtifactToWorkspace(targetWorkspace.ID, artifact.ID); err != nil {
+		return "", nil, err
+	}
+	title := optionalArtifactString(artifact.Title)
+	if title == "" {
+		title = filepath.Base(optionalArtifactString(artifact.RefPath))
+	}
+	if title == "" {
+		title = fmt.Sprintf("artifact %d", artifact.ID)
+	}
+	return fmt.Sprintf("Linked %s from %s to %s.", title, sourceWorkspace.Name, targetWorkspace.Name), map[string]interface{}{
+		"type":                "link_workspace_artifact",
+		"artifact_id":         artifact.ID,
+		"artifact_title":      title,
+		"source_workspace_id": sourceWorkspace.ID,
+		"source_workspace":    sourceWorkspace.Name,
+		"target_workspace_id": targetWorkspace.ID,
+		"target_workspace":    targetWorkspace.Name,
+	}, nil
+}
+
+func linkedArtifactDisplayTitle(artifact store.Artifact) string {
+	title := optionalArtifactString(artifact.Title)
+	if title != "" {
+		return title
+	}
+	refPath := optionalArtifactString(artifact.RefPath)
+	if refPath != "" {
+		return filepath.Base(refPath)
+	}
+	refURL := optionalArtifactString(artifact.RefURL)
+	if refURL != "" {
+		return refURL
+	}
+	return fmt.Sprintf("artifact %d", artifact.ID)
+}
+
+func (a *App) listLinkedArtifacts(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	artifacts, err := a.store.ListLinkedArtifacts(workspace.ID)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(artifacts) == 0 {
+		return fmt.Sprintf("No linked artifacts for workspace %s.", workspace.Name), map[string]interface{}{
+			"type":         "list_linked_artifacts",
+			"workspace_id": workspace.ID,
+			"workspace":    workspace.Name,
+			"artifact_ids": []int64{},
+			"count":        0,
+		}, nil
+	}
+	titles := make([]string, 0, len(artifacts))
+	ids := make([]int64, 0, len(artifacts))
+	lines := make([]string, 0, len(artifacts)+1)
+	lines = append(lines, fmt.Sprintf("Linked artifacts for workspace %s:", workspace.Name))
+	for _, artifact := range artifacts {
+		title := linkedArtifactDisplayTitle(artifact)
+		if homeWorkspaceID, err := a.store.InferWorkspaceForArtifact(artifact); err == nil && homeWorkspaceID != nil {
+			if homeWorkspace, err := a.store.GetWorkspace(*homeWorkspaceID); err == nil {
+				title = fmt.Sprintf("%s (from %s)", title, homeWorkspace.Name)
+			}
+		}
+		lines = append(lines, "- "+title)
+		titles = append(titles, title)
+		ids = append(ids, artifact.ID)
+	}
+	return strings.Join(lines, "\n"), map[string]interface{}{
+		"type":          "list_linked_artifacts",
+		"workspace_id":  workspace.ID,
+		"workspace":     workspace.Name,
+		"artifact_ids":  ids,
+		"artifact_list": titles,
+		"count":         len(ids),
+	}, nil
+}

--- a/internal/web/chat_artifact_links_test.go
+++ b/internal/web/chat_artifact_links_test.go
@@ -1,0 +1,201 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineArtifactLinkIntent(t *testing.T) {
+	cases := []struct {
+		text         string
+		wantAction   string
+		wantArtifact string
+		wantSource   string
+		wantTarget   string
+		wantListFor  string
+	}{
+		{
+			text:         "link results.pdf from eurofusion-sim to eurofusion-paper",
+			wantAction:   "link_workspace_artifact",
+			wantArtifact: "results.pdf",
+			wantSource:   "eurofusion-sim",
+			wantTarget:   "eurofusion-paper",
+		},
+		{
+			text:       "show linked artifacts",
+			wantAction: "list_linked_artifacts",
+		},
+		{
+			text:        "list linked artifacts for paper workspace",
+			wantAction:  "list_linked_artifacts",
+			wantListFor: "paper workspace",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineArtifactLinkIntent(tc.text)
+			if action == nil {
+				t.Fatal("expected artifact link action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if got := systemActionArtifactRef(action.Params); got != tc.wantArtifact {
+				t.Fatalf("artifact ref = %q, want %q", got, tc.wantArtifact)
+			}
+			if got := strings.TrimSpace(systemActionStringParam(action.Params, "source_workspace")); tc.wantSource != "" && got != tc.wantSource {
+				t.Fatalf("source_workspace = %q, want %q", got, tc.wantSource)
+			}
+			if got := strings.TrimSpace(systemActionStringParam(action.Params, "target_workspace")); tc.wantTarget != "" && got != tc.wantTarget {
+				t.Fatalf("target_workspace = %q, want %q", got, tc.wantTarget)
+			}
+			if got := systemActionWorkspaceRef(action.Params); got != tc.wantListFor {
+				t.Fatalf("workspace ref = %q, want %q", got, tc.wantListFor)
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionLinkWorkspaceArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	sourceDir := filepath.Join(t.TempDir(), "sim")
+	targetDir := filepath.Join(t.TempDir(), "paper")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir sim: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir paper: %v", err)
+	}
+	sourceWorkspace, err := app.store.CreateWorkspace("eurofusion-sim", sourceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(sim) error: %v", err)
+	}
+	targetWorkspace, err := app.store.CreateWorkspace("eurofusion-paper", targetDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(paper) error: %v", err)
+	}
+	artifactPath := filepath.Join(sourceDir, "results.pdf")
+	if err := os.WriteFile(artifactPath, []byte("pdf"), 0o644); err != nil {
+		t.Fatalf("write results.pdf: %v", err)
+	}
+	title := "results.pdf"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindPDF, &artifactPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(
+		context.Background(),
+		session.ID,
+		session,
+		"link results.pdf from eurofusion-sim to eurofusion-paper",
+	)
+	if !handled {
+		t.Fatal("expected artifact link command to be handled")
+	}
+	if message != "Linked results.pdf from eurofusion-sim to eurofusion-paper." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "link_workspace_artifact" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := int64FromAny(payloads[0]["artifact_id"]); got != artifact.ID {
+		t.Fatalf("artifact_id = %d, want %d", got, artifact.ID)
+	}
+	if got := int64FromAny(payloads[0]["target_workspace_id"]); got != targetWorkspace.ID {
+		t.Fatalf("target_workspace_id = %d, want %d", got, targetWorkspace.ID)
+	}
+
+	linked, err := app.store.ListLinkedArtifacts(targetWorkspace.ID)
+	if err != nil {
+		t.Fatalf("ListLinkedArtifacts() error: %v", err)
+	}
+	if len(linked) != 1 || linked[0].ID != artifact.ID {
+		t.Fatalf("ListLinkedArtifacts() = %+v, want linked results.pdf", linked)
+	}
+
+	_, _ = sourceWorkspace, targetWorkspace
+}
+
+func TestClassifyAndExecuteSystemActionListLinkedArtifactsUsesActiveWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	sourceDir := filepath.Join(t.TempDir(), "sim")
+	targetDir := filepath.Join(t.TempDir(), "paper")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir sim: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir paper: %v", err)
+	}
+	sourceWorkspace, err := app.store.CreateWorkspace("eurofusion-sim", sourceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(sim) error: %v", err)
+	}
+	targetWorkspace, err := app.store.CreateWorkspace("eurofusion-paper", targetDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(paper) error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(targetWorkspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(target) error: %v", err)
+	}
+	artifactPath := filepath.Join(sourceDir, "results.pdf")
+	if err := os.WriteFile(artifactPath, []byte("pdf"), 0o644); err != nil {
+		t.Fatalf("write results.pdf: %v", err)
+	}
+	title := "results.pdf"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindPDF, &artifactPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	if err := app.store.LinkArtifactToWorkspace(targetWorkspace.ID, artifact.ID); err != nil {
+		t.Fatalf("LinkArtifactToWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show linked artifacts")
+	if !handled {
+		t.Fatal("expected linked artifact listing to be handled")
+	}
+	if !strings.Contains(message, "Linked artifacts for workspace eurofusion-paper:") {
+		t.Fatalf("message = %q", message)
+	}
+	if !strings.Contains(message, "results.pdf (from eurofusion-sim)") {
+		t.Fatalf("message missing linked artifact origin: %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "list_linked_artifacts" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := intFromAny(payloads[0]["count"], 0); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+
+	_, _ = sourceWorkspace, artifact
+}

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -765,6 +765,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return githubIssueActionFailurePrefix(enforced) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	if inlineArtifactAction := parseInlineArtifactLinkIntent(trimmedText); inlineArtifactAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineArtifactAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return "I couldn't resolve the artifact linking request: " + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -292,6 +292,10 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.captureIdeaItem(session, action)
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
+	case "link_workspace_artifact":
+		return a.linkWorkspaceArtifact(session, action)
+	case "list_linked_artifacts":
+		return a.listLinkedArtifacts(session, action)
 	case "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return a.executeSomedayAction(session, action)
 	case "create_github_issue", "create_github_issue_split":


### PR DESCRIPTION
## Summary
Add cross-workspace artifact links backed by a dedicated store table, workspace-scoped artifact listing, and dialogue commands for linking and reviewing linked artifacts.

## Verification
- Requirement: allow linking artifacts across workspaces by reference.
  Evidence: `go test ./internal/store ./internal/web 2>&1 | tee /tmp/tabura-issue-284-test.log`
  Evidence excerpt: `ok   github.com/krystophny/tabura/internal/store` and `ok   github.com/krystophny/tabura/internal/web`
  Evidence detail: `TestWorkspaceArtifactLinksIncludeLinkedArtifactsInWorkspaceListings` and `TestClassifyAndExecuteSystemActionLinkWorkspaceArtifact` verify `results.pdf` can be linked from `eurofusion-sim` to `eurofusion-paper`.
- Requirement: linked artifacts appear in the target workspace's artifact list while keeping the original artifact/file reference.
  Evidence: same command as above.
  Evidence detail: `TestWorkspaceArtifactLinksIncludeLinkedArtifactsInWorkspaceListings` and `TestArtifactListAPIIncludesLinkedArtifactsForWorkspace` verify the target workspace listing returns both its home artifact and the linked `results.pdf`, and the linked entry is the original artifact id rather than a copied artifact.
- Requirement: dialogue supports linking and showing linked artifacts.
  Evidence: same command as above.
  Evidence detail: `TestParseInlineArtifactLinkIntent` covers `link results.pdf from eurofusion-sim to eurofusion-paper` and `show linked artifacts`; `TestClassifyAndExecuteSystemActionListLinkedArtifactsUsesActiveWorkspace` verifies the linked-artifact summary resolves against the active workspace.

## Notes
- Added `workspace_artifact_links` as the storage primitive for cross-workspace references.
- Extended `GET /api/artifacts` with `workspace_id` and optional `linked=true` filtering so linked artifacts surface in workspace-scoped artifact listings.
