### PR TITLE
fix: add Evernote API client (fixes #260)

### DIFF
--- a/internal/evernote/client.go
+++ b/internal/evernote/client.go
@@ -1,0 +1,312 @@
+package evernote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+type Option func(*Client)
+
+func WithBaseURL(raw string) Option {
+	return func(c *Client) {
+		c.baseURL = strings.TrimRight(strings.TrimSpace(raw), "/")
+	}
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
+func NewClient(token string, opts ...Option) (*Client, error) {
+	cleanToken := strings.TrimSpace(token)
+	if cleanToken == "" {
+		return nil, ErrTokenNotConfigured
+	}
+	client := &Client{
+		baseURL:    defaultAPIBaseURL,
+		token:      cleanToken,
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(client)
+		}
+	}
+	if client.baseURL == "" {
+		client.baseURL = defaultAPIBaseURL
+	}
+	if client.httpClient == nil {
+		client.httpClient = http.DefaultClient
+	}
+	return client, nil
+}
+
+func NewClientFromEnv(label string, opts ...Option) (*Client, error) {
+	value, ok := os.LookupEnv(TokenEnvVar(label))
+	if !ok || strings.TrimSpace(value) == "" {
+		return nil, fmt.Errorf("%w: %s", ErrTokenNotConfigured, TokenEnvVar(label))
+	}
+	return NewClient(value, opts...)
+}
+
+func (c *Client) ListNotebooks(ctx context.Context) ([]Notebook, error) {
+	body, err := c.get(ctx, "/notebooks", nil)
+	if err != nil {
+		return nil, err
+	}
+	payloads, err := decodeEnvelopeSlice[notebookPayload](body, "notebooks")
+	if err != nil {
+		return nil, err
+	}
+	notebooks := make([]Notebook, 0, len(payloads))
+	for _, payload := range payloads {
+		notebooks = append(notebooks, decodeNotebook(payload))
+	}
+	return notebooks, nil
+}
+
+func (c *Client) ListNotes(ctx context.Context, notebookID string, opts ListNotesOptions) ([]NoteSummary, error) {
+	query := url.Values{}
+	if clean := strings.TrimSpace(notebookID); clean != "" {
+		query.Set("notebook_id", clean)
+	}
+	if clean := strings.TrimSpace(opts.Query); clean != "" {
+		query.Set("query", clean)
+	}
+	if clean := strings.TrimSpace(opts.Tag); clean != "" {
+		query.Set("tag", clean)
+	}
+	if clean := strings.TrimSpace(opts.UpdatedAfter); clean != "" {
+		query.Set("updated_after", clean)
+	}
+	if opts.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", opts.Limit))
+	}
+	if opts.Offset > 0 {
+		query.Set("offset", fmt.Sprintf("%d", opts.Offset))
+	}
+	body, err := c.get(ctx, "/notes", query)
+	if err != nil {
+		return nil, err
+	}
+	payloads, err := decodeEnvelopeSlice[notePayload](body, "notes")
+	if err != nil {
+		return nil, err
+	}
+	notes := make([]NoteSummary, 0, len(payloads))
+	for _, payload := range payloads {
+		notes = append(notes, decodeNoteSummary(payload))
+	}
+	return notes, nil
+}
+
+func (c *Client) GetNote(ctx context.Context, id string) (Note, error) {
+	noteID := strings.TrimSpace(id)
+	if noteID == "" {
+		return Note{}, ErrNoteIDRequired
+	}
+	body, err := c.get(ctx, "/notes/"+url.PathEscape(noteID), nil)
+	if err != nil {
+		return Note{}, err
+	}
+	payload, err := decodeEnvelopeValue[notePayload](body, "note")
+	if err != nil {
+		return Note{}, err
+	}
+	return decodeNote(payload), nil
+}
+
+func (c *Client) ListTags(ctx context.Context) ([]Tag, error) {
+	body, err := c.get(ctx, "/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	payloads, err := decodeEnvelopeSlice[tagPayload](body, "tags")
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]Tag, 0, len(payloads))
+	for _, payload := range payloads {
+		tags = append(tags, decodeTag(payload))
+	}
+	return tags, nil
+}
+
+func (c *Client) get(ctx context.Context, path string, query url.Values) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return nil, err
+	}
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+	return body, nil
+}
+
+func decodeEnvelopeSlice[T any](body []byte, field string) ([]T, error) {
+	var direct []T
+	if err := json.Unmarshal(body, &direct); err == nil {
+		return direct, nil
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	payload := envelope[field]
+	if len(payload) == 0 {
+		return []T{}, nil
+	}
+	if err := json.Unmarshal(payload, &direct); err != nil {
+		return nil, err
+	}
+	return direct, nil
+}
+
+func decodeEnvelopeValue[T any](body []byte, field string) (T, error) {
+	var direct T
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		if payload := envelope[field]; len(payload) > 0 {
+			if err := json.Unmarshal(payload, &direct); err != nil {
+				return direct, err
+			}
+			return direct, nil
+		}
+	}
+	if err := json.Unmarshal(body, &direct); err != nil {
+		return direct, err
+	}
+	return direct, nil
+}
+
+func (p *notebookPayload) UnmarshalJSON(data []byte) error {
+	type alias notebookPayload
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	raw, err := mustObject(data)
+	if err != nil {
+		return err
+	}
+	*p = notebookPayload(decoded)
+	p.Raw = raw
+	return nil
+}
+
+func (p *notePayload) UnmarshalJSON(data []byte) error {
+	type alias notePayload
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	raw, err := mustObject(data)
+	if err != nil {
+		return err
+	}
+	*p = notePayload(decoded)
+	p.Raw = raw
+	return nil
+}
+
+func (p *tagPayload) UnmarshalJSON(data []byte) error {
+	type alias tagPayload
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	raw, err := mustObject(data)
+	if err != nil {
+		return err
+	}
+	*p = tagPayload(decoded)
+	p.Raw = raw
+	return nil
+}
+
+func decodeNotebook(payload notebookPayload) Notebook {
+	return Notebook{
+		ID:        firstNonEmpty(payload.ID, payload.GUID),
+		Name:      strings.TrimSpace(payload.Name),
+		Stack:     strings.TrimSpace(payload.Stack),
+		UpdatedAt: firstNonEmpty(payload.UpdatedAt, payload.UpdatedTS),
+		Raw:       payload.Raw,
+	}
+}
+
+func decodeNoteSummary(payload notePayload) NoteSummary {
+	text, _, _ := ConvertENMLToText(firstNonEmpty(payload.ContentENML, payload.ENML, payload.Content))
+	return NoteSummary{
+		ID:          firstNonEmpty(payload.ID, payload.GUID),
+		NotebookID:  firstNonEmpty(payload.NotebookID, payload.NotebookGUID),
+		Title:       strings.TrimSpace(payload.Title),
+		UpdatedAt:   firstNonEmpty(payload.UpdatedAt, payload.UpdatedTS),
+		CreatedAt:   firstNonEmpty(payload.CreatedAt, payload.CreatedTS),
+		TagNames:    append([]string(nil), payload.TagNames...),
+		ContentText: text,
+		Raw:         payload.Raw,
+	}
+}
+
+func decodeNote(payload notePayload) Note {
+	enml := firstNonEmpty(payload.ContentENML, payload.ENML, payload.Content)
+	text, markdown, tasks := ConvertENMLToText(enml)
+	return Note{
+		ID:              firstNonEmpty(payload.ID, payload.GUID),
+		NotebookID:      firstNonEmpty(payload.NotebookID, payload.NotebookGUID),
+		Title:           strings.TrimSpace(payload.Title),
+		CreatedAt:       firstNonEmpty(payload.CreatedAt, payload.CreatedTS),
+		UpdatedAt:       firstNonEmpty(payload.UpdatedAt, payload.UpdatedTS),
+		TagNames:        append([]string(nil), payload.TagNames...),
+		ContentENML:     enml,
+		ContentText:     text,
+		ContentMarkdown: markdown,
+		Tasks:           tasks,
+		Raw:             payload.Raw,
+	}
+}
+
+func decodeTag(payload tagPayload) Tag {
+	return Tag{
+		ID:       firstNonEmpty(payload.ID, payload.GUID),
+		Name:     strings.TrimSpace(payload.Name),
+		ParentID: firstNonEmpty(payload.ParentID, payload.ParentGUID),
+		Raw:      payload.Raw,
+	}
+}

