### PR TITLE
fix: Add manual workspace and project reassignment (fixes #216)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -77,6 +77,8 @@ Domain model API:
 - `DELETE /api/items/{item_id}`
 - `PUT /api/items/{item_id}/state`
 - `PUT /api/items/{item_id}/assign`
+- `PUT /api/items/{item_id}/workspace`
+- `PUT /api/items/{item_id}/project`
 
 Canvas/files:
 - `GET /api/canvas/{session_id}/snapshot`

--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -47,6 +47,7 @@ type ItemUpdate struct {
 	Title        *string `json:"title,omitempty"`
 	State        *string `json:"state,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
+	ProjectID    *string `json:"project_id,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`
@@ -58,6 +59,7 @@ type ItemUpdate struct {
 type ItemOptions struct {
 	State        string  `json:"state,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
+	ProjectID    *string `json:"project_id,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`
@@ -146,6 +148,7 @@ type Item struct {
 	Title        string  `json:"title"`
 	State        string  `json:"state"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
+	ProjectID    *string `json:"project_id,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -38,7 +38,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"external_container_mappings": {"id", "provider", "container_type", "container_ref", "workspace_id", "project_id", "sphere"},
 		"workspace_artifact_links":    {"workspace_id", "artifact_id", "created_at"},
 		"external_bindings":           {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
-		"items":                       {"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
+		"items":                       {"id", "title", "state", "workspace_id", "project_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
 	} {
 		got := make(map[string]bool, len(columns[table]))
 		for _, name := range columns[table] {
@@ -70,7 +70,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate foreign keys: %v", err)
 	}
-	for _, table := range []string{"workspaces", "artifacts", "actors"} {
+	for _, table := range []string{"workspaces", "projects", "artifacts", "actors"} {
 		if !targets[table] {
 			t.Fatalf("items missing foreign key to %s", table)
 		}
@@ -196,24 +196,25 @@ func TestItemSchemaAllowsNilOptionalFields(t *testing.T) {
 	}
 
 	var (
-		title                                       string
-		workspaceID, artifactID, actorID            sql.NullInt64
-		visibleAfter, followUpAt, source, sourceRef sql.NullString
+		title                               string
+		workspaceID, artifactID, actorID    sql.NullInt64
+		projectID, visibleAfter, followUpAt sql.NullString
+		source, sourceRef                   sql.NullString
 	)
 	err = s.db.QueryRow(`
-SELECT title, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+SELECT title, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
 FROM items
 WHERE id = ?
-`, id).Scan(&title, &workspaceID, &artifactID, &actorID, &visibleAfter, &followUpAt, &source, &sourceRef)
+`, id).Scan(&title, &workspaceID, &projectID, &artifactID, &actorID, &visibleAfter, &followUpAt, &source, &sourceRef)
 	if err != nil {
 		t.Fatalf("query item: %v", err)
 	}
 	if title != "triage me" {
 		t.Fatalf("title = %q, want triage me", title)
 	}
-	if workspaceID.Valid || artifactID.Valid || actorID.Valid || visibleAfter.Valid || followUpAt.Valid || source.Valid || sourceRef.Valid {
-		t.Fatalf("expected optional fields to remain NULL, got workspace=%v artifact=%v actor=%v visible_after=%v follow_up_at=%v source=%v source_ref=%v",
-			workspaceID, artifactID, actorID, visibleAfter, followUpAt, source, sourceRef)
+	if workspaceID.Valid || projectID.Valid || artifactID.Valid || actorID.Valid || visibleAfter.Valid || followUpAt.Valid || source.Valid || sourceRef.Valid {
+		t.Fatalf("expected optional fields to remain NULL, got workspace=%v project=%v artifact=%v actor=%v visible_after=%v follow_up_at=%v source=%v source_ref=%v",
+			workspaceID, projectID, artifactID, actorID, visibleAfter, followUpAt, source, sourceRef)
 	}
 }
 
@@ -222,6 +223,9 @@ func TestItemSchemaEnforcesForeignKeys(t *testing.T) {
 
 	if _, err := s.db.Exec(`INSERT INTO items (title, workspace_id) VALUES ('invalid', 999)`); err == nil {
 		t.Fatal("expected foreign key violation for missing workspace")
+	}
+	if _, err := s.db.Exec(`INSERT INTO items (title, project_id) VALUES ('invalid', 'missing-project')`); err == nil {
+		t.Fatal("expected foreign key violation for missing project")
 	}
 	if _, err := s.db.Exec(`INSERT INTO items (title, artifact_id) VALUES ('invalid', 999)`); err == nil {
 		t.Fatal("expected foreign key violation for missing artifact")

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -18,6 +18,7 @@ const itemsTableSchema = `CREATE TABLE IF NOT EXISTS items (
   title TEXT NOT NULL,
   state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'someday', 'done')),
   workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
+  project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
   artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
   actor_id INTEGER REFERENCES actors(id) ON DELETE SET NULL,
   visible_after TEXT,
@@ -106,7 +107,10 @@ CREATE INDEX IF NOT EXISTS idx_external_bindings_stale
 	if _, err := s.db.Exec(itemsTableSchema); err != nil {
 		return err
 	}
-	return s.migrateItemTableStateSupport()
+	if err := s.migrateItemTableStateSupport(); err != nil {
+		return err
+	}
+	return s.migrateItemProjectColumnSupport()
 }
 
 func normalizeWorkspaceName(name string) string {
@@ -203,10 +207,10 @@ func (s *Store) migrateItemTableStateSupport() error {
 	}
 	if _, err := tx.Exec(`
 INSERT INTO items (
-	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+	id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 )
 SELECT
-	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+	id, title, state, workspace_id, NULL, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 FROM items_legacy
 `); err != nil {
 		return err
@@ -215,6 +219,18 @@ FROM items_legacy
 		return err
 	}
 	return tx.Commit()
+}
+
+func (s *Store) migrateItemProjectColumnSupport() error {
+	tableColumns, err := s.tableColumnSet("items")
+	if err != nil {
+		return err
+	}
+	if tableColumns["items"]["project_id"] {
+		return nil
+	}
+	_, err = s.db.Exec(`ALTER TABLE items ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE SET NULL`)
+	return err
 }
 
 func scanWorkspace(
@@ -276,15 +292,17 @@ func scanItem(
 	},
 ) (Item, error) {
 	var (
-		out                                         Item
-		workspaceID, artifactID, actorID            sql.NullInt64
-		visibleAfter, followUpAt, source, sourceRef sql.NullString
+		out                                 Item
+		workspaceID, artifactID, actorID    sql.NullInt64
+		projectID, visibleAfter, followUpAt sql.NullString
+		source, sourceRef                   sql.NullString
 	)
 	err := row.Scan(
 		&out.ID,
 		&out.Title,
 		&out.State,
 		&workspaceID,
+		&projectID,
 		&artifactID,
 		&actorID,
 		&visibleAfter,
@@ -300,6 +318,7 @@ func scanItem(
 	out.Title = strings.TrimSpace(out.Title)
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
+	out.ProjectID = nullStringPointer(projectID)
 	out.ArtifactID = nullInt64Pointer(artifactID)
 	out.ActorID = nullInt64Pointer(actorID)
 	out.VisibleAfter = nullStringPointer(visibleAfter)
@@ -315,16 +334,18 @@ func scanItemSummary(
 	},
 ) (ItemSummary, error) {
 	var (
-		out                                         ItemSummary
-		workspaceID, artifactID, actorID            sql.NullInt64
-		visibleAfter, followUpAt, source, sourceRef sql.NullString
-		artifactTitle, artifactKind, actorName      sql.NullString
+		out                                    ItemSummary
+		workspaceID, artifactID, actorID       sql.NullInt64
+		projectID, visibleAfter, followUpAt    sql.NullString
+		source, sourceRef                      sql.NullString
+		artifactTitle, artifactKind, actorName sql.NullString
 	)
 	err := row.Scan(
 		&out.ID,
 		&out.Title,
 		&out.State,
 		&workspaceID,
+		&projectID,
 		&artifactID,
 		&actorID,
 		&visibleAfter,
@@ -343,6 +364,7 @@ func scanItemSummary(
 	out.Title = strings.TrimSpace(out.Title)
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
+	out.ProjectID = nullStringPointer(projectID)
 	out.ArtifactID = nullInt64Pointer(artifactID)
 	out.ActorID = nullInt64Pointer(actorID)
 	out.VisibleAfter = nullStringPointer(visibleAfter)
@@ -1002,11 +1024,12 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 	}
 	res, err := s.db.Exec(
 		`INSERT INTO items (
-			title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		cleanTitle,
 		cleanState,
 		opts.WorkspaceID,
+		normalizeOptionalProjectID(opts.ProjectID),
 		opts.ArtifactID,
 		opts.ActorID,
 		normalizeOptionalString(opts.VisibleAfter),
@@ -1026,7 +1049,7 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 
 func (s *Store) GetItem(id int64) (Item, error) {
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		id,
@@ -1040,7 +1063,7 @@ func (s *Store) GetItemBySource(source, sourceRef string) (Item, error) {
 		return Item{}, errors.New("item source and source_ref are required")
 	}
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE source = ? AND source_ref = ?`,
 		cleanSource,
@@ -1064,10 +1087,11 @@ func (s *Store) UpsertItemFromSource(source, sourceRef, title string, workspaceI
 	case err == nil:
 		res, err := s.db.Exec(
 			`UPDATE items
-			 SET title = ?, workspace_id = ?, updated_at = datetime('now')
-			 WHERE id = ?`,
+			 SET title = ?, workspace_id = ?, project_id = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
 			cleanTitle,
 			workspaceID,
+			normalizeOptionalProjectID(existing.ProjectID),
 			existing.ID,
 		)
 		if err != nil {
@@ -1175,6 +1199,10 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 	if updates.WorkspaceID != nil {
 		parts = append(parts, "workspace_id = ?")
 		args = append(args, nullablePositiveID(*updates.WorkspaceID))
+	}
+	if updates.ProjectID != nil {
+		parts = append(parts, "project_id = ?")
+		args = append(args, normalizeOptionalProjectID(updates.ProjectID))
 	}
 	if updates.ArtifactID != nil {
 		parts = append(parts, "artifact_id = ?")
@@ -1658,7 +1686,7 @@ func (s *Store) ListItemsByState(state string) ([]Item, error) {
 		return nil, errors.New("invalid item state")
 	}
 	rows, err := s.db.Query(
-		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE state = ?`,
 		cleanState,
@@ -1692,6 +1720,7 @@ const itemSummarySelect = `SELECT
  i.title,
  i.state,
  i.workspace_id,
+ i.project_id,
  i.artifact_id,
  i.actor_id,
  i.visible_after,
@@ -1809,7 +1838,7 @@ FROM items
 
 func (s *Store) ListItems() ([]Item, error) {
 	rows, err := s.db.Query(
-		`SELECT id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items`,
 	)
 	if err != nil {

--- a/internal/store/store_item_reassign.go
+++ b/internal/store/store_item_reassign.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+)
+
+func normalizeOptionalProjectID(value *string) any {
+	if value == nil {
+		return nil
+	}
+	clean := strings.TrimSpace(*value)
+	if clean == "" {
+		return nil
+	}
+	return clean
+}
+
+func (s *Store) SetItemWorkspace(id int64, workspaceID *int64) error {
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET workspace_id = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		nullablePositiveID(valueOrZeroInt64(workspaceID)),
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) SetItemProject(id int64, projectID *string) error {
+	res, err := s.db.Exec(
+		`UPDATE items
+		 SET project_id = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		normalizeOptionalProjectID(projectID),
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func valueOrZeroInt64(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -160,6 +160,8 @@ var WebRouteSections = []RouteSection{
 			"DELETE /api/items/{item_id}",
 			"PUT /api/items/{item_id}/state",
 			"PUT /api/items/{item_id}/assign",
+			"PUT /api/items/{item_id}/workspace",
+			"PUT /api/items/{item_id}/project",
 		},
 	},
 	{

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,13 +31,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
+For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -308,6 +308,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.applyIdeaPromotion(session, action)
 	case "make_item", "delegate_item", "snooze_item", "split_items":
 		return a.createConversationItem(sessionID, session, action)
+	case "reassign_workspace", "reassign_project", "clear_workspace", "clear_project":
+		return a.executeItemReassignmentAction(session, action)
 	case "link_workspace_artifact":
 		return a.linkWorkspaceArtifact(session, action)
 	case "list_linked_artifacts":

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -71,6 +71,9 @@ func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode st
 	if ideaPromotionApply := parseInlineIdeaPromotionApplyIntent(text); ideaPromotionApply != nil {
 		return ideaPromotionApply
 	}
+	if reassignment := parseInlineItemReassignmentIntent(text); reassignment != nil {
+		return reassignment
+	}
 	switch normalized {
 	case "make this an item", "track this", "add to inbox":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
@@ -230,7 +233,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return true
 	default:
 		return false
@@ -259,7 +262,7 @@ func itemActionFailurePrefix(action string) string {
 	switch strings.ToLower(strings.TrimSpace(action)) {
 	case "split_items":
 		return "I couldn't create the items: "
-	case "triage_someday", "promote_someday":
+	case "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "triage_someday", "promote_someday":
 		return "I couldn't update the item: "
 	}
 	return "I couldn't create the item: "

--- a/internal/web/chat_items_reassign.go
+++ b/internal/web/chat_items_reassign.go
@@ -1,0 +1,175 @@
+package web
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+var (
+	itemAssignTargetPattern   = regexp.MustCompile(`(?i)^(?:move|assign|reassign)(?:\s+(?:this|it))?\s+to\s+(.+?)$`)
+	itemBelongsProjectPattern = regexp.MustCompile(`(?i)^this\s+belongs\s+to\s+(.+?)$`)
+)
+
+func parseInlineItemReassignmentIntent(text string) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	switch normalized {
+	case "remove workspace from this item", "remove workspace from this", "clear workspace for this item", "clear workspace":
+		return &SystemAction{Action: "clear_workspace", Params: map[string]interface{}{}}
+	case "remove project from this item", "remove project from this", "clear project for this item", "clear project":
+		return &SystemAction{Action: "clear_project", Params: map[string]interface{}{}}
+	}
+	if match := itemBelongsProjectPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
+		if ref := cleanWorkspaceReference(match[1]); ref != "" {
+			return &SystemAction{Action: "reassign_project", Params: map[string]interface{}{"project": ref}}
+		}
+	}
+	if match := itemAssignTargetPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
+		target := cleanWorkspaceReference(match[1])
+		if target == "" {
+			return nil
+		}
+		lower := strings.ToLower(target)
+		if strings.HasSuffix(lower, " workspace") {
+			return &SystemAction{Action: "reassign_workspace", Params: map[string]interface{}{"workspace": trimAssignmentSuffix(target, " workspace")}}
+		}
+		if strings.HasSuffix(lower, " project") {
+			return &SystemAction{Action: "reassign_project", Params: map[string]interface{}{"project": trimAssignmentSuffix(target, " project")}}
+		}
+		if looksLikeWorkspaceReference(target) {
+			return &SystemAction{Action: "reassign_workspace", Params: map[string]interface{}{"workspace": target}}
+		}
+	}
+	return nil
+}
+
+func systemActionAssignmentTarget(params map[string]interface{}) string {
+	for _, key := range []string{"workspace", "project", "target", "name", "path"} {
+		value := strings.TrimSpace(fmt.Sprint(params[key]))
+		if value != "" && value != "<nil>" {
+			return value
+		}
+	}
+	return ""
+}
+
+func trimAssignmentSuffix(raw, suffix string) string {
+	text := strings.TrimSpace(raw)
+	lower := strings.ToLower(text)
+	if strings.HasSuffix(lower, suffix) {
+		return cleanWorkspaceReference(text[:len(text)-len(suffix)])
+	}
+	return cleanWorkspaceReference(text)
+}
+
+func (a *App) resolveConversationTargetItem(session store.ChatSession, project store.Project) (store.Item, error) {
+	if item, err := a.resolveCanvasConversationItem(project); err == nil {
+		return item, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Item{}, err
+	}
+	if workspace, err := a.fallbackWorkspaceForProjectKey(session.ProjectKey); err != nil {
+		return store.Item{}, err
+	} else if workspace != nil {
+		items, listErr := a.listOpenWorkspaceItems(workspace.ID)
+		if listErr != nil {
+			return store.Item{}, listErr
+		}
+		if len(items) > 0 {
+			return items[0], nil
+		}
+	}
+	return store.Item{}, errors.New("no item is available to reassign")
+}
+
+func (a *App) resolveProjectReference(raw string) (store.Project, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" {
+		return store.Project{}, errors.New("project name is required")
+	}
+	if project, err := a.store.GetProject(ref); err == nil {
+		return project, nil
+	}
+	return a.hubFindProjectByName(ref)
+}
+
+func (a *App) executeItemReassignmentAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	item, err := a.resolveConversationTargetItem(session, targetProject)
+	if err != nil {
+		return "", nil, err
+	}
+	switch strings.ToLower(strings.TrimSpace(action.Action)) {
+	case "reassign_workspace":
+		workspace, err := a.resolveWorkspaceReference(session.ProjectKey, systemActionAssignmentTarget(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		warning, err := a.itemWorkspaceChangeWarning(item, &workspace.ID)
+		if err != nil {
+			return "", nil, err
+		}
+		if err := a.store.SetItemWorkspace(item.ID, &workspace.ID); err != nil {
+			return "", nil, err
+		}
+		message := fmt.Sprintf("Moved item %q to workspace %s.", item.Title, workspace.Name)
+		if warning != "" {
+			message += " " + warning
+		}
+		return message, map[string]interface{}{
+			"type":         "item_reassigned",
+			"item_id":      item.ID,
+			"workspace_id": workspace.ID,
+			"warning":      warning,
+		}, nil
+	case "clear_workspace":
+		warning, err := a.itemWorkspaceChangeWarning(item, nil)
+		if err != nil {
+			return "", nil, err
+		}
+		if err := a.store.SetItemWorkspace(item.ID, nil); err != nil {
+			return "", nil, err
+		}
+		message := fmt.Sprintf("Cleared the workspace for item %q.", item.Title)
+		if warning != "" {
+			message += " " + warning
+		}
+		return message, map[string]interface{}{
+			"type":         "item_reassigned",
+			"item_id":      item.ID,
+			"workspace_id": nil,
+			"warning":      warning,
+		}, nil
+	case "reassign_project":
+		project, err := a.resolveProjectReference(systemActionAssignmentTarget(action.Params))
+		if err != nil {
+			return "", nil, err
+		}
+		if err := a.store.SetItemProject(item.ID, &project.ID); err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Assigned item %q to project %s.", item.Title, project.Name), map[string]interface{}{
+			"type":       "item_reassigned",
+			"item_id":    item.ID,
+			"project_id": project.ID,
+		}, nil
+	case "clear_project":
+		if err := a.store.SetItemProject(item.ID, nil); err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("Cleared the project for item %q.", item.Title), map[string]interface{}{
+			"type":       "item_reassigned",
+			"item_id":    item.ID,
+			"project_id": nil,
+		}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported item reassignment action: %s", action.Action)
+	}
+}

--- a/internal/web/chat_items_reassign_test.go
+++ b/internal/web/chat_items_reassign_test.go
@@ -1,0 +1,140 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineItemReassignmentIntent(t *testing.T) {
+	cases := []struct {
+		text       string
+		wantAction string
+		wantTarget string
+	}{
+		{text: "move this to beta workspace", wantAction: "reassign_workspace", wantTarget: "beta"},
+		{text: "assign to ~/write/paper-x", wantAction: "reassign_workspace", wantTarget: "~/write/paper-x"},
+		{text: "assign to EUROfusion project", wantAction: "reassign_project", wantTarget: "EUROfusion"},
+		{text: "this belongs to tabura", wantAction: "reassign_project", wantTarget: "tabura"},
+		{text: "remove workspace from this item", wantAction: "clear_workspace"},
+		{text: "remove project from this item", wantAction: "clear_project"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineItemReassignmentIntent(tc.text)
+			if action == nil {
+				t.Fatal("expected item reassignment action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if tc.wantTarget != "" && systemActionAssignmentTarget(action.Params) != tc.wantTarget {
+				t.Fatalf("target = %q, want %q", systemActionAssignmentTarget(action.Params), tc.wantTarget)
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionItemReassignment(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	alpha, err := app.store.CreateWorkspace("Alpha", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha) error: %v", err)
+	}
+	beta, err := app.store.CreateWorkspace("Beta", filepath.Join(t.TempDir(), "beta"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	taburaProject, err := app.store.CreateProject("Tabura", "tabura", filepath.Join(t.TempDir(), "tabura-project"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	readmePath := filepath.Join(project.RootPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# notes\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	title := "README.md"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &readmePath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Review the README cleanup plan", store.ItemOptions{
+		WorkspaceID: &alpha.ID,
+		ArtifactID:  &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: "README.md",
+		artifactKind:  "text_artifact",
+		artifactText:  "# notes",
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port := serverPort(t, server.Listener.Addr())
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "move this to Beta workspace")
+	if !handled {
+		t.Fatal("expected workspace reassignment command to be handled")
+	}
+	if message == "" || payloads == nil {
+		t.Fatalf("unexpected workspace reassignment result: %q %#v", message, payloads)
+	}
+	updatedItem, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(reassigned workspace) error: %v", err)
+	}
+	if updatedItem.WorkspaceID == nil || *updatedItem.WorkspaceID != beta.ID {
+		t.Fatalf("workspace_id = %v, want %d", updatedItem.WorkspaceID, beta.ID)
+	}
+
+	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "this belongs to Tabura")
+	if !handled {
+		t.Fatal("expected project reassignment command to be handled")
+	}
+	if message == "" || payloads == nil {
+		t.Fatalf("unexpected project reassignment result: %q %#v", message, payloads)
+	}
+	updatedItem, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(reassigned project) error: %v", err)
+	}
+	if updatedItem.ProjectID == nil || *updatedItem.ProjectID != taburaProject.ID {
+		t.Fatalf("project_id = %v, want %q", updatedItem.ProjectID, taburaProject.ID)
+	}
+
+	message, _, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "remove workspace from this item")
+	if !handled {
+		t.Fatal("expected clear workspace command to be handled")
+	}
+	if message == "" {
+		t.Fatal("expected clear workspace confirmation message")
+	}
+	updatedItem, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(cleared workspace) error: %v", err)
+	}
+	if updatedItem.WorkspaceID != nil {
+		t.Fatalf("workspace_id = %v, want nil", updatedItem.WorkspaceID)
+	}
+}

--- a/internal/web/items_reassign.go
+++ b/internal/web/items_reassign.go
@@ -1,0 +1,170 @@
+package web
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type itemWorkspaceUpdateRequest struct {
+	WorkspaceID *int64 `json:"workspace_id"`
+}
+
+type itemProjectUpdateRequest struct {
+	ProjectID *string `json:"project_id"`
+}
+
+var (
+	errItemWorkspaceNotFound = errors.New("workspace not found")
+	errItemProjectNotFound   = errors.New("project not found")
+)
+
+func (a *App) ensureWorkspaceExists(workspaceID int64) error {
+	if workspaceID <= 0 {
+		return errItemWorkspaceNotFound
+	}
+	if _, err := a.store.GetWorkspace(workspaceID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errItemWorkspaceNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (a *App) ensureProjectExists(projectID string) error {
+	if strings.TrimSpace(projectID) == "" {
+		return errItemProjectNotFound
+	}
+	if _, err := a.store.GetProject(projectID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errItemProjectNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (a *App) handleItemWorkspaceUpdate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req itemWorkspaceUpdateRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.WorkspaceID != nil {
+		if err := a.ensureWorkspaceExists(*req.WorkspaceID); err != nil {
+			if errors.Is(err, errItemWorkspaceNotFound) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	warning, err := a.itemWorkspaceChangeWarning(item, req.WorkspaceID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := a.store.SetItemWorkspace(itemID, req.WorkspaceID); err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	item, err = a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":      true,
+		"item":    item,
+		"warning": warning,
+	})
+}
+
+func (a *App) handleItemProjectUpdate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req itemProjectUpdateRequest
+	if err := decodeJSON(r, &req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.ProjectID != nil && strings.TrimSpace(*req.ProjectID) != "" {
+		if err := a.ensureProjectExists(*req.ProjectID); err != nil {
+			if errors.Is(err, errItemProjectNotFound) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	if err := a.store.SetItemProject(itemID, req.ProjectID); err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":   true,
+		"item": item,
+	})
+}
+
+func (a *App) itemWorkspaceChangeWarning(item store.Item, nextWorkspaceID *int64) (string, error) {
+	if item.WorkspaceID == nil || item.ArtifactID == nil {
+		return "", nil
+	}
+	if nextWorkspaceID != nil && *nextWorkspaceID == *item.WorkspaceID {
+		return "", nil
+	}
+	artifact, err := a.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if artifact.RefPath == nil || strings.TrimSpace(*artifact.RefPath) == "" {
+		return "", nil
+	}
+	workspace, err := a.store.GetWorkspace(*item.WorkspaceID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	artifactPath := filepath.Clean(strings.TrimSpace(*artifact.RefPath))
+	if !pathWithinRoot(artifactPath, workspace.DirPath) {
+		return "", nil
+	}
+	return "Artifact link kept: the referenced file still points into the previous workspace.", nil
+}

--- a/internal/web/items_reassign_test.go
+++ b/internal/web/items_reassign_test.go
@@ -1,0 +1,129 @@
+package web
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestItemWorkspaceAndProjectReassignmentAPI(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	oldWorkspace, err := app.store.CreateWorkspace("Alpha", filepath.Join(t.TempDir(), "alpha"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha) error: %v", err)
+	}
+	newWorkspace, err := app.store.CreateWorkspace("Beta", filepath.Join(t.TempDir(), "beta"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	project, err := app.store.CreateProject("Tabura", "tabura", filepath.Join(t.TempDir(), "project"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+
+	refPath := filepath.Join(oldWorkspace.DirPath, "README.md")
+	title := "README.md"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &refPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Review workspace assignment", store.ItemOptions{
+		WorkspaceID: &oldWorkspace.ID,
+		ArtifactID:  &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	rrWorkspace := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/workspace", map[string]any{
+		"workspace_id": newWorkspace.ID,
+	})
+	if rrWorkspace.Code != http.StatusOK {
+		t.Fatalf("workspace reassignment status = %d, want 200: %s", rrWorkspace.Code, rrWorkspace.Body.String())
+	}
+	workspacePayload := decodeJSONResponse(t, rrWorkspace)
+	if got := strFromAny(workspacePayload["warning"]); got == "" {
+		t.Fatalf("workspace warning = %q, want artifact link warning", got)
+	}
+	updatedItem, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(reassigned workspace) error: %v", err)
+	}
+	if updatedItem.WorkspaceID == nil || *updatedItem.WorkspaceID != newWorkspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", updatedItem.WorkspaceID, newWorkspace.ID)
+	}
+	updatedArtifact, err := app.store.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact(updated) error: %v", err)
+	}
+	if updatedArtifact.RefPath == nil || *updatedArtifact.RefPath != refPath {
+		t.Fatalf("artifact ref_path = %v, want %q", updatedArtifact.RefPath, refPath)
+	}
+
+	rrProject := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/project", map[string]any{
+		"project_id": project.ID,
+	})
+	if rrProject.Code != http.StatusOK {
+		t.Fatalf("project reassignment status = %d, want 200: %s", rrProject.Code, rrProject.Body.String())
+	}
+	updatedItem, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(reassigned project) error: %v", err)
+	}
+	if updatedItem.ProjectID == nil || *updatedItem.ProjectID != project.ID {
+		t.Fatalf("project_id = %v, want %q", updatedItem.ProjectID, project.ID)
+	}
+
+	rrClearProject := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/project", map[string]any{
+		"project_id": nil,
+	})
+	if rrClearProject.Code != http.StatusOK {
+		t.Fatalf("clear project status = %d, want 200: %s", rrClearProject.Code, rrClearProject.Body.String())
+	}
+	updatedItem, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(cleared project) error: %v", err)
+	}
+	if updatedItem.ProjectID != nil {
+		t.Fatalf("cleared project_id = %v, want nil", updatedItem.ProjectID)
+	}
+
+	rrClearWorkspace := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/workspace", map[string]any{
+		"workspace_id": nil,
+	})
+	if rrClearWorkspace.Code != http.StatusOK {
+		t.Fatalf("clear workspace status = %d, want 200: %s", rrClearWorkspace.Code, rrClearWorkspace.Body.String())
+	}
+	updatedItem, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(cleared workspace) error: %v", err)
+	}
+	if updatedItem.WorkspaceID != nil {
+		t.Fatalf("cleared workspace_id = %v, want nil", updatedItem.WorkspaceID)
+	}
+}
+
+func TestItemWorkspaceAndProjectReassignmentAPIRejectsUnknownTargets(t *testing.T) {
+	app := newAuthedTestApp(t)
+	item, err := app.store.CreateItem("Reassign me", store.ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	rrWorkspace := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/workspace", map[string]any{
+		"workspace_id": 9999,
+	})
+	if rrWorkspace.Code != http.StatusBadRequest {
+		t.Fatalf("unknown workspace status = %d, want 400: %s", rrWorkspace.Code, rrWorkspace.Body.String())
+	}
+
+	rrProject := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/project", map[string]any{
+		"project_id": "missing-project",
+	})
+	if rrProject.Code != http.StatusBadRequest {
+		t.Fatalf("unknown project status = %d, want 400: %s", rrProject.Code, rrProject.Body.String())
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -417,6 +417,8 @@ func (a *App) Router() http.Handler {
 	r.Put("/api/items/{item_id}/assign", a.handleItemAssign)
 	r.Put("/api/items/{item_id}/unassign", a.handleItemUnassign)
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)
+	r.Put("/api/items/{item_id}/workspace", a.handleItemWorkspaceUpdate)
+	r.Put("/api/items/{item_id}/project", a.handleItemProjectUpdate)
 	r.Put("/api/items/{item_id}/state", a.handleItemStateUpdate)
 	r.Post("/api/items/{item_id}/triage", a.handleItemTriage)
 	r.Get("/api/items/{item_id}/print", a.handleItemPrint)

--- a/internal/web/static/app-item-sidebar-utils.js
+++ b/internal/web/static/app-item-sidebar-utils.js
@@ -229,6 +229,89 @@ export async function fetchItemSidebarActors() {
     .filter((actor) => actor.id > 0 && actor.name);
 }
 
+export async function fetchItemSidebarWorkspaces() {
+  const resp = await fetch(apiURL('workspaces'), { cache: 'no-store' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const payload = await resp.json();
+  const workspaces = Array.isArray(payload?.workspaces) ? payload.workspaces : [];
+  return workspaces
+    .map((workspace) => ({
+      id: Number(workspace?.id || 0),
+      name: String(workspace?.name || '').trim(),
+    }))
+    .filter((workspace) => workspace.id > 0 && workspace.name);
+}
+
+export async function fetchItemSidebarProjects() {
+  const resp = await fetch(apiURL('projects'), { cache: 'no-store' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const payload = await resp.json();
+  const projects = Array.isArray(payload?.projects) ? payload.projects : [];
+  return projects
+    .map((project) => ({
+      id: String(project?.id || '').trim(),
+      name: String(project?.name || '').trim(),
+    }))
+    .filter((project) => project.id && project.name && project.id !== 'hub');
+}
+
+export async function performItemSidebarWorkspaceUpdate(item, workspaceID = null, workspaceName = '') {
+  const itemID = Number(item?.id || 0);
+  if (itemID <= 0) return false;
+  const body = { workspace_id: workspaceID };
+  try {
+    const resp = await fetch(apiURL(`items/${encodeURIComponent(String(itemID))}/workspace`), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    state.itemSidebarActiveItemID = itemID;
+    await loadItemSidebarView(state.itemSidebarView);
+    const warning = String(payload?.warning || '').trim();
+    const label = workspaceID ? `workspace set to ${String(workspaceName || '').trim() || 'selected workspace'}` : 'workspace cleared';
+    showStatus(warning ? `${label}. ${warning}` : label);
+    return true;
+  } catch (err) {
+    showStatus(`workspace picker failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+export async function performItemSidebarProjectUpdate(item, projectID = '', projectName = '') {
+  const itemID = Number(item?.id || 0);
+  if (itemID <= 0) return false;
+  const body = { project_id: projectID || null };
+  try {
+    const resp = await fetch(apiURL(`items/${encodeURIComponent(String(itemID))}/project`), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    state.itemSidebarActiveItemID = itemID;
+    await loadItemSidebarView(state.itemSidebarView);
+    showStatus(projectID ? `project set to ${String(projectName || '').trim() || 'selected project'}` : 'project cleared');
+    return true;
+  } catch (err) {
+    showStatus(`project picker failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
 export async function performItemSidebarTriage(item, action, options = {}) {
   const itemID = Number(item?.id || 0);
   if (itemID <= 0) return false;
@@ -320,6 +403,68 @@ export async function showItemSidebarDelegateMenu(item, x, y) {
   }
 }
 
+export async function showItemSidebarWorkspaceMenu(item, x, y) {
+  try {
+    const workspaces = await fetchItemSidebarWorkspaces();
+    if (workspaces.length === 0) {
+      showStatus('no workspaces available');
+      return false;
+    }
+    const currentWorkspaceID = Number(item?.workspace_id || 0);
+    const entries = [];
+    if (currentWorkspaceID > 0) {
+      entries.push({
+        label: 'Clear workspace',
+        action: 'clear_workspace',
+        onClick: () => performItemSidebarWorkspaceUpdate(item, null, ''),
+      });
+    }
+    workspaces.forEach((workspace) => {
+      entries.push({
+        label: workspace.id === currentWorkspaceID ? `${workspace.name} (current)` : workspace.name,
+        action: 'reassign_workspace',
+        onClick: () => performItemSidebarWorkspaceUpdate(item, workspace.id, workspace.name),
+      });
+    });
+    showItemSidebarMenu(entries, x, y);
+    return true;
+  } catch (err) {
+    showStatus(`workspace picker failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
+export async function showItemSidebarProjectMenu(item, x, y) {
+  try {
+    const projects = await fetchItemSidebarProjects();
+    if (projects.length === 0) {
+      showStatus('no projects available');
+      return false;
+    }
+    const currentProjectID = String(item?.project_id || '').trim();
+    const entries = [];
+    if (currentProjectID) {
+      entries.push({
+        label: 'Clear project',
+        action: 'clear_project',
+        onClick: () => performItemSidebarProjectUpdate(item, '', ''),
+      });
+    }
+    projects.forEach((project) => {
+      entries.push({
+        label: project.id === currentProjectID ? `${project.name} (current)` : project.name,
+        action: 'reassign_project',
+        onClick: () => performItemSidebarProjectUpdate(item, project.id, project.name),
+      });
+    });
+    showItemSidebarMenu(entries, x, y);
+    return true;
+  } catch (err) {
+    showStatus(`project picker failed: ${String(err?.message || err || 'unknown error')}`);
+    return false;
+  }
+}
+
 export function showItemSidebarActionMenu(item, x, y) {
   const view = normalizeItemSidebarView(state.itemSidebarView);
   const entries = view === 'someday'
@@ -335,6 +480,16 @@ export function showItemSidebarActionMenu(item, x, y) {
         onClick: () => performItemSidebarTriage(item, 'done'),
       },
       {
+        label: 'Workspace...',
+        action: 'workspace',
+        onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
+      },
+      {
+        label: 'Project...',
+        action: 'project',
+        onClick: () => showItemSidebarProjectMenu(item, x, y),
+      },
+      {
         label: itemSidebarActionLabel('delete', item),
         action: 'delete',
         onClick: () => performItemSidebarTriage(item, 'delete'),
@@ -345,6 +500,16 @@ export function showItemSidebarActionMenu(item, x, y) {
         label: itemSidebarActionLabel('done', item),
         action: 'done',
         onClick: () => performItemSidebarTriage(item, 'done'),
+      },
+      {
+        label: 'Workspace...',
+        action: 'workspace',
+        onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
+      },
+      {
+        label: 'Project...',
+        action: 'project',
+        onClick: () => showItemSidebarProjectMenu(item, x, y),
       },
       {
         label: itemSidebarActionLabel('later', item),

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -418,6 +418,10 @@
       { id: 2, name: 'Bob', kind: 'human' },
       { id: 3, name: 'Codex', kind: 'agent' },
     ]);
+    const defaultItemSidebarWorkspaces = () => ([
+      { id: 1, name: 'Alpha', dir_path: '/tmp/alpha', is_active: true },
+      { id: 2, name: 'Beta', dir_path: '/tmp/beta', is_active: false },
+    ]);
     const defaultItemSidebarArtifacts = () => ({
       501: {
         id: 501,
@@ -557,6 +561,7 @@
     ].join('\n');
     window.__itemSidebarData = defaultItemSidebarData();
     window.__itemSidebarActors = defaultItemSidebarActors();
+    window.__itemSidebarWorkspaces = defaultItemSidebarWorkspaces();
     window.__itemSidebarArtifacts = defaultItemSidebarArtifacts();
     window.__meetingSummaryProposals = defaultMeetingSummaryProposals();
     window.__itemSidebarResponseDelays = {
@@ -577,6 +582,11 @@
       window.__itemSidebarActors = Array.isArray(next)
         ? next.map((actor) => ({ ...actor }))
         : defaultItemSidebarActors();
+    };
+    window.__setItemSidebarWorkspaces = (next) => {
+      window.__itemSidebarWorkspaces = Array.isArray(next)
+        ? next.map((workspace) => ({ ...workspace }))
+        : defaultItemSidebarWorkspaces();
     };
     window.__setItemSidebarArtifacts = (next) => {
       const source = next && typeof next === 'object' ? next : {};
@@ -658,6 +668,25 @@
       });
       window.__itemSidebarData = data;
       return removed;
+    }
+    function patchItemSidebarEntry(itemID, patch = {}) {
+      const data = window.__itemSidebarData || defaultItemSidebarData();
+      const states = ['inbox', 'waiting', 'someday', 'done'];
+      let updated = null;
+      states.forEach((stateKey) => {
+        const rows = Array.isArray(data[stateKey]) ? data[stateKey] : [];
+        const index = rows.findIndex((entry) => Number(entry?.id || 0) === Number(itemID));
+        if (index < 0) return;
+        updated = {
+          ...cloneItemSidebarEntry(rows[index]),
+          ...patch,
+          updated_at: '2026-03-08 15:00:00',
+        };
+        rows[index] = updated;
+        data[stateKey] = rows;
+      });
+      window.__itemSidebarData = data;
+      return updated;
     }
     function prependInboxItem(entry) {
       const data = window.__itemSidebarData || defaultItemSidebarData();
@@ -1137,6 +1166,10 @@
         if (delayMs > 0) await sleep(delayMs);
         return new Response(JSON.stringify({ ok: true, counts }), { status: 200 });
       }
+      if (u.includes('/api/workspaces')) {
+        const workspaces = Array.isArray(window.__itemSidebarWorkspaces) ? window.__itemSidebarWorkspaces : defaultItemSidebarWorkspaces();
+        return new Response(JSON.stringify({ ok: true, workspaces }), { status: 200 });
+      }
       if (/\/api\/items\/\d+\/triage(?:\?|$)/.test(u) && opts?.method === 'POST') {
         let body = {};
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
@@ -1169,6 +1202,58 @@
         }
         if (action === 'delete') {
           return new Response(JSON.stringify({ ok: true, deleted: true, item_id: itemID }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ ok: true, item }), { status: 200 });
+      }
+      if (/\/api\/items\/\d+\/workspace(?:\?|$)/.test(u) && opts?.method === 'PUT') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        const match = u.match(/\/api\/items\/(\d+)\/workspace(?:\?|$)/);
+        const itemID = Number(match?.[1] || 0);
+        const workspaceID = body.workspace_id == null ? null : Number(body.workspace_id || 0);
+        const workspaces = Array.isArray(window.__itemSidebarWorkspaces) ? window.__itemSidebarWorkspaces : defaultItemSidebarWorkspaces();
+        if (workspaceID !== null && !workspaces.some((workspace) => Number(workspace?.id || 0) === workspaceID)) {
+          return new Response('workspace not found', { status: 400 });
+        }
+        const existingRows = ['inbox', 'waiting', 'someday', 'done']
+          .flatMap((stateKey) => Array.isArray((window.__itemSidebarData || {})[stateKey]) ? (window.__itemSidebarData || {})[stateKey] : []);
+        const existing = existingRows.find((entry) => Number(entry?.id || 0) === itemID) || null;
+        const previousWorkspaceID = existing && existing.workspace_id != null ? Number(existing.workspace_id || 0) : null;
+        const item = patchItemSidebarEntry(itemID, { workspace_id: workspaceID });
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'item_workspace',
+          method: opts?.method || 'PUT',
+          url: u,
+          payload: body,
+        });
+        if (!item) {
+          return new Response('item not found', { status: 404 });
+        }
+        const warning = previousWorkspaceID === null || previousWorkspaceID === workspaceID
+          ? ''
+          : 'Artifact link kept: the referenced file still points into the previous workspace.';
+        return new Response(JSON.stringify({ ok: true, item, warning }), { status: 200 });
+      }
+      if (/\/api\/items\/\d+\/project(?:\?|$)/.test(u) && opts?.method === 'PUT') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        const match = u.match(/\/api\/items\/(\d+)\/project(?:\?|$)/);
+        const itemID = Number(match?.[1] || 0);
+        const projectID = body.project_id == null ? '' : String(body.project_id || '').trim();
+        if (projectID && !harnessProjects.some((project) => String(project.id || '').trim() === projectID)) {
+          return new Response('project not found', { status: 400 });
+        }
+        const item = patchItemSidebarEntry(itemID, { project_id: projectID });
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'item_project',
+          method: opts?.method || 'PUT',
+          url: u,
+          payload: body,
+        });
+        if (!item) {
+          return new Response('item not found', { status: 404 });
         }
         return new Response(JSON.stringify({ ok: true, item }), { status: 200 });
       }

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -244,6 +244,56 @@ test.describe('inbox triage interactions', () => {
     expect(triageCalls.map((entry: any) => entry?.payload?.action)).toEqual(['done', 'delete', 'delegate', 'later']);
   });
 
+  test('desktop context menu workspace and project pickers reassign the active item', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarWorkspaces([
+        { id: 1, name: 'Alpha', dir_path: '/tmp/alpha', is_active: true },
+        { id: 2, name: 'Beta', dir_path: '/tmp/beta', is_active: false },
+      ]);
+    });
+    await openInbox(page);
+    await setInboxItems(page, [{
+      ...parserInboxItem,
+      workspace_id: 1,
+      project_id: '',
+    }]);
+
+    const row = page.locator('#pr-file-list .pr-file-item[data-item-id="101"]');
+
+    await row.click({ button: 'right' });
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Workspace...');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Workspace...' }).click();
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Beta');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Beta' }).click();
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const log = (window as any).__harnessLog || [];
+        return log.some((entry: any) => entry?.action === 'item_workspace');
+      });
+    }).toBe(true);
+
+    await row.click({ button: 'right' });
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Project...');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Project...' }).click();
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Test');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Test' }).click();
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const log = (window as any).__harnessLog || [];
+        return log.some((entry: any) => entry?.action === 'item_project');
+      });
+    }).toBe(true);
+
+    const itemState = await page.evaluate(() => {
+      const data = (window as any).__itemSidebarData || {};
+      return Array.isArray(data.inbox) ? data.inbox[0] : null;
+    });
+    expect(itemState?.workspace_id).toBe(2);
+    expect(itemState?.project_id).toBe('test');
+  });
+
   test('stale inbox reload does not resurrect a triaged item', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitReady(page);


### PR DESCRIPTION
## Summary
- add dedicated item workspace/project reassignment support in the store and API, including preserved artifact-link warnings on workspace moves
- add inline dialogue commands for workspace/project reassignment and clearing
- add inbox context-menu pickers for workspace/project reassignment and refresh the generated route inventory

## Verification
- Items movable between workspaces via dialogue and UI: `go test ./internal/store ./internal/web -run "Test(StoreMigratesDomainTablesOnFreshDatabase|ItemSchemaAllowsNilOptionalFields|ItemSchemaEnforcesForeignKeys|ItemWorkspaceAndProjectReassignmentAPI|ItemWorkspaceAndProjectReassignmentAPIRejectsUnknownTargets|ParseInlineItemReassignmentIntent|ClassifyAndExecuteSystemActionItemReassignment)"` covers `TestClassifyAndExecuteSystemActionItemReassignment`; `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts` covers `desktop context menu workspace and project pickers reassign the active item`. Output excerpts: `ok github.com/krystophny/tabura/internal/web 0.027s`, `8 passed (6.9s)`.
- Items movable between projects via dialogue and UI: same Go and Playwright commands above; the Go chat test assigns the canvas-linked item to project `Tabura`, and the Playwright picker test assigns the inbox item to project `Test`.
- Workspace and project independently overridable: `TestItemWorkspaceAndProjectReassignmentAPI` sets workspace and project independently, then clears each independently through `PUT /api/items/{item_id}/workspace` and `PUT /api/items/{item_id}/project`. Output excerpt: `ok github.com/krystophny/tabura/internal/web 0.027s`.
- Reassignment updates stored correctly: `TestItemWorkspaceAndProjectReassignmentAPI` reads `app.store.GetItem(...)` after each reassignment and clear operation and asserts the persisted `workspace_id` and `project_id` values.
- Artifact links preserved on workspace reassignment: `TestItemWorkspaceAndProjectReassignmentAPI` asserts the artifact `ref_path` stays unchanged after workspace reassignment and that the API returns a warning. Output excerpt: `ok github.com/krystophny/tabura/internal/web 0.027s`.
- Route inventory stays in sync with the new endpoints: `./scripts/sync-surface.sh` updated `docs/interfaces.md`, and `./scripts/sync-surface.sh --check` passed afterward. Output excerpt: `updated: /home/ert/code/assi/tabula/docs/interfaces.md`.
