### PR TITLE
fix: Add idea artifact creation and canvas editing (fixes #210)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,13 +31,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization and someday-review requests use make_item, delegate_item, snooze_item, split_items, capture_idea, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
+For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -453,6 +453,11 @@ func normalizeSystemActionForExecution(action *SystemAction, fallbackText string
 		}
 		if strings.TrimSpace(systemActionStringParam(action.Params, "input_mode")) == "" {
 			action.Params["input_mode"] = chatInputModeText
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(action.Action), "refine_idea_note") {
+		if strings.TrimSpace(systemActionStringParam(action.Params, "text")) == "" {
+			action.Params["text"] = strings.TrimSpace(fallbackText)
 		}
 	}
 	return action

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -290,6 +290,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return status, nil, nil
 	case "capture_idea":
 		return a.captureIdeaItem(session, action)
+	case "refine_idea_note":
+		return a.refineConversationIdea(session, action)
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
 	case "link_workspace_artifact":

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -62,6 +62,9 @@ func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode st
 			},
 		}
 	}
+	if ideaRefinement := parseInlineIdeaRefinementIntent(text); ideaRefinement != nil {
+		return ideaRefinement
+	}
 	switch normalized {
 	case "make this an item", "track this", "add to inbox":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
@@ -221,7 +224,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return true
 	default:
 		return false
@@ -234,6 +237,8 @@ func itemActionFailurePrefix(action string) string {
 		return "I couldn't create the GitHub issue: "
 	case "capture_idea":
 		return "I couldn't capture the idea: "
+	case "refine_idea_note":
+		return "I couldn't update the idea note: "
 	case "print_item":
 		return "I couldn't prepare the print view: "
 	case "review_someday":
@@ -617,21 +622,6 @@ func (a *App) resolveActorByName(name string) (store.Actor, error) {
 	}
 }
 
-func ideaArtifactMeta(title, transcript, inputMode string, capturedAt time.Time) (*string, error) {
-	payload := map[string]string{
-		"title":        title,
-		"transcript":   transcript,
-		"capture_mode": normalizeChatInputMode(inputMode),
-		"captured_at":  capturedAt.UTC().Format(time.RFC3339),
-	}
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	meta := string(raw)
-	return &meta, nil
-}
-
 func ideaCaptureConfirmation(title string) string {
 	clean := strings.TrimSpace(title)
 	if clean == "" {
@@ -667,7 +657,13 @@ func (a *App) captureIdeaItem(session store.ChatSession, action *SystemAction) (
 	}
 	inputMode := normalizeChatInputMode(systemActionStringParam(action.Params, "input_mode"))
 	capturedAt := time.Now().UTC()
-	metaJSON, err := ideaArtifactMeta(title, ideaText, inputMode, capturedAt)
+	workspaceName := ""
+	if workspaceID != nil {
+		if workspace, workspaceErr := a.store.GetWorkspace(*workspaceID); workspaceErr == nil {
+			workspaceName = workspace.Name
+		}
+	}
+	metaJSON, err := ideaArtifactMeta(title, ideaText, inputMode, workspaceName, capturedAt)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/web/chat_items_idea.go
+++ b/internal/web/chat_items_idea.go
@@ -1,0 +1,369 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type ideaNoteMeta struct {
+	Title       string               `json:"title,omitempty"`
+	Transcript  string               `json:"transcript,omitempty"`
+	CaptureMode string               `json:"capture_mode,omitempty"`
+	CapturedAt  string               `json:"captured_at,omitempty"`
+	Workspace   string               `json:"workspace,omitempty"`
+	Notes       []string             `json:"notes,omitempty"`
+	Refinements []ideaNoteRefinement `json:"refinements,omitempty"`
+}
+
+type ideaNoteRefinement struct {
+	Kind      string `json:"kind,omitempty"`
+	Heading   string `json:"heading,omitempty"`
+	Prompt    string `json:"prompt,omitempty"`
+	Body      string `json:"body,omitempty"`
+	RefinedAt string `json:"refined_at,omitempty"`
+}
+
+func ideaNoteString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func ideaArtifactMeta(title, transcript, inputMode, workspaceName string, capturedAt time.Time) (*string, error) {
+	meta := ideaNoteMeta{
+		Title:       strings.TrimSpace(title),
+		Transcript:  normalizeIdeaText(transcript),
+		CaptureMode: normalizeChatInputMode(inputMode),
+		CapturedAt:  capturedAt.UTC().Format(time.RFC3339),
+		Workspace:   strings.TrimSpace(workspaceName),
+	}
+	if meta.Transcript != "" {
+		meta.Notes = []string{meta.Transcript}
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func parseIdeaNoteMeta(metaJSON *string, fallbackTitle string) ideaNoteMeta {
+	meta := ideaNoteMeta{
+		Title: strings.TrimSpace(fallbackTitle),
+	}
+	if metaJSON != nil {
+		if raw := strings.TrimSpace(*metaJSON); raw != "" {
+			var parsed ideaNoteMeta
+			if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
+				meta = parsed
+				if strings.TrimSpace(meta.Title) == "" {
+					meta.Title = strings.TrimSpace(fallbackTitle)
+				}
+			}
+		}
+	}
+	meta.Title = strings.TrimSpace(meta.Title)
+	meta.Transcript = normalizeIdeaText(meta.Transcript)
+	meta.CaptureMode = normalizeChatInputMode(meta.CaptureMode)
+	meta.Workspace = strings.TrimSpace(meta.Workspace)
+	meta.CapturedAt = strings.TrimSpace(meta.CapturedAt)
+	meta.Notes = normalizeIdeaNoteLines(meta.Notes)
+	if len(meta.Notes) == 0 && meta.Transcript != "" {
+		meta.Notes = []string{meta.Transcript}
+	}
+	out := make([]ideaNoteRefinement, 0, len(meta.Refinements))
+	for _, refinement := range meta.Refinements {
+		refinement.Kind = strings.TrimSpace(refinement.Kind)
+		refinement.Heading = strings.TrimSpace(refinement.Heading)
+		refinement.Prompt = strings.TrimSpace(refinement.Prompt)
+		refinement.Body = strings.TrimSpace(refinement.Body)
+		refinement.RefinedAt = strings.TrimSpace(refinement.RefinedAt)
+		if refinement.Body == "" {
+			continue
+		}
+		if refinement.Heading == "" {
+			refinement.Heading = ideaRefinementHeading(refinement.Kind)
+		}
+		out = append(out, refinement)
+	}
+	meta.Refinements = out
+	return meta
+}
+
+func encodeIdeaNoteMeta(meta ideaNoteMeta) (*string, error) {
+	meta = parseIdeaNoteMetaPtr(meta)
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func parseIdeaNoteMetaPtr(meta ideaNoteMeta) ideaNoteMeta {
+	normalized := parseIdeaNoteMeta(nil, meta.Title)
+	normalized.Transcript = meta.Transcript
+	normalized.CaptureMode = meta.CaptureMode
+	normalized.CapturedAt = meta.CapturedAt
+	normalized.Workspace = meta.Workspace
+	normalized.Notes = meta.Notes
+	normalized.Refinements = meta.Refinements
+	return parseIdeaNoteMeta(mustJSONString(normalized), normalized.Title)
+}
+
+func mustJSONString(meta ideaNoteMeta) *string {
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		text := "{}"
+		return &text
+	}
+	text := string(raw)
+	return &text
+}
+
+func normalizeIdeaNoteLines(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(lines))
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		clean := normalizeIdeaText(line)
+		if clean == "" {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	return out
+}
+
+func renderIdeaNoteMarkdown(meta ideaNoteMeta) string {
+	meta = parseIdeaNoteMetaPtr(meta)
+	title := strings.TrimSpace(meta.Title)
+	if title == "" {
+		title = "Idea"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", title)
+	b.WriteString("## Notes\n")
+	if len(meta.Notes) == 0 {
+		b.WriteString("- No notes yet.\n")
+	} else {
+		for _, note := range meta.Notes {
+			fmt.Fprintf(&b, "- %s\n", note)
+		}
+	}
+	b.WriteString("\n## Context\n")
+	contextLines := 0
+	if meta.CaptureMode != "" {
+		fmt.Fprintf(&b, "- Captured: %s\n", meta.CaptureMode)
+		contextLines++
+	}
+	if meta.Workspace != "" {
+		fmt.Fprintf(&b, "- Workspace: %s\n", meta.Workspace)
+		contextLines++
+	}
+	if meta.CapturedAt != "" {
+		fmt.Fprintf(&b, "- Date: %s\n", meta.CapturedAt)
+		contextLines++
+	}
+	if contextLines == 0 {
+		b.WriteString("- Date: unavailable\n")
+	}
+	for _, refinement := range meta.Refinements {
+		heading := strings.TrimSpace(refinement.Heading)
+		if heading == "" {
+			heading = ideaRefinementHeading(refinement.Kind)
+		}
+		body := strings.TrimSpace(refinement.Body)
+		if body == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "\n## %s\n\n%s\n", heading, body)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func parseInlineIdeaRefinementIntent(text string) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	if normalized == "" {
+		return nil
+	}
+	kind := ""
+	switch {
+	case normalized == "expand this idea" || normalized == "expand this" || normalized == "expand on this idea" || normalized == "refine this idea":
+		kind = "expand"
+	case strings.Contains(normalized, "pros and cons"):
+		kind = "pros_cons"
+	case normalized == "compare alternatives" || normalized == "compare options" || normalized == "show alternatives":
+		kind = "alternatives"
+	case normalized == "outline an implementation" || normalized == "outline implementation" || normalized == "draft implementation":
+		kind = "implementation"
+	}
+	if kind == "" {
+		return nil
+	}
+	return &SystemAction{
+		Action: "refine_idea_note",
+		Params: map[string]interface{}{
+			"kind": kind,
+			"text": strings.TrimSpace(text),
+		},
+	}
+}
+
+func ideaRefinementHeading(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "expand":
+		return "Expansion"
+	case "pros_cons":
+		return "Pros and Cons"
+	case "alternatives":
+		return "Alternatives"
+	case "implementation":
+		return "Implementation Outline"
+	default:
+		return "Idea Notes"
+	}
+}
+
+func generateIdeaNoteRefinement(meta ideaNoteMeta, kind, prompt string, refinedAt time.Time) ideaNoteRefinement {
+	subject := strings.TrimSpace(meta.Title)
+	if subject == "" {
+		subject = "This idea"
+	}
+	summary := strings.TrimSpace(meta.Transcript)
+	if summary == "" && len(meta.Notes) > 0 {
+		summary = strings.TrimSpace(meta.Notes[0])
+	}
+	if summary == "" {
+		summary = subject
+	}
+	body := buildIdeaNoteRefinementBody(kind, subject, summary)
+	return ideaNoteRefinement{
+		Kind:      strings.TrimSpace(kind),
+		Heading:   ideaRefinementHeading(kind),
+		Prompt:    strings.TrimSpace(prompt),
+		Body:      body,
+		RefinedAt: refinedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func buildIdeaNoteRefinementBody(kind, subject, summary string) string {
+	switch strings.TrimSpace(kind) {
+	case "expand":
+		return strings.Join([]string{
+			fmt.Sprintf("%s can be turned into a focused workflow instead of a one-off capture.", subject),
+			"",
+			fmt.Sprintf("- Clarify the target outcome behind: %s", summary),
+			"- Start with the smallest slice that proves the workflow is useful.",
+			"- Decide which parts should stay manual and which parts should become repeatable automation.",
+		}, "\n")
+	case "pros_cons":
+		return strings.Join([]string{
+			"### Pros",
+			fmt.Sprintf("- Keeps the work centered on a concrete outcome: %s", subject),
+			"- Creates a reusable structure for follow-up, review, and delegation.",
+			"",
+			"### Cons",
+			"- Adds implementation scope that needs clear boundaries to avoid drift.",
+			"- Will need a lightweight review loop so captured notes stay accurate over time.",
+		}, "\n")
+	case "alternatives":
+		return strings.Join([]string{
+			"1. Lightweight path: keep the idea as a single note and only add minimal metadata for quick retrieval.",
+			"2. Structured path: split the idea into explicit capture, review, and execution stages with clearer ownership.",
+			"3. Deferred path: park the idea until there is a stronger trigger or a specific user workflow to anchor it.",
+		}, "\n")
+	case "implementation":
+		return strings.Join([]string{
+			"1. Capture the current workflow and identify the single user outcome that matters most.",
+			fmt.Sprintf("2. Implement the narrowest end-to-end slice for %s.", subject),
+			"3. Add regression coverage for capture, rendering, and follow-up refinement so the note stays editable.",
+		}, "\n")
+	default:
+		return fmt.Sprintf("- %s", summary)
+	}
+}
+
+func (a *App) resolveActiveIdeaNoteArtifact(projectKey string) (*store.Artifact, error) {
+	canvas := a.resolveCanvasContext(projectKey)
+	if canvas == nil || strings.TrimSpace(canvas.ArtifactTitle) == "" {
+		return nil, errors.New("open the idea note on canvas first")
+	}
+	title := strings.TrimSpace(canvas.ArtifactTitle)
+	artifacts, err := a.store.ListArtifactsByKind(store.ArtifactKindIdeaNote)
+	if err != nil {
+		return nil, err
+	}
+	for _, artifact := range artifacts {
+		if ideaNoteString(artifact.Title) == title {
+			candidate := artifact
+			return &candidate, nil
+		}
+	}
+	return nil, errors.New("active canvas artifact is not an idea note")
+}
+
+func (a *App) renderIdeaNoteOnCanvas(projectKey, title string, meta ideaNoteMeta) error {
+	canvasSessionID := strings.TrimSpace(a.resolveCanvasSessionID(projectKey))
+	if canvasSessionID == "" {
+		return errors.New("canvas session is not available")
+	}
+	port, ok := a.tunnels.getPort(canvasSessionID)
+	if !ok {
+		return errors.New("canvas tunnel is not available")
+	}
+	_, err := a.mcpToolsCall(port, "canvas_artifact_show", map[string]interface{}{
+		"session_id":       canvasSessionID,
+		"kind":             "text",
+		"title":            strings.TrimSpace(title),
+		"markdown_or_text": renderIdeaNoteMarkdown(meta),
+	})
+	return err
+}
+
+func (a *App) refineConversationIdea(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	if action == nil {
+		return "", nil, errors.New("idea action is required")
+	}
+	artifact, err := a.resolveActiveIdeaNoteArtifact(session.ProjectKey)
+	if err != nil {
+		return "", nil, err
+	}
+	meta := parseIdeaNoteMeta(artifact.MetaJSON, ideaNoteString(artifact.Title))
+	refinement := generateIdeaNoteRefinement(
+		meta,
+		systemActionStringParam(action.Params, "kind"),
+		systemActionStringParam(action.Params, "text"),
+		time.Now().UTC(),
+	)
+	meta.Refinements = append(meta.Refinements, refinement)
+	metaJSON, err := encodeIdeaNoteMeta(meta)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := a.store.UpdateArtifact(artifact.ID, store.ArtifactUpdate{MetaJSON: metaJSON}); err != nil {
+		return "", nil, err
+	}
+	if err := a.renderIdeaNoteOnCanvas(session.ProjectKey, meta.Title, meta); err != nil {
+		return "", nil, err
+	}
+	return fmt.Sprintf("Updated idea note with %s.", refinement.Heading), map[string]interface{}{
+		"type":        "artifact_updated",
+		"artifact_id": artifact.ID,
+		"artifact":    meta.Title,
+		"heading":     refinement.Heading,
+	}, nil
+}

--- a/internal/web/chat_items_test.go
+++ b/internal/web/chat_items_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
@@ -33,9 +34,14 @@ func TestParseInlineItemIntent(t *testing.T) {
 		wantActor  string
 		wantWhen   string
 		wantCount  int
+		wantKind   string
 	}{
 		{text: "idea: better swipe triage", wantAction: "capture_idea"},
 		{text: "new idea: add a review inbox", wantAction: "capture_idea"},
+		{text: "expand this idea", wantAction: "refine_idea_note", wantKind: "expand"},
+		{text: "add pros and cons", wantAction: "refine_idea_note", wantKind: "pros_cons"},
+		{text: "compare alternatives", wantAction: "refine_idea_note", wantKind: "alternatives"},
+		{text: "outline an implementation", wantAction: "refine_idea_note", wantKind: "implementation"},
 		{text: "make this an item", wantAction: "make_item"},
 		{text: "delegate this to Codex", wantAction: "delegate_item", wantActor: "Codex"},
 		{text: "remind me tomorrow", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
@@ -60,6 +66,9 @@ func TestParseInlineItemIntent(t *testing.T) {
 			}
 			if tc.wantCount != 0 && systemActionSplitCount(action.Params) != tc.wantCount {
 				t.Fatalf("count = %d, want %d", systemActionSplitCount(action.Params), tc.wantCount)
+			}
+			if tc.wantKind != "" && systemActionStringParam(action.Params, "kind") != tc.wantKind {
+				t.Fatalf("kind = %q, want %q", systemActionStringParam(action.Params, "kind"), tc.wantKind)
 			}
 		})
 	}
@@ -287,13 +296,24 @@ func TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput(
 	if artifact.Kind != store.ArtifactKindIdeaNote {
 		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindIdeaNote)
 	}
-	if artifact.MetaJSON == nil || !containsAll(
-		*artifact.MetaJSON,
-		`"capture_mode":"voice"`,
-		`"transcript":"better swipe triage for waiting items. Capture the blockers too."`,
-		`"title":"Better swipe triage for waiting items."`,
-	) {
+	if artifact.MetaJSON == nil {
 		t.Fatalf("artifact meta_json = %v", artifact.MetaJSON)
+	}
+	meta := parseIdeaNoteMeta(artifact.MetaJSON, ideaNoteString(artifact.Title))
+	if meta.CaptureMode != chatInputModeVoice {
+		t.Fatalf("capture_mode = %q, want %q", meta.CaptureMode, chatInputModeVoice)
+	}
+	if meta.Transcript != "better swipe triage for waiting items. Capture the blockers too." {
+		t.Fatalf("transcript = %q", meta.Transcript)
+	}
+	if meta.Title != "Better swipe triage for waiting items." {
+		t.Fatalf("title = %q", meta.Title)
+	}
+	if meta.Workspace != "Default" {
+		t.Fatalf("workspace = %q, want Default", meta.Workspace)
+	}
+	if len(meta.Notes) != 1 || meta.Notes[0] != meta.Transcript {
+		t.Fatalf("notes = %#v", meta.Notes)
 	}
 }
 
@@ -333,6 +353,94 @@ func TestRunAssistantTurnCaptureIdeaPersistsAssistantConfirmation(t *testing.T) 
 	}
 	if !foundAssistant {
 		t.Fatalf("expected assistant confirmation in chat history, got %#v", messages)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionRefineIdeaUpdatesArtifactAndCanvas(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	if _, err := app.store.CreateWorkspace("Default", project.RootPath); err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	if _, _, handled := app.classifyAndExecuteSystemAction(
+		context.Background(),
+		session.ID,
+		session,
+		"idea: better swipe triage for waiting items. Capture the blockers too.",
+	); !handled {
+		t.Fatal("expected idea capture to be handled")
+	}
+
+	item := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if item.ArtifactID == nil {
+		t.Fatal("expected captured idea artifact")
+	}
+	artifact, err := app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: ideaNoteString(artifact.Title),
+		artifactKind:  "text_artifact",
+		artifactText:  renderIdeaNoteMarkdown(parseIdeaNoteMeta(artifact.MetaJSON, ideaNoteString(artifact.Title))),
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port := serverPort(t, server.Listener.Addr())
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "add pros and cons")
+	if !handled {
+		t.Fatal("expected idea refinement to be handled")
+	}
+	if message != "Updated idea note with Pros and Cons." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "artifact_updated" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	updatedArtifact, err := app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() updated error: %v", err)
+	}
+	meta := parseIdeaNoteMeta(updatedArtifact.MetaJSON, ideaNoteString(updatedArtifact.Title))
+	if len(meta.Refinements) != 1 {
+		t.Fatalf("refinements len = %d, want 1", len(meta.Refinements))
+	}
+	if meta.Refinements[0].Heading != "Pros and Cons" {
+		t.Fatalf("heading = %q, want %q", meta.Refinements[0].Heading, "Pros and Cons")
+	}
+	if !strings.Contains(mock.lastShownContent, "## Pros and Cons") {
+		t.Fatalf("canvas content = %q", mock.lastShownContent)
+	}
+
+	if _, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "outline an implementation"); !handled {
+		t.Fatal("expected second idea refinement to be handled")
+	}
+	updatedArtifact, err = app.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() second update error: %v", err)
+	}
+	meta = parseIdeaNoteMeta(updatedArtifact.MetaJSON, ideaNoteString(updatedArtifact.Title))
+	if len(meta.Refinements) != 2 {
+		raw, _ := json.Marshal(meta)
+		t.Fatalf("refinements len = %d, want 2: %s", len(meta.Refinements), raw)
+	}
+	if !strings.Contains(mock.lastShownContent, "## Implementation Outline") {
+		t.Fatalf("canvas content = %q", mock.lastShownContent)
 	}
 }
 

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -3360,9 +3360,64 @@ function parseSidebarArtifactMeta(raw) {
   }
 }
 
