### PR TITLE
fix: Ensure German language support across all voice, text, and NLP f (fixes #227)

### DIFF
--- a/internal/web/chat_items.go
+++ b/internal/web/chat_items.go
@@ -15,9 +15,9 @@ import (
 
 var (
 	itemTitlePrefixPattern = regexp.MustCompile(`^\s*(?:[#>*-]+|\d+[.)]|(?:\[[ xX]\]))\s*`)
-	itemDelegatePattern    = regexp.MustCompile(`(?i)^(?:delegate|assign)(?:\s+(?:this|it))?\s+to\s+(.+?)$`)
-	itemSplitPattern       = regexp.MustCompile(`(?i)^split\s+(?:this|it)\s+into\s+(.+?)\s+items?$`)
-	ideaPrefixPattern      = regexp.MustCompile(`(?i)^\s*(?:new\s+idea|idea|i\s+have\s+an\s+idea|capture)\s*:\s*(.+?)\s*$`)
+	itemDelegatePattern    = regexp.MustCompile(`(?i)^(?:delegate|assign|delegiere|übergib|uebergib|übergebe|uebergebe|übertrage|uebertrage)(?:\s+(?:this|it|das))?\s+(?:to|an)\s+(.+?)$`)
+	itemSplitPattern       = regexp.MustCompile(`(?i)^(?:split|teile)\s+(?:this|it|das)\s+(?:into|in)\s+(.+?)\s+(?:items?|aufgaben?)$`)
+	ideaPrefixPattern      = regexp.MustCompile(`(?i)^\s*(?:new\s+idea|idea|i\s+have\s+an\s+idea|capture|idee|einfall|ich\s+habe\s+eine\s+idee)\s*:\s*(.+?)\s*$`)
 	ideaSentencePattern    = regexp.MustCompile(`^.*?[.!?](?:\s|$)`)
 )
 
@@ -38,8 +38,19 @@ type conversationItemContext struct {
 
 func normalizeItemCommandText(raw string) string {
 	text := strings.ToLower(strings.TrimSpace(raw))
-	text = strings.Trim(text, " \t\r\n.!?,:;")
+	replacer := strings.NewReplacer(
+		"’", "'",
+		"‘", "'",
+		"ä", "ae",
+		"ö", "oe",
+		"ü", "ue",
+		"ß", "ss",
+	)
+	text = replacer.Replace(text)
+	text = strings.Trim(text, " \t\r\n.!?,:;\"'")
 	text = strings.TrimPrefix(text, "please ")
+	text = strings.TrimPrefix(text, "bitte ")
+	text = strings.Join(strings.Fields(text), " ")
 	return strings.TrimSpace(text)
 }
 
@@ -78,11 +89,11 @@ func parseInlineItemIntentWithInputMode(text string, now time.Time, inputMode st
 		return reassignment
 	}
 	switch normalized {
-	case "make this an item", "track this", "add to inbox":
+	case "make this an item", "track this", "add to inbox", "mach das zu einem item", "mach daraus ein item", "fuege das zum posteingang hinzu":
 		return &SystemAction{Action: "make_item", Params: map[string]interface{}{}}
-	case "print this item", "print this for me":
+	case "print this item", "print this for me", "druck das aus", "druck dieses item aus":
 		return &SystemAction{Action: "print_item", Params: map[string]interface{}{}}
-	case "later", "remind me later":
+	case "later", "remind me later", "spaeter", "erinnere mich spaeter":
 		visibleAfter := defaultReminderTime(now)
 		return &SystemAction{
 			Action: "snooze_item",
@@ -175,6 +186,13 @@ func parseReminderVisibleAfter(text string, now time.Time) (string, bool) {
 	if strings.Contains(lower, "tomorrow") {
 		return defaultReminderTime(now), true
 	}
+	if strings.Contains(lower, "morgen") {
+		return defaultReminderTime(now), true
+	}
+	if strings.Contains(lower, "next week") || strings.Contains(lower, "naechste woche") {
+		base := now.UTC().AddDate(0, 0, 7)
+		return time.Date(base.Year(), base.Month(), base.Day(), 9, 0, 0, 0, time.UTC).Format(time.RFC3339), true
+	}
 	for weekday, name := range map[time.Weekday]string{
 		time.Monday:    "monday",
 		time.Tuesday:   "tuesday",
@@ -183,6 +201,19 @@ func parseReminderVisibleAfter(text string, now time.Time) (string, bool) {
 		time.Friday:    "friday",
 		time.Saturday:  "saturday",
 		time.Sunday:    "sunday",
+	} {
+		if strings.Contains(lower, name) {
+			return nextWeekdayReminderTime(now, weekday), true
+		}
+	}
+	for weekday, name := range map[time.Weekday]string{
+		time.Monday:    "montag",
+		time.Tuesday:   "dienstag",
+		time.Wednesday: "mittwoch",
+		time.Thursday:  "donnerstag",
+		time.Friday:    "freitag",
+		time.Saturday:  "samstag",
+		time.Sunday:    "sonntag",
 	} {
 		if strings.Contains(lower, name) {
 			return nextWeekdayReminderTime(now, weekday), true
@@ -219,16 +250,27 @@ func parseItemSplitCount(raw string) (int, bool) {
 		return n, true
 	}
 	words := map[string]int{
-		"one":   1,
-		"two":   2,
-		"three": 3,
-		"four":  4,
-		"five":  5,
-		"six":   6,
-		"seven": 7,
-		"eight": 8,
-		"nine":  9,
-		"ten":   10,
+		"one":    1,
+		"two":    2,
+		"three":  3,
+		"four":   4,
+		"five":   5,
+		"six":    6,
+		"seven":  7,
+		"eight":  8,
+		"nine":   9,
+		"ten":    10,
+		"eins":   1,
+		"zwei":   2,
+		"drei":   3,
+		"vier":   4,
+		"fuenf":  5,
+		"funf":   5,
+		"sechs":  6,
+		"sieben": 7,
+		"acht":   8,
+		"neun":   9,
+		"zehn":   10,
 	}
 	n, ok := words[value]
 	return n, ok

--- a/internal/web/chat_items_filters.go
+++ b/internal/web/chat_items_filters.go
@@ -10,22 +10,25 @@ import (
 )
 
 var itemFilterSourceCommands = map[string]string{
-	"show todoist tasks":     store.ExternalProviderTodoist,
-	"show todoist items":     store.ExternalProviderTodoist,
-	"show gmail messages":    store.ExternalProviderGmail,
-	"show gmail items":       store.ExternalProviderGmail,
-	"show imap messages":     store.ExternalProviderIMAP,
-	"show imap items":        store.ExternalProviderIMAP,
-	"show exchange messages": store.ExternalProviderExchange,
-	"show exchange items":    store.ExternalProviderExchange,
-	"show github items":      "github",
-	"show manual items":      "manual",
+	"show todoist tasks":      store.ExternalProviderTodoist,
+	"show todoist items":      store.ExternalProviderTodoist,
+	"zeige todoist aufgaben":  store.ExternalProviderTodoist,
+	"zeige todoist items":     store.ExternalProviderTodoist,
+	"show gmail messages":     store.ExternalProviderGmail,
+	"show gmail items":        store.ExternalProviderGmail,
+	"zeige gmail nachrichten": store.ExternalProviderGmail,
+	"show imap messages":      store.ExternalProviderIMAP,
+	"show imap items":         store.ExternalProviderIMAP,
+	"show exchange messages":  store.ExternalProviderExchange,
+	"show exchange items":     store.ExternalProviderExchange,
+	"show github items":       "github",
+	"show manual items":       "manual",
 }
 
 func parseInlineItemFilterIntent(text string) *SystemAction {
 	normalized := normalizeItemCommandText(text)
 	switch normalized {
-	case "show inbox", "open inbox", "show my inbox":
+	case "show inbox", "open inbox", "show my inbox", "zeige posteingang", "oeffne posteingang", "zeige meinen posteingang":
 		return &SystemAction{
 			Action: "show_filtered_items",
 			Params: map[string]interface{}{
@@ -33,7 +36,7 @@ func parseInlineItemFilterIntent(text string) *SystemAction {
 				"clear_filters": true,
 			},
 		}
-	case "show unassigned items", "show unassigned inbox items", "show items without workspace":
+	case "show unassigned items", "show unassigned inbox items", "show items without workspace", "zeige nicht zugeordnete items", "zeige items ohne workspace":
 		return &SystemAction{
 			Action: "show_filtered_items",
 			Params: map[string]interface{}{

--- a/internal/web/chat_items_filters_test.go
+++ b/internal/web/chat_items_filters_test.go
@@ -19,8 +19,11 @@ func TestParseInlineItemIntentFilterCommands(t *testing.T) {
 		wantClear    bool
 	}{
 		{text: "show inbox", wantAction: "show_filtered_items", wantClear: true},
+		{text: "zeige posteingang", wantAction: "show_filtered_items", wantClear: true},
 		{text: "show todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
+		{text: "zeige todoist aufgaben", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
 		{text: "show unassigned items", wantAction: "show_filtered_items", wantNullWork: true},
+		{text: "zeige nicht zugeordnete items", wantAction: "show_filtered_items", wantNullWork: true},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/chat_items_idea.go
+++ b/internal/web/chat_items_idea.go
@@ -377,13 +377,13 @@ func parseInlineIdeaRefinementIntent(text string) *SystemAction {
 	}
 	kind := ""
 	switch {
-	case normalized == "expand this idea" || normalized == "expand this" || normalized == "expand on this idea" || normalized == "refine this idea":
+	case normalized == "expand this idea" || normalized == "expand this" || normalized == "expand on this idea" || normalized == "refine this idea" || normalized == "baue diese idee aus" || normalized == "baue das aus" || normalized == "verfeinere diese idee":
 		kind = "expand"
-	case strings.Contains(normalized, "pros and cons"):
+	case strings.Contains(normalized, "pros and cons") || strings.Contains(normalized, "vor und nachteile") || strings.Contains(normalized, "vor- und nachteile") || strings.Contains(normalized, "pro und contra"):
 		kind = "pros_cons"
-	case normalized == "compare alternatives" || normalized == "compare options" || normalized == "show alternatives":
+	case normalized == "compare alternatives" || normalized == "compare options" || normalized == "show alternatives" || normalized == "vergleiche alternativen" || normalized == "vergleiche optionen" || normalized == "zeige alternativen":
 		kind = "alternatives"
-	case normalized == "outline an implementation" || normalized == "outline implementation" || normalized == "draft implementation":
+	case normalized == "outline an implementation" || normalized == "outline implementation" || normalized == "draft implementation" || normalized == "skizziere eine umsetzung" || normalized == "umsetzung skizzieren" || normalized == "entwirf eine umsetzung":
 		kind = "implementation"
 	}
 	if kind == "" {

--- a/internal/web/chat_items_idea_promotion.go
+++ b/internal/web/chat_items_idea_promotion.go
@@ -23,12 +23,15 @@ const (
 )
 
 var (
-	ideaPromotionSelectionPattern = regexp.MustCompile(`(?i)\b(?:selected|items?)\s+([0-9][0-9,\s]*)`)
+	ideaPromotionSelectionPattern = regexp.MustCompile(`(?i)\b(?:selected|items?)\s+([0-9][0-9a-z,\s]*)`)
 	ideaPromotionActionVerbSet    = map[string]struct{}{
 		"add": {}, "break": {}, "build": {}, "capture": {}, "clarify": {}, "create": {}, "define": {},
 		"document": {}, "draft": {}, "explore": {}, "file": {}, "fix": {}, "implement": {}, "investigate": {},
 		"outline": {}, "plan": {}, "prepare": {}, "prototype": {}, "refactor": {}, "review": {}, "ship": {},
 		"split": {}, "test": {}, "write": {},
+		"analysiere": {}, "baue": {}, "behebe": {}, "dokumentiere": {}, "entwirf": {}, "erkunde": {},
+		"erstelle": {}, "fixe": {}, "implementiere": {}, "plane": {}, "pruefe": {}, "refaktorisiere": {},
+		"schreibe": {}, "skizziere": {}, "teste": {}, "untersuche": {}, "zerlege": {},
 	}
 )
 
@@ -71,11 +74,11 @@ func parseInlineIdeaPromotionIntent(text string) *SystemAction {
 	}
 	target := ""
 	switch {
-	case normalized == "make this actionable" || normalized == "turn this idea into a task" || normalized == "turn this idea into an item":
+	case normalized == "make this actionable" || normalized == "turn this idea into a task" || normalized == "turn this idea into an item" || normalized == "mach diese idee umsetzbar" || normalized == "wandle diese idee in eine aufgabe um" || normalized == "wandle diese idee in ein item um":
 		target = ideaPromotionTargetTask
-	case normalized == "turn this idea into items" || normalized == "turn this idea into tasks" || normalized == "split this idea into tasks" || normalized == "split this into tasks" || normalized == "break this down":
+	case normalized == "turn this idea into items" || normalized == "turn this idea into tasks" || normalized == "split this idea into tasks" || normalized == "split this into tasks" || normalized == "break this down" || normalized == "wandle diese idee in items um" || normalized == "wandle diese idee in aufgaben um" || normalized == "zerlege diese idee in aufgaben":
 		target = ideaPromotionTargetItems
-	case normalized == "create a github issue from this idea" || normalized == "file this idea as a github issue":
+	case normalized == "create a github issue from this idea" || normalized == "file this idea as a github issue" || normalized == "erstelle aus dieser idee ein github issue":
 		target = ideaPromotionTargetGitHub
 	}
 	if target == "" {
@@ -100,6 +103,12 @@ func parseInlineIdeaPromotionApplyIntent(text string) *SystemAction {
 		target = ideaPromotionTargetItems
 	case strings.HasPrefix(normalized, "create this idea github issue"):
 		target = ideaPromotionTargetGitHub
+	case strings.HasPrefix(normalized, "erstelle diese idee aufgabe"), strings.HasPrefix(normalized, "erstelle diese idee item"):
+		target = ideaPromotionTargetTask
+	case strings.HasPrefix(normalized, "erstelle diese idee items"), strings.HasPrefix(normalized, "erstelle ausgewaehlte idee items"):
+		target = ideaPromotionTargetItems
+	case strings.HasPrefix(normalized, "erstelle diese idee github issue"):
+		target = ideaPromotionTargetGitHub
 	}
 	if target == "" {
 		return nil
@@ -123,11 +132,11 @@ func parseInlineIdeaPromotionApplyIntent(text string) *SystemAction {
 
 func ideaPromotionDispositionFromText(normalized string) string {
 	switch {
-	case strings.Contains(normalized, "mark this idea done"), strings.Contains(normalized, "mark it done"), strings.Contains(normalized, "mark idea done"):
+	case strings.Contains(normalized, "mark this idea done"), strings.Contains(normalized, "mark it done"), strings.Contains(normalized, "mark idea done"), strings.Contains(normalized, "markiere diese idee als erledigt"), strings.Contains(normalized, "markiere sie als erledigt"):
 		return ideaPromotionDispositionDone
-	case strings.Contains(normalized, "move this idea to someday"), strings.Contains(normalized, "send this idea to someday"):
+	case strings.Contains(normalized, "move this idea to someday"), strings.Contains(normalized, "send this idea to someday"), strings.Contains(normalized, "verschiebe diese idee auf irgendwann"):
 		return ideaPromotionDispositionSomeday
-	case strings.Contains(normalized, "keep this idea"), strings.Contains(normalized, "keep it"):
+	case strings.Contains(normalized, "keep this idea"), strings.Contains(normalized, "keep it"), strings.Contains(normalized, "behalte diese idee"), strings.Contains(normalized, "behalte sie"):
 		return ideaPromotionDispositionKeep
 	default:
 		return ideaPromotionDispositionKeep
@@ -139,7 +148,8 @@ func parseIdeaPromotionSelection(normalized string) []int {
 	if len(match) != 2 {
 		return nil
 	}
-	parts := strings.Split(match[1], ",")
+	selectionText := strings.NewReplacer(" und ", ",", " and ", ",").Replace(match[1])
+	parts := strings.Split(selectionText, ",")
 	out := make([]int, 0, len(parts))
 	seen := map[int]struct{}{}
 	for _, part := range parts {

--- a/internal/web/chat_items_idea_promotion_test.go
+++ b/internal/web/chat_items_idea_promotion_test.go
@@ -88,9 +88,13 @@ func TestParseInlineItemIntentIdeaPromotion(t *testing.T) {
 		wantSelected    []int
 	}{
 		{text: "make this actionable", wantAction: "promote_idea", wantTarget: ideaPromotionTargetTask},
+		{text: "Mach diese Idee umsetzbar", wantAction: "promote_idea", wantTarget: ideaPromotionTargetTask},
 		{text: "turn this idea into tasks", wantAction: "promote_idea", wantTarget: ideaPromotionTargetItems},
+		{text: "Wandle diese Idee in Aufgaben um", wantAction: "promote_idea", wantTarget: ideaPromotionTargetItems},
 		{text: "create this idea GitHub issue", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetGitHub, wantDisposition: ideaPromotionDispositionKeep},
+		{text: "Erstelle diese Idee GitHub Issue", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetGitHub, wantDisposition: ideaPromotionDispositionKeep},
 		{text: "create selected idea items 1, 3 and mark this idea done", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetItems, wantDisposition: ideaPromotionDispositionDone, wantSelected: []int{1, 3}},
+		{text: "Erstelle ausgewählte Idee Items 1 und 3 und markiere diese Idee als erledigt", wantAction: "apply_idea_promotion", wantTarget: ideaPromotionTargetItems, wantDisposition: ideaPromotionDispositionDone, wantSelected: []int{1, 3}},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/chat_items_someday.go
+++ b/internal/web/chat_items_someday.go
@@ -11,15 +11,15 @@ import (
 func parseInlineSomedayIntent(text string) *SystemAction {
 	normalized := normalizeItemCommandText(text)
 	switch normalized {
-	case "review my someday list", "review someday list", "what's in someday", "what is in someday":
+	case "review my someday list", "review someday list", "what's in someday", "what is in someday", "zeige irgendwann", "was ist auf irgendwann":
 		return &SystemAction{Action: "review_someday", Params: map[string]interface{}{}}
-	case "someday", "not now", "maybe later", "defer to someday", "defer this to someday", "defer it to someday":
+	case "someday", "not now", "maybe later", "defer to someday", "defer this to someday", "defer it to someday", "irgendwann", "nicht jetzt", "vielleicht spaeter":
 		return &SystemAction{Action: "triage_someday", Params: map[string]interface{}{}}
-	case "bring this back", "make this active", "move this to inbox", "move it to inbox":
+	case "bring this back", "make this active", "move this to inbox", "move it to inbox", "hol das zurueck", "mach das wieder aktiv", "verschiebe das in den posteingang":
 		return &SystemAction{Action: "promote_someday", Params: map[string]interface{}{}}
-	case "turn off someday reminders", "disable someday reminders", "disable someday review reminders":
+	case "turn off someday reminders", "disable someday reminders", "disable someday review reminders", "schalte irgendwann erinnerungen aus":
 		return &SystemAction{Action: "toggle_someday_review_nudge", Params: map[string]interface{}{"enabled": false}}
-	case "turn on someday reminders", "enable someday reminders", "enable someday review reminders":
+	case "turn on someday reminders", "enable someday reminders", "enable someday review reminders", "schalte irgendwann erinnerungen an":
 		return &SystemAction{Action: "toggle_someday_review_nudge", Params: map[string]interface{}{"enabled": true}}
 	default:
 		return nil

--- a/internal/web/chat_items_someday_test.go
+++ b/internal/web/chat_items_someday_test.go
@@ -18,11 +18,16 @@ func TestParseInlineItemIntentSomedayCommands(t *testing.T) {
 		checkBool   bool
 	}{
 		{text: "review my someday list", wantAction: "review_someday"},
+		{text: "zeige irgendwann", wantAction: "review_someday"},
 		{text: "what's in someday?", wantAction: "review_someday"},
 		{text: "not now", wantAction: "triage_someday"},
+		{text: "nicht jetzt", wantAction: "triage_someday"},
 		{text: "bring this back", wantAction: "promote_someday"},
+		{text: "hol das zurück", wantAction: "promote_someday"},
 		{text: "turn off someday reminders", wantAction: "toggle_someday_review_nudge", wantEnabled: false, checkBool: true},
+		{text: "schalte irgendwann erinnerungen aus", wantAction: "toggle_someday_review_nudge", wantEnabled: false, checkBool: true},
 		{text: "enable someday reminders", wantAction: "toggle_someday_review_nudge", wantEnabled: true, checkBool: true},
+		{text: "schalte irgendwann erinnerungen an", wantAction: "toggle_someday_review_nudge", wantEnabled: true, checkBool: true},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/chat_items_test.go
+++ b/internal/web/chat_items_test.go
@@ -38,14 +38,24 @@ func TestParseInlineItemIntent(t *testing.T) {
 	}{
 		{text: "idea: better swipe triage", wantAction: "capture_idea"},
 		{text: "new idea: add a review inbox", wantAction: "capture_idea"},
+		{text: "Idee: bessere Rückfragen für den Review-Modus", wantAction: "capture_idea"},
 		{text: "expand this idea", wantAction: "refine_idea_note", wantKind: "expand"},
+		{text: "Baue diese Idee aus", wantAction: "refine_idea_note", wantKind: "expand"},
 		{text: "add pros and cons", wantAction: "refine_idea_note", wantKind: "pros_cons"},
+		{text: "Ergänze Vor- und Nachteile", wantAction: "refine_idea_note", wantKind: "pros_cons"},
 		{text: "compare alternatives", wantAction: "refine_idea_note", wantKind: "alternatives"},
+		{text: "Vergleiche Alternativen", wantAction: "refine_idea_note", wantKind: "alternatives"},
 		{text: "outline an implementation", wantAction: "refine_idea_note", wantKind: "implementation"},
+		{text: "Skizziere eine Umsetzung", wantAction: "refine_idea_note", wantKind: "implementation"},
 		{text: "make this an item", wantAction: "make_item"},
+		{text: "Mach das zu einem Item", wantAction: "make_item"},
 		{text: "delegate this to Codex", wantAction: "delegate_item", wantActor: "Codex"},
+		{text: "Delegiere das an Codex", wantAction: "delegate_item", wantActor: "Codex"},
 		{text: "remind me tomorrow", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
+		{text: "Erinnere mich morgen", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
+		{text: "Erinnere mich am Montag", wantAction: "snooze_item", wantWhen: "2026-03-09T09:00:00Z"},
 		{text: "split this into three items", wantAction: "split_items", wantCount: 3},
+		{text: "Teile das in drei Aufgaben", wantAction: "split_items", wantCount: 3},
 	}
 
 	for _, tc := range cases {
@@ -71,6 +81,13 @@ func TestParseInlineItemIntent(t *testing.T) {
 				t.Fatalf("kind = %q, want %q", systemActionStringParam(action.Params, "kind"), tc.wantKind)
 			}
 		})
+	}
+}
+
+func TestDeriveIdeaTitlePreservesGermanText(t *testing.T) {
+	title := deriveIdeaTitle("größere Übersicht für Öl-Temperatur prüfen. Danach Details sammeln.")
+	if title != "Größere Übersicht für Öl-Temperatur prüfen." {
+		t.Fatalf("title = %q", title)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -180,6 +180,10 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	} else if resolvedSTTURL == "" {
 		resolvedSTTURL = DefaultSTTURL
 	}
+	resolvedLocaleLanguage := normalizeLanguageCodeEnv(strings.TrimSpace(os.Getenv("TABURA_LANGUAGE")))
+	if resolvedLocaleLanguage == "" {
+		resolvedLocaleLanguage = normalizeLanguageCodeEnv(strings.TrimSpace(os.Getenv("TABURA_LOCALE")))
+	}
 	resolvedSTTAllowedLanguages := parseLanguageListEnv(strings.TrimSpace(os.Getenv("TABURA_STT_ALLOWED_LANGUAGES")))
 	if len(resolvedSTTAllowedLanguages) == 0 {
 		resolvedSTTAllowedLanguages = parseLanguageListEnv(strings.TrimSpace(os.Getenv("TABURA_STT_LANGUAGE")))
@@ -187,9 +191,12 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	if len(resolvedSTTAllowedLanguages) == 0 {
 		resolvedSTTAllowedLanguages = parseLanguageListEnv(DefaultSTTAllowedLanguages)
 	}
+	resolvedSTTAllowedLanguages = prependPreferredLanguage(resolvedSTTAllowedLanguages, resolvedLocaleLanguage)
 	resolvedSTTFallbackLanguage := normalizeLanguageCodeEnv(strings.TrimSpace(os.Getenv("TABURA_STT_FALLBACK_LANGUAGE")))
 	if resolvedSTTFallbackLanguage == "" {
-		if len(resolvedSTTAllowedLanguages) > 0 {
+		if resolvedLocaleLanguage != "" {
+			resolvedSTTFallbackLanguage = resolvedLocaleLanguage
+		} else if len(resolvedSTTAllowedLanguages) > 0 {
 			resolvedSTTFallbackLanguage = resolvedSTTAllowedLanguages[0]
 		} else {
 			resolvedSTTFallbackLanguage = DefaultSTTFallbackLanguage

--- a/internal/web/stt_config.go
+++ b/internal/web/stt_config.go
@@ -67,6 +67,23 @@ func parseLanguageListEnv(raw string) []string {
 	return out
 }
 
+func prependPreferredLanguage(languages []string, preferred string) []string {
+	lang := normalizeLanguageCodeEnv(preferred)
+	if lang == "" || lang == "auto" {
+		return languages
+	}
+	out := make([]string, 0, len(languages)+1)
+	out = append(out, lang)
+	for _, existing := range languages {
+		clean := normalizeLanguageCodeEnv(existing)
+		if clean == "" || clean == "auto" || clean == lang {
+			continue
+		}
+		out = append(out, clean)
+	}
+	return out
+}
+
 func parseEnvBoolDefault(key string, fallback bool) bool {
 	raw := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
 	switch raw {

--- a/internal/web/stt_config_test.go
+++ b/internal/web/stt_config_test.go
@@ -90,3 +90,16 @@ func TestSTTConfigDefaultAndRoundTrip(t *testing.T) {
 		t.Fatal("opts.PreVAD.Enabled=true, want false")
 	}
 }
+
+func TestSTTConfigLocalePrefersGermanFallback(t *testing.T) {
+	t.Setenv("TABURA_LOCALE", "de_AT.UTF-8")
+	app := newAuthedTestApp(t)
+
+	cfg := app.loadSTTConfig()
+	if cfg.FallbackLanguage != "de" {
+		t.Fatalf("fallback_language=%q, want de", cfg.FallbackLanguage)
+	}
+	if len(cfg.AllowedLanguages) == 0 || cfg.AllowedLanguages[0] != "de" {
+		t.Fatalf("allowed_languages=%v, want de first", cfg.AllowedLanguages)
+	}
+}


### PR DESCRIPTION
## Summary
- expand deterministic natural-language parsing so core item, idea, inbox, someday, and idea-promotion commands accept German aliases alongside English
- add German reminder words, weekday parsing, and split-count words without breaking mixed German/English phrasing
- respect `TABURA_LANGUAGE` / `TABURA_LOCALE` when choosing the default STT fallback language

## Verification
- German command parsing: `go test ./internal/web -run 'Test(ParseInlineItemIntent|DeriveIdeaTitlePreservesGermanText|STTConfig)'`
  - Output: `ok   github.com/krystophny/tabura/internal/web	0.023s`
  - Evidence: `internal/web/chat_items_test.go` covers German idea capture/refinement, item creation, delegation, reminders, and split commands.
  - Evidence: `internal/web/chat_items_filters_test.go` covers German inbox and source-filter commands.
  - Evidence: `internal/web/chat_items_someday_test.go` covers German someday triage/review/reminder commands.
  - Evidence: `internal/web/chat_items_idea_promotion_test.go` covers German idea-promotion preview/apply commands, including `und` selection parsing.
- German date/time expressions: same command above
  - Evidence: `TestParseInlineItemIntent` now asserts `morgen` and `am Montag` resolve to `2026-03-09T09:00:00Z`.
- Umlauts, mixed text, and locale defaults: same command above
  - Evidence: `TestDeriveIdeaTitlePreservesGermanText` preserves `Größere Übersicht für Öl-Temperatur prüfen.` in derived titles.
  - Evidence: `TestSTTConfigLocalePrefersGermanFallback` verifies `TABURA_LOCALE=de_AT.UTF-8` prefers `de` as the STT fallback.
