### PR TITLE
fix: add workspace CRUD and management via hub dialogue (fixes #283)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -48,6 +48,7 @@ Domain model API:
 - `GET /api/workspaces`
 - `POST /api/workspaces`
 - `GET /api/workspaces/{workspace_id}`
+- `PUT /api/workspaces/{workspace_id}`
 - `DELETE /api/workspaces/{workspace_id}`
 - `GET /api/external-accounts`
 - `POST /api/external-accounts`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -298,6 +298,16 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	if workspaceA.IsActive {
 		t.Fatal("expected inactive workspace after SetActiveWorkspace")
 	}
+	workspaceA, err = s.UpdateWorkspaceName(workspaceA.ID, " Workspace Alpha ")
+	if err != nil {
+		t.Fatalf("UpdateWorkspaceName() error: %v", err)
+	}
+	if workspaceA.Name != "Workspace Alpha" {
+		t.Fatalf("UpdateWorkspaceName().Name = %q, want %q", workspaceA.Name, "Workspace Alpha")
+	}
+	if _, err := s.UpdateWorkspaceName(999999, "Missing"); err == nil {
+		t.Fatal("expected missing workspace rename error")
+	}
 
 	human, err := s.CreateActor("Alice", ActorKindHuman)
 	if err != nil {

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -617,6 +617,25 @@ func (s *Store) SetActiveWorkspace(id int64) error {
 	return tx.Commit()
 }
 
+func (s *Store) UpdateWorkspaceName(id int64, name string) (Workspace, error) {
+	cleanName := normalizeWorkspaceName(name)
+	if cleanName == "" {
+		return Workspace{}, errors.New("workspace name is required")
+	}
+	res, err := s.db.Exec(`UPDATE workspaces SET name = ?, updated_at = datetime('now') WHERE id = ?`, cleanName, id)
+	if err != nil {
+		return Workspace{}, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return Workspace{}, err
+	}
+	if affected == 0 {
+		return Workspace{}, sql.ErrNoRows
+	}
+	return s.GetWorkspace(id)
+}
+
 func (s *Store) DeleteWorkspace(id int64) error {
 	res, err := s.db.Exec(`DELETE FROM workspaces WHERE id = ?`, id)
 	if err != nil {

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -131,6 +131,7 @@ var WebRouteSections = []RouteSection{
 			"GET /api/workspaces",
 			"POST /api/workspaces",
 			"GET /api/workspaces/{workspace_id}",
+			"PUT /api/workspaces/{workspace_id}",
 			"DELETE /api/workspaces/{workspace_id}",
 			"GET /api/external-accounts",
 			"POST /api/external-accounts",

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "create_workspace_from_git", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -220,6 +220,10 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			"name":         workspace.Name,
 			"dir_path":     workspace.DirPath,
 		}, nil
+	case "list_workspaces":
+		return a.executeListWorkspacesAction(session)
+	case "create_workspace":
+		return a.executeCreateWorkspaceAction(session, action)
 	case "list_workspace_items":
 		workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
 		if err != nil {
@@ -256,6 +260,12 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			"dir_path":     workspace.DirPath,
 			"repo_url":     repoURL,
 		}, nil
+	case "rename_workspace":
+		return a.executeRenameWorkspaceAction(session, action)
+	case "delete_workspace":
+		return a.executeDeleteWorkspaceAction(session, action)
+	case "show_workspace_details":
+		return a.executeShowWorkspaceDetailsAction(session, action)
 	case "switch_model":
 		targetProject, err := a.systemActionTargetProject(session)
 		if err != nil {

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -5,10 +5,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/krystophny/tabura/internal/store"
+)
+
+var (
+	workspaceCreatePattern        = regexp.MustCompile(`(?i)^(?:create|add|register)\s+workspace\s+(.+?)$`)
+	workspaceScratchCreatePattern = regexp.MustCompile(`(?i)^(?:create|add)\s+scratch\s+workspace(?:\s+(.+?))?$`)
+	workspaceRenamePattern        = regexp.MustCompile(`(?i)^rename\s+workspace\s+(.+?)\s+to\s+(.+?)$`)
+	workspaceDeletePattern        = regexp.MustCompile(`(?i)^(?:delete|remove)\s+workspace\s+(.+?)$`)
+	workspaceDetailsPattern       = regexp.MustCompile(`(?i)^(?:show\s+)?workspace\s+details(?:\s+for\s+(.+?))?$`)
 )
 
 func parseInlineWorkspaceIntent(text string) *SystemAction {
@@ -23,6 +33,45 @@ func parseInlineWorkspaceIntent(text string) *SystemAction {
 	switch lower {
 	case "show items here", "show open items here", "show items for this workspace", "what's open", "what is open", "what's open here", "what is open here":
 		return &SystemAction{Action: "list_workspace_items", Params: map[string]interface{}{}}
+	case "list workspaces", "show my workspaces", "show workspaces":
+		return &SystemAction{Action: "list_workspaces", Params: map[string]interface{}{}}
+	case "show workspace details":
+		return &SystemAction{Action: "show_workspace_details", Params: map[string]interface{}{}}
+	}
+	if match := workspaceScratchCreatePattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		params := map[string]interface{}{"scratch": true}
+		if name := cleanWorkspaceReference(match[1]); name != "" {
+			params["name"] = name
+		}
+		return &SystemAction{Action: "create_workspace", Params: params}
+	}
+	if match := workspaceRenamePattern.FindStringSubmatch(trimmed); len(match) == 3 {
+		workspaceRef := cleanWorkspaceReference(match[1])
+		newName := cleanWorkspaceReference(match[2])
+		if workspaceRef != "" && newName != "" {
+			return &SystemAction{
+				Action: "rename_workspace",
+				Params: map[string]interface{}{"workspace": workspaceRef, "new_name": newName},
+			}
+		}
+	}
+	if match := workspaceDeletePattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		if workspaceRef := cleanWorkspaceReference(match[1]); workspaceRef != "" {
+			return &SystemAction{Action: "delete_workspace", Params: map[string]interface{}{"workspace": workspaceRef}}
+		}
+	}
+	if match := workspaceDetailsPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		params := map[string]interface{}{}
+		if workspaceRef := cleanWorkspaceReference(match[1]); workspaceRef != "" {
+			params["workspace"] = workspaceRef
+		}
+		return &SystemAction{Action: "show_workspace_details", Params: params}
+	}
+	if match := workspaceCreatePattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		pathRef := cleanWorkspaceReference(match[1])
+		if pathRef != "" && !strings.HasPrefix(strings.ToLower(pathRef), "from ") {
+			return &SystemAction{Action: "create_workspace", Params: map[string]interface{}{"path": pathRef}}
+		}
 	}
 
 	if name, ok := cutPrefixedWorkspaceReference(trimmed, "open workspace "); ok {
@@ -73,6 +122,17 @@ func looksLikeWorkspaceReference(raw string) bool {
 	return false
 }
 
+func cleanWorkspaceReference(raw string) string {
+	text := strings.TrimSpace(raw)
+	text = strings.Trim(text, " \t\r\n!?,:;")
+	for _, suffix := range []string{" please", " thanks", " thank you"} {
+		if strings.HasSuffix(strings.ToLower(text), suffix) {
+			text = strings.TrimSpace(text[:len(text)-len(suffix)])
+		}
+	}
+	return strings.TrimSpace(text)
+}
+
 func systemActionWorkspaceRef(params map[string]interface{}) string {
 	for _, key := range []string{"workspace", "name", "path", "target"} {
 		value := strings.TrimSpace(fmt.Sprint(params[key]))
@@ -81,6 +141,27 @@ func systemActionWorkspaceRef(params map[string]interface{}) string {
 		}
 	}
 	return ""
+}
+
+func systemActionWorkspaceNewName(params map[string]interface{}) string {
+	for _, key := range []string{"new_name", "rename_to", "label"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func systemActionBoolParam(params map[string]interface{}, key string) bool {
+	switch value := params[key].(type) {
+	case bool:
+		return value
+	case string:
+		return strings.EqualFold(strings.TrimSpace(value), "true")
+	default:
+		return false
+	}
 }
 
 func expandWorkspacePathReference(raw string) string {
@@ -247,4 +328,249 @@ func prependWorkspacePromptContext(prompt string, ctx *workspacePromptContext) s
 
 func (a *App) applyWorkspacePromptContext(projectKey, prompt string) string {
 	return prependWorkspacePromptContext(prompt, a.loadWorkspacePromptContext(projectKey))
+}
+
+func (a *App) workspaceActionBaseDir(projectKey string) string {
+	if strings.TrimSpace(projectKey) != "" {
+		if project, err := a.store.GetProjectByProjectKey(projectKey); err == nil {
+			if root := strings.TrimSpace(project.RootPath); root != "" {
+				return root
+			}
+		}
+	}
+	if root := strings.TrimSpace(a.localProjectDir); root != "" {
+		return root
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return "."
+}
+
+func (a *App) resolveWorkspaceCreationPath(projectKey, rawPath string) string {
+	pathRef := expandWorkspacePathReference(rawPath)
+	if pathRef == "" {
+		return ""
+	}
+	if filepath.IsAbs(pathRef) {
+		return filepath.Clean(pathRef)
+	}
+	return filepath.Clean(filepath.Join(a.workspaceActionBaseDir(projectKey), pathRef))
+}
+
+func slugifyWorkspaceName(raw string) string {
+	clean := strings.ToLower(strings.TrimSpace(raw))
+	if clean == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range clean {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			lastDash = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func scratchWorkspaceName(now time.Time) string {
+	return "scratch-" + now.UTC().Format("20060102-150405")
+}
+
+func workspaceOpenItemCounts(items []store.Item) map[int64]int {
+	counts := make(map[int64]int)
+	for _, item := range items {
+		if item.WorkspaceID == nil || item.State == store.ItemStateDone {
+			continue
+		}
+		counts[*item.WorkspaceID]++
+	}
+	return counts
+}
+
+func summarizeWorkspaces(workspaces []store.Workspace, openCounts map[int64]int) string {
+	if len(workspaces) == 0 {
+		return "No workspaces registered."
+	}
+	var b strings.Builder
+	b.WriteString("Workspaces:\n")
+	for _, workspace := range workspaces {
+		active := " "
+		if workspace.IsActive {
+			active = "*"
+		}
+		fmt.Fprintf(&b, "%s %s — %s (%d open items)\n", active, workspace.Name, workspace.DirPath, openCounts[workspace.ID])
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func (a *App) createWorkspaceFromDialogIntent(projectKey string, action *SystemAction) (store.Workspace, bool, error) {
+	scratch := systemActionBoolParam(action.Params, "scratch")
+	var (
+		dirPath string
+		name    string
+	)
+	if scratch {
+		name = cleanWorkspaceReference(systemActionStringParam(action.Params, "name"))
+		if name == "" {
+			name = scratchWorkspaceName(time.Now())
+		}
+		baseDir := filepath.Join(a.workspaceActionBaseDir(projectKey), ".tabura", "artifacts", "tmp")
+		dirName := slugifyWorkspaceName(name)
+		if dirName == "" {
+			dirName = scratchWorkspaceName(time.Now())
+		}
+		dirPath = filepath.Join(baseDir, dirName)
+		if _, err := os.Stat(dirPath); err == nil {
+			dirPath = filepath.Join(baseDir, dirName+"-"+time.Now().UTC().Format("150405"))
+		}
+	} else {
+		dirPath = a.resolveWorkspaceCreationPath(projectKey, systemActionWorkspaceRef(action.Params))
+		if dirPath == "" {
+			return store.Workspace{}, false, errors.New("workspace path is required")
+		}
+		name = filepath.Base(dirPath)
+	}
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		return store.Workspace{}, false, err
+	}
+	workspace, err := a.store.CreateWorkspace(name, dirPath)
+	if err != nil {
+		return store.Workspace{}, false, err
+	}
+	if err := a.store.SetActiveWorkspace(workspace.ID); err != nil {
+		return store.Workspace{}, false, err
+	}
+	workspace, err = a.store.GetWorkspace(workspace.ID)
+	if err != nil {
+		return store.Workspace{}, false, err
+	}
+	return workspace, scratch, nil
+}
+
+func (a *App) executeListWorkspacesAction(session store.ChatSession) (string, map[string]interface{}, error) {
+	workspaces, err := a.store.ListWorkspaces()
+	if err != nil {
+		return "", nil, err
+	}
+	items, err := a.store.ListItems()
+	if err != nil {
+		return "", nil, err
+	}
+	openCounts := workspaceOpenItemCounts(items)
+	payloadList := make([]map[string]interface{}, 0, len(workspaces))
+	for _, workspace := range workspaces {
+		payloadList = append(payloadList, map[string]interface{}{
+			"workspace_id": workspace.ID,
+			"name":         workspace.Name,
+			"dir_path":     workspace.DirPath,
+			"is_active":    workspace.IsActive,
+			"open_items":   openCounts[workspace.ID],
+		})
+	}
+	return summarizeWorkspaces(workspaces, openCounts), map[string]interface{}{
+		"type":            "list_workspaces",
+		"workspace_count": len(workspaces),
+		"workspaces":      payloadList,
+	}, nil
+}
+
+func (a *App) executeCreateWorkspaceAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	workspace, scratch, err := a.createWorkspaceFromDialogIntent(session.ProjectKey, action)
+	if err != nil {
+		return "", nil, err
+	}
+	payloadType := "create_workspace"
+	message := fmt.Sprintf("Created workspace %s at %s.", workspace.Name, workspace.DirPath)
+	if scratch {
+		payloadType = "create_scratch_workspace"
+		message = fmt.Sprintf("Created scratch workspace %s at %s.", workspace.Name, workspace.DirPath)
+	}
+	return message, map[string]interface{}{
+		"type":         payloadType,
+		"workspace_id": workspace.ID,
+		"name":         workspace.Name,
+		"dir_path":     workspace.DirPath,
+		"is_active":    workspace.IsActive,
+	}, nil
+}
+
+func (a *App) executeRenameWorkspaceAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	updated, err := a.store.UpdateWorkspaceName(workspace.ID, systemActionWorkspaceNewName(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	return fmt.Sprintf("Renamed workspace %s to %s.", workspace.Name, updated.Name), map[string]interface{}{
+		"type":         "rename_workspace",
+		"workspace_id": updated.ID,
+		"name":         updated.Name,
+		"dir_path":     updated.DirPath,
+		"is_active":    updated.IsActive,
+	}, nil
+}
+
+func (a *App) executeDeleteWorkspaceAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	if err := a.store.DeleteWorkspace(workspace.ID); err != nil {
+		return "", nil, err
+	}
+	return fmt.Sprintf("Deleted workspace %s.", workspace.Name), map[string]interface{}{
+		"type":         "delete_workspace",
+		"workspace_id": workspace.ID,
+		"name":         workspace.Name,
+		"dir_path":     workspace.DirPath,
+	}, nil
+}
+
+func (a *App) executeShowWorkspaceDetailsAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionWorkspaceRef(action.Params))
+	if err != nil {
+		return "", nil, err
+	}
+	items, err := a.listOpenWorkspaceItems(workspace.ID)
+	if err != nil {
+		return "", nil, err
+	}
+	repo, err := a.store.GitHubRepoForWorkspace(workspace.ID)
+	if err != nil {
+		return "", nil, err
+	}
+	status := "inactive"
+	if workspace.IsActive {
+		status = "active"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Workspace %s\n", workspace.Name)
+	fmt.Fprintf(&b, "- Path: %s\n", workspace.DirPath)
+	fmt.Fprintf(&b, "- Status: %s\n", status)
+	fmt.Fprintf(&b, "- Open items: %d\n", len(items))
+	if repo != "" {
+		fmt.Fprintf(&b, "- GitHub remote: %s\n", repo)
+	}
+	return strings.TrimSpace(b.String()), map[string]interface{}{
+		"type":         "show_workspace_details",
+		"workspace_id": workspace.ID,
+		"name":         workspace.Name,
+		"dir_path":     workspace.DirPath,
+		"is_active":    workspace.IsActive,
+		"open_items":   len(items),
+		"github_repo":  repo,
+	}, nil
 }

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -18,12 +18,20 @@ func TestParseInlineWorkspaceIntent(t *testing.T) {
 		wantWorkspace string
 		wantRepoURL   string
 		wantTarget    string
+		wantNewName   string
+		wantScratch   bool
 	}{
 		{text: "open workspace Alpha", wantAction: "switch_workspace", wantWorkspace: "Alpha"},
 		{text: "switch to workspace Beta", wantAction: "switch_workspace", wantWorkspace: "Beta"},
 		{text: "switch to ./repo", wantAction: "switch_workspace", wantWorkspace: "./repo"},
 		{text: "show items here", wantAction: "list_workspace_items"},
 		{text: "what's open", wantAction: "list_workspace_items"},
+		{text: "list workspaces", wantAction: "list_workspaces"},
+		{text: "create workspace ./notes", wantAction: "create_workspace", wantWorkspace: "./notes"},
+		{text: "create scratch workspace", wantAction: "create_workspace", wantScratch: true},
+		{text: "rename workspace Alpha to Beta", wantAction: "rename_workspace", wantWorkspace: "Alpha", wantNewName: "Beta"},
+		{text: "delete workspace Alpha", wantAction: "delete_workspace", wantWorkspace: "Alpha"},
+		{text: "show workspace details for Alpha", wantAction: "show_workspace_details", wantWorkspace: "Alpha"},
 		{text: "create workspace from git@github.com:user/repo.git", wantAction: "create_workspace_from_git", wantRepoURL: "git@github.com:user/repo.git"},
 		{text: "create workspace from https://gitlab.example.com/user/data-repo.git to ~/write/proposal", wantAction: "create_workspace_from_git", wantRepoURL: "https://gitlab.example.com/user/data-repo.git", wantTarget: "~/write/proposal"},
 	}
@@ -41,11 +49,17 @@ func TestParseInlineWorkspaceIntent(t *testing.T) {
 			if got := systemActionWorkspaceRef(action.Params); got != tc.wantWorkspace {
 				t.Fatalf("workspace ref = %q, want %q", got, tc.wantWorkspace)
 			}
+			if got := systemActionWorkspaceNewName(action.Params); got != tc.wantNewName {
+				t.Fatalf("new_name = %q, want %q", got, tc.wantNewName)
+			}
 			if got := systemActionGitRepoURL(action.Params); got != tc.wantRepoURL {
 				t.Fatalf("repo_url = %q, want %q", got, tc.wantRepoURL)
 			}
-			if got := systemActionGitTargetPath(action.Params); got != tc.wantTarget {
+			if got := systemActionGitTargetPath(action.Params); tc.wantAction == "create_workspace_from_git" && got != tc.wantTarget {
 				t.Fatalf("target_path = %q, want %q", got, tc.wantTarget)
+			}
+			if got := systemActionBoolParam(action.Params, "scratch"); got != tc.wantScratch {
+				t.Fatalf("scratch = %v, want %v", got, tc.wantScratch)
 			}
 		})
 	}
@@ -231,6 +245,119 @@ func TestClassifyAndExecuteSystemActionCreateWorkspaceFromGit(t *testing.T) {
 	}
 	if strings.TrimSpace(string(readmeBody)) != "# example-workspace" {
 		t.Fatalf("README = %q", string(readmeBody))
+	}
+}
+
+func TestClassifyAndExecuteSystemActionWorkspaceManagement(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create workspace ./notes")
+	if !handled {
+		t.Fatal("expected create workspace command to be handled")
+	}
+	expectedDir := filepath.Join(hub.RootPath, "notes")
+	if message != "Created workspace notes at "+expectedDir+"." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "create_workspace" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	workspaceID := int64FromAny(payloads[0]["workspace_id"])
+	workspace, err := app.store.GetWorkspace(workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace(notes) error: %v", err)
+	}
+	if workspace.Name != "notes" {
+		t.Fatalf("workspace.Name = %q, want %q", workspace.Name, "notes")
+	}
+	if workspace.DirPath != expectedDir {
+		t.Fatalf("workspace.DirPath = %q, want %q", workspace.DirPath, expectedDir)
+	}
+	if !workspace.IsActive {
+		t.Fatal("expected created workspace to be active")
+	}
+	if _, err := os.Stat(expectedDir); err != nil {
+		t.Fatalf("expected workspace directory to exist: %v", err)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create scratch workspace research lab")
+	if !handled {
+		t.Fatal("expected scratch workspace command to be handled")
+	}
+	if !strings.Contains(message, "Created scratch workspace research lab at ") {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "create_scratch_workspace" {
+		t.Fatalf("scratch payloads = %#v", payloads)
+	}
+	scratchDir := strFromAny(payloads[0]["dir_path"])
+	if !strings.Contains(filepath.ToSlash(scratchDir), "/.tabura/artifacts/tmp/") {
+		t.Fatalf("scratch dir = %q, want .tabura/artifacts/tmp path", scratchDir)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "list workspaces")
+	if !handled {
+		t.Fatal("expected list workspaces command to be handled")
+	}
+	if !strings.Contains(message, "Workspaces:") || !strings.Contains(message, "research lab") || !strings.Contains(message, "notes") {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "list_workspaces" {
+		t.Fatalf("list payloads = %#v", payloads)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show workspace details for notes")
+	if !handled {
+		t.Fatal("expected show workspace details command to be handled")
+	}
+	if !strings.Contains(message, "Workspace notes") || !strings.Contains(message, "- Path: "+expectedDir) {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "show_workspace_details" {
+		t.Fatalf("details payloads = %#v", payloads)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "rename workspace notes to Research Notes")
+	if !handled {
+		t.Fatal("expected rename workspace command to be handled")
+	}
+	if message != "Renamed workspace notes to Research Notes." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "rename_workspace" {
+		t.Fatalf("rename payloads = %#v", payloads)
+	}
+	renamed, err := app.store.GetWorkspace(workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace(renamed) error: %v", err)
+	}
+	if renamed.Name != "Research Notes" {
+		t.Fatalf("renamed.Name = %q, want %q", renamed.Name, "Research Notes")
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "delete workspace Research Notes")
+	if !handled {
+		t.Fatal("expected delete workspace command to be handled")
+	}
+	if message != "Deleted workspace Research Notes." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "delete_workspace" {
+		t.Fatalf("delete payloads = %#v", payloads)
+	}
+	if _, err := app.store.GetWorkspace(workspaceID); err == nil {
+		t.Fatal("expected deleted workspace to be gone")
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -388,6 +388,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/workspaces", a.handleWorkspaceList)
 	r.Post("/api/workspaces", a.handleWorkspaceCreate)
 	r.Get("/api/workspaces/{workspace_id}", a.handleWorkspaceGet)
+	r.Put("/api/workspaces/{workspace_id}", a.handleWorkspaceUpdate)
 	r.Delete("/api/workspaces/{workspace_id}", a.handleWorkspaceDelete)
 	r.Get("/api/external-accounts", a.handleExternalAccountList)
 	r.Post("/api/external-accounts", a.handleExternalAccountCreate)

--- a/internal/web/workspaces.go
+++ b/internal/web/workspaces.go
@@ -8,6 +8,11 @@ type workspaceCreateRequest struct {
 	IsActive bool   `json:"is_active"`
 }
 
+type workspaceUpdateRequest struct {
+	Name     *string `json:"name"`
+	IsActive *bool   `json:"is_active"`
+}
+
 func (a *App) handleWorkspaceList(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
@@ -43,6 +48,57 @@ func (a *App) handleWorkspaceCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		workspace, err = a.store.GetWorkspace(workspace.ID)
+		if err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+	}
+	writeJSON(w, map[string]any{
+		"ok":        true,
+		"workspace": workspace,
+	})
+}
+
+func (a *App) handleWorkspaceUpdate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	workspaceID, err := parseURLInt64Param(r, "workspace_id")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req workspaceUpdateRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.Name == nil && req.IsActive == nil {
+		http.Error(w, "at least one workspace update is required", http.StatusBadRequest)
+		return
+	}
+	workspace, err := a.store.GetWorkspace(workspaceID)
+	if err != nil {
+		writeDomainStoreError(w, err)
+		return
+	}
+	if req.Name != nil {
+		workspace, err = a.store.UpdateWorkspaceName(workspaceID, *req.Name)
+		if err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+	}
+	if req.IsActive != nil {
+		if !*req.IsActive {
+			http.Error(w, "is_active=false is not supported", http.StatusBadRequest)
+			return
+		}
+		if err := a.store.SetActiveWorkspace(workspaceID); err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+		workspace, err = a.store.GetWorkspace(workspaceID)
 		if err != nil {
 			writeDomainStoreError(w, err)
 			return

--- a/internal/web/workspaces_test.go
+++ b/internal/web/workspaces_test.go
@@ -46,6 +46,25 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 		t.Fatalf("get workspace status = %d, want 200: %s", rrGet.Code, rrGet.Body.String())
 	}
 
+	rrUpdate := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/workspaces/"+itoa(workspaceID), map[string]any{
+		"name":      "Renamed Workspace",
+		"is_active": true,
+	})
+	if rrUpdate.Code != http.StatusOK {
+		t.Fatalf("update workspace status = %d, want 200: %s", rrUpdate.Code, rrUpdate.Body.String())
+	}
+	updatePayload := decodeJSONResponse(t, rrUpdate)
+	updatedWorkspace, ok := updatePayload["workspace"].(map[string]any)
+	if !ok {
+		t.Fatalf("update workspace payload = %#v", updatePayload)
+	}
+	if updatedWorkspace["name"] != "Renamed Workspace" {
+		t.Fatalf("updated workspace name = %#v, want %q", updatedWorkspace["name"], "Renamed Workspace")
+	}
+	if isActive, _ := updatedWorkspace["is_active"].(bool); !isActive {
+		t.Fatalf("updated workspace payload = %#v, want active workspace", updatedWorkspace)
+	}
+
 	rrDuplicate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/workspaces", map[string]any{
 		"name":     "Duplicate",
 		"dir_path": workspacePath,


### PR DESCRIPTION
## Summary

Adds missing workspace-management flows around the existing workspace model:
- dialogue commands for list, create, scratch create, rename, delete, and details
- `PUT /api/workspaces/{workspace_id}` for rename/activate updates
- store support for workspace renames and interface inventory updates

## Verification

- Workspace dialogue CRUD and details: `go test ./internal/web -run 'TestParseInlineWorkspaceIntent|TestClassifyAndExecuteSystemActionWorkspaceManagement|TestWorkspaceCRUDAPI|TestClassifyAndExecuteSystemAction(SwitchWorkspace|ListWorkspaceItemsUsesActiveWorkspace|CreateWorkspaceFromGit)|TestApplyWorkspacePromptContextIncludesActiveWorkspaceSummary'`
  - Excerpt: `ok   github.com/krystophny/tabura/internal/web 0.071s`
  - Evidence: `TestClassifyAndExecuteSystemActionWorkspaceManagement` covers `create workspace ./notes`, `create scratch workspace research lab`, `list workspaces`, `show workspace details`, `rename workspace`, and `delete workspace`.
  - Evidence: `TestWorkspaceCRUDAPI` covers `PUT /api/workspaces/{workspace_id}` rename + activate behavior.

- Workspace rename persistence in the store: `go test ./internal/store -run TestDomainCRUDRoundTrip`
  - Excerpt: `ok   github.com/krystophny/tabura/internal/store 0.013s`
  - Evidence: `TestDomainCRUDRoundTrip` now exercises `UpdateWorkspaceName` success and missing-workspace failure.

- Interface inventory updated for the new API route:
  - Evidence: `internal/surface/definitions.go` and `docs/interfaces.md` both include `PUT /api/workspaces/{workspace_id}`.