+function ideaRefinementHeading(entry) {
+  const explicit = String(entry?.heading || '').trim();
+  if (explicit) return explicit;
+  const kind = String(entry?.kind || '').trim().toLowerCase();
+  if (kind === 'expand') return 'Expansion';
+  if (kind === 'pros_cons') return 'Pros and Cons';
+  if (kind === 'alternatives') return 'Alternatives';
+  if (kind === 'implementation') return 'Implementation Outline';
+  return 'Idea Notes';
+}
+
+function buildIdeaNoteMarkdown(title, artifactMeta) {
+  const noteTitle = String(artifactMeta?.title || title || 'Idea').trim() || 'Idea';
+  const notes = Array.isArray(artifactMeta?.notes)
+    ? artifactMeta.notes.map((entry) => String(entry || '').trim()).filter(Boolean)
+    : [];
+  const transcript = String(artifactMeta?.transcript || '').trim();
+  if (notes.length === 0 && transcript) {
+    notes.push(transcript);
+  }
+  const detail = [
+    `# ${noteTitle}`,
+    '',
+    '## Notes',
+  ];
+  if (notes.length > 0) {
+    notes.forEach((note) => {
+      detail.push(`- ${note}`);
+    });
+  } else {
+    detail.push('- No notes yet.');
+  }
+  detail.push('', '## Context');
+  const captureMode = String(artifactMeta?.capture_mode || '').trim();
+  if (captureMode) detail.push(`- Captured: ${captureMode}`);
+  const workspace = String(artifactMeta?.workspace || '').trim();
+  if (workspace) detail.push(`- Workspace: ${workspace}`);
+  const capturedAt = String(artifactMeta?.captured_at || '').trim();
+  if (capturedAt) detail.push(`- Date: ${capturedAt}`);
+  if (detail[detail.length - 1] === '## Context') {
+    detail.push('- Date: unavailable');
+  }
+  const refinements = Array.isArray(artifactMeta?.refinements) ? artifactMeta.refinements : [];
+  refinements.forEach((entry) => {
+    const body = String(entry?.body || '').trim();
+    if (!body) return;
+    detail.push('', `## ${ideaRefinementHeading(entry)}`, '', body);
+  });
+  return detail.join('\n');
+}
+
 function buildSidebarItemFallbackText(item, artifact = null) {
   const artifactMeta = parseSidebarArtifactMeta(artifact?.meta_json || '');
   const title = String(artifact?.title || item?.artifact_title || item?.title || 'Item').trim() || 'Item';
+  const artifactKind = String(artifact?.kind || item?.artifact_kind || '').trim().toLowerCase();
+  if (artifactKind === 'idea_note') {
+    return buildIdeaNoteMarkdown(title, artifactMeta);
+  }
   const detail = [
     `# ${title}`,
     '',

--- a/internal/web/static/capture.js
+++ b/internal/web/static/capture.js
@@ -335,11 +335,16 @@
     if (!title) {
       throw new Error('Transcription was empty after cleanup. Retry this memo.');
     }
+    const capturedAt = new Date().toISOString();
     const artifactPayload = await postJSON('./api/artifacts', {
       kind: 'idea_note',
       title,
       meta_json: JSON.stringify({
+        title,
         transcript,
+        capture_mode: 'voice',
+        captured_at: capturedAt,
+        notes: [transcript],
         source: 'capture_stt',
       }),
     });

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -40,9 +40,10 @@ test.describe('capture page', () => {
     expect(artifactRequests).toHaveLength(1);
     expect(artifactRequests[0].kind).toBe('idea_note');
     expect(artifactRequests[0].title).toBe('Voice memo from capture harness.');
-    expect(JSON.parse(String(artifactRequests[0].meta_json)).transcript).toBe(
-      'Voice memo from capture harness. Follow up tomorrow morning.',
-    );
+    const meta = JSON.parse(String(artifactRequests[0].meta_json));
+    expect(meta.transcript).toBe('Voice memo from capture harness. Follow up tomorrow morning.');
+    expect(meta.capture_mode).toBe('voice');
+    expect(meta.notes).toEqual(['Voice memo from capture harness. Follow up tomorrow morning.']);
 
     const itemRequests = await page.evaluate(() => (window as any).__captureRequests);
     expect(itemRequests).toHaveLength(1);

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -424,7 +424,12 @@
         kind: 'idea_note',
         title: 'Parser cleanup plan',
         meta_json: JSON.stringify({
+          title: 'Parser cleanup plan',
           transcript: 'Break parser cleanup into a small refactor, a test pass, and one cleanup issue.',
+          capture_mode: 'voice',
+          captured_at: '2026-03-08T09:40:00Z',
+          workspace: 'Default',
+          notes: ['Break parser cleanup into a small refactor, a test pass, and one cleanup issue.'],
         }),
       },
       502: {

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -126,6 +126,19 @@ test.describe('inbox triage interactions', () => {
     await expect(page.locator('#canvas-text')).toContainText('Break parser cleanup into a small refactor');
   });
 
+  test('idea items open as structured idea notes on canvas', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+
+    await page.locator('#pr-file-list .pr-file-item[data-item-id="101"]').click();
+
+    await expect(page.locator('#canvas-text')).toContainText('Parser cleanup plan');
+    await expect(page.locator('#canvas-text')).toContainText('Notes');
+    await expect(page.locator('#canvas-text')).toContainText('Context');
+    await expect(page.locator('#canvas-text')).toContainText('Workspace: Default');
+  });
+
   test('touch gestures expose feedback and commit done, delete, delegate, and later', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitReady(page);


### PR DESCRIPTION
## Summary
- store `idea_note` artifacts as structured note metadata and render them as structured markdown on canvas
- add local idea-note refinement actions for `expand this idea`, `add pros and cons`, `compare alternatives`, and `outline an implementation`
- keep existing artifact-editor and pen annotation flows working for the updated idea-note surface

## Verification
- Structured markdown artifact on capture:
  `go test ./internal/web -run "TestParseInlineItemIntent|TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput|TestClassifyAndExecuteSystemActionRefineIdeaUpdatesArtifactAndCanvas"`
  Output: `ok   github.com/krystophny/tabura/internal/web 0.024s`
  Evidence: `TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput` verifies `title`, `notes`, `capture_mode`, `workspace`, and transcript are stored in the `idea_note` metadata.
- Opening an idea item shows the structured artifact on canvas:
  `npx playwright test tests/playwright/inbox-triage.spec.ts -g "idea items open as structured idea notes on canvas"`
  Output: `1 passed`
  Evidence: the canvas contains `Parser cleanup plan`, `Notes`, `Context`, and `Workspace: Default`.
- Dialogue can expand, analyze, and refine the note, and refinements append instead of replacing:
  `go test ./internal/web -run "TestParseInlineItemIntent|TestClassifyAndExecuteSystemActionCaptureIdeaCreatesInboxItemFromUserInput|TestClassifyAndExecuteSystemActionRefineIdeaUpdatesArtifactAndCanvas"`
  Output: `ok   github.com/krystophny/tabura/internal/web 0.024s`
  Evidence: `TestClassifyAndExecuteSystemActionRefineIdeaUpdatesArtifactAndCanvas` appends `Pros and Cons` and then `Implementation Outline`, verifies two stored refinements, and verifies the refreshed canvas content includes the appended sections.
- Updated idea notes remain editable on canvas:
  `npx playwright test tests/playwright/artifact-context.spec.ts -g "right-click on artifact opens artifact editor"`
  Output: `1 passed`
  Evidence: right-clicking the canvas artifact opens `#artifact-editor`.
- Updated idea notes remain annotatable with pen:
  `npx playwright test tests/playwright/canvas.spec.ts -g "pen stroke shows submit controls and submits ink artifact flow"`
  Output: `1 passed`
  Evidence: the test submits ink through `#ink-submit` and verifies the generated artifact image flow.
- Voice memo idea notes use the same structured metadata shape:
  `npx playwright test tests/playwright/capture.spec.ts -g "transcribes a voice memo and saves an artifact-backed inbox item"`
  Output: `1 passed`
  Evidence: the captured `idea_note` now carries `transcript`, `capture_mode: voice`, and `notes`.
