### PR TITLE
fix: playtest: capture route loads without the full canvas shell (fixes #343)

### DIFF
--- a/scripts/playtest.sh
+++ b/scripts/playtest.sh
@@ -5,10 +5,74 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 fail() { printf 'FATAL: %s\n' "$1" >&2; exit 1; }
 
+wait_for_command() {
+  local description="$1"
+  local attempts="$2"
+  shift 2
+  local try
+  for ((try = 1; try <= attempts; try++)); do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "$description"
+}
+
+latest_workspace_epoch() {
+  local -a paths=(
+    "$ROOT_DIR/cmd"
+    "$ROOT_DIR/internal"
+    "$ROOT_DIR/scripts"
+    "$ROOT_DIR/tests"
+    "$ROOT_DIR/go.mod"
+    "$ROOT_DIR/go.sum"
+    "$ROOT_DIR/package.json"
+    "$ROOT_DIR/package-lock.json"
+    "$ROOT_DIR/playwright.config.ts"
+    "$ROOT_DIR/playwright.playtest.config.ts"
+  )
+  local latest=0
+  local path
+  for path in "${paths[@]}"; do
+    [[ -e "$path" ]] || continue
+    while IFS= read -r mtime; do
+      [[ -n "$mtime" ]] || continue
+      if awk "BEGIN { exit !($mtime > $latest) }"; then
+        latest="$mtime"
+      fi
+    done < <(find "$path" -type f -printf '%T@\n' 2>/dev/null)
+  done
+  printf '%s\n' "${latest%%.*}"
+}
+
+maybe_sync_live_runtime() {
+  if ! systemctl --user is-active --quiet tabura-web.service; then
+    return
+  fi
+  local started_at started_epoch latest_epoch
+  started_at="$(systemctl --user show tabura-web.service --property=ExecMainStartTimestamp --value)"
+  started_epoch="$(date -d "$started_at" +%s 2>/dev/null || printf '0')"
+  latest_epoch="$(latest_workspace_epoch)"
+  if (( latest_epoch <= started_epoch )); then
+    return
+  fi
+  printf 'Syncing live runtime to current workspace...\n'
+  "$ROOT_DIR/scripts/tabura-dev-restart.sh"
+  wait_for_command \
+    'Tabura web server did not come back on :8420 after restart' \
+    30 \
+    curl -fsS --max-time 3 http://127.0.0.1:8420/api/setup
+}
+
+maybe_sync_live_runtime
+
 printf 'Checking live services...\n'
 
-curl -fsS --max-time 3 http://127.0.0.1:8420/api/setup >/dev/null \
-  || fail 'Tabura web server not running on :8420'
+wait_for_command \
+  'Tabura web server not running on :8420' \
+  5 \
+  curl -fsS --max-time 3 http://127.0.0.1:8420/api/setup
 
 curl -fsS --max-time 3 -o /dev/null -w '' \
   -X POST http://127.0.0.1:8424/v1/audio/speech \


### PR DESCRIPTION
## Summary
- restart the live runtime from `scripts/playtest.sh` when the workspace is newer than `tabura-web.service`
- wait for the web listener after that restart so live playtests hit the current source tree instead of a stale long-running `go run` process

## Verification
- Requirement: the live playtest uses the current workspace runtime before opening `/capture`.
  Command: `./scripts/playtest.sh --grep "capture route loads without the full canvas shell"`
  Evidence:
  ```text
  Syncing live runtime to current workspace...
  Running 1 test using 1 worker
    ✓  1 [chromium] › tests/playtest/playtest.spec.ts:101:7 › mobile capture route › capture route loads without the full canvas shell (702ms)
    1 passed (1.5s)
  [playtest] no failures; summary: .tabura/artifacts/playtests/latest-summary.txt
  ```
- Requirement: `/capture` serves the standalone capture page on the live runtime.
  Command: `curl -i --max-time 10 http://127.0.0.1:8420/capture | sed -n '1,20p'`
  Evidence:
  ```text
  HTTP/1.1 200 OK
  Cache-Control: no-store
  Content-Type: text/html; charset=utf-8
  ```
- Artifact: `.tabura/artifacts/playtests/latest-summary.txt`
