### PR TITLE
fix: Expose Item model on MCP surface for external tool integration (fixes #203)

### DIFF
--- a/cmd/tabura/main.go
+++ b/cmd/tabura/main.go
@@ -129,6 +129,7 @@ func cmdBootstrap(args []string) int {
 func cmdMCPServer(args []string) int {
 	fs := flag.NewFlagSet("mcp-server", flag.ContinueOnError)
 	projectDir := fs.String("project-dir", ".", "project dir")
+	dataDir := fs.String("data-dir", filepath.Join(os.Getenv("HOME"), ".tabura-web"), "data dir")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -138,7 +139,13 @@ func cmdMCPServer(args []string) int {
 		return 1
 	}
 	adapter := canvas.NewAdapter(res.Paths.ProjectDir, nil)
-	return mcp.RunStdio(adapter)
+	st, err := store.New(filepath.Join(*dataDir, "tabura.db"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer st.Close()
+	return mcp.RunStdioWithStore(adapter, st)
 }
 
 func cmdServer(args []string) int {
@@ -239,7 +246,7 @@ func runServer(cfg *serverConfig) int {
 }
 
 func startMCPListener(cfg *serverConfig, projectDir string) (*serve.App, chan error, string) {
-	mcpApp := serve.NewApp(projectDir)
+	mcpApp := serve.NewApp(projectDir, cfg.dataDir)
 	mcpErrCh := make(chan error, 1)
 	go func() {
 		mcpErrCh <- mcpApp.Start(cfg.mcpHost, cfg.mcpPort)

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -146,6 +146,19 @@ Defined in `internal/surface/definitions.go` and used by `internal/mcp/server.go
 - `canvas_import_handoff`
 - `temp_file_create`
 - `temp_file_remove`
+- `workspace_list`
+- `workspace_activate`
+- `workspace_get`
+- `item_list`
+- `item_get`
+- `item_create`
+- `item_triage`
+- `item_assign`
+- `item_update`
+- `artifact_get`
+- `artifact_list`
+- `actor_list`
+- `actor_create`
 
 ## Stability Statement
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/krystophny/tabura/internal/appserver"
 	"github.com/krystophny/tabura/internal/canvas"
+	"github.com/krystophny/tabura/internal/store"
 )
 
 const (
@@ -51,6 +52,7 @@ type RPCError struct {
 type Server struct {
 	adapter         *canvas.Adapter
 	appServerClient *appserver.Client
+	store           *store.Store
 
 	delegateMu   sync.Mutex
 	delegateJobs map[string]*delegateJob
@@ -93,6 +95,10 @@ type delegateProgressEvent struct {
 }
 
 func NewServer(adapter *canvas.Adapter, appServerClient ...*appserver.Client) *Server {
+	return NewServerWithStore(adapter, nil, appServerClient...)
+}
+
+func NewServerWithStore(adapter *canvas.Adapter, st *store.Store, appServerClient ...*appserver.Client) *Server {
 	var client *appserver.Client
 	if len(appServerClient) > 0 {
 		client = appServerClient[0]
@@ -100,6 +106,7 @@ func NewServer(adapter *canvas.Adapter, appServerClient ...*appserver.Client) *S
 	return &Server{
 		adapter:         adapter,
 		appServerClient: client,
+		store:           st,
 		delegateJobs:    make(map[string]*delegateJob),
 	}
 }
@@ -231,6 +238,32 @@ func (s *Server) callTool(name string, args map[string]interface{}) (map[string]
 		return s.tempFileCreate(args)
 	case "temp_file_remove":
 		return s.tempFileRemove(args)
+	case "workspace_list":
+		return s.workspaceList(args)
+	case "workspace_activate":
+		return s.workspaceActivate(args)
+	case "workspace_get":
+		return s.workspaceGet(args)
+	case "item_list":
+		return s.itemList(args)
+	case "item_get":
+		return s.itemGet(args)
+	case "item_create":
+		return s.itemCreate(args)
+	case "item_triage":
+		return s.itemTriage(args)
+	case "item_assign":
+		return s.itemAssign(args)
+	case "item_update":
+		return s.itemUpdate(args)
+	case "artifact_get":
+		return s.artifactGet(args)
+	case "artifact_list":
+		return s.artifactList(args)
+	case "actor_list":
+		return s.actorList(args)
+	case "actor_create":
+		return s.actorCreate(args)
 	case "delegate_to_model":
 		return s.delegateToModel(args)
 	case "delegate_to_model_status":
@@ -247,7 +280,11 @@ func (s *Server) callTool(name string, args map[string]interface{}) (map[string]
 }
 
 func RunStdio(adapter *canvas.Adapter) int {
-	s := NewServer(adapter)
+	return RunStdioWithStore(adapter, nil)
+}
+
+func RunStdioWithStore(adapter *canvas.Adapter, st *store.Store) int {
+	s := NewServerWithStore(adapter, st)
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		msg, framed, err := readMessage(reader)

--- a/internal/mcp/server_domain.go
+++ b/internal/mcp/server_domain.go
@@ -1,0 +1,563 @@
+package mcp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const maxArtifactContentBytes = 64 * 1024
+
+func (s *Server) requireStore() (*store.Store, error) {
+	if s.store == nil {
+		return nil, errors.New("domain store unavailable for this MCP server")
+	}
+	return s.store, nil
+}
+
+func int64Arg(args map[string]interface{}, key string) (int64, error) {
+	v, ok := args[key]
+	if !ok {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	switch typed := v.(type) {
+	case float64:
+		return int64(typed), nil
+	case int:
+		return int64(typed), nil
+	case int64:
+		return typed, nil
+	default:
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+}
+
+func optionalInt64Arg(args map[string]interface{}, key string) (*int64, bool, error) {
+	v, ok := args[key]
+	if !ok {
+		return nil, false, nil
+	}
+	switch typed := v.(type) {
+	case float64:
+		value := int64(typed)
+		return &value, true, nil
+	case int:
+		value := int64(typed)
+		return &value, true, nil
+	case int64:
+		value := typed
+		return &value, true, nil
+	default:
+		return nil, false, fmt.Errorf("%s must be an integer", key)
+	}
+}
+
+func optionalStringArg(args map[string]interface{}, key string) (*string, bool) {
+	v, ok := args[key]
+	if !ok {
+		return nil, false
+	}
+	value, ok := v.(string)
+	if !ok {
+		return nil, false
+	}
+	clean := strings.TrimSpace(value)
+	return &clean, true
+}
+
+func boolArg(args map[string]interface{}, key string) bool {
+	v, _ := args[key].(bool)
+	return v
+}
+
+func domainItemFilter(args map[string]interface{}) (store.ItemListFilter, error) {
+	filter := store.ItemListFilter{
+		Sphere: strings.TrimSpace(strArg(args, "sphere")),
+		Source: strings.TrimSpace(strArg(args, "source")),
+	}
+	if workspaceID, ok, err := optionalInt64Arg(args, "workspace_id"); err != nil {
+		return store.ItemListFilter{}, err
+	} else if ok && workspaceID != nil {
+		if *workspaceID <= 0 {
+			filter.WorkspaceUnassigned = true
+		} else {
+			filter.WorkspaceID = workspaceID
+		}
+	}
+	return filter, nil
+}
+
+func (s *Server) workspaceList(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	workspaces, err := st.ListWorkspacesForSphere(strings.TrimSpace(strArg(args, "sphere")))
+	if err != nil {
+		return nil, err
+	}
+	var activeID int64
+	for _, workspace := range workspaces {
+		if workspace.IsActive {
+			activeID = workspace.ID
+			break
+		}
+	}
+	return map[string]interface{}{
+		"workspaces":          workspaces,
+		"active_workspace_id": activeID,
+	}, nil
+}
+
+func (s *Server) workspaceActivate(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	workspaceID, err := int64Arg(args, "workspace_id")
+	if err != nil {
+		return nil, err
+	}
+	if workspaceID <= 0 {
+		return nil, errors.New("workspace_id must be positive")
+	}
+	if err := st.SetActiveWorkspace(workspaceID); err != nil {
+		return nil, err
+	}
+	workspace, err := st.GetWorkspace(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"workspace": workspace}, nil
+}
+
+func (s *Server) workspaceGet(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	workspaceID, err := int64Arg(args, "workspace_id")
+	if err != nil {
+		return nil, err
+	}
+	if workspaceID <= 0 {
+		return nil, errors.New("workspace_id must be positive")
+	}
+	workspace, err := st.GetWorkspace(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	filter := store.ItemListFilter{WorkspaceID: &workspaceID}
+	counts, err := st.CountItemsByStateFiltered(time.Now(), filter)
+	if err != nil {
+		return nil, err
+	}
+	openCount := counts[store.ItemStateInbox] + counts[store.ItemStateWaiting] + counts[store.ItemStateSomeday]
+	return map[string]interface{}{
+		"workspace":   workspace,
+		"item_counts": counts,
+		"open_count":  openCount,
+	}, nil
+}
+
+func (s *Server) itemList(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	filter, err := domainItemFilter(args)
+	if err != nil {
+		return nil, err
+	}
+	state := strings.TrimSpace(strArg(args, "state"))
+	var items []store.Item
+	if state == "" {
+		items, err = st.ListItemsFiltered(filter)
+	} else {
+		items, err = st.ListItemsByStateFiltered(state, filter)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if limit := intArg(args, "limit", 0); limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return map[string]interface{}{
+		"items": items,
+		"count": len(items),
+	}, nil
+}
+
+func (s *Server) itemGet(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := int64Arg(args, "item_id")
+	if err != nil {
+		return nil, err
+	}
+	item, err := st.GetItem(itemID)
+	if err != nil {
+		return nil, err
+	}
+	result := map[string]interface{}{"item": item}
+	if item.WorkspaceID != nil {
+		workspace, err := st.GetWorkspace(*item.WorkspaceID)
+		if err != nil {
+			return nil, err
+		}
+		result["workspace"] = workspace
+	}
+	if item.ActorID != nil {
+		actor, err := st.GetActor(*item.ActorID)
+		if err != nil {
+			return nil, err
+		}
+		result["actor"] = actor
+	}
+	if item.ArtifactID != nil {
+		artifact, err := st.GetArtifact(*item.ArtifactID)
+		if err != nil {
+			return nil, err
+		}
+		result["artifact"] = artifact
+	}
+	artifacts, err := st.ListItemArtifacts(itemID)
+	if err != nil {
+		return nil, err
+	}
+	result["artifacts"] = artifacts
+	return result, nil
+}
+
+func (s *Server) itemCreate(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	title := strings.TrimSpace(strArg(args, "title"))
+	if title == "" {
+		return nil, errors.New("title is required")
+	}
+	state := strings.TrimSpace(strArg(args, "state"))
+	if state == "" {
+		state = store.ItemStateInbox
+	}
+	workspaceID, _, err := optionalInt64Arg(args, "workspace_id")
+	if err != nil {
+		return nil, err
+	}
+	artifactID, _, err := optionalInt64Arg(args, "artifact_id")
+	if err != nil {
+		return nil, err
+	}
+	actorID, _, err := optionalInt64Arg(args, "actor_id")
+	if err != nil {
+		return nil, err
+	}
+	if workspaceID != nil && *workspaceID <= 0 {
+		workspaceID = nil
+	}
+	if artifactID != nil && *artifactID <= 0 {
+		artifactID = nil
+	}
+	if actorID != nil && *actorID <= 0 {
+		actorID = nil
+	}
+	sphere, _ := optionalStringArg(args, "sphere")
+	visibleAfter, _ := optionalStringArg(args, "visible_after")
+	followUpAt, _ := optionalStringArg(args, "follow_up_at")
+	source, _ := optionalStringArg(args, "source")
+	sourceRef, _ := optionalStringArg(args, "source_ref")
+	item, err := st.CreateItem(title, store.ItemOptions{
+		State:        state,
+		WorkspaceID:  workspaceID,
+		Sphere:       sphere,
+		ArtifactID:   artifactID,
+		ActorID:      actorID,
+		VisibleAfter: visibleAfter,
+		FollowUpAt:   followUpAt,
+		Source:       source,
+		SourceRef:    sourceRef,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"item": item}, nil
+}
+
+func (s *Server) itemTriage(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := int64Arg(args, "item_id")
+	if err != nil {
+		return nil, err
+	}
+	action := strings.ToLower(strings.TrimSpace(strArg(args, "action")))
+	switch action {
+	case "done":
+		err = st.TriageItemDone(itemID)
+	case "later":
+		err = st.TriageItemLater(itemID, strings.TrimSpace(strArg(args, "visible_after")))
+	case "delegate":
+		actorID, actorErr := int64Arg(args, "actor_id")
+		if actorErr != nil {
+			return nil, actorErr
+		}
+		err = st.TriageItemDelegate(itemID, actorID)
+	case "delete":
+		err = st.TriageItemDelete(itemID)
+	case "someday":
+		err = st.TriageItemSomeday(itemID)
+	default:
+		return nil, errors.New("action must be one of done, later, delegate, delete, someday")
+	}
+	if err != nil {
+		return nil, err
+	}
+	if action == "delete" {
+		return map[string]interface{}{
+			"deleted": true,
+			"item_id": itemID,
+		}, nil
+	}
+	item, err := st.GetItem(itemID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"item": item}, nil
+}
+
+func (s *Server) itemAssign(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := int64Arg(args, "item_id")
+	if err != nil {
+		return nil, err
+	}
+	actorID, err := int64Arg(args, "actor_id")
+	if err != nil {
+		return nil, err
+	}
+	if err := st.AssignItem(itemID, actorID); err != nil {
+		return nil, err
+	}
+	item, err := st.GetItem(itemID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"item": item}, nil
+}
+
+func (s *Server) itemUpdate(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	itemID, err := int64Arg(args, "item_id")
+	if err != nil {
+		return nil, err
+	}
+	var updates store.ItemUpdate
+	changed := false
+	if title, ok := optionalStringArg(args, "title"); ok {
+		updates.Title = title
+		changed = true
+	}
+	if state, ok := optionalStringArg(args, "state"); ok {
+		updates.State = state
+		changed = true
+	}
+	if workspaceID, ok, err := optionalInt64Arg(args, "workspace_id"); err != nil {
+		return nil, err
+	} else if ok {
+		updates.WorkspaceID = workspaceID
+		changed = true
+	}
+	if artifactID, ok, err := optionalInt64Arg(args, "artifact_id"); err != nil {
+		return nil, err
+	} else if ok {
+		updates.ArtifactID = artifactID
+		changed = true
+	}
+	if actorID, ok, err := optionalInt64Arg(args, "actor_id"); err != nil {
+		return nil, err
+	} else if ok {
+		updates.ActorID = actorID
+		changed = true
+	}
+	if sphere, ok := optionalStringArg(args, "sphere"); ok {
+		updates.Sphere = sphere
+		changed = true
+	}
+	if visibleAfter, ok := optionalStringArg(args, "visible_after"); ok {
+		updates.VisibleAfter = visibleAfter
+		changed = true
+	}
+	if followUpAt, ok := optionalStringArg(args, "follow_up_at"); ok {
+		updates.FollowUpAt = followUpAt
+		changed = true
+	}
+	if source, ok := optionalStringArg(args, "source"); ok {
+		updates.Source = source
+		changed = true
+	}
+	if sourceRef, ok := optionalStringArg(args, "source_ref"); ok {
+		updates.SourceRef = sourceRef
+		changed = true
+	}
+	if !changed {
+		return nil, errors.New("at least one item update is required")
+	}
+	if err := st.UpdateItem(itemID, updates); err != nil {
+		return nil, err
+	}
+	item, err := st.GetItem(itemID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"item": item}, nil
+}
+
+func (s *Server) artifactGet(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	artifactID, err := int64Arg(args, "artifact_id")
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := st.GetArtifact(artifactID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := st.ListArtifactItems(artifactID)
+	if err != nil {
+		return nil, err
+	}
+	result := map[string]interface{}{
+		"artifact": artifact,
+		"items":    items,
+	}
+	if content, reason := s.readArtifactContent(artifact); reason == "" {
+		result["content_text"] = content
+	} else {
+		result["content_unavailable_reason"] = reason
+	}
+	return result, nil
+}
+
+func (s *Server) artifactList(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	kind := store.ArtifactKind(strings.TrimSpace(strArg(args, "kind")))
+	workspaceID, hasWorkspace, err := optionalInt64Arg(args, "workspace_id")
+	if err != nil {
+		return nil, err
+	}
+	linkedOnly := boolArg(args, "linked_only")
+	var artifacts []store.Artifact
+	switch {
+	case hasWorkspace && workspaceID != nil && *workspaceID > 0:
+		if linkedOnly {
+			artifacts, err = st.ListLinkedArtifacts(*workspaceID)
+		} else {
+			artifacts, err = st.ListArtifactsForWorkspace(*workspaceID)
+		}
+	case kind != "":
+		artifacts, err = st.ListArtifactsByKind(kind)
+	default:
+		artifacts, err = st.ListArtifacts()
+	}
+	if err != nil {
+		return nil, err
+	}
+	if limit := intArg(args, "limit", 0); limit > 0 && len(artifacts) > limit {
+		artifacts = artifacts[:limit]
+	}
+	return map[string]interface{}{
+		"artifacts": artifacts,
+		"count":     len(artifacts),
+	}, nil
+}
+
+func (s *Server) actorList(_ map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	actors, err := st.ListActors()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"actors": actors,
+		"count":  len(actors),
+	}, nil
+}
+
+func (s *Server) actorCreate(args map[string]interface{}) (map[string]interface{}, error) {
+	st, err := s.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(strArg(args, "name"))
+	kind := strings.TrimSpace(strArg(args, "kind"))
+	if name == "" {
+		return nil, errors.New("name is required")
+	}
+	if kind == "" {
+		return nil, errors.New("kind is required")
+	}
+	actor, err := st.CreateActor(name, kind)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"actor": actor}, nil
+}
+
+func (s *Server) readArtifactContent(artifact store.Artifact) (string, string) {
+	if artifact.RefPath == nil || strings.TrimSpace(*artifact.RefPath) == "" {
+		return "", "artifact has no local ref_path"
+	}
+	projectDir := strings.TrimSpace(s.adapter.ProjectDir())
+	if projectDir == "" {
+		return "", "project dir unavailable"
+	}
+	target := strings.TrimSpace(*artifact.RefPath)
+	var absPath string
+	if filepath.IsAbs(target) {
+		absPath = filepath.Clean(target)
+	} else {
+		absPath = filepath.Clean(filepath.Join(projectDir, target))
+	}
+	if !isPathWithinDir(absPath, projectDir) {
+		return "", "artifact ref_path is outside the project root"
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return "", err.Error()
+	}
+	if len(data) > maxArtifactContentBytes {
+		return "", fmt.Sprintf("artifact content exceeds %d bytes", maxArtifactContentBytes)
+	}
+	if bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(data) {
+		return "", "artifact content is not valid UTF-8 text"
+	}
+	return string(data), ""
+}

--- a/internal/mcp/server_domain_test.go
+++ b/internal/mcp/server_domain_test.go
@@ -1,0 +1,261 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/canvas"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func newDomainServerForTest(t *testing.T) (*Server, *store.Store, string) {
+	t.Helper()
+	projectDir := t.TempDir()
+	st, err := store.New(filepath.Join(t.TempDir(), "tabura.db"))
+	if err != nil {
+		t.Fatalf("store.New() error: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	adapter := canvas.NewAdapter(projectDir, nil)
+	return NewServerWithStore(adapter, st), st, projectDir
+}
+
+func TestWorkspaceTools(t *testing.T) {
+	s, st, projectDir := newDomainServerForTest(t)
+
+	alpha, err := st.CreateWorkspace("Alpha", projectDir, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha) error: %v", err)
+	}
+	beta, err := st.CreateWorkspace("Beta", filepath.Join(projectDir, "beta"), store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta) error: %v", err)
+	}
+	if err := st.SetActiveWorkspace(beta.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(beta) error: %v", err)
+	}
+	if _, err := st.CreateItem("Inbox item", store.ItemOptions{State: store.ItemStateInbox, WorkspaceID: &alpha.ID}); err != nil {
+		t.Fatalf("CreateItem(inbox) error: %v", err)
+	}
+	if _, err := st.CreateItem("Waiting item", store.ItemOptions{State: store.ItemStateWaiting, WorkspaceID: &alpha.ID}); err != nil {
+		t.Fatalf("CreateItem(waiting) error: %v", err)
+	}
+	if _, err := st.CreateItem("Done item", store.ItemOptions{State: store.ItemStateDone, WorkspaceID: &alpha.ID}); err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+
+	listed, err := s.callTool("workspace_list", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("workspace_list failed: %v", err)
+	}
+	workspaces, _ := listed["workspaces"].([]store.Workspace)
+	if len(workspaces) != 2 {
+		t.Fatalf("workspace_list len = %d, want 2", len(workspaces))
+	}
+	if got, _ := listed["active_workspace_id"].(int64); got != beta.ID {
+		t.Fatalf("active_workspace_id = %d, want %d", got, beta.ID)
+	}
+
+	activated, err := s.callTool("workspace_activate", map[string]interface{}{"workspace_id": alpha.ID})
+	if err != nil {
+		t.Fatalf("workspace_activate failed: %v", err)
+	}
+	workspace, _ := activated["workspace"].(store.Workspace)
+	if workspace.ID != alpha.ID || !workspace.IsActive {
+		t.Fatalf("workspace_activate returned %+v", workspace)
+	}
+
+	got, err := s.callTool("workspace_get", map[string]interface{}{"workspace_id": alpha.ID})
+	if err != nil {
+		t.Fatalf("workspace_get failed: %v", err)
+	}
+	if openCount, _ := got["open_count"].(int); openCount != 2 {
+		t.Fatalf("open_count = %d, want 2", openCount)
+	}
+	counts, _ := got["item_counts"].(map[string]int)
+	if counts[store.ItemStateDone] != 1 {
+		t.Fatalf("done count = %d, want 1", counts[store.ItemStateDone])
+	}
+}
+
+func TestItemToolsRoundTrip(t *testing.T) {
+	s, st, projectDir := newDomainServerForTest(t)
+
+	workspace, err := st.CreateWorkspace("Alpha", projectDir, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	actor, err := st.CreateActor("Ada", store.ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	artifactPath := filepath.Join(projectDir, "notes.md")
+	if err := os.WriteFile(artifactPath, []byte("artifact body\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(notes.md) error: %v", err)
+	}
+	refPath := "notes.md"
+	title := "Notes"
+	artifact, err := st.CreateArtifact(store.ArtifactKindMarkdown, &refPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	created, err := s.callTool("item_create", map[string]interface{}{
+		"title":        "Read paper",
+		"workspace_id": workspace.ID,
+		"artifact_id":  artifact.ID,
+		"sphere":       store.SphereWork,
+	})
+	if err != nil {
+		t.Fatalf("item_create failed: %v", err)
+	}
+	item, _ := created["item"].(store.Item)
+	if item.State != store.ItemStateInbox {
+		t.Fatalf("created state = %q, want %q", item.State, store.ItemStateInbox)
+	}
+
+	assigned, err := s.callTool("item_assign", map[string]interface{}{
+		"item_id":  item.ID,
+		"actor_id": actor.ID,
+	})
+	if err != nil {
+		t.Fatalf("item_assign failed: %v", err)
+	}
+	item, _ = assigned["item"].(store.Item)
+	if item.ActorID == nil || *item.ActorID != actor.ID || item.State != store.ItemStateWaiting {
+		t.Fatalf("assigned item = %+v", item)
+	}
+
+	followUp := "2026-03-09T10:11:12Z"
+	updated, err := s.callTool("item_update", map[string]interface{}{
+		"item_id":      item.ID,
+		"title":        "Read paper carefully",
+		"follow_up_at": followUp,
+	})
+	if err != nil {
+		t.Fatalf("item_update failed: %v", err)
+	}
+	item, _ = updated["item"].(store.Item)
+	if item.Title != "Read paper carefully" || item.FollowUpAt == nil || *item.FollowUpAt != followUp {
+		t.Fatalf("updated item = %+v", item)
+	}
+
+	listed, err := s.callTool("item_list", map[string]interface{}{
+		"state":        store.ItemStateWaiting,
+		"workspace_id": workspace.ID,
+	})
+	if err != nil {
+		t.Fatalf("item_list failed: %v", err)
+	}
+	items, _ := listed["items"].([]store.Item)
+	if len(items) != 1 || items[0].ID != item.ID {
+		t.Fatalf("item_list items = %+v", items)
+	}
+
+	got, err := s.callTool("item_get", map[string]interface{}{"item_id": item.ID})
+	if err != nil {
+		t.Fatalf("item_get failed: %v", err)
+	}
+	if gotItem, _ := got["item"].(store.Item); gotItem.ID != item.ID {
+		t.Fatalf("item_get item = %+v", gotItem)
+	}
+	if gotActor, _ := got["actor"].(store.Actor); gotActor.ID != actor.ID {
+		t.Fatalf("item_get actor = %+v", gotActor)
+	}
+	if gotArtifact, _ := got["artifact"].(store.Artifact); gotArtifact.ID != artifact.ID {
+		t.Fatalf("item_get artifact = %+v", gotArtifact)
+	}
+	artifacts, _ := got["artifacts"].([]store.ItemArtifact)
+	if len(artifacts) != 1 || artifacts[0].Artifact.ID != artifact.ID || artifacts[0].Role != "source" {
+		t.Fatalf("item_get artifacts = %+v", artifacts)
+	}
+
+	triaged, err := s.callTool("item_triage", map[string]interface{}{
+		"item_id":       item.ID,
+		"action":        "later",
+		"visible_after": "2026-03-10T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("item_triage failed: %v", err)
+	}
+	item, _ = triaged["item"].(store.Item)
+	if item.VisibleAfter == nil || *item.VisibleAfter != "2026-03-10T09:00:00Z" {
+		t.Fatalf("triaged item = %+v", item)
+	}
+}
+
+func TestArtifactAndActorTools(t *testing.T) {
+	s, st, projectDir := newDomainServerForTest(t)
+
+	workspace, err := st.CreateWorkspace("Alpha", projectDir, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	createdActor, err := s.callTool("actor_create", map[string]interface{}{
+		"name": "Codex",
+		"kind": store.ActorKindAgent,
+	})
+	if err != nil {
+		t.Fatalf("actor_create failed: %v", err)
+	}
+	actor, _ := createdActor["actor"].(store.Actor)
+	if actor.Name != "Codex" || actor.Kind != store.ActorKindAgent {
+		t.Fatalf("actor_create returned %+v", actor)
+	}
+
+	listedActors, err := s.callTool("actor_list", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("actor_list failed: %v", err)
+	}
+	actors, _ := listedActors["actors"].([]store.Actor)
+	if len(actors) != 1 || actors[0].ID != actor.ID {
+		t.Fatalf("actor_list returned %+v", actors)
+	}
+
+	artifactPath := filepath.Join(projectDir, "paper.md")
+	if err := os.WriteFile(artifactPath, []byte("# Paper\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(paper.md) error: %v", err)
+	}
+	refPath := "paper.md"
+	title := "Paper"
+	artifact, err := st.CreateArtifact(store.ArtifactKindMarkdown, &refPath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	if err := st.LinkArtifactToWorkspace(workspace.ID, artifact.ID); err != nil {
+		t.Fatalf("LinkArtifactToWorkspace() error: %v", err)
+	}
+	item, err := st.CreateItem("Review paper", store.ItemOptions{
+		State:       store.ItemStateInbox,
+		WorkspaceID: &workspace.ID,
+		ArtifactID:  &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	listedArtifacts, err := s.callTool("artifact_list", map[string]interface{}{
+		"workspace_id": workspace.ID,
+		"kind":         string(store.ArtifactKindMarkdown),
+	})
+	if err != nil {
+		t.Fatalf("artifact_list failed: %v", err)
+	}
+	artifacts, _ := listedArtifacts["artifacts"].([]store.Artifact)
+	if len(artifacts) != 1 || artifacts[0].ID != artifact.ID {
+		t.Fatalf("artifact_list returned %+v", artifacts)
+	}
+
+	gotArtifact, err := s.callTool("artifact_get", map[string]interface{}{"artifact_id": artifact.ID})
+	if err != nil {
+		t.Fatalf("artifact_get failed: %v", err)
+	}
+	if content, _ := gotArtifact["content_text"].(string); content != "# Paper\n" {
+		t.Fatalf("artifact_get content_text = %q", content)
+	}
+	gotItems, _ := gotArtifact["items"].([]store.Item)
+	if len(gotItems) != 1 || gotItems[0].ID != item.ID {
+		t.Fatalf("artifact_get items = %+v", gotItems)
+	}
+}

--- a/internal/serve/app.go
+++ b/internal/serve/app.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/krystophny/tabura/internal/appserver"
 	"github.com/krystophny/tabura/internal/canvas"
 	"github.com/krystophny/tabura/internal/mcp"
+	"github.com/krystophny/tabura/internal/store"
 )
 
 const (
@@ -30,6 +32,7 @@ type App struct {
 	ProjectDir string
 	Adapter    *canvas.Adapter
 	Server     *mcp.Server
+	Store      *store.Store
 
 	mu           sync.Mutex
 	pending      []canvas.Event
@@ -39,7 +42,7 @@ type App struct {
 	shutdownDone chan struct{}
 }
 
-func NewApp(projectDir string) *App {
+func NewApp(projectDir, dataDir string) *App {
 	a := &App{
 		ProjectDir:   projectDir,
 		wsClients:    map[*websocket.Conn]struct{}{},
@@ -47,7 +50,15 @@ func NewApp(projectDir string) *App {
 		shutdownDone: make(chan struct{}),
 	}
 	a.Adapter = canvas.NewAdapter(projectDir, a.queueEvent)
-	a.Server = mcp.NewServer(a.Adapter, mcpAppServerClient())
+	if strings.TrimSpace(dataDir) != "" {
+		dbPath := filepath.Join(dataDir, "tabura.db")
+		if st, err := store.New(dbPath); err == nil {
+			a.Store = st
+		} else {
+			fmt.Printf("domain MCP tools disabled: store unavailable (%v)\n", err)
+		}
+	}
+	a.Server = mcp.NewServerWithStore(a.Adapter, a.Store, mcpAppServerClient())
 	return a
 }
 
@@ -237,10 +248,15 @@ func (a *App) Start(host string, port int) error {
 }
 
 func (a *App) Stop(ctx context.Context) error {
-	if a.httpServer == nil {
-		return nil
+	var shutdownErr error
+	if a.httpServer != nil {
+		shutdownErr = a.httpServer.Shutdown(ctx)
 	}
-	return a.httpServer.Shutdown(ctx)
+	if a.Store != nil {
+		shutdownErr = errors.Join(shutdownErr, a.Store.Close())
+		a.Store = nil
+	}
+	return shutdownErr
 }
 
 func writeJSON(w http.ResponseWriter, payload interface{}) {

--- a/internal/serve/app_files_test.go
+++ b/internal/serve/app_files_test.go
@@ -20,7 +20,7 @@ func TestHandleFilesDecodesEncodedNestedPath(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	app := NewApp(tmp)
+	app := NewApp(tmp, "")
 	req := httptest.NewRequest(http.MethodGet, "/files/docs%2Ftest.pdf", nil)
 	rr := httptest.NewRecorder()
 	app.Router().ServeHTTP(rr, req)
@@ -31,7 +31,7 @@ func TestHandleFilesDecodesEncodedNestedPath(t *testing.T) {
 }
 
 func TestHandleFilesRejectsEncodedTraversal(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	req := httptest.NewRequest(http.MethodGet, "/files/%2e%2e%2Fsecret.pdf", nil)
 	rr := httptest.NewRecorder()
 	app.Router().ServeHTTP(rr, req)
@@ -52,7 +52,7 @@ func TestHandleFilesResolvesProjectAbsolutePathPrefix(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	app := NewApp(tmp)
+	app := NewApp(tmp, "")
 	absLike := strings.TrimPrefix(filepath.ToSlash(target), "/")
 	req := httptest.NewRequest(http.MethodGet, "/files/"+absLike, nil)
 	rr := httptest.NewRecorder()

--- a/internal/serve/app_runtime_test.go
+++ b/internal/serve/app_runtime_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHandleMCPPostParseError(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString("{bad-json"))
 	rr := httptest.NewRecorder()
 
@@ -33,7 +33,7 @@ func TestHandleMCPPostParseError(t *testing.T) {
 }
 
 func TestHandleMCPPostInitializeSetsSessionHeader(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	body := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -57,7 +57,7 @@ func TestHandleMCPPostInitializeSetsSessionHeader(t *testing.T) {
 }
 
 func TestHandleMCPPostNotificationReturnsAccepted(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	body := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "ping",
@@ -75,7 +75,7 @@ func TestHandleMCPPostNotificationReturnsAccepted(t *testing.T) {
 
 func TestHandleHealthIncludesStatusAndProjectDir(t *testing.T) {
 	projectDir := t.TempDir()
-	app := NewApp(projectDir)
+	app := NewApp(projectDir, "")
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rr := httptest.NewRecorder()
 
@@ -117,14 +117,14 @@ func TestRandomSessionIDIsNumeric(t *testing.T) {
 }
 
 func TestStopNoServerIsNoop(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	if err := app.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop(nil server) error: %v", err)
 	}
 }
 
 func TestHandleMCPGetReturnsEventStreamHeaders(t *testing.T) {
-	app := NewApp(t.TempDir())
+	app := NewApp(t.TempDir(), "")
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil).WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -78,6 +78,273 @@ var MCPTools = []Tool{
 			},
 		},
 	},
+	{
+		Name:        "workspace_list",
+		Description: "List workspaces, optionally filtered by sphere.",
+		Properties: map[string]ToolProperty{
+			"sphere": {
+				Type:        "string",
+				Description: "Optional workspace sphere filter.",
+				Enum:        []string{"work", "private"},
+			},
+		},
+	},
+	{
+		Name:        "workspace_activate",
+		Description: "Set the active workspace.",
+		Required:    []string{"workspace_id"},
+		Properties: map[string]ToolProperty{
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Workspace id to activate.",
+			},
+		},
+	},
+	{
+		Name:        "workspace_get",
+		Description: "Get workspace details and open item counts.",
+		Required:    []string{"workspace_id"},
+		Properties: map[string]ToolProperty{
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Workspace id to inspect.",
+			},
+		},
+	},
+	{
+		Name:        "item_list",
+		Description: "List items, optionally filtered by state, workspace, sphere, or source.",
+		Properties: map[string]ToolProperty{
+			"state": {
+				Type:        "string",
+				Description: "Optional item state filter.",
+				Enum:        []string{"inbox", "waiting", "someday", "done"},
+			},
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Optional workspace id filter. Use 0 for unassigned items.",
+			},
+			"sphere": {
+				Type:        "string",
+				Description: "Optional sphere filter.",
+				Enum:        []string{"work", "private"},
+			},
+			"source": {
+				Type:        "string",
+				Description: "Optional source filter.",
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Optional maximum number of items to return.",
+			},
+		},
+	},
+	{
+		Name:        "item_get",
+		Description: "Get an item with linked workspace, actor, and artifact details.",
+		Required:    []string{"item_id"},
+		Properties: map[string]ToolProperty{
+			"item_id": {
+				Type:        "integer",
+				Description: "Item id to inspect.",
+			},
+		},
+	},
+	{
+		Name:        "item_create",
+		Description: "Create a new item with optional workspace, artifact, actor, and timing links.",
+		Required:    []string{"title"},
+		Properties: map[string]ToolProperty{
+			"title": {
+				Type:        "string",
+				Description: "Item title.",
+			},
+			"state": {
+				Type:        "string",
+				Description: "Optional initial state. Defaults to inbox.",
+				Enum:        []string{"inbox", "waiting", "someday", "done"},
+			},
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Optional workspace id.",
+			},
+			"artifact_id": {
+				Type:        "integer",
+				Description: "Optional primary artifact id.",
+			},
+			"actor_id": {
+				Type:        "integer",
+				Description: "Optional actor id.",
+			},
+			"sphere": {
+				Type:        "string",
+				Description: "Optional sphere override.",
+				Enum:        []string{"work", "private"},
+			},
+			"visible_after": {
+				Type:        "string",
+				Description: "Optional RFC3339 visibility timestamp.",
+			},
+			"follow_up_at": {
+				Type:        "string",
+				Description: "Optional RFC3339 follow-up timestamp.",
+			},
+			"source": {
+				Type:        "string",
+				Description: "Optional source provider name.",
+			},
+			"source_ref": {
+				Type:        "string",
+				Description: "Optional provider-specific source reference.",
+			},
+		},
+	},
+	{
+		Name:        "item_triage",
+		Description: "Triage an item to done, later, delegate, someday, or delete.",
+		Required:    []string{"item_id", "action"},
+		Properties: map[string]ToolProperty{
+			"item_id": {
+				Type:        "integer",
+				Description: "Item id to triage.",
+			},
+			"action": {
+				Type:        "string",
+				Description: "Triage action.",
+				Enum:        []string{"done", "later", "delegate", "someday", "delete"},
+			},
+			"actor_id": {
+				Type:        "integer",
+				Description: "Required when action=delegate.",
+			},
+			"visible_after": {
+				Type:        "string",
+				Description: "Required when action=later, in RFC3339 format.",
+			},
+		},
+	},
+	{
+		Name:        "item_assign",
+		Description: "Assign an item to an actor.",
+		Required:    []string{"item_id", "actor_id"},
+		Properties: map[string]ToolProperty{
+			"item_id": {
+				Type:        "integer",
+				Description: "Item id to assign.",
+			},
+			"actor_id": {
+				Type:        "integer",
+				Description: "Actor id to assign.",
+			},
+		},
+	},
+	{
+		Name:        "item_update",
+		Description: "Update an item's title, state, links, source, or timing fields.",
+		Required:    []string{"item_id"},
+		Properties: map[string]ToolProperty{
+			"item_id": {
+				Type:        "integer",
+				Description: "Item id to update.",
+			},
+			"title": {
+				Type:        "string",
+				Description: "Optional updated title.",
+			},
+			"state": {
+				Type:        "string",
+				Description: "Optional updated state.",
+				Enum:        []string{"inbox", "waiting", "someday", "done"},
+			},
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Optional workspace id. Use 0 to clear.",
+			},
+			"artifact_id": {
+				Type:        "integer",
+				Description: "Optional primary artifact id. Use 0 to clear.",
+			},
+			"actor_id": {
+				Type:        "integer",
+				Description: "Optional actor id. Use 0 to clear.",
+			},
+			"sphere": {
+				Type:        "string",
+				Description: "Optional sphere override.",
+				Enum:        []string{"work", "private"},
+			},
+			"visible_after": {
+				Type:        "string",
+				Description: "Optional RFC3339 visibility timestamp.",
+			},
+			"follow_up_at": {
+				Type:        "string",
+				Description: "Optional RFC3339 follow-up timestamp.",
+			},
+			"source": {
+				Type:        "string",
+				Description: "Optional provider source name.",
+			},
+			"source_ref": {
+				Type:        "string",
+				Description: "Optional provider source reference.",
+			},
+		},
+	},
+	{
+		Name:        "artifact_get",
+		Description: "Get an artifact with linked items and readable local text content when available.",
+		Required:    []string{"artifact_id"},
+		Properties: map[string]ToolProperty{
+			"artifact_id": {
+				Type:        "integer",
+				Description: "Artifact id to inspect.",
+			},
+		},
+	},
+	{
+		Name:        "artifact_list",
+		Description: "List artifacts, optionally filtered by kind or workspace.",
+		Properties: map[string]ToolProperty{
+			"kind": {
+				Type:        "string",
+				Description: "Optional artifact kind filter.",
+				Enum:        []string{"email", "document", "pdf", "markdown", "image", "github_issue", "github_pr", "external_task", "transcript", "plan_note", "idea_note"},
+			},
+			"workspace_id": {
+				Type:        "integer",
+				Description: "Optional workspace id filter.",
+			},
+			"linked_only": {
+				Type:        "boolean",
+				Description: "Only include explicitly linked workspace artifacts.",
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Optional maximum number of artifacts to return.",
+			},
+		},
+	},
+	{
+		Name:        "actor_list",
+		Description: "List actors.",
+	},
+	{
+		Name:        "actor_create",
+		Description: "Create an actor.",
+		Required:    []string{"name", "kind"},
+		Properties: map[string]ToolProperty{
+			"name": {
+				Type:        "string",
+				Description: "Actor display name.",
+			},
+			"kind": {
+				Type:        "string",
+				Description: "Actor kind.",
+				Enum:        []string{"human", "agent"},
+			},
+		},
+	},
 }
 
 var MCPDaemonRoutes = []string{

--- a/internal/web/projects_model.go
+++ b/internal/web/projects_model.go
@@ -179,7 +179,7 @@ func (a *App) startProjectServe(sessionID, projectDir string) error {
 	if err != nil {
 		return err
 	}
-	projectApp := serve.NewApp(projectDir)
+	projectApp := serve.NewApp(projectDir, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		_ = projectApp.Start("127.0.0.1", port)

--- a/internal/web/server_relay.go
+++ b/internal/web/server_relay.go
@@ -316,7 +316,7 @@ func (a *App) startLocalServe() error {
 		return nil
 	}
 
-	app := serve.NewApp(a.localProjectDir)
+	app := serve.NewApp(a.localProjectDir, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	a.tunnels.setLocalServe(app, cancel)
 	go func() {


### PR DESCRIPTION
## Summary
- expose workspace, item, artifact, and actor MCP tools backed by the shared Tabura store
- wire the shared store into both `tabura server`'s local MCP listener and `tabura mcp-server`
- sync the published MCP surface docs with the new tool set

## Verification
- Workspace MCP tools: `go test ./cmd/tabura ./internal/mcp ./internal/serve ./internal/web ./internal/surface` -> `ok   github.com/krystophny/tabura/internal/mcp`, covered by `TestWorkspaceTools`
- Item CRUD and triage via MCP: `go test ./cmd/tabura ./internal/mcp ./internal/serve ./internal/web ./internal/surface` -> `ok   github.com/krystophny/tabura/internal/mcp`, covered by `TestItemToolsRoundTrip`
- Artifact and actor MCP tools: `go test ./cmd/tabura ./internal/mcp ./internal/serve ./internal/web ./internal/surface` -> `ok   github.com/krystophny/tabura/internal/mcp`, covered by `TestArtifactAndActorTools`
- Shared-store MCP availability in runtime entry points: `go test ./cmd/tabura ./internal/mcp ./internal/serve ./internal/web ./internal/surface` -> `ok   github.com/krystophny/tabura/cmd/tabura`, `ok   github.com/krystophny/tabura/internal/serve`
- Surface docs in sync: `./scripts/sync-surface.sh --check` -> exit 0 after regenerating `docs/interfaces.md`