--- a/internal/evernote/client_test.go
+++ b/internal/evernote/client_test.go
@@ -1,0 +1,186 @@
+package evernote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		"token-1",
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	return client
+}
+
+func TestTokenEnvVarAndNewClientFromEnv(t *testing.T) {
+	if got, want := TokenEnvVar("Lab Notes"), "TABURA_EVERNOTE_TOKEN_LAB_NOTES"; got != want {
+		t.Fatalf("TokenEnvVar() = %q, want %q", got, want)
+	}
+
+	t.Setenv(TokenEnvVar("Lab Notes"), "token-xyz")
+	client, err := NewClientFromEnv("Lab Notes")
+	if err != nil {
+		t.Fatalf("NewClientFromEnv() error: %v", err)
+	}
+	if client.token != "token-xyz" {
+		t.Fatalf("token = %q, want token-xyz", client.token)
+	}
+
+	if _, err := NewClientFromEnv("Missing"); !errors.Is(err, ErrTokenNotConfigured) {
+		t.Fatalf("NewClientFromEnv(missing) error = %v, want ErrTokenNotConfigured", err)
+	}
+}
+
+func TestListEndpointsAndNoteDecoding(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token-1" {
+			t.Fatalf("Authorization = %q, want Bearer token-1", got)
+		}
+		switch r.URL.Path {
+		case "/notebooks":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notebooks": []map[string]any{{
+					"id":         "nb-1",
+					"name":       "Research",
+					"stack":      "Work",
+					"updated_at": "2026-03-08T12:00:00Z",
+				}},
+			})
+		case "/notes":
+			if got := r.URL.Query().Get("notebook_id"); got != "nb-1" {
+				t.Fatalf("notebook_id = %q, want nb-1", got)
+			}
+			if got := r.URL.Query().Get("query"); got != "fusion" {
+				t.Fatalf("query = %q, want fusion", got)
+			}
+			if got := r.URL.Query().Get("limit"); got != "10" {
+				t.Fatalf("limit = %q, want 10", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notes": []map[string]any{{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "EUROfusion summary",
+					"tag_names":   []string{"fusion", "reading"},
+					"content":     `<en-note><div>Latest results</div></en-note>`,
+				}},
+			})
+		case "/notes/note-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"note": map[string]any{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "EUROfusion summary",
+					"created_at":  "2026-03-01T09:00:00Z",
+					"updated_at":  "2026-03-08T12:30:00Z",
+					"tag_names":   []string{"fusion", "reading"},
+					"content_enml": `<en-note>` +
+						`<div>Review section 2</div>` +
+						`<div><en-todo checked="true"/>Check bibliography</div>` +
+						`<div><en-todo/>Draft summary paragraph</div>` +
+						`</en-note>`,
+				},
+			})
+		case "/tags":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id":        "tag-1",
+				"name":      "fusion",
+				"parent_id": "tag-root",
+			}})
+		default:
+			t.Fatalf("unexpected request %s", r.URL.String())
+		}
+	})
+
+	notebooks, err := client.ListNotebooks(context.Background())
+	if err != nil {
+		t.Fatalf("ListNotebooks() error: %v", err)
+	}
+	if len(notebooks) != 1 || notebooks[0].ID != "nb-1" || notebooks[0].Stack != "Work" {
+		t.Fatalf("notebooks = %#v", notebooks)
+	}
+
+	notes, err := client.ListNotes(context.Background(), "nb-1", ListNotesOptions{
+		Query: "fusion",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListNotes() error: %v", err)
+	}
+	if len(notes) != 1 || notes[0].Title != "EUROfusion summary" || notes[0].ContentText != "Latest results" {
+		t.Fatalf("notes = %#v", notes)
+	}
+
+	note, err := client.GetNote(context.Background(), "note-1")
+	if err != nil {
+		t.Fatalf("GetNote() error: %v", err)
+	}
+	if note.ContentENML == "" || note.ContentText == "" || note.ContentMarkdown == "" {
+		t.Fatalf("note content not decoded: %#v", note)
+	}
+	if len(note.Tasks) != 2 {
+		t.Fatalf("tasks len = %d, want 2", len(note.Tasks))
+	}
+	if !note.Tasks[0].Checked || note.Tasks[0].Text != "Check bibliography" {
+		t.Fatalf("first task = %#v", note.Tasks[0])
+	}
+	if note.Tasks[1].Checked || note.Tasks[1].Text != "Draft summary paragraph" {
+		t.Fatalf("second task = %#v", note.Tasks[1])
+	}
+
+	tags, err := client.ListTags(context.Background())
+	if err != nil {
+		t.Fatalf("ListTags() error: %v", err)
+	}
+	if len(tags) != 1 || tags[0].ParentID != "tag-root" {
+		t.Fatalf("tags = %#v", tags)
+	}
+}
+
+func TestAPIErrorAndValidation(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	})
+
+	if _, err := client.ListTags(context.Background()); err == nil {
+		t.Fatal("ListTags() error = nil, want APIError")
+	} else {
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("ListTags() error = %v, want APIError 429", err)
+		}
+	}
+
+	if _, err := client.GetNote(context.Background(), ""); !errors.Is(err, ErrNoteIDRequired) {
+		t.Fatalf("GetNote(empty) error = %v, want ErrNoteIDRequired", err)
+	}
+}
+
+func TestConvertENMLToText(t *testing.T) {
+	text, markdown, tasks := ConvertENMLToText(
+		`<en-note><div>Alpha</div><div><en-todo checked="checked"/>Beta task</div><ul><li>Gamma</li></ul></en-note>`,
+	)
+
+	if text != "Alpha\n\n[x] Beta task\n\n- Gamma" {
+		t.Fatalf("text = %q", text)
+	}
+	if markdown != "Alpha\n\n[x] Beta task\n\n- Gamma" {
+		t.Fatalf("markdown = %q", markdown)
+	}
+	if len(tasks) != 1 || tasks[0].Text != "Beta task" || !tasks[0].Checked {
+		t.Fatalf("tasks = %#v", tasks)
+	}
+}

