### PR TITLE
fix: Add idea promotion to work items and GitHub issues (fixes #211)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,13 +31,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
+For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -292,6 +292,10 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.captureIdeaItem(session, action)
 	case "refine_idea_note":
 		return a.refineConversationIdea(session, action)
+	case "promote_idea":
+		return a.previewIdeaPromotion(session, action)
+	case "apply_idea_promotion":
+		return a.applyIdeaPromotion(session, action)
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
 	case "link_workspace_artifact":

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -65,6 +65,12 @@ func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode st
 	if ideaRefinement := parseInlineIdeaRefinementIntent(text); ideaRefinement != nil {
 		return ideaRefinement
 	}
+	if ideaPromotion := parseInlineIdeaPromotionIntent(text); ideaPromotion != nil {
+		return ideaPromotion
+	}
+	if ideaPromotionApply := parseInlineIdeaPromotionApplyIntent(text); ideaPromotionApply != nil {
+		return ideaPromotionApply
+	}
 	switch normalized {
 	case "make this an item", "track this", "add to inbox":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
@@ -224,7 +230,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return true
 	default:
 		return false
@@ -239,6 +245,10 @@ func itemActionFailurePrefix(action string) string {
 		return "I couldn't capture the idea: "
 	case "refine_idea_note":
 		return "I couldn't update the idea note: "
+	case "promote_idea":
+		return "I couldn't prepare the idea promotion: "
+	case "apply_idea_promotion":
+		return "I couldn't promote the idea: "
 	case "print_item":
 		return "I couldn't prepare the print view: "
 	case "review_someday":

--- a/internal/web/chat_items_idea.go
+++ b/internal/web/chat_items_idea.go
@@ -11,13 +11,15 @@ import (
 )
 
 type ideaNoteMeta struct {
-	Title       string               `json:"title,omitempty"`
-	Transcript  string               `json:"transcript,omitempty"`
-	CaptureMode string               `json:"capture_mode,omitempty"`
-	CapturedAt  string               `json:"captured_at,omitempty"`
-	Workspace   string               `json:"workspace,omitempty"`
-	Notes       []string             `json:"notes,omitempty"`
-	Refinements []ideaNoteRefinement `json:"refinements,omitempty"`
+	Title            string                `json:"title,omitempty"`
+	Transcript       string                `json:"transcript,omitempty"`
+	CaptureMode      string                `json:"capture_mode,omitempty"`
+	CapturedAt       string                `json:"captured_at,omitempty"`
+	Workspace        string                `json:"workspace,omitempty"`
+	Notes            []string              `json:"notes,omitempty"`
+	Refinements      []ideaNoteRefinement  `json:"refinements,omitempty"`
+	PromotionPreview *ideaPromotionPreview `json:"promotion_preview,omitempty"`
+	Promotions       []ideaPromotionRecord `json:"promotions,omitempty"`
 }
 
 type ideaNoteRefinement struct {
@@ -26,6 +28,31 @@ type ideaNoteRefinement struct {
 	Prompt    string `json:"prompt,omitempty"`
 	Body      string `json:"body,omitempty"`
 	RefinedAt string `json:"refined_at,omitempty"`
+}
+
+type ideaPromotionPreview struct {
+	Target     string                   `json:"target,omitempty"`
+	CreatedAt  string                   `json:"created_at,omitempty"`
+	Candidates []ideaPromotionCandidate `json:"candidates,omitempty"`
+	Issue      *ideaPromotionIssueDraft `json:"issue,omitempty"`
+}
+
+type ideaPromotionCandidate struct {
+	Index   int    `json:"index,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
+type ideaPromotionIssueDraft struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+type ideaPromotionRecord struct {
+	Target    string   `json:"target,omitempty"`
+	CreatedAt string   `json:"created_at,omitempty"`
+	Count     int      `json:"count,omitempty"`
+	Refs      []string `json:"refs,omitempty"`
 }
 
 func ideaNoteString(value *string) string {
@@ -94,6 +121,8 @@ func parseIdeaNoteMeta(metaJSON *string, fallbackTitle string) ideaNoteMeta {
 		out = append(out, refinement)
 	}
 	meta.Refinements = out
+	meta.PromotionPreview = normalizeIdeaPromotionPreview(meta.PromotionPreview)
+	meta.Promotions = normalizeIdeaPromotionRecords(meta.Promotions)
 	return meta
 }
 
@@ -115,6 +144,8 @@ func parseIdeaNoteMetaPtr(meta ideaNoteMeta) ideaNoteMeta {
 	normalized.Workspace = meta.Workspace
 	normalized.Notes = meta.Notes
 	normalized.Refinements = meta.Refinements
+	normalized.PromotionPreview = meta.PromotionPreview
+	normalized.Promotions = meta.Promotions
 	return parseIdeaNoteMeta(mustJSONString(normalized), normalized.Title)
 }
 
@@ -144,6 +175,82 @@ func normalizeIdeaNoteLines(lines []string) []string {
 		}
 		seen[clean] = struct{}{}
 		out = append(out, clean)
+	}
+	return out
+}
+
+func normalizeIdeaPromotionPreview(preview *ideaPromotionPreview) *ideaPromotionPreview {
+	if preview == nil {
+		return nil
+	}
+	normalized := &ideaPromotionPreview{
+		Target:    normalizeIdeaPromotionTarget(preview.Target),
+		CreatedAt: strings.TrimSpace(preview.CreatedAt),
+	}
+	for _, candidate := range preview.Candidates {
+		title := strings.TrimSpace(candidate.Title)
+		details := strings.TrimSpace(candidate.Details)
+		if title == "" {
+			continue
+		}
+		index := candidate.Index
+		if index <= 0 {
+			index = len(normalized.Candidates) + 1
+		}
+		normalized.Candidates = append(normalized.Candidates, ideaPromotionCandidate{
+			Index:   index,
+			Title:   title,
+			Details: details,
+		})
+	}
+	if preview.Issue != nil {
+		title := strings.TrimSpace(preview.Issue.Title)
+		body := strings.TrimSpace(preview.Issue.Body)
+		if title != "" || body != "" {
+			normalized.Issue = &ideaPromotionIssueDraft{
+				Title: title,
+				Body:  body,
+			}
+		}
+	}
+	if normalized.Target == "" {
+		return nil
+	}
+	if normalized.Target == ideaPromotionTargetGitHub && normalized.Issue == nil {
+		return nil
+	}
+	if normalized.Target != ideaPromotionTargetGitHub && len(normalized.Candidates) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeIdeaPromotionRecords(records []ideaPromotionRecord) []ideaPromotionRecord {
+	if len(records) == 0 {
+		return nil
+	}
+	out := make([]ideaPromotionRecord, 0, len(records))
+	for _, record := range records {
+		target := normalizeIdeaPromotionTarget(record.Target)
+		if target == "" {
+			continue
+		}
+		refs := make([]string, 0, len(record.Refs))
+		for _, ref := range record.Refs {
+			clean := strings.TrimSpace(ref)
+			if clean != "" {
+				refs = append(refs, clean)
+			}
+		}
+		out = append(out, ideaPromotionRecord{
+			Target:    target,
+			CreatedAt: strings.TrimSpace(record.CreatedAt),
+			Count:     record.Count,
+			Refs:      refs,
+		})
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -192,7 +299,75 @@ func renderIdeaNoteMarkdown(meta ideaNoteMeta) string {
 		}
 		fmt.Fprintf(&b, "\n## %s\n\n%s\n", heading, body)
 	}
+	appendIdeaPromotionPreviewMarkdown(&b, meta.PromotionPreview)
+	appendIdeaPromotionHistoryMarkdown(&b, meta.Promotions)
 	return strings.TrimSpace(b.String())
+}
+
+func appendIdeaPromotionPreviewMarkdown(b *strings.Builder, preview *ideaPromotionPreview) {
+	preview = normalizeIdeaPromotionPreview(preview)
+	if preview == nil {
+		return
+	}
+	b.WriteString("\n\n## Promotion Review\n\n")
+	switch preview.Target {
+	case ideaPromotionTargetTask:
+		b.WriteString("- Pending: task draft\n")
+		b.WriteString("- Confirm with: `create this idea task`\n")
+	case ideaPromotionTargetItems:
+		b.WriteString("- Pending: item proposals\n")
+		b.WriteString("- Confirm with: `create these idea items` or `create selected idea items 1,2`\n")
+	case ideaPromotionTargetGitHub:
+		b.WriteString("- Pending: GitHub issue draft\n")
+		b.WriteString("- Confirm with: `create this idea GitHub issue`\n")
+	}
+	b.WriteString("- Optional: add `and mark this idea done` or `and keep this idea`\n")
+	switch preview.Target {
+	case ideaPromotionTargetTask, ideaPromotionTargetItems:
+		for _, candidate := range preview.Candidates {
+			fmt.Fprintf(b, "\n### %d. %s\n", candidate.Index, candidate.Title)
+			if candidate.Details != "" {
+				fmt.Fprintf(b, "\n%s\n", candidate.Details)
+			}
+		}
+	case ideaPromotionTargetGitHub:
+		if preview.Issue != nil {
+			fmt.Fprintf(b, "\n### %s\n", preview.Issue.Title)
+			if preview.Issue.Body != "" {
+				fmt.Fprintf(b, "\n%s\n", preview.Issue.Body)
+			}
+		}
+	}
+}
+
+func appendIdeaPromotionHistoryMarkdown(b *strings.Builder, records []ideaPromotionRecord) {
+	records = normalizeIdeaPromotionRecords(records)
+	if len(records) == 0 {
+		return
+	}
+	b.WriteString("\n\n## Promotions\n")
+	for _, record := range records {
+		label := record.Target
+		switch record.Target {
+		case ideaPromotionTargetTask:
+			label = "task"
+		case ideaPromotionTargetItems:
+			label = "items"
+		case ideaPromotionTargetGitHub:
+			label = "GitHub issue"
+		}
+		line := fmt.Sprintf("- %s", label)
+		if record.Count > 0 {
+			line += fmt.Sprintf(" x%d", record.Count)
+		}
+		if record.CreatedAt != "" {
+			line += fmt.Sprintf(" on %s", record.CreatedAt)
+		}
+		if len(record.Refs) > 0 {
+			line += fmt.Sprintf(" [%s]", strings.Join(record.Refs, ", "))
+		}
+		b.WriteString(line + "\n")
+	}
 }
 
 func parseInlineIdeaRefinementIntent(text string) *SystemAction {

--- a/internal/web/chat_items_idea_promotion.go
+++ b/internal/web/chat_items_idea_promotion.go
@@ -1,0 +1,615 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	ideaPromotionTargetTask   = "task"
+	ideaPromotionTargetItems  = "items"
+	ideaPromotionTargetGitHub = "github"
+
+	ideaPromotionDispositionKeep    = "keep"
+	ideaPromotionDispositionDone    = "done"
+	ideaPromotionDispositionSomeday = "someday"
+)
+
+var (
+	ideaPromotionSelectionPattern = regexp.MustCompile(`(?i)\b(?:selected|items?)\s+([0-9][0-9,\s]*)`)
+	ideaPromotionActionVerbSet    = map[string]struct{}{
+		"add": {}, "break": {}, "build": {}, "capture": {}, "clarify": {}, "create": {}, "define": {},
+		"document": {}, "draft": {}, "explore": {}, "file": {}, "fix": {}, "implement": {}, "investigate": {},
+		"outline": {}, "plan": {}, "prepare": {}, "prototype": {}, "refactor": {}, "review": {}, "ship": {},
+		"split": {}, "test": {}, "write": {},
+	}
+)
+
+type activeIdeaNoteContext struct {
+	Item     store.Item
+	Artifact store.Artifact
+	Meta     ideaNoteMeta
+}
+
+func normalizeIdeaPromotionTarget(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case ideaPromotionTargetTask, "single_task", "single-item", "single_item", "item":
+		return ideaPromotionTargetTask
+	case ideaPromotionTargetItems, "tasks":
+		return ideaPromotionTargetItems
+	case ideaPromotionTargetGitHub, "github_issue", "github issue", "issue":
+		return ideaPromotionTargetGitHub
+	default:
+		return ""
+	}
+}
+
+func normalizeIdeaPromotionDisposition(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", ideaPromotionDispositionKeep:
+		return ideaPromotionDispositionKeep
+	case ideaPromotionDispositionDone:
+		return ideaPromotionDispositionDone
+	case ideaPromotionDispositionSomeday:
+		return ideaPromotionDispositionSomeday
+	default:
+		return ""
+	}
+}
+
+func parseInlineIdeaPromotionIntent(text string) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	if normalized == "" {
+		return nil
+	}
+	target := ""
+	switch {
+	case normalized == "make this actionable" || normalized == "turn this idea into a task" || normalized == "turn this idea into an item":
+		target = ideaPromotionTargetTask
+	case normalized == "turn this idea into items" || normalized == "turn this idea into tasks" || normalized == "split this idea into tasks" || normalized == "split this into tasks" || normalized == "break this down":
+		target = ideaPromotionTargetItems
+	case normalized == "create a github issue from this idea" || normalized == "file this idea as a github issue":
+		target = ideaPromotionTargetGitHub
+	}
+	if target == "" {
+		return nil
+	}
+	return &SystemAction{
+		Action: "promote_idea",
+		Params: map[string]interface{}{"target": target},
+	}
+}
+
+func parseInlineIdeaPromotionApplyIntent(text string) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	if normalized == "" {
+		return nil
+	}
+	target := ""
+	switch {
+	case strings.HasPrefix(normalized, "create this idea task"):
+		target = ideaPromotionTargetTask
+	case strings.HasPrefix(normalized, "create these idea items"), strings.HasPrefix(normalized, "create selected idea items"), strings.HasPrefix(normalized, "create idea items"):
+		target = ideaPromotionTargetItems
+	case strings.HasPrefix(normalized, "create this idea github issue"):
+		target = ideaPromotionTargetGitHub
+	}
+	if target == "" {
+		return nil
+	}
+	params := map[string]interface{}{
+		"target":      target,
+		"disposition": ideaPromotionDispositionFromText(normalized),
+	}
+	if selection := parseIdeaPromotionSelection(normalized); len(selection) > 0 {
+		values := make([]interface{}, 0, len(selection))
+		for _, index := range selection {
+			values = append(values, index)
+		}
+		params["selected"] = values
+	}
+	return &SystemAction{
+		Action: "apply_idea_promotion",
+		Params: params,
+	}
+}
+
+func ideaPromotionDispositionFromText(normalized string) string {
+	switch {
+	case strings.Contains(normalized, "mark this idea done"), strings.Contains(normalized, "mark it done"), strings.Contains(normalized, "mark idea done"):
+		return ideaPromotionDispositionDone
+	case strings.Contains(normalized, "move this idea to someday"), strings.Contains(normalized, "send this idea to someday"):
+		return ideaPromotionDispositionSomeday
+	case strings.Contains(normalized, "keep this idea"), strings.Contains(normalized, "keep it"):
+		return ideaPromotionDispositionKeep
+	default:
+		return ideaPromotionDispositionKeep
+	}
+}
+
+func parseIdeaPromotionSelection(normalized string) []int {
+	match := ideaPromotionSelectionPattern.FindStringSubmatch(normalized)
+	if len(match) != 2 {
+		return nil
+	}
+	parts := strings.Split(match[1], ",")
+	out := make([]int, 0, len(parts))
+	seen := map[int]struct{}{}
+	for _, part := range parts {
+		value, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || value <= 0 {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func ideaPromotionSourceRef(ideaItemID int64, index int) string {
+	return fmt.Sprintf("idea-%d:%d", ideaItemID, index)
+}
+
+func splitIdeaPromotionSegments(raw string) []string {
+	text := strings.ReplaceAll(raw, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(rawLine, ""))
+		if line == "" {
+			continue
+		}
+		start := 0
+		for i, r := range line {
+			switch r {
+			case '.', ';':
+				segment := strings.TrimSpace(line[start:i])
+				if segment != "" {
+					out = append(out, segment)
+				}
+				start = i + 1
+			}
+		}
+		if tail := strings.TrimSpace(line[start:]); tail != "" {
+			out = append(out, tail)
+		}
+	}
+	return out
+}
+
+func looksLikeIdeaPromotionAction(segment string) bool {
+	words := strings.Fields(strings.ToLower(strings.TrimSpace(segment)))
+	if len(words) == 0 {
+		return false
+	}
+	_, ok := ideaPromotionActionVerbSet[words[0]]
+	return ok
+}
+
+func normalizeIdeaPromotionTitle(raw string) string {
+	title := strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(raw, ""))
+	title = strings.Trim(title, " \t\r\n-:;,.!?")
+	if strings.HasPrefix(strings.ToLower(title), "to ") {
+		title = strings.TrimSpace(title[3:])
+	}
+	title = strings.Join(strings.Fields(title), " ")
+	if title == "" {
+		return ""
+	}
+	runes := []rune(title)
+	first := strings.ToUpper(string(runes[0]))
+	if len(runes) == 1 {
+		return first
+	}
+	return first + string(runes[1:])
+}
+
+func buildIdeaPromotionCandidates(meta ideaNoteMeta) []ideaPromotionCandidate {
+	lines := append([]string{}, meta.Notes...)
+	for _, refinement := range meta.Refinements {
+		lines = append(lines, refinement.Body)
+	}
+	candidates := make([]ideaPromotionCandidate, 0, len(lines))
+	seen := map[string]struct{}{}
+	for _, line := range lines {
+		for _, segment := range splitIdeaPromotionSegments(line) {
+			if !looksLikeIdeaPromotionAction(segment) {
+				continue
+			}
+			title := normalizeIdeaPromotionTitle(segment)
+			if title == "" {
+				continue
+			}
+			key := strings.ToLower(title)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, ideaPromotionCandidate{
+				Index:   len(candidates) + 1,
+				Title:   title,
+				Details: strings.TrimSpace(segment),
+			})
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates
+	}
+	title := normalizeIdeaPromotionTitle(meta.Title)
+	if title == "" {
+		title = "Explore this idea"
+	}
+	if !looksLikeIdeaPromotionAction(title) {
+		title = "Prototype " + title
+	}
+	return []ideaPromotionCandidate{{
+		Index:   1,
+		Title:   title,
+		Details: strings.TrimSpace(meta.Transcript),
+	}}
+}
+
+func buildIdeaPromotionIssueDraft(meta ideaNoteMeta) *ideaPromotionIssueDraft {
+	title := strings.TrimSpace(meta.Title)
+	if title == "" {
+		title = "Idea follow-up"
+	}
+	lines := []string{
+		"## Idea",
+	}
+	if meta.Transcript != "" {
+		lines = append(lines, "", meta.Transcript)
+	}
+	if len(meta.Notes) > 0 {
+		lines = append(lines, "", "## Notes", "")
+		for _, note := range meta.Notes {
+			lines = append(lines, "- "+note)
+		}
+	}
+	for _, refinement := range meta.Refinements {
+		body := strings.TrimSpace(refinement.Body)
+		if body == "" {
+			continue
+		}
+		heading := strings.TrimSpace(refinement.Heading)
+		if heading == "" {
+			heading = ideaRefinementHeading(refinement.Kind)
+		}
+		lines = append(lines, "", "## "+heading, "", body)
+	}
+	body := strings.TrimSpace(strings.Join(lines, "\n"))
+	if body == "" {
+		body = title
+	}
+	return &ideaPromotionIssueDraft{
+		Title: title,
+		Body:  body,
+	}
+}
+
+func findItemByArtifactAndSource(items []store.Item, artifactID int64, source string) *store.Item {
+	for _, item := range items {
+		if item.ArtifactID == nil || *item.ArtifactID != artifactID {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(stringFromPointer(item.Source)), source) {
+			continue
+		}
+		candidate := item
+		return &candidate
+	}
+	return nil
+}
+
+func (a *App) findIdeaNoteItem(artifactID int64) (*store.Item, error) {
+	for _, state := range []string{
+		store.ItemStateInbox,
+		store.ItemStateWaiting,
+		store.ItemStateSomeday,
+		store.ItemStateDone,
+	} {
+		items, err := a.store.ListItemsByState(state)
+		if err != nil {
+			return nil, err
+		}
+		if item := findItemByArtifactAndSource(items, artifactID, "idea"); item != nil {
+			return item, nil
+		}
+	}
+	return nil, nil
+}
+
+func (a *App) resolveActiveIdeaNoteContext(session store.ChatSession) (*activeIdeaNoteContext, error) {
+	artifact, err := a.resolveActiveIdeaNoteArtifact(session.ProjectKey)
+	if err != nil {
+		return nil, err
+	}
+	item, err := a.findIdeaNoteItem(artifact.ID)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		return nil, errors.New("idea note is not linked to an item")
+	}
+	return &activeIdeaNoteContext{
+		Item:     *item,
+		Artifact: *artifact,
+		Meta:     parseIdeaNoteMeta(artifact.MetaJSON, ideaNoteString(artifact.Title)),
+	}, nil
+}
+
+func ideaPromotionSelectionFromParams(params map[string]interface{}) []int {
+	raw, ok := params["selected"]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []int:
+		return typed
+	case []interface{}:
+		out := make([]int, 0, len(typed))
+		seen := map[int]struct{}{}
+		for _, entry := range typed {
+			value, err := strconv.Atoi(strings.TrimSpace(fmt.Sprint(entry)))
+			if err != nil || value <= 0 {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			out = append(out, value)
+		}
+		sort.Ints(out)
+		return out
+	default:
+		value, err := strconv.Atoi(strings.TrimSpace(fmt.Sprint(typed)))
+		if err != nil || value <= 0 {
+			return nil
+		}
+		return []int{value}
+	}
+}
+
+func selectIdeaPromotionCandidates(candidates []ideaPromotionCandidate, selected []int) ([]ideaPromotionCandidate, error) {
+	if len(candidates) == 0 {
+		return nil, errors.New("idea promotion preview has no candidates")
+	}
+	if len(selected) == 0 {
+		return candidates, nil
+	}
+	byIndex := make(map[int]ideaPromotionCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byIndex[candidate.Index] = candidate
+	}
+	out := make([]ideaPromotionCandidate, 0, len(selected))
+	for _, index := range selected {
+		candidate, ok := byIndex[index]
+		if !ok {
+			return nil, fmt.Errorf("idea proposal %d is not available", index)
+		}
+		out = append(out, candidate)
+	}
+	return out, nil
+}
+
+func (a *App) persistIdeaNoteMeta(session store.ChatSession, artifact store.Artifact, meta ideaNoteMeta) error {
+	metaJSON, err := encodeIdeaNoteMeta(meta)
+	if err != nil {
+		return err
+	}
+	if err := a.store.UpdateArtifact(artifact.ID, store.ArtifactUpdate{MetaJSON: metaJSON}); err != nil {
+		return err
+	}
+	return a.renderIdeaNoteOnCanvas(session.ProjectKey, meta.Title, meta)
+}
+
+func (a *App) previewIdeaPromotion(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	ctx, err := a.resolveActiveIdeaNoteContext(session)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(ctx.Meta.Promotions) > 0 {
+		return "", nil, errors.New("idea has already been promoted")
+	}
+	target := normalizeIdeaPromotionTarget(systemActionStringParam(action.Params, "target"))
+	if target == "" {
+		return "", nil, errors.New("idea promotion target is required")
+	}
+	preview := &ideaPromotionPreview{
+		Target:    target,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	switch target {
+	case ideaPromotionTargetTask:
+		candidates := buildIdeaPromotionCandidates(ctx.Meta)
+		preview.Candidates = []ideaPromotionCandidate{candidates[0]}
+	case ideaPromotionTargetItems:
+		preview.Candidates = buildIdeaPromotionCandidates(ctx.Meta)
+	case ideaPromotionTargetGitHub:
+		preview.Issue = buildIdeaPromotionIssueDraft(ctx.Meta)
+	default:
+		return "", nil, errors.New("unsupported idea promotion target")
+	}
+	ctx.Meta.PromotionPreview = preview
+	if err := a.persistIdeaNoteMeta(session, ctx.Artifact, ctx.Meta); err != nil {
+		return "", nil, err
+	}
+	message := ""
+	switch target {
+	case ideaPromotionTargetTask:
+		message = `Drafted a task promotion on canvas. Say "create this idea task" to confirm.`
+	case ideaPromotionTargetItems:
+		message = `Drafted idea item proposals on canvas. Say "create these idea items" or "create selected idea items 1,2" to confirm.`
+	case ideaPromotionTargetGitHub:
+		message = `Drafted a GitHub issue on canvas. Say "create this idea GitHub issue" to confirm.`
+	}
+	payload := map[string]interface{}{
+		"type":        "idea_promotion_preview",
+		"target":      target,
+		"artifact_id": ctx.Artifact.ID,
+	}
+	if len(preview.Candidates) > 0 {
+		payload["candidate_count"] = len(preview.Candidates)
+	}
+	if preview.Issue != nil {
+		payload["issue_title"] = preview.Issue.Title
+	}
+	return message, payload, nil
+}
+
+func (a *App) applyIdeaPromotionDisposition(itemID int64, disposition string) (string, error) {
+	switch normalizeIdeaPromotionDisposition(disposition) {
+	case ideaPromotionDispositionKeep:
+		item, err := a.store.GetItem(itemID)
+		if err != nil {
+			return "", err
+		}
+		return item.State, nil
+	case ideaPromotionDispositionDone:
+		if err := a.store.TriageItemDone(itemID); err != nil {
+			return "", err
+		}
+	case ideaPromotionDispositionSomeday:
+		if err := a.store.TriageItemSomeday(itemID); err != nil {
+			return "", err
+		}
+	default:
+		return "", errors.New("invalid idea disposition")
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		return "", err
+	}
+	return item.State, nil
+}
+
+func (a *App) applyIdeaPromotion(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	ctx, err := a.resolveActiveIdeaNoteContext(session)
+	if err != nil {
+		return "", nil, err
+	}
+	preview := normalizeIdeaPromotionPreview(ctx.Meta.PromotionPreview)
+	if preview == nil {
+		return "", nil, errors.New("review the promotion on canvas first")
+	}
+	target := normalizeIdeaPromotionTarget(systemActionStringParam(action.Params, "target"))
+	if target == "" {
+		target = preview.Target
+	}
+	if target != preview.Target {
+		return "", nil, fmt.Errorf("active promotion is for %s", preview.Target)
+	}
+
+	disposition := normalizeIdeaPromotionDisposition(systemActionStringParam(action.Params, "disposition"))
+	if disposition == "" {
+		disposition = ideaPromotionDispositionKeep
+	}
+
+	payload := map[string]interface{}{
+		"type":         "idea_promotion_applied",
+		"target":       target,
+		"idea_item_id": ctx.Item.ID,
+	}
+	record := ideaPromotionRecord{
+		Target:    target,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	switch target {
+	case ideaPromotionTargetTask, ideaPromotionTargetItems:
+		selected, err := selectIdeaPromotionCandidates(preview.Candidates, ideaPromotionSelectionFromParams(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		itemIDs := make([]int64, 0, len(selected))
+		refs := make([]string, 0, len(selected))
+		source := "idea"
+		for _, candidate := range selected {
+			sourceRef := ideaPromotionSourceRef(ctx.Item.ID, candidate.Index)
+			item, err := a.store.CreateItem(candidate.Title, store.ItemOptions{
+				WorkspaceID: ctx.Item.WorkspaceID,
+				ArtifactID:  &ctx.Artifact.ID,
+				Source:      &source,
+				SourceRef:   &sourceRef,
+			})
+			if err != nil {
+				return "", nil, err
+			}
+			itemIDs = append(itemIDs, item.ID)
+			refs = append(refs, sourceRef)
+		}
+		payload["created_item_ids"] = itemIDs
+		record.Count = len(itemIDs)
+		record.Refs = refs
+	case ideaPromotionTargetGitHub:
+		if ctx.Item.WorkspaceID == nil {
+			return "", nil, errors.New("idea is not linked to a workspace")
+		}
+		workspace, err := a.store.GetWorkspace(*ctx.Item.WorkspaceID)
+		if err != nil {
+			return "", nil, err
+		}
+		repo, err := a.store.GitHubRepoForWorkspace(workspace.ID)
+		if err != nil {
+			return "", nil, err
+		}
+		if strings.TrimSpace(repo) == "" {
+			return "", nil, errors.New("workspace has no GitHub origin remote")
+		}
+		issue, err := a.createGitHubIssueInWorkspace(
+			workspace.DirPath,
+			preview.Issue.Title,
+			preview.Issue.Body,
+			nil,
+			nil,
+		)
+		if err != nil {
+			return "", nil, err
+		}
+		payload["issue_no"] = issue.Number
+		payload["issue_url"] = strings.TrimSpace(issue.URL)
+		record.Count = 1
+		record.Refs = []string{strings.TrimSpace(issue.URL)}
+	default:
+		return "", nil, errors.New("unsupported idea promotion target")
+	}
+
+	ideaState, err := a.applyIdeaPromotionDisposition(ctx.Item.ID, disposition)
+	if err != nil {
+		return "", nil, err
+	}
+	payload["idea_state"] = ideaState
+	ctx.Meta.PromotionPreview = nil
+	ctx.Meta.Promotions = append(ctx.Meta.Promotions, record)
+	if err := a.persistIdeaNoteMeta(session, ctx.Artifact, ctx.Meta); err != nil {
+		return "", nil, err
+	}
+
+	switch target {
+	case ideaPromotionTargetTask:
+		ids, _ := payload["created_item_ids"].([]int64)
+		if len(ids) == 1 {
+			return "Created 1 task from the idea.", payload, nil
+		}
+		return fmt.Sprintf("Created %d tasks from the idea.", len(ids)), payload, nil
+	case ideaPromotionTargetItems:
+		ids, _ := payload["created_item_ids"].([]int64)
+		return fmt.Sprintf("Created %d items from the idea.", len(ids)), payload, nil
+	case ideaPromotionTargetGitHub:
+		return fmt.Sprintf("Created GitHub issue #%v from the idea: %s", payload["issue_no"], payload["issue_url"]), payload, nil
+	default:
+		return "Applied the idea promotion.", payload, nil
+	}
+}

--- a/internal/web/chat_items_idea_promotion_test.go
+++ b/internal/web/chat_items_idea_promotion_test.go
@@ -1,0 +1,321 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func seedActiveIdeaNote(
+	t *testing.T,
+	app *App,
+	notes []string,
+	refinements []ideaNoteRefinement,
+	withWorkspace bool,
+) (store.Project, store.ChatSession, store.Item, store.Artifact, *canvasMCPMock) {
+	t.Helper()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	var workspaceID *int64
+	workspaceName := ""
+	if withWorkspace {
+		workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+		if err != nil {
+			t.Fatalf("CreateWorkspace() error: %v", err)
+		}
+		workspaceID = &workspace.ID
+		workspaceName = workspace.Name
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	title := "Parser cleanup plan"
+	metaJSON, err := encodeIdeaNoteMeta(ideaNoteMeta{
+		Title:       title,
+		Transcript:  strings.Join(notes, " "),
+		CaptureMode: chatInputModeText,
+		CapturedAt:  "2026-03-08T09:40:00Z",
+		Workspace:   workspaceName,
+		Notes:       notes,
+		Refinements: refinements,
+	})
+	if err != nil {
+		t.Fatalf("encodeIdeaNoteMeta() error: %v", err)
+	}
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindIdeaNote, nil, nil, &title, metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	source := "idea"
+	item, err := app.store.CreateItem(title, store.ItemOptions{
+		WorkspaceID: workspaceID,
+		ArtifactID:  &artifact.ID,
+		Source:      &source,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: title,
+		artifactKind:  "text_artifact",
+		artifactText:  renderIdeaNoteMarkdown(parseIdeaNoteMeta(artifact.MetaJSON, title)),
+	}
+	server := mock.setupServer(t)
+	t.Cleanup(server.Close)
+	port := serverPort(t, server.Listener.Addr())
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	return project, session, item, artifact, mock
+}
+
+func TestParseInlineItemIntentIdeaPromotion(t *testing.T) {
+	now := timeStub()
+	cases := []struct {
+		text            string
+		wantAction      string
+		wantTarget      string
+		wantDisposition string
+		wantSelected    []int
+	}{
+		{text: "make this actionable", wantAction: "promote_idea", wantTarget: ideaPromotionTargetTask},
+		{text: "turn this idea into tasks", wantAction: "promote_idea", wantTarget: ideaPromotionTargetItems},
+		{text: "create this idea GitHub issue", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetGitHub, wantDisposition: ideaPromotionDispositionKeep},
+		{text: "create selected idea items 1, 3 and mark this idea done", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetItems, wantDisposition: ideaPromotionDispositionDone, wantSelected: []int{1, 3}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineItemIntent(tc.text, now)
+			if action == nil {
+				t.Fatal("expected inline idea promotion action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if got := normalizeIdeaPromotionTarget(systemActionStringParam(action.Params, "target")); got != tc.wantTarget {
+				t.Fatalf("target = %q, want %q", got, tc.wantTarget)
+			}
+			if tc.wantDisposition != "" {
+				if got := normalizeIdeaPromotionDisposition(systemActionStringParam(action.Params, "disposition")); got != tc.wantDisposition {
+					t.Fatalf("disposition = %q, want %q", got, tc.wantDisposition)
+				}
+			}
+			if len(tc.wantSelected) > 0 {
+				got := ideaPromotionSelectionFromParams(action.Params)
+				if len(got) != len(tc.wantSelected) {
+					t.Fatalf("selected len = %d, want %d (%v)", len(got), len(tc.wantSelected), got)
+				}
+				for i, want := range tc.wantSelected {
+					if got[i] != want {
+						t.Fatalf("selected[%d] = %d, want %d", i, got[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionPreviewIdeaPromotionRendersReview(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	_, session, _, artifact, mock := seedActiveIdeaNote(t, app, []string{
+		"Draft the rollout checklist",
+		"Add regression coverage",
+		"File the cleanup follow-up",
+	}, nil, true)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "turn this idea into tasks")
+	if !handled {
+		t.Fatal("expected idea promotion preview to be handled")
+	}
+	if message != `Drafted idea item proposals on canvas. Say "create these idea items" or "create selected idea items 1,2" to confirm.` {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "idea_promotion_preview" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := intFromAny(payloads[0]["candidate_count"], 0); got != 3 {
+		t.Fatalf("candidate_count = %d, want 3", got)
+	}
+
+	updatedArtifact, err := app.store.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	meta := parseIdeaNoteMeta(updatedArtifact.MetaJSON, ideaNoteString(updatedArtifact.Title))
+	if meta.PromotionPreview == nil {
+		t.Fatal("expected promotion preview in idea note meta")
+	}
+	if meta.PromotionPreview.Target != ideaPromotionTargetItems {
+		t.Fatalf("preview target = %q, want %q", meta.PromotionPreview.Target, ideaPromotionTargetItems)
+	}
+	if len(meta.PromotionPreview.Candidates) != 3 {
+		t.Fatalf("candidate len = %d, want 3", len(meta.PromotionPreview.Candidates))
+	}
+	if !containsAll(mock.lastShownContent, "## Promotion Review", "### 1. Draft the rollout checklist", "### 2. Add regression coverage") {
+		t.Fatalf("canvas content = %q", mock.lastShownContent)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesItemsAndMarksDone(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	_, session, ideaItem, artifact, _ := seedActiveIdeaNote(t, app, []string{
+		"Draft the rollout checklist",
+		"Add regression coverage",
+		"File the cleanup follow-up",
+	}, nil, true)
+
+	if _, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "turn this idea into tasks"); !handled {
+		t.Fatal("expected preview command to be handled")
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create selected idea items 1, 2 and mark this idea done")
+	if !handled {
+		t.Fatal("expected promotion apply command to be handled")
+	}
+	if message != "Created 2 items from the idea." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "idea_promotion_applied" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strFromAny(payloads[0]["idea_state"]); got != store.ItemStateDone {
+		t.Fatalf("idea_state = %q, want done", got)
+	}
+
+	inboxItems, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(inboxItems) != 2 {
+		t.Fatalf("inbox item count = %d, want 2", len(inboxItems))
+	}
+	for _, item := range inboxItems {
+		if item.ArtifactID == nil || *item.ArtifactID != artifact.ID {
+			t.Fatalf("artifact_id = %v, want %d", item.ArtifactID, artifact.ID)
+		}
+		if item.Source == nil || *item.Source != "idea" {
+			t.Fatalf("item.Source = %v, want idea", item.Source)
+		}
+		if item.SourceRef == nil || !strings.HasPrefix(*item.SourceRef, ideaPromotionSourceRef(ideaItem.ID, 1)[:len(fmt.Sprintf("idea-%d:", ideaItem.ID))]) {
+			t.Fatalf("item.SourceRef = %v, want idea source ref prefix", item.SourceRef)
+		}
+	}
+
+	updatedIdea, err := app.store.GetItem(ideaItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(idea) error: %v", err)
+	}
+	if updatedIdea.State != store.ItemStateDone {
+		t.Fatalf("idea state = %q, want done", updatedIdea.State)
+	}
+
+	updatedArtifact, err := app.store.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	meta := parseIdeaNoteMeta(updatedArtifact.MetaJSON, ideaNoteString(updatedArtifact.Title))
+	if meta.PromotionPreview != nil {
+		t.Fatalf("promotion preview = %#v, want nil", meta.PromotionPreview)
+	}
+	if len(meta.Promotions) != 1 {
+		t.Fatalf("promotion history len = %d, want 1", len(meta.Promotions))
+	}
+	if meta.Promotions[0].Target != ideaPromotionTargetItems {
+		t.Fatalf("promotion target = %q, want items", meta.Promotions[0].Target)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "make this actionable")
+	if !handled {
+		t.Fatal("expected already-promoted idea to be handled")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != "I couldn't prepare the idea promotion: idea has already been promoted" {
+		t.Fatalf("message = %q", message)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesGitHubIssue(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, session, ideaItem, _, _ := seedActiveIdeaNote(t, app, []string{
+		"Draft the rollout checklist",
+		"Add regression coverage",
+	}, []ideaNoteRefinement{{
+		Kind:    "implementation",
+		Heading: "Implementation Outline",
+		Body:    "1. Build the parser patch.\n2. Add coverage for the missing case.",
+	}}, true)
+	initGitHubWorkspaceRepo(t, project.RootPath, "https://github.com/owner/tabula.git")
+
+	var calls [][]string
+	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
+		calls = append(calls, append([]string{}, args...))
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/owner/tabula/issues/88\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":88,"title":"Parser cleanup plan","url":"https://github.com/owner/tabula/issues/88","state":"OPEN","labels":[],"assignees":[]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	if _, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create a GitHub issue from this idea"); !handled {
+		t.Fatal("expected GitHub preview to be handled")
+	}
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create this idea GitHub issue and keep this idea")
+	if !handled {
+		t.Fatal("expected GitHub apply to be handled")
+	}
+	if message != "Created GitHub issue #88 from the idea: https://github.com/owner/tabula/issues/88" {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "idea_promotion_applied" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strFromAny(payloads[0]["issue_url"]); got != "https://github.com/owner/tabula/issues/88" {
+		t.Fatalf("issue_url = %q", got)
+	}
+	if got := strFromAny(payloads[0]["idea_state"]); got != store.ItemStateInbox {
+		t.Fatalf("idea_state = %q, want inbox", got)
+	}
+	updatedIdea, err := app.store.GetItem(ideaItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if updatedIdea.State != store.ItemStateInbox {
+		t.Fatalf("updated idea state = %q, want inbox", updatedIdea.State)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("gh call count = %d, want 2", len(calls))
+	}
+	createCall := strings.Join(calls[0], " ")
+	if !containsAll(createCall, "issue create", "--title Parser cleanup plan", "## Notes", "## Implementation Outline", "Add regression coverage") {
+		t.Fatalf("gh create args = %q", createCall)
+	}
+}
+
+func timeStub() time.Time {
+	return time.Date(2026, time.March, 8, 15, 4, 5, 0, time.UTC)
+}

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -3371,6 +3371,67 @@ function ideaRefinementHeading(entry) {
   return 'Idea Notes';
 }
 
+function appendIdeaPromotionPreview(detail, preview) {
+  const target = String(preview?.target || '').trim().toLowerCase();
+  if (!target) return;
+  detail.push('', '## Promotion Review', '');
+  if (target === 'task') {
+    detail.push('- Pending: task draft');
+    detail.push('- Confirm with: `create this idea task`');
+  } else if (target === 'items') {
+    detail.push('- Pending: item proposals');
+    detail.push('- Confirm with: `create these idea items` or `create selected idea items 1,2`');
+  } else if (target === 'github') {
+    detail.push('- Pending: GitHub issue draft');
+    detail.push('- Confirm with: `create this idea GitHub issue`');
+  }
+  detail.push('- Optional: add `and mark this idea done` or `and keep this idea`');
+  if (target === 'github') {
+    const title = String(preview?.issue?.title || '').trim();
+    const body = String(preview?.issue?.body || '').trim();
+    if (title) {
+      detail.push('', `### ${title}`);
+    }
+    if (body) {
+      detail.push('', body);
+    }
+    return;
+  }
+  const candidates = Array.isArray(preview?.candidates) ? preview.candidates : [];
+  candidates.forEach((entry, offset) => {
+    const title = String(entry?.title || '').trim();
+    if (!title) return;
+    const index = Number(entry?.index || offset + 1) || (offset + 1);
+    detail.push('', `### ${index}. ${title}`);
+    const body = String(entry?.details || '').trim();
+    if (body) {
+      detail.push('', body);
+    }
+  });
+}
+
+function appendIdeaPromotions(detail, promotions) {
+  const records = Array.isArray(promotions) ? promotions : [];
+  if (records.length === 0) return;
+  detail.push('', '## Promotions');
+  records.forEach((entry) => {
+    const target = String(entry?.target || '').trim().toLowerCase();
+    if (!target) return;
+    let label = target;
+    if (target === 'github') label = 'GitHub issue';
+    let line = `- ${label}`;
+    const count = Number(entry?.count || 0);
+    if (count > 0) line += ` x${count}`;
+    const createdAt = String(entry?.created_at || '').trim();
+    if (createdAt) line += ` on ${createdAt}`;
+    const refs = Array.isArray(entry?.refs)
+      ? entry.refs.map((ref) => String(ref || '').trim()).filter(Boolean)
+      : [];
+    if (refs.length > 0) line += ` [${refs.join(', ')}]`;
+    detail.push(line);
+  });
+}
+
 function buildIdeaNoteMarkdown(title, artifactMeta) {
   const noteTitle = String(artifactMeta?.title || title || 'Idea').trim() || 'Idea';
   const notes = Array.isArray(artifactMeta?.notes)
@@ -3408,6 +3469,8 @@ function buildIdeaNoteMarkdown(title, artifactMeta) {
     if (!body) return;
     detail.push('', `## ${ideaRefinementHeading(entry)}`, '', body);
   });
+  appendIdeaPromotionPreview(detail, artifactMeta?.promotion_preview);
+  appendIdeaPromotions(detail, artifactMeta?.promotions);
   return detail.join('\n');
 }
 

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -161,6 +161,46 @@ test.describe('inbox triage interactions', () => {
     await expect(page.locator('#canvas-text')).toContainText('Workspace: Default');
   });
 
+  test('idea notes render promotion review details on canvas', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarArtifacts({
+        501: {
+          id: 501,
+          kind: 'idea_note',
+          title: 'Parser cleanup plan',
+          meta_json: JSON.stringify({
+            title: 'Parser cleanup plan',
+            transcript: 'Break parser cleanup into a small refactor, a test pass, and one cleanup issue.',
+            capture_mode: 'voice',
+            captured_at: '2026-03-08T09:40:00Z',
+            workspace: 'Default',
+            notes: [
+              'Draft the rollout checklist',
+              'Add regression coverage',
+            ],
+            promotion_preview: {
+              target: 'items',
+              candidates: [
+                { index: 1, title: 'Draft the rollout checklist', details: 'Draft the rollout checklist' },
+                { index: 2, title: 'Add regression coverage', details: 'Add regression coverage' },
+              ],
+            },
+          }),
+        },
+      });
+    });
+    await openInbox(page);
+
+    await page.locator('#pr-file-list .pr-file-item[data-item-id="101"]').click();
+
+    await expect(page.locator('#canvas-text')).toContainText('Promotion Review');
+    await expect(page.locator('#canvas-text')).toContainText('create these idea items');
+    await expect(page.locator('#canvas-text')).toContainText('Draft the rollout checklist');
+    await expect(page.locator('#canvas-text')).toContainText('Add regression coverage');
+  });
+
   test('touch gestures expose feedback and commit done, delete, delegate, and later', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitReady(page);


### PR DESCRIPTION
## Summary
- add explicit idea-promotion preview/apply actions that persist review state in idea-note metadata and render it on canvas
- create task/item promotions linked back to the source idea with optional done/keep disposition handling
- reuse the GitHub issue creation flow for idea notes and surface promotion review/history in the UI

## Verification
- [x] Ideas are promotable to a single task, multiple items, or a GitHub issue via dialogue: `go test ./internal/web -run 'Test(ParseInlineItemIntentIdeaPromotion|ClassifyAndExecuteSystemActionPreviewIdeaPromotionRendersReview|ClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesItemsAndMarksDone|ClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesGitHubIssue)$'` -> `ok   github.com/krystophny/tabura/internal/web 0.035s`.
- [x] Proposals are generated from idea-note content: `TestClassifyAndExecuteSystemActionPreviewIdeaPromotionRendersReview` seeds note lines and verifies the generated review candidates on canvas (`Draft the rollout checklist`, `Add regression coverage`, `File the cleanup follow-up`).
- [x] The user reviews and confirms before creation: the same Go test verifies preview creation, while `TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesItemsAndMarksDone` only creates items after the explicit follow-up command `create selected idea items 1, 2 and mark this idea done`.
- [x] Generated items link back to the source idea: `TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesItemsAndMarksDone` verifies each created inbox item keeps the original `artifact_id` and an `idea-<source_id>:<proposal_index>` source reference.
- [x] The original idea can be marked done or kept: the item promotion test drives `mark this idea done`; `TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesGitHubIssue` drives `keep this idea` and verifies the idea item remains `inbox`.
- [x] The GitHub issue path reuses the existing issue creation flow: `TestClassifyAndExecuteSystemActionApplyIdeaPromotionCreatesGitHubIssue` stubs `gh issue create`/`gh issue view` and verifies the generated body includes the idea notes and implementation outline.
- [x] The review state is visible in the UI: `npx playwright test tests/playwright/inbox-triage.spec.ts -g 'idea notes render promotion review details on canvas'` -> `1 passed (1.6s)`.
