### PR TITLE
fix: add unified external inbox view with provider filters (fixes #268)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -70,6 +70,14 @@ type ItemOptions struct {
 	SourceRef    *string `json:"source_ref,omitempty"`
 }
 
+type ItemListFilter struct {
+	Sphere              string  `json:"sphere,omitempty"`
+	Source              string  `json:"source,omitempty"`
+	WorkspaceID         *int64  `json:"workspace_id,omitempty"`
+	WorkspaceUnassigned bool    `json:"workspace_unassigned,omitempty"`
+	ProjectID           *string `json:"project_id,omitempty"`
+}
+
 type Workspace struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -1077,6 +1077,90 @@ func TestItemStateSummariesAndCounts(t *testing.T) {
 	}
 }
 
+func TestItemSummaryFilters(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Date(2026, time.March, 8, 10, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	workspace, err := s.CreateWorkspace("Alpha", filepath.Join(t.TempDir(), "alpha"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	project, err := s.CreateProject("Alpha Project", "alpha-project", filepath.Join(t.TempDir(), "project"), "managed", "", "canvas-alpha", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	projectID := project.ID
+	sourceTodoist := ExternalProviderTodoist
+	sourceExchange := ExternalProviderExchange
+
+	unassignedItem, err := s.CreateItem("Unassigned todoist item", ItemOptions{
+		State:        ItemStateInbox,
+		VisibleAfter: &past,
+		Source:       &sourceTodoist,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(unassigned) error: %v", err)
+	}
+	if _, err := s.CreateItem("Workspace todoist item", ItemOptions{
+		State:        ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		ProjectID:    &projectID,
+		VisibleAfter: &past,
+		Source:       &sourceTodoist,
+	}); err != nil {
+		t.Fatalf("CreateItem(workspace todoist) error: %v", err)
+	}
+	if _, err := s.CreateItem("Workspace exchange item", ItemOptions{
+		State:        ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+		Source:       &sourceExchange,
+	}); err != nil {
+		t.Fatalf("CreateItem(workspace exchange) error: %v", err)
+	}
+
+	todoistItems, err := s.ListInboxItemsFiltered(now, ItemListFilter{Source: ExternalProviderTodoist})
+	if err != nil {
+		t.Fatalf("ListInboxItemsFiltered(todoist) error: %v", err)
+	}
+	if len(todoistItems) != 2 {
+		t.Fatalf("ListInboxItemsFiltered(todoist) len = %d, want 2", len(todoistItems))
+	}
+
+	unassignedItems, err := s.ListInboxItemsFiltered(now, ItemListFilter{WorkspaceUnassigned: true})
+	if err != nil {
+		t.Fatalf("ListInboxItemsFiltered(unassigned) error: %v", err)
+	}
+	if len(unassignedItems) != 1 || unassignedItems[0].ID != unassignedItem.ID {
+		t.Fatalf("ListInboxItemsFiltered(unassigned) = %+v, want only item %d", unassignedItems, unassignedItem.ID)
+	}
+
+	workspaceItems, err := s.ListInboxItemsFiltered(now, ItemListFilter{WorkspaceID: &workspace.ID})
+	if err != nil {
+		t.Fatalf("ListInboxItemsFiltered(workspace) error: %v", err)
+	}
+	if len(workspaceItems) != 2 {
+		t.Fatalf("ListInboxItemsFiltered(workspace) len = %d, want 2", len(workspaceItems))
+	}
+
+	projectItems, err := s.ListInboxItemsFiltered(now, ItemListFilter{ProjectID: &projectID})
+	if err != nil {
+		t.Fatalf("ListInboxItemsFiltered(project) error: %v", err)
+	}
+	if len(projectItems) != 1 {
+		t.Fatalf("ListInboxItemsFiltered(project) len = %d, want 1", len(projectItems))
+	}
+
+	counts, err := s.CountItemsByStateFiltered(now, ItemListFilter{Source: ExternalProviderTodoist})
+	if err != nil {
+		t.Fatalf("CountItemsByStateFiltered(todoist) error: %v", err)
+	}
+	if got := counts[ItemStateInbox]; got != 2 {
+		t.Fatalf("CountItemsByStateFiltered(todoist)[inbox] = %d, want 2", got)
+	}
+}
+
 func TestFindWorkspaceContainingPathPrefersDeepestMatch(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -196,6 +196,65 @@ func normalizeOptionalString(v *string) any {
 	return clean
 }
 
+func normalizeOptionalSourceFilter(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func normalizeItemListFilter(filter ItemListFilter) (ItemListFilter, error) {
+	normalized := ItemListFilter{
+		Source:              normalizeOptionalSourceFilter(filter.Source),
+		WorkspaceUnassigned: filter.WorkspaceUnassigned,
+	}
+	sphere, err := normalizeOptionalSphereFilter(filter.Sphere)
+	if err != nil {
+		return ItemListFilter{}, err
+	}
+	normalized.Sphere = sphere
+	if filter.WorkspaceID != nil {
+		if *filter.WorkspaceID <= 0 {
+			return ItemListFilter{}, errors.New("workspace_id must be a positive integer")
+		}
+		value := *filter.WorkspaceID
+		normalized.WorkspaceID = &value
+	}
+	if normalized.WorkspaceID != nil && normalized.WorkspaceUnassigned {
+		return ItemListFilter{}, errors.New("workspace_id cannot be combined with workspace_id=null")
+	}
+	if filter.ProjectID != nil {
+		projectID := strings.TrimSpace(*filter.ProjectID)
+		if projectID != "" {
+			normalized.ProjectID = &projectID
+		}
+	}
+	return normalized, nil
+}
+
+func appendItemFilterClauses(parts []string, args []any, filter ItemListFilter, alias string) ([]string, []any) {
+	column := func(name string) string {
+		return alias + name
+	}
+	if filter.Sphere != "" {
+		parts = append(parts, column("sphere")+" = ?")
+		args = append(args, filter.Sphere)
+	}
+	if filter.Source != "" {
+		parts = append(parts, "lower(trim("+column("source")+")) = ?")
+		args = append(args, filter.Source)
+	}
+	if filter.WorkspaceID != nil {
+		parts = append(parts, column("workspace_id")+" = ?")
+		args = append(args, *filter.WorkspaceID)
+	}
+	if filter.WorkspaceUnassigned {
+		parts = append(parts, column("workspace_id")+" IS NULL")
+	}
+	if filter.ProjectID != nil {
+		parts = append(parts, column("project_id")+" = ?")
+		args = append(args, *filter.ProjectID)
+	}
+	return parts, args
+}
+
 func normalizeArtifactKind(kind ArtifactKind) ArtifactKind {
 	return ArtifactKind(strings.TrimSpace(string(kind)))
 }
@@ -1941,26 +2000,28 @@ func (s *Store) DeleteItem(id int64) error {
 }
 
 func (s *Store) ListItemsByState(state string) ([]Item, error) {
-	return s.ListItemsByStateForSphere(state, "")
+	return s.ListItemsByStateFiltered(state, ItemListFilter{})
 }
 
 func (s *Store) ListItemsByStateForSphere(state, sphere string) ([]Item, error) {
+	return s.ListItemsByStateFiltered(state, ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) ListItemsByStateFiltered(state string, filter ItemListFilter) ([]Item, error) {
 	cleanState := normalizeItemState(state)
 	if cleanState == "" {
 		return nil, errors.New("invalid item state")
 	}
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
+	parts := []string{"state = ?"}
+	args := []any{cleanState}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "")
 	query := `SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
 		 FROM items
-		 WHERE state = ?`
-	args := []any{cleanState}
-	if cleanSphere != "" {
-		query += ` AND sphere = ?`
-		args = append(args, cleanSphere)
-	}
+		 WHERE ` + stringsJoin(parts, " AND ")
 	rows, err := s.db.Query(
 		query,
 		args...,
@@ -2042,105 +2103,119 @@ func (s *Store) listItemSummaries(query string, args ...any) ([]ItemSummary, err
 }
 
 func (s *Store) ListInboxItems(now time.Time) ([]ItemSummary, error) {
-	return s.ListInboxItemsForSphere(now, "")
+	return s.ListInboxItemsFiltered(now, ItemListFilter{})
 }
 
 func (s *Store) ListInboxItemsForSphere(now time.Time, sphere string) ([]ItemSummary, error) {
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	return s.ListInboxItemsFiltered(now, ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) ListInboxItemsFiltered(now time.Time, filter ItemListFilter) ([]ItemSummary, error) {
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
 	cutoff := now.UTC().Format(time.RFC3339Nano)
-	query := itemSummarySelect + `
- WHERE i.state = ?
-   AND (
-     i.visible_after IS NULL
-     OR trim(i.visible_after) = ''
-     OR datetime(i.visible_after) <= datetime(?)
-   )
-`
-	args := []any{ItemStateInbox, cutoff}
-	if cleanSphere != "" {
-		query += `   AND i.sphere = ?` + "\n"
-		args = append(args, cleanSphere)
+	parts := []string{
+		`i.state = ?`,
+		`(
+	     i.visible_after IS NULL
+	     OR trim(i.visible_after) = ''
+	     OR datetime(i.visible_after) <= datetime(?)
+	   )`,
 	}
-	query += ` ORDER BY i.updated_at DESC, i.id ASC`
+	args := []any{ItemStateInbox, cutoff}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + `
+ WHERE ` + stringsJoin(parts, `
+   AND `) + `
+ ORDER BY i.updated_at DESC, i.id ASC`
 	return s.listItemSummaries(query, args...)
 }
 
 func (s *Store) ListWaitingItems() ([]ItemSummary, error) {
-	return s.ListWaitingItemsForSphere("")
+	return s.ListWaitingItemsFiltered(ItemListFilter{})
 }
 
 func (s *Store) ListWaitingItemsForSphere(sphere string) ([]ItemSummary, error) {
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	return s.ListWaitingItemsFiltered(ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) ListWaitingItemsFiltered(filter ItemListFilter) ([]ItemSummary, error) {
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
-	query := itemSummarySelect + ` WHERE i.state = ?`
+	parts := []string{"i.state = ?"}
 	args := []any{ItemStateWaiting}
-	if cleanSphere != "" {
-		query += ` AND i.sphere = ?`
-		args = append(args, cleanSphere)
-	}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + ` WHERE ` + stringsJoin(parts, ` AND `)
 	query += ` ORDER BY i.updated_at DESC, i.id ASC`
 	return s.listItemSummaries(query, args...)
 }
 
 func (s *Store) ListSomedayItems() ([]ItemSummary, error) {
-	return s.ListSomedayItemsForSphere("")
+	return s.ListSomedayItemsFiltered(ItemListFilter{})
 }
 
 func (s *Store) ListSomedayItemsForSphere(sphere string) ([]ItemSummary, error) {
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	return s.ListSomedayItemsFiltered(ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) ListSomedayItemsFiltered(filter ItemListFilter) ([]ItemSummary, error) {
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
-	query := itemSummarySelect + ` WHERE i.state = ?`
+	parts := []string{"i.state = ?"}
 	args := []any{ItemStateSomeday}
-	if cleanSphere != "" {
-		query += ` AND i.sphere = ?`
-		args = append(args, cleanSphere)
-	}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + ` WHERE ` + stringsJoin(parts, ` AND `)
 	query += ` ORDER BY i.updated_at DESC, i.id ASC`
 	return s.listItemSummaries(query, args...)
 }
 
 func (s *Store) ListDoneItems(limit int) ([]ItemSummary, error) {
-	return s.ListDoneItemsForSphere(limit, "")
+	return s.ListDoneItemsFiltered(limit, ItemListFilter{})
 }
 
 func (s *Store) ListDoneItemsForSphere(limit int, sphere string) ([]ItemSummary, error) {
+	return s.ListDoneItemsFiltered(limit, ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) ListDoneItemsFiltered(limit int, filter ItemListFilter) ([]ItemSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
-	query := itemSummarySelect + ` WHERE i.state = ?`
+	parts := []string{"i.state = ?"}
 	args := []any{ItemStateDone}
-	if cleanSphere != "" {
-		query += ` AND i.sphere = ?`
-		args = append(args, cleanSphere)
-	}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + ` WHERE ` + stringsJoin(parts, ` AND `)
 	query += ` ORDER BY i.updated_at DESC, i.id ASC LIMIT ?`
 	args = append(args, limit)
 	return s.listItemSummaries(query, args...)
 }
 
 func (s *Store) CountItemsByState(now time.Time) (map[string]int, error) {
-	return s.CountItemsByStateForSphere(now, "")
+	return s.CountItemsByStateFiltered(now, ItemListFilter{})
 }
 
 func (s *Store) CountItemsByStateForSphere(now time.Time, sphere string) (map[string]int, error) {
+	return s.CountItemsByStateFiltered(now, ItemListFilter{Sphere: sphere})
+}
+
+func (s *Store) CountItemsByStateFiltered(now time.Time, filter ItemListFilter) (map[string]int, error) {
 	counts := map[string]int{
 		ItemStateInbox:   0,
 		ItemStateWaiting: 0,
 		ItemStateSomeday: 0,
 		ItemStateDone:    0,
 	}
-	cleanSphere, err := normalizeOptionalSphereFilter(sphere)
+	normalizedFilter, err := normalizeItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -2168,9 +2243,10 @@ FROM items
 		ItemStateSomeday,
 		ItemStateDone,
 	}
-	if cleanSphere != "" {
-		query += ` WHERE sphere = ?`
-		args = append(args, cleanSphere)
+	parts := []string{}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "")
+	if len(parts) > 0 {
+		query += ` WHERE ` + stringsJoin(parts, ` AND `)
 	}
 	if err := s.db.QueryRow(query, args...).Scan(&inbox, &waiting, &someday, &done); err != nil {
 		return nil, err
@@ -2183,9 +2259,25 @@ FROM items
 }
 
 func (s *Store) ListItems() ([]Item, error) {
+	return s.ListItemsFiltered(ItemListFilter{})
+}
+
+func (s *Store) ListItemsFiltered(filter ItemListFilter) ([]Item, error) {
+	normalizedFilter, err := normalizeItemListFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+	query := `SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
+		 FROM items`
+	args := []any{}
+	parts := []string{}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "")
+	if len(parts) > 0 {
+		query += ` WHERE ` + stringsJoin(parts, ` AND `)
+	}
 	rows, err := s.db.Query(
-		`SELECT id, title, state, workspace_id, project_id, sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, created_at, updated_at
-		 FROM items`,
+		query,
+		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,13 +31,13 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
 For open/show/display file requests, end with {"action":"open_file_canvas","path":"..."}.
 If exact path is uncertain, use multi-step {"actions":[...]}: shell search first, then open_file_canvas with path="$last_shell_path".
-For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, or toggle_someday_review_nudge.
+For item materialization and idea/someday-review requests use make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, or show_filtered_items.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
 
 type localIntentClassifierResponse struct {
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -316,6 +316,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.listLinkedArtifacts(session, action)
 	case "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
 		return a.executeSomedayAction(session, action)
+	case "show_filtered_items":
+		return a.executeFilteredItemViewAction(action)
 	case "create_github_issue", "create_github_issue_split":
 		return a.createGitHubIssueFromConversation(sessionID, session, action)
 	case "shell":

--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -49,6 +49,9 @@ func parseInlineItemIntent(text string, now time.Time) *SystemAction {
 
 func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode string) *SystemAction {
 	normalized := normalizeItemCommandText(text)
+	if filterAction := parseInlineItemFilterIntent(text); filterAction != nil {
+		return filterAction
+	}
 	if somedayAction := parseInlineSomedayIntent(text); somedayAction != nil {
 		return somedayAction
 	}
@@ -233,7 +236,7 @@ func parseItemSplitCount(raw string) (int, bool) {
 
 func isItemSystemAction(action string) bool {
 	switch strings.ToLower(strings.TrimSpace(action)) {
-	case "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge":
+	case "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items":
 		return true
 	default:
 		return false
@@ -256,6 +259,8 @@ func itemActionFailurePrefix(action string) string {
 		return "I couldn't prepare the print view: "
 	case "review_someday":
 		return "I couldn't open the someday list: "
+	case "show_filtered_items":
+		return "I couldn't open the filtered item list: "
 	case "toggle_someday_review_nudge":
 		return "I couldn't update the someday reminder setting: "
 	}

--- a/internal/web/chat_items_filters.go
+++ b/internal/web/chat_items_filters.go
@@ -1,0 +1,214 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+var itemFilterSourceCommands = map[string]string{
+	"show todoist tasks":     store.ExternalProviderTodoist,
+	"show todoist items":     store.ExternalProviderTodoist,
+	"show gmail messages":    store.ExternalProviderGmail,
+	"show gmail items":       store.ExternalProviderGmail,
+	"show imap messages":     store.ExternalProviderIMAP,
+	"show imap items":        store.ExternalProviderIMAP,
+	"show exchange messages": store.ExternalProviderExchange,
+	"show exchange items":    store.ExternalProviderExchange,
+	"show github items":      "github",
+	"show manual items":      "manual",
+}
+
+func parseInlineItemFilterIntent(text string) *SystemAction {
+	normalized := normalizeItemCommandText(text)
+	switch normalized {
+	case "show inbox", "open inbox", "show my inbox":
+		return &SystemAction{
+			Action: "show_filtered_items",
+			Params: map[string]interface{}{
+				"view":          store.ItemStateInbox,
+				"clear_filters": true,
+			},
+		}
+	case "show unassigned items", "show unassigned inbox items", "show items without workspace":
+		return &SystemAction{
+			Action: "show_filtered_items",
+			Params: map[string]interface{}{
+				"view": store.ItemStateInbox,
+				"filters": map[string]interface{}{
+					"workspace_id": "null",
+				},
+			},
+		}
+	}
+	if source, ok := itemFilterSourceCommands[normalized]; ok {
+		return &SystemAction{
+			Action: "show_filtered_items",
+			Params: map[string]interface{}{
+				"view": store.ItemStateInbox,
+				"filters": map[string]interface{}{
+					"source": source,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+func systemActionTruthyParam(params map[string]interface{}, key string) bool {
+	value, ok := params[key]
+	if !ok {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "1", "true", "yes", "on":
+			return true
+		}
+	}
+	return false
+}
+
+func systemActionNestedParams(params map[string]interface{}, key string) map[string]interface{} {
+	if params == nil {
+		return nil
+	}
+	nested, _ := params[key].(map[string]interface{})
+	return nested
+}
+
+func itemFilterFromActionParams(params map[string]interface{}) (store.ItemListFilter, error) {
+	filterParams := systemActionNestedParams(params, "filters")
+	if filterParams == nil {
+		filterParams = params
+	}
+	filter := store.ItemListFilter{
+		Source: systemActionStringParam(filterParams, "source"),
+	}
+	workspaceValue := strings.TrimSpace(fmt.Sprint(filterParams["workspace_id"]))
+	if workspaceValue != "" && workspaceValue != "<nil>" {
+		if strings.EqualFold(workspaceValue, "null") {
+			filter.WorkspaceUnassigned = true
+		} else {
+			workspaceID := systemActionItemID(map[string]interface{}{"item_id": filterParams["workspace_id"]})
+			if workspaceID <= 0 {
+				return store.ItemListFilter{}, errors.New("workspace_id must be positive or null")
+			}
+			filter.WorkspaceID = &workspaceID
+		}
+	}
+	projectID := systemActionStringParam(filterParams, "project_id")
+	if projectID != "" && projectID != "<nil>" {
+		filter.ProjectID = &projectID
+	}
+	return filter, nil
+}
+
+func filteredItemViewMessage(view string, filter store.ItemListFilter, count int) string {
+	listName := "inbox"
+	if view == store.ItemStateWaiting || view == store.ItemStateSomeday || view == store.ItemStateDone {
+		listName = view
+	}
+	filterText := ""
+	switch {
+	case filter.Source != "":
+		filterText = fmt.Sprintf(" filtered to %s", filter.Source)
+	case filter.WorkspaceUnassigned:
+		filterText = " filtered to unassigned items"
+	case filter.WorkspaceID != nil:
+		filterText = " filtered to one workspace"
+	case filter.ProjectID != nil:
+		filterText = " filtered to one project"
+	}
+	if count == 0 {
+		return fmt.Sprintf("Opened %s%s. There are no matching items right now.", listName, filterText)
+	}
+	return fmt.Sprintf("Opened %s%s with %d item(s).", listName, filterText, count)
+}
+
+func itemFilterPayload(filter store.ItemListFilter) map[string]interface{} {
+	payload := map[string]interface{}{}
+	if filter.Source != "" {
+		payload["source"] = filter.Source
+	}
+	if filter.WorkspaceID != nil {
+		payload["workspace_id"] = *filter.WorkspaceID
+	}
+	if filter.WorkspaceUnassigned {
+		payload["workspace_id"] = "null"
+	}
+	if filter.ProjectID != nil {
+		payload["project_id"] = *filter.ProjectID
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	return payload
+}
+
+func (a *App) executeFilteredItemViewAction(action *SystemAction) (string, map[string]interface{}, error) {
+	view := strings.ToLower(strings.TrimSpace(systemActionStringParam(action.Params, "view")))
+	switch view {
+	case "", store.ItemStateInbox:
+		view = store.ItemStateInbox
+	case store.ItemStateWaiting, store.ItemStateSomeday, store.ItemStateDone:
+	default:
+		return "", nil, errors.New("view must be inbox, waiting, someday, or done")
+	}
+
+	filter, err := itemFilterFromActionParams(action.Params)
+	if err != nil {
+		return "", nil, err
+	}
+	activeSphere, err := a.store.ActiveSphere()
+	if err != nil {
+		return "", nil, err
+	}
+	filter.Sphere = activeSphere
+
+	var count int
+	switch view {
+	case store.ItemStateInbox:
+		items, err := a.store.ListInboxItemsFiltered(time.Now().UTC(), filter)
+		if err != nil {
+			return "", nil, err
+		}
+		count = len(items)
+	case store.ItemStateWaiting:
+		items, err := a.store.ListWaitingItemsFiltered(filter)
+		if err != nil {
+			return "", nil, err
+		}
+		count = len(items)
+	case store.ItemStateSomeday:
+		items, err := a.store.ListSomedayItemsFiltered(filter)
+		if err != nil {
+			return "", nil, err
+		}
+		count = len(items)
+	case store.ItemStateDone:
+		items, err := a.store.ListDoneItemsFiltered(50, filter)
+		if err != nil {
+			return "", nil, err
+		}
+		count = len(items)
+	}
+
+	payload := map[string]interface{}{
+		"type":  "show_item_sidebar_view",
+		"view":  view,
+		"count": count,
+	}
+	if systemActionTruthyParam(action.Params, "clear_filters") {
+		payload["clear_filters"] = true
+	} else if filters := itemFilterPayload(filter); filters != nil {
+		payload["filters"] = filters
+	}
+	return filteredItemViewMessage(view, filter, count), payload, nil
+}

--- a/internal/web/chat_items_filters_test.go
+++ b/internal/web/chat_items_filters_test.go
@@ -1,0 +1,107 @@
+package web
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineItemIntentFilterCommands(t *testing.T) {
+	now := time.Date(2026, time.March, 8, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		text         string
+		wantAction   string
+		wantSource   string
+		wantNullWork bool
+		wantClear    bool
+	}{
+		{text: "show inbox", wantAction: "show_filtered_items", wantClear: true},
+		{text: "show todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
+		{text: "show unassigned items", wantAction: "show_filtered_items", wantNullWork: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.text, func(t *testing.T) {
+			action := parseInlineItemIntent(tc.text, now)
+			if action == nil {
+				t.Fatal("expected inline action")
+			}
+			if action.Action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action.Action, tc.wantAction)
+			}
+			if tc.wantClear && !systemActionTruthyParam(action.Params, "clear_filters") {
+				t.Fatalf("expected clear_filters in %#v", action.Params)
+			}
+			filters := systemActionNestedParams(action.Params, "filters")
+			if tc.wantSource != "" && systemActionStringParam(filters, "source") != tc.wantSource {
+				t.Fatalf("source = %q, want %q", systemActionStringParam(filters, "source"), tc.wantSource)
+			}
+			if tc.wantNullWork && systemActionStringParam(filters, "workspace_id") != "null" {
+				t.Fatalf("workspace_id = %q, want null", systemActionStringParam(filters, "workspace_id"))
+			}
+		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionShowFilteredItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Default", filepath.Join(t.TempDir(), "workspace"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	sourceTodoist := store.ExternalProviderTodoist
+	sourceExchange := store.ExternalProviderExchange
+	if _, err := app.store.CreateItem("Todoist follow-up", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+		Source:       &sourceTodoist,
+	}); err != nil {
+		t.Fatalf("CreateItem(todoist) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Exchange follow-up", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+		Source:       &sourceExchange,
+	}); err != nil {
+		t.Fatalf("CreateItem(exchange) error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show todoist tasks")
+	if !handled {
+		t.Fatal("expected filter command to be handled")
+	}
+	if message != "Opened inbox filtered to todoist with 1 item(s)." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strFromAny(payloads[0]["type"]); got != "show_item_sidebar_view" {
+		t.Fatalf("payload type = %q, want show_item_sidebar_view", got)
+	}
+	filters, ok := payloads[0]["filters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filters payload = %#v", payloads[0])
+	}
+	if got := strFromAny(filters["source"]); got != store.ExternalProviderTodoist {
+		t.Fatalf("filters.source = %q, want %q", got, store.ExternalProviderTodoist)
+	}
+}

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -79,6 +79,31 @@ func writeItemStoreError(w http.ResponseWriter, err error) {
 	writeAPIError(w, itemResponseErrorStatus(err), err.Error())
 }
 
+func parseItemListFilterQuery(r *http.Request) (store.ItemListFilter, error) {
+	filter := store.ItemListFilter{
+		Sphere: strings.TrimSpace(r.URL.Query().Get("sphere")),
+		Source: strings.TrimSpace(r.URL.Query().Get("source")),
+	}
+	if rawWorkspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id")); rawWorkspaceID != "" {
+		if strings.EqualFold(rawWorkspaceID, "null") {
+			filter.WorkspaceUnassigned = true
+		} else {
+			workspaceID, err := strconv.ParseInt(rawWorkspaceID, 10, 64)
+			if err != nil || workspaceID <= 0 {
+				return store.ItemListFilter{}, errors.New("workspace_id must be a positive integer or null")
+			}
+			filter.WorkspaceID = &workspaceID
+		}
+	}
+	if rawProjectID := strings.TrimSpace(r.URL.Query().Get("project_id")); rawProjectID != "" {
+		if strings.EqualFold(rawProjectID, "null") {
+			return store.ItemListFilter{}, errors.New("project_id must not be null")
+		}
+		filter.ProjectID = &rawProjectID
+	}
+	return filter, nil
+}
+
 func (a *App) ensureActorExists(actorID int64) error {
 	if actorID <= 0 {
 		return errItemActorRequired
@@ -97,15 +122,18 @@ func (a *App) handleItemList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	state := strings.TrimSpace(r.URL.Query().Get("state"))
-	sphere := strings.TrimSpace(r.URL.Query().Get("sphere"))
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	var (
 		items []store.Item
-		err   error
 	)
 	if state != "" {
-		items, err = a.store.ListItemsByStateForSphere(state, sphere)
+		items, err = a.store.ListItemsByStateFiltered(state, filter)
 	} else {
-		items, err = a.store.ListItems()
+		items, err = a.store.ListItemsFiltered(filter)
 	}
 	if err != nil {
 		writeItemStoreError(w, err)
@@ -126,7 +154,12 @@ func (a *App) handleItemInbox(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
-	items, err := a.store.ListInboxItemsForSphere(time.Now(), strings.TrimSpace(r.URL.Query().Get("sphere")))
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	items, err := a.store.ListInboxItemsFiltered(time.Now(), filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
@@ -138,7 +171,12 @@ func (a *App) handleItemWaiting(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
-	items, err := a.store.ListWaitingItemsForSphere(strings.TrimSpace(r.URL.Query().Get("sphere")))
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	items, err := a.store.ListWaitingItemsFiltered(filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
@@ -150,7 +188,12 @@ func (a *App) handleItemSomeday(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
-	items, err := a.store.ListSomedayItemsForSphere(strings.TrimSpace(r.URL.Query().Get("sphere")))
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	items, err := a.store.ListSomedayItemsFiltered(filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
@@ -162,6 +205,11 @@ func (a *App) handleItemDone(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	limit := 50
 	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
 		value, err := strconv.Atoi(raw)
@@ -171,7 +219,7 @@ func (a *App) handleItemDone(w http.ResponseWriter, r *http.Request) {
 		}
 		limit = value
 	}
-	items, err := a.store.ListDoneItemsForSphere(limit, strings.TrimSpace(r.URL.Query().Get("sphere")))
+	items, err := a.store.ListDoneItemsFiltered(limit, filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
@@ -183,7 +231,12 @@ func (a *App) handleItemCounts(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
-	counts, err := a.store.CountItemsByStateForSphere(time.Now(), strings.TrimSpace(r.URL.Query().Get("sphere")))
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	counts, err := a.store.CountItemsByStateFiltered(time.Now(), filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return

--- a/internal/web/items_test.go
+++ b/internal/web/items_test.go
@@ -440,6 +440,110 @@ func TestItemStateViewAPIFiltersBySphere(t *testing.T) {
 	}
 }
 
+func TestItemStateViewAPIFiltersBySourceWorkspaceAndProject(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspace, err := app.store.CreateWorkspace("Inbox Workspace", filepath.Join(t.TempDir(), "workspace"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	project, err := app.store.CreateProject("Inbox Project", "inbox-project", filepath.Join(t.TempDir(), "project"), "managed", "", "canvas-inbox", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	projectID := project.ID
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	sourceTodoist := store.ExternalProviderTodoist
+	sourceExchange := store.ExternalProviderExchange
+
+	if _, err := app.store.CreateItem("Unassigned todoist", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		VisibleAfter: &past,
+		Source:       &sourceTodoist,
+	}); err != nil {
+		t.Fatalf("CreateItem(unassigned todoist) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Workspace todoist", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		ProjectID:    &projectID,
+		VisibleAfter: &past,
+		Source:       &sourceTodoist,
+	}); err != nil {
+		t.Fatalf("CreateItem(workspace todoist) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Workspace exchange", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+		Source:       &sourceExchange,
+	}); err != nil {
+		t.Fatalf("CreateItem(workspace exchange) error: %v", err)
+	}
+
+	rrSource := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?source=todoist", nil)
+	if rrSource.Code != http.StatusOK {
+		t.Fatalf("todoist inbox status = %d, want 200: %s", rrSource.Code, rrSource.Body.String())
+	}
+	sourceItems, ok := decodeJSONResponse(t, rrSource)["items"].([]any)
+	if !ok || len(sourceItems) != 2 {
+		t.Fatalf("todoist inbox payload = %#v", decodeJSONResponse(t, rrSource))
+	}
+
+	rrUnassigned := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?workspace_id=null", nil)
+	if rrUnassigned.Code != http.StatusOK {
+		t.Fatalf("unassigned inbox status = %d, want 200: %s", rrUnassigned.Code, rrUnassigned.Body.String())
+	}
+	unassignedItems, ok := decodeJSONResponse(t, rrUnassigned)["items"].([]any)
+	if !ok || len(unassignedItems) != 1 {
+		t.Fatalf("unassigned inbox payload = %#v", decodeJSONResponse(t, rrUnassigned))
+	}
+	if got := strFromAny(unassignedItems[0].(map[string]any)["title"]); got != "Unassigned todoist" {
+		t.Fatalf("unassigned title = %q, want %q", got, "Unassigned todoist")
+	}
+
+	rrProject := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?project_id="+projectID, nil)
+	if rrProject.Code != http.StatusOK {
+		t.Fatalf("project inbox status = %d, want 200: %s", rrProject.Code, rrProject.Body.String())
+	}
+	projectItems, ok := decodeJSONResponse(t, rrProject)["items"].([]any)
+	if !ok || len(projectItems) != 1 {
+		t.Fatalf("project inbox payload = %#v", decodeJSONResponse(t, rrProject))
+	}
+	if got := strFromAny(projectItems[0].(map[string]any)["title"]); got != "Workspace todoist" {
+		t.Fatalf("project title = %q, want %q", got, "Workspace todoist")
+	}
+
+	rrCounts := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/counts?source=todoist", nil)
+	if rrCounts.Code != http.StatusOK {
+		t.Fatalf("todoist counts status = %d, want 200: %s", rrCounts.Code, rrCounts.Body.String())
+	}
+	counts, ok := decodeJSONResponse(t, rrCounts)["counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("todoist counts payload = %#v", decodeJSONResponse(t, rrCounts))
+	}
+	if got := int(counts[store.ItemStateInbox].(float64)); got != 2 {
+		t.Fatalf("todoist counts[inbox] = %d, want 2", got)
+	}
+
+	rrList := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items?state=inbox&source=exchange&workspace_id="+itoa(workspace.ID), nil)
+	if rrList.Code != http.StatusOK {
+		t.Fatalf("filtered item list status = %d, want 200: %s", rrList.Code, rrList.Body.String())
+	}
+	listItems, ok := decodeJSONDataResponse(t, rrList)["items"].([]any)
+	if !ok || len(listItems) != 1 {
+		t.Fatalf("filtered item list payload = %#v", decodeJSONDataResponse(t, rrList))
+	}
+	if got := strFromAny(listItems[0].(map[string]any)["title"]); got != "Workspace exchange" {
+		t.Fatalf("filtered item list title = %q, want %q", got, "Workspace exchange")
+	}
+
+	rrBadWorkspace := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?workspace_id=bad", nil)
+	if rrBadWorkspace.Code != http.StatusBadRequest {
+		t.Fatalf("bad workspace filter status = %d, want 400: %s", rrBadWorkspace.Code, rrBadWorkspace.Body.String())
+	}
+}
+
 func TestItemDomainAPIRejectsConflictAndInvalidState(t *testing.T) {
 	app := newAuthedTestApp(t)
 

--- a/internal/web/static/app-chat-transport.js
+++ b/internal/web/static/app-chat-transport.js
@@ -287,7 +287,10 @@ export function handleChatEvent(payload) {
       toggleTTSSilentMode();
     } else if (actionType === 'show_item_sidebar_view') {
       const view = normalizeItemSidebarView(action?.view || 'inbox');
-      void openItemSidebarView(view);
+      const filters = action?.clear_filters
+        ? {}
+        : (action?.filters && typeof action.filters === 'object' ? action.filters : {});
+      void openItemSidebarView(view, filters);
     } else if (actionType === 'set_someday_review_nudge') {
       const enabled = parseOptionalBoolean(action?.enabled);
       if (enabled !== null) {

--- a/internal/web/static/app-context.js
+++ b/internal/web/static/app-context.js
@@ -171,6 +171,7 @@ export const state = {
   workspaceStepInFlight: false,
   sidebarEdgeTapAt: 0,
   itemSidebarView: 'inbox',
+  itemSidebarFilters: { source: '', workspace_id: null, project_id: '', workspace_unassigned: false },
   itemSidebarItems: [],
   itemSidebarCounts: { inbox: 0, waiting: 0, someday: 0, done: 0 },
   itemSidebarLoading: false,

--- a/internal/web/static/app-item-sidebar-ui.js
+++ b/internal/web/static/app-item-sidebar-ui.js
@@ -9,6 +9,7 @@ const refreshWorkspaceBrowser = (...args) => refs.refreshWorkspaceBrowser(...arg
 const setPrReviewDrawerOpen = (...args) => refs.setPrReviewDrawerOpen(...args);
 const renderPrReviewFileList = (...args) => refs.renderPrReviewFileList(...args);
 const normalizeItemSidebarView = (...args) => refs.normalizeItemSidebarView(...args);
+const normalizeItemSidebarFilters = (...args) => refs.normalizeItemSidebarFilters(...args);
 const showItemSidebarActionMenu = (...args) => refs.showItemSidebarActionMenu(...args);
 const defaultItemSidebarCounts = (...args) => refs.defaultItemSidebarCounts(...args);
 const closeEdgePanels = (...args) => refs.closeEdgePanels(...args);
@@ -30,13 +31,13 @@ const parentWorkspaceBrowserPath = (...args) => refs.parentWorkspaceBrowserPath(
 const workspaceCompanionEntries = (...args) => refs.workspaceCompanionEntries(...args);
 const openWorkspaceSidebarFile = (...args) => refs.openWorkspaceSidebarFile(...args);
 
-export async function openItemSidebarView(view = state.itemSidebarView) {
+export async function openItemSidebarView(view = state.itemSidebarView, filters = null) {
   state.fileSidebarMode = 'items';
   if (!state.prReviewDrawerOpen) {
     setPrReviewDrawerOpen(true);
   }
   renderPrReviewFileList();
-  return loadItemSidebarView(view);
+  return loadItemSidebarView(view, filters);
 }
 
 export function activeItemSidebarShortcutTarget() {
@@ -50,13 +51,15 @@ export function activeItemSidebarShortcutTarget() {
   return items.find((item) => Number(item?.id || 0) === activeID) || items[0];
 }
 
-export async function loadItemSidebarView(view = state.itemSidebarView) {
+export async function loadItemSidebarView(view = state.itemSidebarView, filters = null) {
   const normalizedView = normalizeItemSidebarView(view);
+  const normalizedFilters = normalizeItemSidebarFilters(filters === null ? state.itemSidebarFilters : filters);
   const projectID = String(state.activeProjectId || '').trim();
   const loadSeq = Number(state.itemSidebarLoadSeq || 0) + 1;
   state.itemSidebarLoadSeq = loadSeq;
   hideItemSidebarMenu();
   state.itemSidebarView = normalizedView;
+  state.itemSidebarFilters = normalizedFilters;
   state.itemSidebarLoading = true;
   state.itemSidebarError = '';
   if (!state.prReviewMode) {
@@ -72,8 +75,8 @@ export async function loadItemSidebarView(view = state.itemSidebarView) {
   }
   try {
     const [itemsResp, countsResp] = await Promise.all([
-      fetch(apiURL(itemSidebarEndpoint(normalizedView)), { cache: 'no-store' }),
-      fetch(apiURL(itemSidebarCountsEndpoint()), { cache: 'no-store' }),
+      fetch(apiURL(itemSidebarEndpoint(normalizedView, normalizedFilters)), { cache: 'no-store' }),
+      fetch(apiURL(itemSidebarCountsEndpoint(normalizedFilters)), { cache: 'no-store' }),
     ]);
     if (!itemsResp.ok) {
       const detail = (await itemsResp.text()).trim() || `HTTP ${itemsResp.status}`;

--- a/internal/web/static/app-item-sidebar-utils.js
+++ b/internal/web/static/app-item-sidebar-utils.js
@@ -34,14 +34,50 @@ export function normalizeItemSidebarView(rawView) {
   return 'inbox';
 }
 
-export function itemSidebarEndpoint(view) {
-  const normalized = normalizeItemSidebarView(view);
-  if (normalized === 'done') return appendSphereQuery(`items/${normalized}?limit=50`);
-  return appendSphereQuery(`items/${normalized}`);
+export function normalizeItemSidebarFilters(rawFilters = null) {
+  const filters = rawFilters && typeof rawFilters === 'object' ? rawFilters : {};
+  const source = String(filters.source || '').trim().toLowerCase();
+  const projectID = String(filters.project_id || '').trim();
+  const workspaceRaw = filters.workspace_id;
+  const workspaceUnassigned = String(workspaceRaw || '').trim().toLowerCase() === 'null'
+    || filters.workspace_unassigned === true;
+  let workspaceID = null;
+  if (!workspaceUnassigned && Number.isFinite(Number(workspaceRaw)) && Number(workspaceRaw) > 0) {
+    workspaceID = Math.trunc(Number(workspaceRaw));
+  }
+  return {
+    source,
+    workspace_id: workspaceID,
+    project_id: projectID,
+    workspace_unassigned: workspaceUnassigned,
+  };
 }
 
-export function itemSidebarCountsEndpoint() {
-  return appendSphereQuery('items/counts');
+function appendItemSidebarFilterQuery(path, filters = state.itemSidebarFilters) {
+  const normalized = normalizeItemSidebarFilters(filters);
+  let nextPath = String(path || '');
+  if (normalized.source) {
+    nextPath = `${nextPath}${nextPath.includes('?') ? '&' : '?'}source=${encodeURIComponent(normalized.source)}`;
+  }
+  if (normalized.workspace_unassigned) {
+    nextPath = `${nextPath}${nextPath.includes('?') ? '&' : '?'}workspace_id=null`;
+  } else if (Number.isFinite(normalized.workspace_id) && normalized.workspace_id > 0) {
+    nextPath = `${nextPath}${nextPath.includes('?') ? '&' : '?'}workspace_id=${encodeURIComponent(String(normalized.workspace_id))}`;
+  }
+  if (normalized.project_id) {
+    nextPath = `${nextPath}${nextPath.includes('?') ? '&' : '?'}project_id=${encodeURIComponent(normalized.project_id)}`;
+  }
+  return nextPath;
+}
+
+export function itemSidebarEndpoint(view, filters = state.itemSidebarFilters) {
+  const normalized = normalizeItemSidebarView(view);
+  if (normalized === 'done') return appendItemSidebarFilterQuery(appendSphereQuery(`items/${normalized}?limit=50`), filters);
+  return appendItemSidebarFilterQuery(appendSphereQuery(`items/${normalized}`), filters);
+}
+
+export function itemSidebarCountsEndpoint(filters = state.itemSidebarFilters) {
+  return appendItemSidebarFilterQuery(appendSphereQuery('items/counts'), filters);
 }
 
 export function normalizeItemSidebarCounts(rawCounts) {

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -826,6 +826,37 @@
       } catch (_) {}
       return '';
     }
+    function requestedItemFilters(url) {
+      try {
+        const parsed = new URL(url, window.location.origin);
+        const source = String(parsed.searchParams.get('source') || '').trim().toLowerCase();
+        const workspaceRaw = String(parsed.searchParams.get('workspace_id') || '').trim().toLowerCase();
+        const projectID = String(parsed.searchParams.get('project_id') || '').trim();
+        return {
+          source,
+          workspace_id: workspaceRaw === 'null' || workspaceRaw === '' ? workspaceRaw : Number(workspaceRaw),
+          project_id: projectID,
+        };
+      } catch (_) {
+        return { source: '', workspace_id: '', project_id: '' };
+      }
+    }
+    function matchesItemFilters(item, sphere, filters) {
+      const itemSphere = String(item?.sphere || '').trim().toLowerCase();
+      if (sphere && itemSphere !== sphere) return false;
+      const itemSource = String(item?.source || '').trim().toLowerCase();
+      if (filters?.source && itemSource !== filters.source) return false;
+      if (filters?.workspace_id === 'null') {
+        return item?.workspace_id == null;
+      }
+      if (Number.isFinite(Number(filters?.workspace_id)) && Number(filters.workspace_id) > 0) {
+        return Number(item?.workspace_id || 0) === Number(filters.workspace_id);
+      }
+      if (filters?.project_id) {
+        return String(item?.project_id || '').trim() === filters.project_id;
+      }
+      return true;
+    }
     const nextHarnessProjectId = (kind) => {
       const cleanKind = String(kind || 'project').trim().toLowerCase() || 'project';
       let suffix = 1;
@@ -1274,11 +1305,12 @@
       if (u.includes('/api/items/counts')) {
         const itemData = window.__itemSidebarData || defaultItemSidebarData();
         const sphere = requestedSphere(u);
+        const filters = requestedItemFilters(u);
         const counts = {
-          inbox: Array.isArray(itemData.inbox) ? itemData.inbox.filter((item) => !sphere || String(item?.sphere || '').trim().toLowerCase() === sphere).length : 0,
-          waiting: Array.isArray(itemData.waiting) ? itemData.waiting.filter((item) => !sphere || String(item?.sphere || '').trim().toLowerCase() === sphere).length : 0,
-          someday: Array.isArray(itemData.someday) ? itemData.someday.filter((item) => !sphere || String(item?.sphere || '').trim().toLowerCase() === sphere).length : 0,
-          done: Array.isArray(itemData.done) ? itemData.done.filter((item) => !sphere || String(item?.sphere || '').trim().toLowerCase() === sphere).length : 0,
+          inbox: Array.isArray(itemData.inbox) ? itemData.inbox.filter((item) => matchesItemFilters(item, sphere, filters)).length : 0,
+          waiting: Array.isArray(itemData.waiting) ? itemData.waiting.filter((item) => matchesItemFilters(item, sphere, filters)).length : 0,
+          someday: Array.isArray(itemData.someday) ? itemData.someday.filter((item) => matchesItemFilters(item, sphere, filters)).length : 0,
+          done: Array.isArray(itemData.done) ? itemData.done.filter((item) => matchesItemFilters(item, sphere, filters)).length : 0,
         };
         const delayMs = nextItemSidebarResponseDelay('counts');
         if (delayMs > 0) await sleep(delayMs);
@@ -1450,8 +1482,9 @@
         if (u.includes('/api/items/someday')) key = 'someday';
         if (u.includes('/api/items/done')) key = 'done';
         const sphere = requestedSphere(u);
+        const filters = requestedItemFilters(u);
         const items = cloneItemSidebarEntries(itemData[key])
-          .filter((item) => !sphere || String(item?.sphere || '').trim().toLowerCase() === sphere);
+          .filter((item) => matchesItemFilters(item, sphere, filters));
         const delayMs = nextItemSidebarResponseDelay(key);
         window.__harnessLog.push({
           type: 'api_fetch',

--- a/tests/playwright/inbox.spec.ts
+++ b/tests/playwright/inbox.spec.ts
@@ -11,6 +11,21 @@ async function waitReady(page: Page) {
   }, null, { timeout: 8_000 });
 }
 
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((p) => {
+    const app = (window as any)._taburaApp;
+    const activeChatWs = app?.getState?.().chatWs;
+    if (activeChatWs && typeof activeChatWs.injectEvent === 'function') {
+      activeChatWs.injectEvent(p);
+      return;
+    }
+    const sessions = (window as any).__mockWsSessions || [];
+    const candidates = sessions.filter((ws: any) => ws.url && ws.url.includes('/ws/chat/'));
+    const chatWs = candidates[candidates.length - 1];
+    if (chatWs && typeof chatWs.injectEvent === 'function') chatWs.injectEvent(p);
+  }, payload);
+}
+
 test.describe('item inbox sidebar', () => {
   test('renders inbox metadata and exposes inbox count on the trigger', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
@@ -84,5 +99,61 @@ test.describe('item inbox sidebar', () => {
 
     const log = await page.evaluate(() => (window as any).__harnessLog || []);
     expect(log.some((entry: any) => entry?.type === 'command_sent' && entry?.command === '/pr 144')).toBe(true);
+  });
+
+  test('system actions can open provider-filtered and unassigned inbox views', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [
+          {
+            id: 301,
+            title: 'Todoist follow-up',
+            state: 'inbox',
+            sphere: 'private',
+            source: 'todoist',
+            workspace_id: null,
+            artifact_kind: 'plan_note',
+            updated_at: '2026-03-08 10:05:00',
+          },
+          {
+            id: 302,
+            title: 'Exchange triage',
+            state: 'inbox',
+            sphere: 'private',
+            source: 'exchange',
+            workspace_id: 9,
+            artifact_kind: 'email',
+            updated_at: '2026-03-08 10:06:00',
+          },
+        ],
+      });
+    });
+
+    await injectChatEvent(page, {
+      type: 'system_action',
+      action: {
+        type: 'show_item_sidebar_view',
+        view: 'inbox',
+        filters: { source: 'todoist' },
+      },
+    });
+    await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+    await expect(page.locator('#pr-file-list')).toContainText('Todoist follow-up');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Exchange triage');
+    await expect(page.locator('#edge-left-tap')).toHaveAttribute('data-inbox-count', '1');
+
+    await injectChatEvent(page, {
+      type: 'system_action',
+      action: {
+        type: 'show_item_sidebar_view',
+        view: 'inbox',
+        filters: { workspace_id: 'null' },
+      },
+    });
+    await expect(page.locator('#pr-file-list')).toContainText('Todoist follow-up');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Exchange triage');
   });
 });


### PR DESCRIPTION
## Summary
Add source/workspace/project filters to the unified item inbox APIs, preserve those filters in the item sidebar, and expose chat commands that open filtered inbox views.

## Verification
- Unified inbox stays sphere-scoped while supporting provider filters: `go test ./internal/store ./internal/web` -> `ok   github.com/krystophny/tabura/internal/store` and `ok   github.com/krystophny/tabura/internal/web`; covered by `TestItemSummaryFilters` and `TestItemStateViewAPIFiltersBySourceWorkspaceAndProject`.
- Source filter works for inbox and counts: `TestItemSummaryFilters` asserts `ListInboxItemsFiltered(now, ItemListFilter{Source: ExternalProviderTodoist})` returns 2 items and `CountItemsByStateFiltered(... Source: ExternalProviderTodoist)` returns `inbox=2`; `TestItemStateViewAPIFiltersBySourceWorkspaceAndProject` exercises `/api/items/inbox?source=todoist` and `/api/items/counts?source=todoist`.
- Workspace filter works for specific and unassigned items: `TestItemSummaryFilters` covers `WorkspaceID` and `WorkspaceUnassigned`; `TestItemStateViewAPIFiltersBySourceWorkspaceAndProject` exercises `/api/items/inbox?workspace_id=null` and rejects `/api/items/inbox?workspace_id=bad` with HTTP 400.
- Project filter works in the inbox API: `TestItemSummaryFilters` and `TestItemStateViewAPIFiltersBySourceWorkspaceAndProject` both filter by `project_id` and assert only the linked item remains.
- Sidebar view carries provider filters end-to-end: `./scripts/playwright.sh tests/playwright/inbox.spec.ts` -> `4 passed (2.7s)`; `tests/playwright/inbox.spec.ts` opens `show_item_sidebar_view` actions with `filters: { source: 'todoist' }` and `filters: { workspace_id: 'null' }`, then verifies the sidebar contents and filtered inbox count.
- Dialogue examples are implemented: `TestParseInlineItemIntentFilterCommands` covers `show inbox`, `show todoist tasks`, and `show unassigned items`; `TestClassifyAndExecuteSystemActionShowFilteredItems` verifies `show todoist tasks` emits a `show_item_sidebar_view` action with `filters.source = todoist`.

## Verification Command
```bash
bash -lc 'set -o pipefail; go test ./internal/store ./internal/web && ./scripts/playwright.sh tests/playwright/inbox.spec.ts' 2>&1 | tee /tmp/issue-268-verification.log
```