--- a/internal/evernote/enml.go
+++ b/internal/evernote/enml.go
@@ -1,0 +1,232 @@
+package evernote
+
+import (
+	"encoding/xml"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type enmlRenderer struct {
+	text     strings.Builder
+	markdown strings.Builder
+	tasks    []Task
+	task     *Task
+}
+
+func ConvertENMLToText(enml string) (text string, markdown string, tasks []Task) {
+	clean := strings.TrimSpace(enml)
+	if clean == "" {
+		return "", "", nil
+	}
+	decoder := xml.NewDecoder(strings.NewReader(clean))
+	decoder.Strict = false
+	renderer := &enmlRenderer{}
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		switch tok := token.(type) {
+		case xml.StartElement:
+			renderer.handleStart(tok)
+		case xml.EndElement:
+			renderer.handleEnd(tok)
+		case xml.CharData:
+			renderer.handleText(string(tok))
+		}
+	}
+	renderer.finishTask()
+	text = strings.TrimSpace(normalizeRenderedText(renderer.text.String()))
+	markdown = strings.TrimSpace(normalizeRenderedText(renderer.markdown.String()))
+	return text, markdown, renderer.tasks
+}
+
+func (r *enmlRenderer) handleStart(tok xml.StartElement) {
+	switch strings.ToLower(tok.Name.Local) {
+	case "en-note", "div", "p":
+		r.startBlock("")
+	case "li":
+		r.startBlock("- ")
+	case "br":
+		r.endBlock()
+	case "en-todo":
+		r.finishTask()
+		r.startBlock("")
+		checked := false
+		for _, attr := range tok.Attr {
+			if strings.EqualFold(attr.Name.Local, "checked") && isTruthy(attr.Value) {
+				checked = true
+				break
+			}
+		}
+		r.task = &Task{Checked: checked}
+		marker := "[ ] "
+		if checked {
+			marker = "[x] "
+		}
+		r.writeLiteral(marker)
+	}
+}
+
+func (r *enmlRenderer) handleEnd(tok xml.EndElement) {
+	switch strings.ToLower(tok.Name.Local) {
+	case "div", "p", "li", "en-note":
+		r.endBlock()
+	}
+}
+
+func (r *enmlRenderer) handleText(raw string) {
+	text := collapseWhitespace(raw)
+	if text == "" {
+		return
+	}
+	r.writeText(text)
+	if r.task != nil {
+		if r.task.Text != "" {
+			r.task.Text += " "
+		}
+		r.task.Text += text
+	}
+}
+
+func (r *enmlRenderer) finishTask() {
+	if r.task == nil {
+		return
+	}
+	r.task.Text = strings.TrimSpace(r.task.Text)
+	if r.task.Text != "" {
+		r.tasks = append(r.tasks, *r.task)
+	}
+	r.task = nil
+}
+
+func (r *enmlRenderer) startBlock(prefix string) {
+	r.finishTask()
+	r.ensureParagraphBreak()
+	if prefix != "" {
+		r.writeLiteral(prefix)
+	}
+}
+
+func (r *enmlRenderer) endBlock() {
+	r.finishTask()
+	r.writeNewline()
+}
+
+func (r *enmlRenderer) ensureParagraphBreak() {
+	ensureParagraphBreak(&r.text)
+	ensureParagraphBreak(&r.markdown)
+}
+
+func (r *enmlRenderer) writeLiteral(value string) {
+	if value == "" {
+		return
+	}
+	r.text.WriteString(value)
+	r.markdown.WriteString(value)
+}
+
+func (r *enmlRenderer) writeText(value string) {
+	if value == "" {
+		return
+	}
+	writeSeparated(&r.text, value)
+	writeSeparated(&r.markdown, value)
+}
+
+func (r *enmlRenderer) writeNewline() {
+	writeNewline(&r.text)
+	writeNewline(&r.markdown)
+}
+
+func writeSeparated(b *strings.Builder, value string) {
+	if b.Len() > 0 {
+		last, _ := lastRune(b.String())
+		if !unicode.IsSpace(last) && last != '[' && last != '(' && last != '-' {
+			b.WriteByte(' ')
+		}
+	}
+	b.WriteString(value)
+}
+
+func writeNewline(b *strings.Builder) {
+	s := b.String()
+	if s == "" || strings.HasSuffix(s, "\n") {
+		return
+	}
+	b.WriteByte('\n')
+}
+
+func ensureParagraphBreak(b *strings.Builder) {
+	s := b.String()
+	if s == "" {
+		return
+	}
+	switch {
+	case strings.HasSuffix(s, "\n\n"):
+		return
+	case strings.HasSuffix(s, "\n"):
+		b.WriteByte('\n')
+	default:
+		b.WriteString("\n\n")
+	}
+}
+
+func normalizeRenderedText(raw string) string {
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(collapseWhitespace(line))
+	}
+	var kept []string
+	blank := false
+	for _, line := range lines {
+		if line == "" {
+			if !blank && len(kept) > 0 {
+				kept = append(kept, "")
+			}
+			blank = true
+			continue
+		}
+		kept = append(kept, line)
+		blank = false
+	}
+	return strings.Join(kept, "\n")
+}
+
+func collapseWhitespace(raw string) string {
+	var b strings.Builder
+	space := false
+	for _, r := range strings.TrimSpace(raw) {
+		if unicode.IsSpace(r) {
+			space = true
+			continue
+		}
+		if space && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+		space = false
+	}
+	return b.String()
+}
+
+func isTruthy(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "checked", "1", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func lastRune(raw string) (rune, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	r, _ := utf8.DecodeLastRuneInString(raw)
+	if r == utf8.RuneError && len(raw) == 1 {
+		return 0, false
+	}
+	return r, true
+}

--- a/internal/evernote/types.go
+++ b/internal/evernote/types.go
@@ -1,0 +1,164 @@
+package evernote
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const defaultAPIBaseURL = "https://api.evernote.com"
+
+var (
+	ErrTokenNotConfigured = errors.New("evernote token is not configured")
+	ErrNoteIDRequired     = errors.New("evernote note id is required")
+)
+
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("evernote API returned HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("evernote API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+type Notebook struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Stack     string         `json:"stack,omitempty"`
+	UpdatedAt string         `json:"updated_at,omitempty"`
+	Raw       map[string]any `json:"raw,omitempty"`
+}
+
+type NoteSummary struct {
+	ID          string         `json:"id"`
+	NotebookID  string         `json:"notebook_id,omitempty"`
+	Title       string         `json:"title,omitempty"`
+	UpdatedAt   string         `json:"updated_at,omitempty"`
+	CreatedAt   string         `json:"created_at,omitempty"`
+	TagNames    []string       `json:"tag_names,omitempty"`
+	ContentText string         `json:"content_text,omitempty"`
+	Raw         map[string]any `json:"raw,omitempty"`
+}
+
+type Task struct {
+	Text    string `json:"text"`
+	Checked bool   `json:"checked"`
+}
+
+type Note struct {
+	ID              string         `json:"id"`
+	NotebookID      string         `json:"notebook_id,omitempty"`
+	Title           string         `json:"title,omitempty"`
+	CreatedAt       string         `json:"created_at,omitempty"`
+	UpdatedAt       string         `json:"updated_at,omitempty"`
+	TagNames        []string       `json:"tag_names,omitempty"`
+	ContentENML     string         `json:"content_enml,omitempty"`
+	ContentText     string         `json:"content_text,omitempty"`
+	ContentMarkdown string         `json:"content_markdown,omitempty"`
+	Tasks           []Task         `json:"tasks,omitempty"`
+	Raw             map[string]any `json:"raw,omitempty"`
+}
+
+type Tag struct {
+	ID       string         `json:"id"`
+	Name     string         `json:"name"`
+	ParentID string         `json:"parent_id,omitempty"`
+	Raw      map[string]any `json:"raw,omitempty"`
+}
+
+type ListNotesOptions struct {
+	Query        string
+	Tag          string
+	UpdatedAfter string
+	Limit        int
+	Offset       int
+}
+
+type notebookPayload struct {
+	ID        string         `json:"id"`
+	GUID      string         `json:"guid"`
+	Name      string         `json:"name"`
+	Stack     string         `json:"stack"`
+	UpdatedAt string         `json:"updated_at"`
+	UpdatedTS string         `json:"updated"`
+	Raw       map[string]any `json:"-"`
+}
+
+type notePayload struct {
+	ID           string         `json:"id"`
+	GUID         string         `json:"guid"`
+	NotebookID   string         `json:"notebook_id"`
+	NotebookGUID string         `json:"notebookGuid"`
+	Title        string         `json:"title"`
+	UpdatedAt    string         `json:"updated_at"`
+	UpdatedTS    string         `json:"updated"`
+	CreatedAt    string         `json:"created_at"`
+	CreatedTS    string         `json:"created"`
+	TagNames     []string       `json:"tag_names"`
+	Content      string         `json:"content"`
+	ContentENML  string         `json:"content_enml"`
+	ENML         string         `json:"enml"`
+	Raw          map[string]any `json:"-"`
+}
+
+type tagPayload struct {
+	ID         string         `json:"id"`
+	GUID       string         `json:"guid"`
+	Name       string         `json:"name"`
+	ParentID   string         `json:"parent_id"`
+	ParentGUID string         `json:"parentGuid"`
+	Raw        map[string]any `json:"-"`
+}
+
+func TokenEnvVar(label string) string {
+	return "TABURA_EVERNOTE_TOKEN_" + sanitizeEnvSegment(label)
+}
+
+func sanitizeEnvSegment(raw string) string {
+	var b strings.Builder
+	lastUnderscore := true
+	for _, r := range strings.ToUpper(strings.TrimSpace(raw)) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastUnderscore = false
+		case !lastUnderscore:
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	clean := strings.Trim(b.String(), "_")
+	if clean == "" {
+		return "DEFAULT"
+	}
+	return clean
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if clean := strings.TrimSpace(value); clean != "" {
+			return clean
+		}
+	}
+	return ""
+}
+
+func mustObject(data []byte) (map[string]any, error) {
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return map[string]any{}, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- add a new `internal/evernote` leaf package with env-backed token auth and typed `ListNotebooks`, `ListNotes`, `GetNote`, and `ListTags` methods
- decode both direct JSON payloads and envelope payloads while preserving raw note/notebook/tag fields for later sync work
- convert ENML into plain text/markdown and extract checkbox tasks for downstream artifact storage

## Verification
- `ListNotebooks(ctx)`: covered by `TestListEndpointsAndNoteDecoding` in `internal/evernote/client_test.go`; the test serves `/notebooks` and asserts the decoded notebook id/stack.
- `ListNotes(ctx, notebookID, opts)`: covered by `TestListEndpointsAndNoteDecoding`; it asserts `notebook_id=nb-1`, `query=fusion`, and `limit=10` on the request and verifies the decoded note summary text.
- `GetNote(ctx, id)` returns note content and tasks: covered by `TestListEndpointsAndNoteDecoding`; it verifies `ContentENML`, decoded plain-text/markdown content, and two extracted tasks from ENML.
- `ListTags(ctx)`: covered by `TestListEndpointsAndNoteDecoding`; it verifies direct-array tag decoding and parent tag linkage.
- OAuth token env lookup via `TABURA_EVERNOTE_TOKEN_<LABEL>`: covered by `TestTokenEnvVarAndNewClientFromEnv` in `internal/evernote/client_test.go`.
- ENML conversion for artifact storage while preserving original ENML: covered by `TestListEndpointsAndNoteDecoding` and `TestConvertENMLToText` in `internal/evernote/client_test.go`.
- Regression / error handling: `TestAPIErrorAndValidation` covers 429 API errors and empty-note-id validation.
- Command: `go test ./internal/evernote -run 'Test(TokenEnvVarAndNewClientFromEnv|ListEndpointsAndNoteDecoding|APIErrorAndValidation|ConvertENMLToText)$' 2>&1 | tee /tmp/tabura-issue-260-rerun.log`
- Output: `ok   github.com/krystophny/tabura/internal/evernote 0.004s`