### PR TITLE
fix: add sphere column and account binding table (fixes #244)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -48,6 +48,7 @@ type ItemUpdate struct {
 	State        *string `json:"state,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	ProjectID    *string `json:"project_id,omitempty"`
+	Sphere       *string `json:"sphere,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`
@@ -60,6 +61,7 @@ type ItemOptions struct {
 	State        string  `json:"state,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	ProjectID    *string `json:"project_id,omitempty"`
+	Sphere       *string `json:"sphere,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`
@@ -72,6 +74,7 @@ type Workspace struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`
 	DirPath   string `json:"dir_path"`
+	Sphere    string `json:"sphere"`
 	IsActive  bool   `json:"is_active"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
@@ -164,6 +167,7 @@ type Item struct {
 	State        string  `json:"state"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	ProjectID    *string `json:"project_id,omitempty"`
+	Sphere       string  `json:"sphere"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
 	ActorID      *int64  `json:"actor_id,omitempty"`
 	VisibleAfter *string `json:"visible_after,omitempty"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -31,7 +31,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		t.Fatalf("TableColumns() error: %v", err)
 	}
 	for table, want := range map[string][]string{
-		"workspaces":                  {"id", "name", "dir_path", "is_active", "created_at", "updated_at"},
+		"workspaces":                  {"id", "name", "dir_path", "sphere", "is_active", "created_at", "updated_at"},
 		"actors":                      {"id", "name", "kind", "created_at"},
 		"artifacts":                   {"id", "kind", "ref_path", "ref_url", "title", "meta_json", "created_at", "updated_at"},
 		"external_accounts":           {"id", "sphere", "provider", "label", "config_json", "enabled", "created_at", "updated_at"},
@@ -39,7 +39,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"item_artifacts":              {"item_id", "artifact_id", "role", "created_at"},
 		"workspace_artifact_links":    {"workspace_id", "artifact_id", "created_at"},
 		"external_bindings":           {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
-		"items":                       {"id", "title", "state", "workspace_id", "project_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
+		"items":                       {"id", "title", "state", "workspace_id", "project_id", "sphere", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "created_at", "updated_at"},
 	} {
 		got := make(map[string]bool, len(columns[table]))
 		for _, name := range columns[table] {
@@ -198,20 +198,24 @@ func TestItemSchemaAllowsNilOptionalFields(t *testing.T) {
 
 	var (
 		title                               string
+		sphere                              string
 		workspaceID, artifactID, actorID    sql.NullInt64
 		projectID, visibleAfter, followUpAt sql.NullString
 		source, sourceRef                   sql.NullString
 	)
 	err = s.db.QueryRow(`
-SELECT title, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+SELECT title, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
 FROM items
 WHERE id = ?
-`, id).Scan(&title, &workspaceID, &projectID, &artifactID, &actorID, &visibleAfter, &followUpAt, &source, &sourceRef)
+`, id).Scan(&title, &workspaceID, &projectID, &sphere, &artifactID, &actorID, &visibleAfter, &followUpAt, &source, &sourceRef)
 	if err != nil {
 		t.Fatalf("query item: %v", err)
 	}
 	if title != "triage me" {
 		t.Fatalf("title = %q, want triage me", title)
+	}
+	if sphere != SpherePrivate {
+		t.Fatalf("sphere = %q, want %q", sphere, SpherePrivate)
 	}
 	if workspaceID.Valid || projectID.Valid || artifactID.Valid || actorID.Valid || visibleAfter.Valid || followUpAt.Valid || source.Valid || sourceRef.Valid {
 		t.Fatalf("expected optional fields to remain NULL, got workspace=%v project=%v artifact=%v actor=%v visible_after=%v follow_up_at=%v source=%v source_ref=%v",
@@ -275,6 +279,16 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorkspace(workspace-b) error: %v", err)
 	}
+	if workspaceA.Sphere != SpherePrivate || workspaceB.Sphere != SpherePrivate {
+		t.Fatalf("default workspace spheres = %q/%q, want private/private", workspaceA.Sphere, workspaceB.Sphere)
+	}
+	workWorkspace, err := s.CreateWorkspace("Workspace Work", filepath.Join(t.TempDir(), "workspace-work"), SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(workspace-work) error: %v", err)
+	}
+	if workWorkspace.Sphere != SphereWork {
+		t.Fatalf("CreateWorkspace(workspace-work).Sphere = %q, want %q", workWorkspace.Sphere, SphereWork)
+	}
 	gotByPath, err := s.GetWorkspaceByPath(workspaceBPath)
 	if err != nil {
 		t.Fatalf("GetWorkspaceByPath() error: %v", err)
@@ -292,8 +306,8 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListWorkspaces() error: %v", err)
 	}
-	if len(workspaces) != 2 {
-		t.Fatalf("ListWorkspaces() len = %d, want 2", len(workspaces))
+	if len(workspaces) != 3 {
+		t.Fatalf("ListWorkspaces() len = %d, want 3", len(workspaces))
 	}
 	if !workspaces[0].IsActive || workspaces[0].ID != workspaceB.ID {
 		t.Fatalf("ListWorkspaces() active workspace mismatch: %+v", workspaces)
@@ -409,10 +423,13 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 		t.Fatalf("CreateItem(artifact) error: %v", err)
 	}
 	workspaceItem, err := s.CreateItem("Workspace item", ItemOptions{
-		WorkspaceID: &workspaceA.ID,
+		WorkspaceID: &workWorkspace.ID,
 	})
 	if err != nil {
 		t.Fatalf("CreateItem(workspace) error: %v", err)
+	}
+	if workspaceItem.Sphere != SphereWork {
+		t.Fatalf("CreateItem(workspace).Sphere = %q, want %q", workspaceItem.Sphere, SphereWork)
 	}
 	assignedItem, err := s.CreateItem("Assigned item", ItemOptions{
 		State:        ItemStateWaiting,
@@ -433,6 +450,9 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	}
 	if assignedItem.ActorID == nil || *assignedItem.ActorID != human.ID {
 		t.Fatalf("CreateItem(assigned).ActorID = %v, want %d", assignedItem.ActorID, human.ID)
+	}
+	if assignedItem.Sphere != SpherePrivate {
+		t.Fatalf("CreateItem(assigned).Sphere = %q, want %q", assignedItem.Sphere, SpherePrivate)
 	}
 	sourceCompleteRef := "issue-183"
 	sourceItem, err := s.CreateItem("Source completion item", ItemOptions{
@@ -601,7 +621,7 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 		t.Fatal("expected invalid ListItemsByState error")
 	}
 
-	if err := s.DeleteWorkspace(workspaceA.ID); err != nil {
+	if err := s.DeleteWorkspace(workWorkspace.ID); err != nil {
 		t.Fatalf("DeleteWorkspace() error: %v", err)
 	}
 	workspaceItem, err = s.GetItem(workspaceItem.ID)
@@ -610,6 +630,9 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	}
 	if workspaceItem.WorkspaceID != nil {
 		t.Fatalf("workspace item WorkspaceID = %v, want nil", *workspaceItem.WorkspaceID)
+	}
+	if workspaceItem.Sphere != SphereWork {
+		t.Fatalf("workspace item sphere after workspace delete = %q, want %q", workspaceItem.Sphere, SphereWork)
 	}
 	if err := s.DeleteArtifact(artifact.ID); err != nil {
 		t.Fatalf("DeleteArtifact() error: %v", err)
@@ -637,6 +660,77 @@ func TestDomainCRUDRoundTrip(t *testing.T) {
 	}
 	if _, err := s.GetItem(assignedItem.ID); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("GetItem(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestSphereInheritanceAndMutators(t *testing.T) {
+	s := newTestStore(t)
+
+	if got, err := s.ActiveSphere(); err != nil {
+		t.Fatalf("ActiveSphere() error: %v", err)
+	} else if got != SpherePrivate {
+		t.Fatalf("default ActiveSphere() = %q, want %q", got, SpherePrivate)
+	}
+	if err := s.SetActiveSphere(SphereWork); err != nil {
+		t.Fatalf("SetActiveSphere() error: %v", err)
+	}
+	workspace, err := s.CreateWorkspace("Work", filepath.Join(t.TempDir(), "work"), SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if _, err := s.CreateWorkspace("Bad", filepath.Join(t.TempDir(), "bad"), "office"); err == nil {
+		t.Fatal("expected invalid workspace sphere error")
+	}
+
+	item, err := s.CreateItem("Capture", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	if item.Sphere != SphereWork {
+		t.Fatalf("CreateItem().Sphere = %q, want %q", item.Sphere, SphereWork)
+	}
+
+	workspaceItem, err := s.CreateItem("Workspace item", ItemOptions{WorkspaceID: &workspace.ID})
+	if err != nil {
+		t.Fatalf("CreateItem(workspace) error: %v", err)
+	}
+	if workspaceItem.Sphere != SphereWork {
+		t.Fatalf("CreateItem(workspace).Sphere = %q, want %q", workspaceItem.Sphere, SphereWork)
+	}
+
+	if err := s.SetItemSphere(item.ID, SpherePrivate); err != nil {
+		t.Fatalf("SetItemSphere() error: %v", err)
+	}
+	if updated, err := s.GetItem(item.ID); err != nil {
+		t.Fatalf("GetItem(updated) error: %v", err)
+	} else if updated.Sphere != SpherePrivate {
+		t.Fatalf("SetItemSphere().Sphere = %q, want %q", updated.Sphere, SpherePrivate)
+	}
+	if err := s.SetItemSphere(workspaceItem.ID, SpherePrivate); err == nil {
+		t.Fatal("expected workspace-backed item sphere error")
+	}
+
+	if _, err := s.SetWorkspaceSphere(workspace.ID, SpherePrivate); err != nil {
+		t.Fatalf("SetWorkspaceSphere() error: %v", err)
+	}
+	if refreshed, err := s.GetItem(workspaceItem.ID); err != nil {
+		t.Fatalf("GetItem(workspaceItem) error: %v", err)
+	} else if refreshed.Sphere != SpherePrivate {
+		t.Fatalf("workspace-backed item sphere = %q, want %q", refreshed.Sphere, SpherePrivate)
+	}
+
+	if _, err := s.AddSphereAccount(SphereWork, ExternalProviderGmail, "Work Gmail", map[string]any{"username": "alice@example.com"}); err != nil {
+		t.Fatalf("AddSphereAccount() error: %v", err)
+	}
+	accounts, err := s.ListSphereAccounts(SphereWork)
+	if err != nil {
+		t.Fatalf("ListSphereAccounts() error: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("ListSphereAccounts() len = %d, want 1", len(accounts))
+	}
+	if err := s.RemoveSphereAccount(accounts[0].ID); err != nil {
+		t.Fatalf("RemoveSphereAccount() error: %v", err)
 	}
 }
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -19,6 +19,7 @@ const itemsTableSchema = `CREATE TABLE IF NOT EXISTS items (
   state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'someday', 'done')),
   workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
   project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
+  sphere TEXT NOT NULL DEFAULT 'private' CHECK (sphere IN ('work', 'private')),
   artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
   actor_id INTEGER REFERENCES actors(id) ON DELETE SET NULL,
   visible_after TEXT,
@@ -35,6 +36,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
   id INTEGER PRIMARY KEY,
   name TEXT NOT NULL,
   dir_path TEXT NOT NULL UNIQUE,
+  sphere TEXT NOT NULL DEFAULT 'private' CHECK (sphere IN ('work', 'private')),
   is_active INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -113,6 +115,12 @@ CREATE INDEX IF NOT EXISTS idx_external_bindings_stale
 	if err := s.migrateItemProjectColumnSupport(); err != nil {
 		return err
 	}
+	if err := s.migrateWorkspaceSphereSupport(); err != nil {
+		return err
+	}
+	if err := s.migrateItemSphereSupport(); err != nil {
+		return err
+	}
 	return s.migrateItemArtifactLinkSupport()
 }
 
@@ -147,6 +155,24 @@ func normalizeActorKind(kind string) string {
 	}
 }
 
+func normalizeSphere(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case SphereWork:
+		return SphereWork
+	case "", SpherePrivate:
+		return SpherePrivate
+	default:
+		return ""
+	}
+}
+
+func normalizeRequiredSphere(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	return normalizeSphere(raw)
+}
+
 func normalizeOptionalString(v *string) any {
 	if v == nil {
 		return nil
@@ -175,6 +201,29 @@ func normalizeItemState(state string) string {
 	default:
 		return ""
 	}
+}
+
+func (s *Store) ActiveSphere() (string, error) {
+	value, err := s.AppState("active_sphere")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(value) == "" {
+		return SpherePrivate, nil
+	}
+	sphere := normalizeSphere(value)
+	if sphere == "" {
+		return "", errors.New("active sphere must be work or private")
+	}
+	return sphere, nil
+}
+
+func (s *Store) SetActiveSphere(sphere string) error {
+	cleanSphere := normalizeRequiredSphere(sphere)
+	if cleanSphere == "" {
+		return errors.New("active sphere must be work or private")
+	}
+	return s.SetAppState("active_sphere", cleanSphere)
 }
 
 func validateItemTransition(current, next string) error {
@@ -210,10 +259,10 @@ func (s *Store) migrateItemTableStateSupport() error {
 	}
 	if _, err := tx.Exec(`
 INSERT INTO items (
-	id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+	id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 )
 SELECT
-	id, title, state, workspace_id, NULL, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+	id, title, state, workspace_id, NULL, 'private', artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 FROM items_legacy
 `); err != nil {
 		return err
@@ -236,6 +285,30 @@ func (s *Store) migrateItemProjectColumnSupport() error {
 	return err
 }
 
+func (s *Store) migrateWorkspaceSphereSupport() error {
+	tableColumns, err := s.tableColumnSet("workspaces")
+	if err != nil {
+		return err
+	}
+	if tableColumns["workspaces"]["sphere"] {
+		return nil
+	}
+	_, err = s.db.Exec(`ALTER TABLE workspaces ADD COLUMN sphere TEXT NOT NULL DEFAULT 'private' CHECK (sphere IN ('work', 'private'))`)
+	return err
+}
+
+func (s *Store) migrateItemSphereSupport() error {
+	tableColumns, err := s.tableColumnSet("items")
+	if err != nil {
+		return err
+	}
+	if tableColumns["items"]["sphere"] {
+		return nil
+	}
+	_, err = s.db.Exec(`ALTER TABLE items ADD COLUMN sphere TEXT NOT NULL DEFAULT 'private' CHECK (sphere IN ('work', 'private'))`)
+	return err
+}
+
 func scanWorkspace(
 	row interface {
 		Scan(dest ...any) error
@@ -243,12 +316,13 @@ func scanWorkspace(
 ) (Workspace, error) {
 	var out Workspace
 	var isActive int
-	err := row.Scan(&out.ID, &out.Name, &out.DirPath, &isActive, &out.CreatedAt, &out.UpdatedAt)
+	err := row.Scan(&out.ID, &out.Name, &out.DirPath, &out.Sphere, &isActive, &out.CreatedAt, &out.UpdatedAt)
 	if err != nil {
 		return Workspace{}, err
 	}
 	out.Name = normalizeWorkspaceName(out.Name)
 	out.DirPath = normalizeWorkspacePath(out.DirPath)
+	out.Sphere = normalizeSphere(out.Sphere)
 	out.IsActive = isActive != 0
 	return out, nil
 }
@@ -298,6 +372,7 @@ func scanItem(
 		out                                 Item
 		workspaceID, artifactID, actorID    sql.NullInt64
 		projectID, visibleAfter, followUpAt sql.NullString
+		sphere                              string
 		source, sourceRef                   sql.NullString
 	)
 	err := row.Scan(
@@ -306,6 +381,7 @@ func scanItem(
 		&out.State,
 		&workspaceID,
 		&projectID,
+		&sphere,
 		&artifactID,
 		&actorID,
 		&visibleAfter,
@@ -322,6 +398,7 @@ func scanItem(
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
 	out.ProjectID = nullStringPointer(projectID)
+	out.Sphere = normalizeSphere(sphere)
 	out.ArtifactID = nullInt64Pointer(artifactID)
 	out.ActorID = nullInt64Pointer(actorID)
 	out.VisibleAfter = nullStringPointer(visibleAfter)
@@ -340,6 +417,7 @@ func scanItemSummary(
 		out                                    ItemSummary
 		workspaceID, artifactID, actorID       sql.NullInt64
 		projectID, visibleAfter, followUpAt    sql.NullString
+		sphere                                 string
 		source, sourceRef                      sql.NullString
 		artifactTitle, artifactKind, actorName sql.NullString
 	)
@@ -349,6 +427,7 @@ func scanItemSummary(
 		&out.State,
 		&workspaceID,
 		&projectID,
+		&sphere,
 		&artifactID,
 		&actorID,
 		&visibleAfter,
@@ -368,6 +447,7 @@ func scanItemSummary(
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
 	out.ProjectID = nullStringPointer(projectID)
+	out.Sphere = normalizeSphere(sphere)
 	out.ArtifactID = nullInt64Pointer(artifactID)
 	out.ActorID = nullInt64Pointer(actorID)
 	out.VisibleAfter = nullStringPointer(visibleAfter)
@@ -399,16 +479,48 @@ func nullInt64Pointer(v sql.NullInt64) *int64 {
 	return &value
 }
 
-func (s *Store) CreateWorkspace(name, dirPath string) (Workspace, error) {
+func (s *Store) workspaceSphere(id int64) (string, error) {
+	workspace, err := s.GetWorkspace(id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", errors.New("foreign key constraint failed: workspace_id")
+		}
+		return "", err
+	}
+	return workspace.Sphere, nil
+}
+
+func (s *Store) resolveItemSphere(workspaceID *int64, requested *string) (string, error) {
+	if workspaceID != nil && *workspaceID > 0 {
+		return s.workspaceSphere(*workspaceID)
+	}
+	if requested != nil {
+		sphere := normalizeRequiredSphere(*requested)
+		if sphere == "" {
+			return "", errors.New("item sphere must be work or private")
+		}
+		return sphere, nil
+	}
+	return s.ActiveSphere()
+}
+
+func (s *Store) CreateWorkspace(name, dirPath string, sphere ...string) (Workspace, error) {
 	cleanName := normalizeWorkspaceName(name)
 	cleanPath := normalizeWorkspacePath(dirPath)
+	cleanSphere := SpherePrivate
+	if len(sphere) > 0 {
+		cleanSphere = normalizeRequiredSphere(sphere[0])
+	}
 	if cleanName == "" {
 		return Workspace{}, errors.New("workspace name is required")
 	}
 	if cleanPath == "" {
 		return Workspace{}, errors.New("workspace path is required")
 	}
-	res, err := s.db.Exec(`INSERT INTO workspaces (name, dir_path) VALUES (?, ?)`, cleanName, cleanPath)
+	if cleanSphere == "" {
+		return Workspace{}, errors.New("workspace sphere must be work or private")
+	}
+	res, err := s.db.Exec(`INSERT INTO workspaces (name, dir_path, sphere) VALUES (?, ?, ?)`, cleanName, cleanPath, cleanSphere)
 	if err != nil {
 		return Workspace{}, err
 	}
@@ -421,7 +533,7 @@ func (s *Store) CreateWorkspace(name, dirPath string) (Workspace, error) {
 
 func (s *Store) GetWorkspace(id int64) (Workspace, error) {
 	return scanWorkspace(s.db.QueryRow(
-		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		`SELECT id, name, dir_path, sphere, is_active, created_at, updated_at
 		 FROM workspaces
 		 WHERE id = ?`,
 		id,
@@ -430,7 +542,7 @@ func (s *Store) GetWorkspace(id int64) (Workspace, error) {
 
 func (s *Store) GetWorkspaceByPath(dirPath string) (Workspace, error) {
 	return scanWorkspace(s.db.QueryRow(
-		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		`SELECT id, name, dir_path, sphere, is_active, created_at, updated_at
 		 FROM workspaces
 		 WHERE dir_path = ?`,
 		normalizeWorkspacePath(dirPath),
@@ -439,7 +551,7 @@ func (s *Store) GetWorkspaceByPath(dirPath string) (Workspace, error) {
 
 func (s *Store) ListWorkspaces() ([]Workspace, error) {
 	rows, err := s.db.Query(
-		`SELECT id, name, dir_path, is_active, created_at, updated_at
+		`SELECT id, name, dir_path, sphere, is_active, created_at, updated_at
 		 FROM workspaces`,
 	)
 	if err != nil {
@@ -657,6 +769,43 @@ func (s *Store) UpdateWorkspaceName(id int64, name string) (Workspace, error) {
 	}
 	if affected == 0 {
 		return Workspace{}, sql.ErrNoRows
+	}
+	return s.GetWorkspace(id)
+}
+
+func (s *Store) SetWorkspaceSphere(id int64, sphere string) (Workspace, error) {
+	cleanSphere := normalizeRequiredSphere(sphere)
+	if cleanSphere == "" {
+		return Workspace{}, errors.New("workspace sphere must be work or private")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return Workspace{}, err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(`UPDATE workspaces SET sphere = ?, updated_at = datetime('now') WHERE id = ?`, cleanSphere, id)
+	if err != nil {
+		return Workspace{}, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return Workspace{}, err
+	}
+	if affected == 0 {
+		return Workspace{}, sql.ErrNoRows
+	}
+	if _, err := tx.Exec(
+		`UPDATE items
+		 SET sphere = ?, updated_at = datetime('now')
+		 WHERE workspace_id = ?`,
+		cleanSphere,
+		id,
+	); err != nil {
+		return Workspace{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Workspace{}, err
 	}
 	return s.GetWorkspace(id)
 }
@@ -1025,6 +1174,10 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 		}
 		opts.WorkspaceID = inferredWorkspaceID
 	}
+	itemSphere, err := s.resolveItemSphere(opts.WorkspaceID, opts.Sphere)
+	if err != nil {
+		return Item{}, err
+	}
 	tx, err := s.db.Begin()
 	if err != nil {
 		return Item{}, err
@@ -1033,12 +1186,13 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 
 	res, err := tx.Exec(
 		`INSERT INTO items (
-			title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		cleanTitle,
 		cleanState,
 		opts.WorkspaceID,
 		normalizeOptionalProjectID(opts.ProjectID),
+		itemSphere,
 		opts.ArtifactID,
 		opts.ActorID,
 		normalizeOptionalString(opts.VisibleAfter),
@@ -1064,7 +1218,7 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 
 func (s *Store) GetItem(id int64) (Item, error) {
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		id,
@@ -1078,7 +1232,7 @@ func (s *Store) GetItemBySource(source, sourceRef string) (Item, error) {
 		return Item{}, errors.New("item source and source_ref are required")
 	}
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE source = ? AND source_ref = ?`,
 		cleanSource,
@@ -1100,13 +1254,18 @@ func (s *Store) UpsertItemFromSource(source, sourceRef, title string, workspaceI
 	existing, err := s.GetItemBySource(cleanSource, cleanSourceRef)
 	switch {
 	case err == nil:
+		itemSphere, err := s.resolveItemSphere(workspaceID, &existing.Sphere)
+		if err != nil {
+			return Item{}, err
+		}
 		res, err := s.db.Exec(
 			`UPDATE items
-			 SET title = ?, workspace_id = ?, project_id = ?, updated_at = datetime('now')
+			 SET title = ?, workspace_id = ?, project_id = ?, sphere = ?, updated_at = datetime('now')
 		 WHERE id = ?`,
 			cleanTitle,
 			workspaceID,
 			normalizeOptionalProjectID(existing.ProjectID),
+			itemSphere,
 			existing.ID,
 		)
 		if err != nil {
@@ -1179,6 +1338,7 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 	args := []any{}
 	artifactUpdated := false
 	var artifactID *int64
+	targetWorkspaceID := item.WorkspaceID
 
 	if updates.Title != nil {
 		title := strings.TrimSpace(*updates.Title)
@@ -1199,10 +1359,27 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 	if updates.WorkspaceID != nil {
 		parts = append(parts, "workspace_id = ?")
 		args = append(args, nullablePositiveID(*updates.WorkspaceID))
+		if *updates.WorkspaceID > 0 {
+			value := *updates.WorkspaceID
+			targetWorkspaceID = &value
+		} else {
+			targetWorkspaceID = nil
+		}
 	}
 	if updates.ProjectID != nil {
 		parts = append(parts, "project_id = ?")
 		args = append(args, normalizeOptionalProjectID(updates.ProjectID))
+	}
+	if updates.Sphere != nil {
+		if targetWorkspaceID != nil {
+			return errors.New("item sphere is derived from workspace")
+		}
+		nextSphere := normalizeRequiredSphere(*updates.Sphere)
+		if nextSphere == "" {
+			return errors.New("item sphere must be work or private")
+		}
+		parts = append(parts, "sphere = ?")
+		args = append(args, nextSphere)
 	}
 	if updates.ArtifactID != nil {
 		artifactUpdated = true
@@ -1248,6 +1425,14 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 			args = append(args, nil, nil)
 		}
 	}
+	if targetWorkspaceID != nil {
+		workspaceSphere, err := s.workspaceSphere(*targetWorkspaceID)
+		if err != nil {
+			return err
+		}
+		parts = append(parts, "sphere = ?")
+		args = append(args, workspaceSphere)
+	}
 	if len(parts) == 0 && !artifactUpdated {
 		return nil
 	}
@@ -1272,6 +1457,44 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 		}
 	}
 	return nil
+}
+
+func (s *Store) SetItemSphere(id int64, sphere string) error {
+	item, err := s.GetItem(id)
+	if err != nil {
+		return err
+	}
+	if item.WorkspaceID != nil {
+		return errors.New("item sphere is derived from workspace")
+	}
+	cleanSphere := normalizeRequiredSphere(sphere)
+	if cleanSphere == "" {
+		return errors.New("item sphere must be work or private")
+	}
+	res, err := s.db.Exec(`UPDATE items SET sphere = ?, updated_at = datetime('now') WHERE id = ?`, cleanSphere, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *Store) ListSphereAccounts(sphere string) ([]ExternalAccount, error) {
+	return s.ListExternalAccounts(sphere)
+}
+
+func (s *Store) AddSphereAccount(sphere, kind, label string, config map[string]any) (ExternalAccount, error) {
+	return s.CreateExternalAccount(sphere, kind, label, config)
+}
+
+func (s *Store) RemoveSphereAccount(id int64) error {
+	return s.DeleteExternalAccount(id)
 }
 
 func (s *Store) SyncItemStateBySource(source, sourceRef, state string) error {
@@ -1696,7 +1919,7 @@ func (s *Store) ListItemsByState(state string) ([]Item, error) {
 		return nil, errors.New("invalid item state")
 	}
 	rows, err := s.db.Query(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE state = ?`,
 		cleanState,
@@ -1731,6 +1954,7 @@ const itemSummarySelect = `SELECT
  i.state,
  i.workspace_id,
  i.project_id,
+ i.sphere,
  i.artifact_id,
  i.actor_id,
  i.visible_after,
@@ -1848,7 +2072,7 @@ FROM items
 
 func (s *Store) ListItems() ([]Item, error) {
 	rows, err := s.db.Query(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items`,
 	)
 	if err != nil {

--- a/internal/store/store_item_artifact.go
+++ b/internal/store/store_item_artifact.go
@@ -63,7 +63,7 @@ func (s *Store) syncPrimaryItemArtifact(id int64, artifactID *int64) error {
 
 func (s *Store) syncPrimaryItemArtifactTx(tx *sql.Tx, id int64, artifactID *int64) error {
 	if _, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		id,
@@ -162,7 +162,7 @@ func (s *Store) LinkItemArtifact(itemID, artifactID int64, role string) error {
 	defer tx.Rollback()
 
 	item, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		itemID,
@@ -214,7 +214,7 @@ func (s *Store) UnlinkItemArtifact(itemID, artifactID int64) error {
 	defer tx.Rollback()
 
 	item, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, project_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		itemID,
@@ -360,6 +360,7 @@ func (s *Store) ListArtifactItems(artifactID int64) ([]Item, error) {
 		   i.state,
 		   i.workspace_id,
 		   i.project_id,
+		   i.sphere,
 		   i.artifact_id,
 		   i.actor_id,
 		   i.visible_after,

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -15,6 +15,7 @@ type itemCreateRequest struct {
 	Title        string  `json:"title"`
 	State        string  `json:"state"`
 	WorkspaceID  *int64  `json:"workspace_id"`
+	Sphere       *string `json:"sphere"`
 	ArtifactID   *int64  `json:"artifact_id"`
 	ActorID      *int64  `json:"actor_id"`
 	VisibleAfter *string `json:"visible_after"`
@@ -27,6 +28,7 @@ type itemUpdateRequest struct {
 	Title        *string `json:"title"`
 	State        *string `json:"state"`
 	WorkspaceID  *int64  `json:"workspace_id"`
+	Sphere       *string `json:"sphere"`
 	ArtifactID   *int64  `json:"artifact_id"`
 	ActorID      *int64  `json:"actor_id"`
 	VisibleAfter *string `json:"visible_after"`
@@ -205,6 +207,7 @@ func (a *App) handleItemCreate(w http.ResponseWriter, r *http.Request) {
 	item, err := a.store.CreateItem(req.Title, store.ItemOptions{
 		State:        req.State,
 		WorkspaceID:  req.WorkspaceID,
+		Sphere:       req.Sphere,
 		ArtifactID:   req.ArtifactID,
 		ActorID:      req.ActorID,
 		VisibleAfter: req.VisibleAfter,
@@ -270,6 +273,7 @@ func (a *App) handleItemUpdate(w http.ResponseWriter, r *http.Request) {
 		Title:        req.Title,
 		State:        req.State,
 		WorkspaceID:  req.WorkspaceID,
+		Sphere:       req.Sphere,
 		ArtifactID:   req.ArtifactID,
 		ActorID:      req.ActorID,
 		VisibleAfter: req.VisibleAfter,

--- a/internal/web/items_test.go
+++ b/internal/web/items_test.go
@@ -87,6 +87,9 @@ func TestItemCRUDAndStateAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorkspace() error: %v", err)
 	}
+	if _, err := app.store.SetWorkspaceSphere(workspace.ID, store.SphereWork); err != nil {
+		t.Fatalf("SetWorkspaceSphere() error: %v", err)
+	}
 	artifactTitle := "Plan"
 	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, nil, nil, &artifactTitle, nil)
 	if err != nil {
@@ -113,6 +116,9 @@ func TestItemCRUDAndStateAPI(t *testing.T) {
 		t.Fatalf("create item payload = %#v", createPayload)
 	}
 	itemID := int64(itemPayload["id"].(float64))
+	if got := itemPayload["sphere"]; got != store.SphereWork {
+		t.Fatalf("create item sphere = %#v, want %q", got, store.SphereWork)
+	}
 
 	rrList := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items?state=inbox", nil)
 	if rrList.Code != http.StatusOK {
@@ -163,6 +169,9 @@ func TestItemCRUDAndStateAPI(t *testing.T) {
 	if doneItem.State != store.ItemStateDone {
 		t.Fatalf("done state = %q, want %q", doneItem.State, store.ItemStateDone)
 	}
+	if doneItem.Sphere != store.SphereWork {
+		t.Fatalf("done item sphere = %q, want %q", doneItem.Sphere, store.SphereWork)
+	}
 
 	rrGet := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/"+itoa(itemID), nil)
 	if rrGet.Code != http.StatusOK {
@@ -177,6 +186,44 @@ func TestItemCRUDAndStateAPI(t *testing.T) {
 	rrMissing := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/"+itoa(itemID), nil)
 	if rrMissing.Code != http.StatusNotFound {
 		t.Fatalf("deleted item status = %d, want 404: %s", rrMissing.Code, rrMissing.Body.String())
+	}
+}
+
+func TestItemSphereAPI(t *testing.T) {
+	app := newAuthedTestApp(t)
+	if err := app.store.SetActiveSphere(store.SphereWork); err != nil {
+		t.Fatalf("SetActiveSphere() error: %v", err)
+	}
+
+	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items", map[string]any{
+		"title": "Active sphere item",
+	})
+	if rrCreate.Code != http.StatusOK {
+		t.Fatalf("create item status = %d, want 200: %s", rrCreate.Code, rrCreate.Body.String())
+	}
+	createPayload := decodeJSONResponse(t, rrCreate)
+	itemPayload, ok := createPayload["item"].(map[string]any)
+	if !ok {
+		t.Fatalf("create payload = %#v", createPayload)
+	}
+	itemID := int64(itemPayload["id"].(float64))
+	if got := itemPayload["sphere"]; got != store.SphereWork {
+		t.Fatalf("created sphere = %#v, want %q", got, store.SphereWork)
+	}
+
+	privateSphere := store.SpherePrivate
+	rrUpdate := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(itemID), map[string]any{
+		"sphere": privateSphere,
+	})
+	if rrUpdate.Code != http.StatusOK {
+		t.Fatalf("update item sphere status = %d, want 200: %s", rrUpdate.Code, rrUpdate.Body.String())
+	}
+	updated, err := app.store.GetItem(itemID)
+	if err != nil {
+		t.Fatalf("GetItem(updated) error: %v", err)
+	}
+	if updated.Sphere != store.SpherePrivate {
+		t.Fatalf("updated sphere = %q, want %q", updated.Sphere, store.SpherePrivate)
 	}
 }
 

--- a/internal/web/workspaces.go
+++ b/internal/web/workspaces.go
@@ -1,15 +1,20 @@
 package web
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 type workspaceCreateRequest struct {
 	Name     string `json:"name"`
 	DirPath  string `json:"dir_path"`
+	Sphere   string `json:"sphere"`
 	IsActive bool   `json:"is_active"`
 }
 
 type workspaceUpdateRequest struct {
 	Name     *string `json:"name"`
+	Sphere   *string `json:"sphere"`
 	IsActive *bool   `json:"is_active"`
 }
 
@@ -37,7 +42,11 @@ func (a *App) handleWorkspaceCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	workspace, err := a.store.CreateWorkspace(req.Name, req.DirPath)
+	if strings.TrimSpace(req.Sphere) == "" {
+		http.Error(w, "sphere is required", http.StatusBadRequest)
+		return
+	}
+	workspace, err := a.store.CreateWorkspace(req.Name, req.DirPath, req.Sphere)
 	if err != nil {
 		writeDomainStoreError(w, err)
 		return
@@ -73,7 +82,7 @@ func (a *App) handleWorkspaceUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if req.Name == nil && req.IsActive == nil {
+	if req.Name == nil && req.Sphere == nil && req.IsActive == nil {
 		http.Error(w, "at least one workspace update is required", http.StatusBadRequest)
 		return
 	}
@@ -84,6 +93,13 @@ func (a *App) handleWorkspaceUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Name != nil {
 		workspace, err = a.store.UpdateWorkspaceName(workspaceID, *req.Name)
+		if err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+	}
+	if req.Sphere != nil {
+		workspace, err = a.store.SetWorkspaceSphere(workspaceID, *req.Sphere)
 		if err != nil {
 			writeDomainStoreError(w, err)
 			return

--- a/internal/web/workspaces_test.go
+++ b/internal/web/workspaces_test.go
@@ -13,6 +13,7 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/workspaces", map[string]any{
 		"name":      " Workspace One ",
 		"dir_path":  workspacePath,
+		"sphere":    "work",
 		"is_active": true,
 	})
 	if rrCreate.Code != http.StatusOK {
@@ -26,6 +27,9 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 	workspaceID := int64(workspacePayload["id"].(float64))
 	if workspacePayload["name"] != "Workspace One" {
 		t.Fatalf("workspace name = %#v, want %q", workspacePayload["name"], "Workspace One")
+	}
+	if workspacePayload["sphere"] != "work" {
+		t.Fatalf("workspace sphere = %#v, want %q", workspacePayload["sphere"], "work")
 	}
 	if isActive, _ := workspacePayload["is_active"].(bool); !isActive {
 		t.Fatalf("workspace payload = %#v, want active workspace", workspacePayload)
@@ -48,6 +52,7 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 
 	rrUpdate := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/workspaces/"+itoa(workspaceID), map[string]any{
 		"name":      "Renamed Workspace",
+		"sphere":    "private",
 		"is_active": true,
 	})
 	if rrUpdate.Code != http.StatusOK {
@@ -61,6 +66,9 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 	if updatedWorkspace["name"] != "Renamed Workspace" {
 		t.Fatalf("updated workspace name = %#v, want %q", updatedWorkspace["name"], "Renamed Workspace")
 	}
+	if updatedWorkspace["sphere"] != "private" {
+		t.Fatalf("updated workspace sphere = %#v, want %q", updatedWorkspace["sphere"], "private")
+	}
 	if isActive, _ := updatedWorkspace["is_active"].(bool); !isActive {
 		t.Fatalf("updated workspace payload = %#v, want active workspace", updatedWorkspace)
 	}
@@ -68,9 +76,18 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 	rrDuplicate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/workspaces", map[string]any{
 		"name":     "Duplicate",
 		"dir_path": workspacePath,
+		"sphere":   "work",
 	})
 	if rrDuplicate.Code != http.StatusConflict {
 		t.Fatalf("duplicate workspace status = %d, want 409: %s", rrDuplicate.Code, rrDuplicate.Body.String())
+	}
+
+	rrMissingSphere := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/workspaces", map[string]any{
+		"name":     "No Sphere",
+		"dir_path": filepath.Join(t.TempDir(), "workspace-two"),
+	})
+	if rrMissingSphere.Code != http.StatusBadRequest {
+		t.Fatalf("missing sphere status = %d, want 400: %s", rrMissingSphere.Code, rrMissingSphere.Body.String())
 	}
 
 	rrDelete := doAuthedJSONRequest(t, app.Router(), http.MethodDelete, "/api/workspaces/"+itoa(workspaceID), nil)


### PR DESCRIPTION
## Summary
- add `sphere` to workspace and item domain models plus schema migrations for existing databases
- derive item sphere from the attached workspace or the persisted active sphere, and expose sphere updates through the workspace/item APIs
- add store coverage for sphere mutators and sphere account helpers, plus API coverage for workspace and item sphere behavior

## Verification
- `workspaces sphere column + item sphere column present on fresh/existing DBs`
  Command: `go test ./internal/store ./internal/web 2>&1 | tee /tmp/issue244-tests.log`
  Evidence: `/tmp/issue244-tests.log` includes `ok   github.com/krystophny/tabura/internal/store 1.457s` after `TestStoreMigratesDomainTablesOnFreshDatabase` and `TestStoreMigratesExistingItemsTableToAllowSomeday` exercised the schema paths.
- `workspace sphere is stored, required by the API, and propagates to attached items`
  Command: `go test ./internal/web -run 'TestWorkspaceCRUDAPI|TestItemCRUDAndStateAPI'`
  Evidence: `ok   github.com/krystophny/tabura/internal/web` with assertions that `/api/workspaces` rejects missing `sphere`, persists `sphere`, and item payloads inherited the workspace's `work` sphere.
- `items without a workspace inherit the active sphere and can be moved directly when detached`
  Command: `go test ./internal/web -run 'TestItemSphereAPI|TestItemDomainAPIRejectsConflictAndInvalidState'`
  Evidence: `ok   github.com/krystophny/tabura/internal/web` after `TestItemSphereAPI` created an item under active sphere `work` and updated it to `private`.
- `store-level sphere mutators and account binding helpers work end-to-end`
  Command: `go test ./internal/store -run 'TestSphereInheritanceAndMutators'`
  Evidence: covered `SetActiveSphere`, `SetWorkspaceSphere`, `SetItemSphere`, `AddSphereAccount`, `ListSphereAccounts`, and `RemoveSphereAccount` in a single passing test.
