### PR TITLE
fix: autonomous playtest suite against live instance with auto-file (fixes #306)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test:e2e": "./scripts/playwright.sh",
     "test:e2e:headed": "./scripts/playwright.sh --headed",
     "test:e2e:local": "./scripts/e2e-local.sh",
+    "test:playtest": "./scripts/playtest.sh",
     "test:reports": "./scripts/test-reports.sh"
   },
   "devDependencies": {

--- a/playwright.playtest.config.ts
+++ b/playwright.playtest.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from '@playwright/test';
+
+const audioFile = process.env.E2E_AUDIO_FILE;
+if (!audioFile) {
+  throw new Error('E2E_AUDIO_FILE env var required (path to speech WAV for fake mic input)');
+}
+
+export default defineConfig({
+  testDir: 'tests',
+  testMatch: /(?:e2e|playtest)\/.*\.spec\.ts$/,
+  timeout: 60_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  expect: {
+    timeout: 10_000,
+  },
+  outputDir: 'test-results/playtest',
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report/playtest' }],
+    ['./tests/playtest/github-reporter.cjs'],
+  ],
+  use: {
+    baseURL: 'http://127.0.0.1:8420',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        launchOptions: {
+          args: [
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream',
+            `--use-file-audio-capture=${audioFile}`,
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/scripts/playtest.sh
+++ b/scripts/playtest.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'FATAL: %s\n' "$1" >&2; exit 1; }
+
+printf 'Checking live services...\n'
+
+curl -fsS --max-time 3 http://127.0.0.1:8420/api/setup >/dev/null \
+  || fail 'Tabura web server not running on :8420'
+
+curl -fsS --max-time 3 -o /dev/null -w '' \
+  -X POST http://127.0.0.1:8424/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"ok","voice":"en","response_format":"wav"}' \
+  || fail 'Piper TTS not running on :8424'
+
+curl -fsS --max-time 3 http://127.0.0.1:8427/healthz >/dev/null \
+  || fail 'voxtype STT not running on :8427'
+
+if python3 - <<'PY' >/dev/null 2>&1
+import socket
+sock = socket.create_connection(("127.0.0.1", 8425), timeout=3)
+sock.close()
+PY
+then
+  printf 'Intent classifier detected on :8425.\n'
+else
+  printf 'Intent classifier not detected on :8425; continuing with live runtime defaults.\n'
+fi
+
+if python3 - <<'PY' >/dev/null 2>&1
+import socket
+sock = socket.create_connection(("127.0.0.1", 8426), timeout=3)
+sock.close()
+PY
+then
+  printf 'Intent LLM fallback detected on :8426.\n'
+else
+  printf 'Intent LLM fallback not detected on :8426; continuing with live runtime defaults.\n'
+fi
+
+python3 - <<'PY' >/dev/null 2>&1 || fail 'Codex app-server websocket not reachable on :8787'
+import socket
+sock = socket.create_connection(("127.0.0.1", 8787), timeout=3)
+sock.close()
+PY
+
+command -v ffmpeg >/dev/null 2>&1 || fail 'ffmpeg not installed'
+command -v gh >/dev/null 2>&1 || fail 'gh not installed'
+command -v curl >/dev/null 2>&1 || fail 'curl not installed'
+
+printf 'All services OK.\n'
+
+SPEECH_WAV="/tmp/tabura-playtest-speech-raw.wav"
+PADDED_WAV="/tmp/tabura-playtest-speech.wav"
+
+printf 'Generating voice sample via Piper TTS...\n'
+curl -sS -X POST http://127.0.0.1:8424/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"Hello, this is a test of voice recording.","voice":"en","response_format":"wav"}' \
+  -o "$SPEECH_WAV"
+
+ffmpeg -hide_banner -loglevel error -nostdin -y \
+  -f lavfi -t 0.5 -i anullsrc=r=22050:cl=mono \
+  -i "$SPEECH_WAV" \
+  -f lavfi -t 3 -i anullsrc=r=22050:cl=mono \
+  -filter_complex '[0][1][2]concat=n=3:v=0:a=1[out]' \
+  -map '[out]' -ar 22050 -ac 1 -c:a pcm_s16le "$PADDED_WAV"
+
+printf 'Audio ready: %s\n' "$PADDED_WAV"
+
+export E2E_AUDIO_FILE="$PADDED_WAV"
+export PLAYTEST_FILE_ISSUES="${PLAYTEST_FILE_ISSUES:-1}"
+
+cd "$ROOT_DIR"
+exec npx playwright test --config=playwright.playtest.config.ts "$@"

--- a/tests/e2e/app-load.spec.ts
+++ b/tests/e2e/app-load.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import { SERVER_URL, authenticate, authFetch } from './helpers';
 
 test.describe('app load smoke test', () => {

--- a/tests/e2e/live.ts
+++ b/tests/e2e/live.ts
@@ -1,0 +1,163 @@
+import base, { expect, type Page, type TestInfo } from '@playwright/test';
+import { mkdir, writeFile } from 'fs/promises';
+
+type PlaytestMeta = {
+  tested?: string;
+  expected?: string;
+  steps?: string[];
+};
+
+async function collectPageState(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(async () => {
+    const localStorageState: Record<string, string> = {};
+    const sessionStorageState: Record<string, string> = {};
+    try {
+      for (let i = 0; i < window.localStorage.length; i += 1) {
+        const key = window.localStorage.key(i);
+        if (!key) continue;
+        localStorageState[key] = window.localStorage.getItem(key) || '';
+      }
+    } catch {}
+    try {
+      for (let i = 0; i < window.sessionStorage.length; i += 1) {
+        const key = window.sessionStorage.key(i);
+        if (!key) continue;
+        sessionStorageState[key] = window.sessionStorage.getItem(key) || '';
+      }
+    } catch {}
+    const edgeTop = document.getElementById('edge-top');
+    const edgeRight = document.getElementById('edge-right');
+    return {
+      url: window.location.href,
+      title: document.title,
+      bodyClass: document.body?.className || '',
+      activeElement:
+        document.activeElement instanceof HTMLElement
+          ? {
+              tag: document.activeElement.tagName,
+              id: document.activeElement.id || '',
+              className: document.activeElement.className || '',
+            }
+          : null,
+      overlayVisible: Boolean(document.getElementById('overlay')),
+      floatingInputVisible: Boolean(document.getElementById('floating-input')),
+      fileSidebarOpen: document.body?.classList.contains('file-sidebar-open') || false,
+      edgeTopClass: edgeTop?.className || '',
+      edgeRightClass: edgeRight?.className || '',
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      },
+      localStorage: localStorageState,
+      sessionStorage: sessionStorageState,
+    };
+  });
+}
+
+async function attachFailureArtifacts(page: Page, testInfo: TestInfo, browserLogs: string[]) {
+  const failed = testInfo.status !== testInfo.expectedStatus;
+  if (!failed) return;
+
+  const artifactDir = testInfo.outputPath('playtest-failure');
+  await mkdir(artifactDir, { recursive: true });
+
+  const screenshotPath = testInfo.outputPath('playtest-failure', 'screenshot.png');
+  try {
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await testInfo.attach('playtest-screenshot', {
+      path: screenshotPath,
+      contentType: 'image/png',
+    });
+  } catch {}
+
+  const pageStatePath = testInfo.outputPath('playtest-failure', 'page-state.json');
+  try {
+    const pageState = await collectPageState(page);
+    await writeFile(pageStatePath, `${JSON.stringify(pageState, null, 2)}\n`, 'utf8');
+    await testInfo.attach('page-state', {
+      path: pageStatePath,
+      contentType: 'application/json',
+    });
+  } catch (error) {
+    await writeFile(
+      pageStatePath,
+      `${JSON.stringify({ error: String(error || 'collect page state failed') }, null, 2)}\n`,
+      'utf8',
+    );
+    await testInfo.attach('page-state', {
+      path: pageStatePath,
+      contentType: 'application/json',
+    });
+  }
+
+  if (browserLogs.length > 0) {
+    const browserLogPath = testInfo.outputPath('playtest-failure', 'browser-logs.txt');
+    await writeFile(browserLogPath, `${browserLogs.join('\n')}\n`, 'utf8');
+    await testInfo.attach('browser-logs', {
+      path: browserLogPath,
+      contentType: 'text/plain',
+    });
+  }
+}
+
+export const test = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    const browserLogs: string[] = [];
+    page.on('console', (message) => {
+      const location = message.location();
+      const suffix = location?.url
+        ? ` (${location.url}:${location.lineNumber || 0}:${location.columnNumber || 0})`
+        : '';
+      browserLogs.push(`[console:${message.type()}] ${message.text()}${suffix}`);
+    });
+    page.on('pageerror', (error) => {
+      browserLogs.push(`[pageerror] ${error.stack || error.message}`);
+    });
+    page.on('requestfailed', (request) => {
+      browserLogs.push(
+        `[requestfailed] ${request.method()} ${request.url()} ${request.failure()?.errorText || 'request failed'}`,
+      );
+    });
+    await use(page);
+    await attachFailureArtifacts(page, testInfo, browserLogs);
+  },
+});
+
+export { expect };
+
+export async function applySessionCookie(page: Page, sessionToken: string) {
+  if (!sessionToken) return;
+  await page.context().addCookies([{
+    name: 'tabura_session',
+    value: sessionToken,
+    domain: '127.0.0.1',
+    path: '/',
+  }]);
+}
+
+export async function openLiveApp(page: Page, sessionToken: string) {
+  await applySessionCookie(page, sessionToken);
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.waitForFunction(() => {
+    const app = (window as { _taburaApp?: { getState?: () => { activeProjectId?: string } } })._taburaApp;
+    if (!app || typeof app.getState !== 'function') return false;
+    const state = app.getState();
+    return Boolean(String(state?.activeProjectId || '').trim());
+  }, null, { timeout: 10_000 }).catch(() => {});
+}
+
+export function annotatePlaytest(testInfo: TestInfo, meta: PlaytestMeta) {
+  if (meta.tested) {
+    testInfo.annotations.push({ type: 'playtest-tested', description: meta.tested });
+  }
+  if (meta.expected) {
+    testInfo.annotations.push({ type: 'playtest-expected', description: meta.expected });
+  }
+  if (meta.steps && meta.steps.length > 0) {
+    testInfo.annotations.push({
+      type: 'playtest-steps',
+      description: meta.steps.join(' || '),
+    });
+  }
+}

--- a/tests/e2e/stt-http.spec.ts
+++ b/tests/e2e/stt-http.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import { authenticate, synthesizePiperWav, transcodeWavToM4A, postSTTTranscribeAPI, buildWavSilence } from './helpers';
 
 test.describe('STT over HTTP', () => {

--- a/tests/e2e/stt-tts-roundtrip.spec.ts
+++ b/tests/e2e/stt-tts-roundtrip.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import { WS_URL, authenticate, getChatSessionId, openRawWS } from './helpers';
 
 test.describe('STT+TTS round-trip', () => {

--- a/tests/e2e/stt-tts-system.spec.ts
+++ b/tests/e2e/stt-tts-system.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import {
   WS_URL,
   authenticate,

--- a/tests/e2e/stt-ws.spec.ts
+++ b/tests/e2e/stt-ws.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import {
   WS_URL,
   authenticate,

--- a/tests/e2e/tts-ws.spec.ts
+++ b/tests/e2e/tts-ws.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import { WS_URL, authenticate, getChatSessionId, openRawWS } from './helpers';
 
 test.describe('TTS over WebSocket', () => {

--- a/tests/e2e/voice-e2e.spec.ts
+++ b/tests/e2e/voice-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './live';
 import { authenticate } from './helpers';
 
 test.describe('full browser voice flow', () => {

--- a/tests/playtest/github-reporter.cjs
+++ b/tests/playtest/github-reporter.cjs
@@ -1,0 +1,305 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const BUG_LABELS = {
+  bug: { color: 'd73a4a', description: "Something isn't working" },
+  p0: { color: 'b60205', description: 'Highest priority' },
+};
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function sanitizeSlug(value, max = 48) {
+  const clean = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, max);
+  return clean || 'failure';
+}
+
+function truncate(value, max) {
+  const clean = stripAnsi(String(value || '')).trim().replace(/\s+/g, ' ');
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max - 3).replace(/[ .,;:!?-]+$/g, '')}...`;
+}
+
+function stripAnsi(value) {
+  return String(value || '').replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyAttachment(attachment, artifactDir) {
+  if (!attachment || !attachment.name) return null;
+  const ext = path.extname(attachment.path || '') || (
+    attachment.contentType === 'application/json' ? '.json' :
+      attachment.contentType === 'text/plain' ? '.txt' :
+        attachment.contentType === 'image/png' ? '.png' :
+          attachment.contentType === 'application/zip' ? '.zip' :
+            ''
+  );
+  const targetName = `${sanitizeSlug(attachment.name, 24)}${ext}`;
+  const targetPath = path.join(artifactDir, targetName);
+  if (attachment.path && fs.existsSync(attachment.path)) {
+    fs.copyFileSync(attachment.path, targetPath);
+    return targetPath;
+  }
+  if (attachment.body) {
+    const buffer = Buffer.isBuffer(attachment.body) ? attachment.body : Buffer.from(attachment.body, 'base64');
+    fs.writeFileSync(targetPath, buffer);
+    return targetPath;
+  }
+  return null;
+}
+
+function readTextIfPresent(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return '';
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function findAnnotation(annotations, type) {
+  const hit = (annotations || []).find((annotation) => annotation && annotation.type === type && annotation.description);
+  return hit ? String(hit.description).trim() : '';
+}
+
+function buildExpectedBehavior(failure) {
+  return (
+    findAnnotation(failure.annotations, 'playtest-expected')
+    || `The live playtest "${failure.title}" should pass without errors.`
+  );
+}
+
+function buildStepsToReproduce(failure) {
+  const steps = findAnnotation(failure.annotations, 'playtest-steps')
+    .split('||')
+    .map((step) => step.trim())
+    .filter(Boolean);
+  if (steps.length > 0) return steps;
+  return [
+    `./scripts/playtest.sh --grep "${failure.title.replace(/"/g, '\\"')}"`,
+    `Open ${failure.baseURL || 'http://127.0.0.1:8420'} and follow ${failure.file}:${failure.line}.`,
+  ];
+}
+
+function buildConsoleSection(browserLogs) {
+  if (!browserLogs) return 'None captured.';
+  const lines = browserLogs
+    .split('\n')
+    .map((line) => stripAnsi(line).trim())
+    .filter(Boolean)
+    .slice(0, 40);
+  if (lines.length === 0) return 'None captured.';
+  return lines.join('\n');
+}
+
+function runGitHub(args, cwd) {
+  return execFileSync('gh', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function ensureGitHubLabels(cwd) {
+  const raw = runGitHub(['label', 'list', '--json', 'name', '--limit', '200'], cwd);
+  const existing = new Set(JSON.parse(raw).map((label) => String(label.name || '').toLowerCase()));
+  for (const [name, spec] of Object.entries(BUG_LABELS)) {
+    if (existing.has(name)) continue;
+    runGitHub(['label', 'create', name, '--color', spec.color, '--description', spec.description], cwd);
+  }
+}
+
+function uploadScreenshot(filePath, cwd) {
+  if (!filePath || !fs.existsSync(filePath)) return '';
+  return execFileSync(
+    'curl',
+    ['-fsS', '-F', 'reqtype=fileupload', '-F', `fileToUpload=@${filePath}`, 'https://catbox.moe/user/api.php'],
+    {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  ).trim();
+}
+
+function createIssue(cwd, title, body) {
+  const bodyFile = path.join(cwd, '.tabura', 'artifacts', 'playtests', `${nowStamp()}-${sanitizeSlug(title, 32)}.txt`);
+  ensureDir(path.dirname(bodyFile));
+  fs.writeFileSync(bodyFile, `${body.trim()}\n`, 'utf8');
+  const url = runGitHub(
+    ['issue', 'create', '--label', 'bug', '--label', 'p0', '--title', title, '--body-file', bodyFile],
+    cwd,
+  );
+  return { url, bodyFile };
+}
+
+function buildIssueBody(failure, screenshotURL, artifactDir) {
+  const browserLogs = readTextIfPresent(failure.browserLogPath);
+  const steps = buildStepsToReproduce(failure);
+  const tested = findAnnotation(failure.annotations, 'playtest-tested')
+    || `${failure.projectName} :: ${failure.file}:${failure.line}`;
+  const actual = truncate(failure.errorText, 4000);
+  const evidenceLines = [
+    screenshotURL ? `- Screenshot link: ${screenshotURL}` : '- Screenshot link: upload failed',
+    `- Local artifact dir: \`${path.relative(failure.cwd, artifactDir)}\``,
+  ];
+  if (failure.pageStatePath) {
+    evidenceLines.push(`- Page state: \`${path.relative(failure.cwd, failure.pageStatePath)}\``);
+  }
+  if (failure.browserLogPath) {
+    evidenceLines.push(`- Browser logs: \`${path.relative(failure.cwd, failure.browserLogPath)}\``);
+  }
+  return [
+    '## What was tested',
+    '',
+    tested,
+    '',
+    '## Expected behavior',
+    '',
+    buildExpectedBehavior(failure),
+    '',
+    '## Actual behavior',
+    '',
+    actual || 'Playwright reported an unexpected failure.',
+    '',
+    '## Console errors',
+    '',
+    '```text',
+    buildConsoleSection(browserLogs),
+    '```',
+    '',
+    '## Steps to reproduce',
+    '',
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+    '',
+    '## Evidence',
+    '',
+    ...evidenceLines,
+  ].join('\n');
+}
+
+class GitHubPlaytestReporter {
+  constructor() {
+    this.cwd = process.cwd();
+    this.failures = [];
+    this.issueResults = [];
+  }
+
+  onBegin(config) {
+    this.config = config;
+    this.baseURL = config.projects[0] && config.projects[0].use ? config.projects[0].use.baseURL : '';
+  }
+
+  onTestEnd(test, result) {
+    if (!result) return;
+    if (result.status === test.expectedStatus) return;
+    if (result.status === 'skipped') return;
+    const titlePath = typeof test.titlePath === 'function' ? test.titlePath() : [test.title];
+    const errorText = [...new Set(
+      [result.error && result.error.message, ...(result.errors || []).map((error) => error && error.message)]
+        .filter(Boolean)
+        .map((value) => stripAnsi(value)),
+    )].join('\n\n');
+    this.failures.push({
+      title: test.title,
+      titlePath,
+      file: test.location.file,
+      line: test.location.line,
+      column: test.location.column,
+      projectName: result.projectName || 'chromium',
+      annotations: (test.annotations || []).map((annotation) => ({
+        type: annotation.type,
+        description: annotation.description,
+      })),
+      attachments: (result.attachments || []).map((attachment) => ({
+        name: attachment.name,
+        path: attachment.path,
+        contentType: attachment.contentType,
+        body: attachment.body,
+      })),
+      errorText,
+      cwd: this.cwd,
+      baseURL: this.baseURL,
+    });
+  }
+
+  async onEnd() {
+    const summaryDir = path.join(this.cwd, '.tabura', 'artifacts', 'playtests');
+    ensureDir(summaryDir);
+    const summaryPath = path.join(summaryDir, 'latest-summary.txt');
+
+    if (this.failures.length === 0) {
+      fs.writeFileSync(summaryPath, 'playtest: no failures\n', 'utf8');
+      console.log(`[playtest] no failures; summary: ${path.relative(this.cwd, summaryPath)}`);
+      return;
+    }
+
+    const fileIssues = process.env.PLAYTEST_FILE_ISSUES !== '0';
+    if (fileIssues) {
+      ensureGitHubLabels(this.cwd);
+    }
+
+    const summaryLines = [];
+    for (const failure of this.failures) {
+      const artifactDir = path.join(
+        this.cwd,
+        '.tabura',
+        'artifacts',
+        'bugs',
+        `${nowStamp()}-${sanitizeSlug(`${failure.projectName}-${failure.title}`, 36)}`,
+      );
+      ensureDir(artifactDir);
+
+      let screenshotPath = '';
+      let pageStatePath = '';
+      let browserLogPath = '';
+      for (const attachment of failure.attachments) {
+        const copied = copyAttachment(attachment, artifactDir);
+        if (!copied) continue;
+        if (attachment.name === 'playtest-screenshot' || attachment.contentType === 'image/png') {
+          screenshotPath = copied;
+        } else if (attachment.name === 'page-state') {
+          pageStatePath = copied;
+        } else if (attachment.name === 'browser-logs') {
+          browserLogPath = copied;
+        }
+      }
+      failure.pageStatePath = pageStatePath;
+      failure.browserLogPath = browserLogPath;
+
+      let issueURL = '';
+      if (fileIssues) {
+        const screenshotURL = uploadScreenshot(screenshotPath, this.cwd);
+        const title = truncate(`playtest: ${failure.title}`, 96);
+        const body = buildIssueBody(failure, screenshotURL, artifactDir);
+        issueURL = createIssue(this.cwd, title, body).url;
+      }
+
+      summaryLines.push(
+        `${failure.file}:${failure.line} ${failure.title}`,
+        `artifact_dir=${path.relative(this.cwd, artifactDir)}`,
+        issueURL ? `issue=${issueURL}` : 'issue=not-filed',
+        '',
+      );
+      if (issueURL) {
+        console.log(`[playtest] filed ${issueURL} for ${failure.title}`);
+      } else {
+        console.log(`[playtest] captured local artifacts for ${failure.title}`);
+      }
+    }
+
+    fs.writeFileSync(summaryPath, `${summaryLines.join('\n')}\n`, 'utf8');
+    console.log(`[playtest] summary: ${path.relative(this.cwd, summaryPath)}`);
+  }
+}
+
+module.exports = GitHubPlaytestReporter;

--- a/tests/playtest/playtest.spec.ts
+++ b/tests/playtest/playtest.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, annotatePlaytest, openLiveApp, applySessionCookie } from '../e2e/live';
+import { authenticate } from '../e2e/helpers';
+
+async function openTopEdge(page: Parameters<typeof openLiveApp>[0]) {
+  await page.mouse.move(160, 2);
+  const edgeTop = page.locator('#edge-top');
+  await expect(edgeTop).toHaveClass(/edge-active/);
+  await expect(page.locator('#edge-top-projects')).toBeVisible();
+  await expect(page.locator('#edge-top-models')).toBeVisible();
+}
+
+test.describe('live playtest smoke', () => {
+  let sessionToken = '';
+
+  test.beforeAll(async () => {
+    sessionToken = await authenticate();
+  });
+
+  test('edge chrome opens and escape collapses the live shell', async ({ page }, testInfo) => {
+    annotatePlaytest(testInfo, {
+      tested: 'Live canvas shell navigation via top, right, and left edge controls.',
+      expected: 'The edge panels should open on the real app, the file sidebar should toggle, and Escape should collapse transient UI.',
+      steps: [
+        './scripts/playtest.sh --grep "edge chrome opens and escape collapses the live shell"',
+        'Open the live app at http://127.0.0.1:8420/ and trigger the top, right, and left edge controls.',
+      ],
+    });
+
+    await openLiveApp(page, sessionToken);
+    await expect(page.locator('#workspace')).toBeVisible();
+    await expect(page.locator('#canvas-column')).toBeVisible();
+
+    await openTopEdge(page);
+
+    await page.locator('#edge-right-tap').click();
+    await expect(page.locator('#edge-right')).toHaveClass(/edge-pinned/);
+
+    await page.locator('#edge-left-tap').click();
+    await expect(page.locator('body')).toHaveClass(/file-sidebar-open/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('body')).not.toHaveClass(/file-sidebar-open/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#edge-right')).not.toHaveClass(/edge-pinned/);
+    await expect(page.locator('#edge-top')).not.toHaveClass(/edge-active/);
+  });
+
+  test('yolo and silent toggles update runtime state and survive a refresh', async ({ page }, testInfo) => {
+    annotatePlaytest(testInfo, {
+      tested: 'Live runtime preference controls for yolo mode and silent mode.',
+      expected: 'Toggling yolo and silent should update the live shell immediately and persist after a refresh.',
+      steps: [
+        './scripts/playtest.sh --grep "yolo and silent toggles update runtime state and survive a refresh"',
+        'Open the top edge model controls, toggle yolo and silent, then refresh the page.',
+      ],
+    });
+
+    await openLiveApp(page, sessionToken);
+    await openTopEdge(page);
+
+    const yoloButton = page.locator('.edge-yolo-btn');
+    const silentButton = page.locator('.edge-silent-btn');
+
+    const initialYolo = await yoloButton.getAttribute('aria-pressed');
+    const initialSilent = await silentButton.getAttribute('aria-pressed');
+    const nextYolo = initialYolo === 'true' ? 'false' : 'true';
+    const nextSilent = initialSilent === 'true' ? 'false' : 'true';
+
+    await yoloButton.click();
+    await expect(yoloButton).toHaveAttribute('aria-pressed', nextYolo);
+
+    await silentButton.click();
+    await expect(silentButton).toHaveAttribute('aria-pressed', nextSilent);
+    if (nextSilent === 'true') {
+      await expect(page.locator('body')).toHaveClass(/silent-mode/);
+    } else {
+      await expect(page.locator('body')).not.toHaveClass(/silent-mode/);
+    }
+
+    await page.reload({ waitUntil: 'networkidle' });
+    await openTopEdge(page);
+    await expect(page.locator('.edge-yolo-btn')).toHaveAttribute('aria-pressed', nextYolo);
+    await expect(page.locator('.edge-silent-btn')).toHaveAttribute('aria-pressed', nextSilent);
+  });
+});
+
+test.describe('mobile capture route', () => {
+  test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+  });
+
+  let sessionToken = '';
+
+  test.beforeAll(async () => {
+    sessionToken = await authenticate();
+  });
+
+  test('capture route loads without the full canvas shell', async ({ page }, testInfo) => {
+    annotatePlaytest(testInfo, {
+      tested: 'The dedicated mobile capture route on the live runtime.',
+      expected: 'The capture UI should load on a mobile viewport while the full canvas shell stays absent.',
+      steps: [
+        './scripts/playtest.sh --grep "capture route loads without the full canvas shell"',
+        'Open http://127.0.0.1:8420/capture on a mobile-sized viewport.',
+      ],
+    });
+
+    await applySessionCookie(page, sessionToken);
+    await page.goto('/capture');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#capture-page')).toBeVisible();
+    await expect(page.locator('#capture-record')).toBeVisible();
+    await expect(page.locator('#workspace')).toHaveCount(0);
+    await expect(page.locator('#edge-left-tap')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `./scripts/playtest.sh` for live-instance Playwright runs with service preflight and fake-mic setup
- adds `playwright.playtest.config.ts`, `tests/playtest/playtest.spec.ts`, and `tests/e2e/live.ts` so live E2E and smoke tests capture screenshots, page state, and browser logs on failure
- adds a GitHub reporter that uploads failure screenshots to Catbox and files `bug`/`p0` issues automatically

## Verification

- Runnable live suite: `./scripts/playtest.sh`
  - full captured run: `./scripts/playtest.sh 2>&1 | tee /tmp/test.log`
  - output excerpt: `27 passed (25.1s)` and `1 failed`
- Live bug filing works: reporter filed [#343](https://github.com/krystophny/tabura/issues/343) from the failing `/capture` smoke test during that run
  - output excerpt: `[playtest] filed https://github.com/krystophny/tabura/issues/343 for capture route loads without the full canvas shell`
- Failure evidence capture works for output-affecting bugs
  - screenshot/page-state/browser-log attachments were emitted under `test-results/playtest/playtest-playtest-mobile-c-34aca-thout-the-full-canvas-shell-chromium/`
  - mirrored artifact bundle: `.tabura/artifacts/bugs/2026-03-09T04-34-52-592Z-chromium-capture-route-loads-without`
  - screenshot link in the filed issue: `https://files.catbox.moe/jt9w5m.png`
- Reporter syntax check after the ANSI-stripping cleanup: `node --check tests/playtest/github-reporter.cjs`
