### PR TITLE
fix: add PDF-to-source location mapping for LaTeX and Pandoc (fixes #273)

### DIFF
--- a/internal/document/pandoc.go
+++ b/internal/document/pandoc.go
@@ -1,0 +1,203 @@
+package document
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultPandocLinesPerPage = 45
+	DefaultPDFPageHeight      = 792.0
+	defaultPDFXOffset         = 72.0
+)
+
+type PandocSourceMap struct {
+	sourcePath   string
+	linesPerPage int
+	pageHeight   float64
+	pages        []pandocPage
+}
+
+type pandocPage struct {
+	number    int
+	startLine int
+	endLine   int
+}
+
+func ParsePandocSourceMap(path string) (*PandocSourceMap, error) {
+	return ParsePandocSourceMapWithOptions(path, DefaultPandocLinesPerPage)
+}
+
+func ParsePandocSourceMapWithOptions(path string, linesPerPage int) (*PandocSourceMap, error) {
+	cleanPath := strings.TrimSpace(path)
+	if cleanPath == "" {
+		return nil, fmt.Errorf("parse pandoc source map: missing path")
+	}
+	if linesPerPage < 1 {
+		return nil, fmt.Errorf("lines per page must be >= 1")
+	}
+	absPath, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	pages, err := buildPandocPages(file, linesPerPage)
+	if err != nil {
+		return nil, err
+	}
+	return &PandocSourceMap{
+		sourcePath:   absPath,
+		linesPerPage: linesPerPage,
+		pageHeight:   DefaultPDFPageHeight,
+		pages:        pages,
+	}, nil
+}
+
+func (m *PandocSourceMap) SourceLocation(page int, _ float64, y float64) (file string, line int, err error) {
+	target, ok := m.page(page)
+	if !ok {
+		return "", 0, fmt.Errorf("page %d is out of range", page)
+	}
+	span := target.endLine - target.startLine + 1
+	if span < 1 {
+		return m.sourcePath, target.startLine, nil
+	}
+	fraction := clamp(y/m.pageHeight, 0, 0.999999)
+	line = target.startLine + int(float64(span)*fraction)
+	if line > target.endLine {
+		line = target.endLine
+	}
+	return m.sourcePath, line, nil
+}
+
+func (m *PandocSourceMap) PDFLocation(file string, line int) (page int, x, y float64, err error) {
+	if line < 1 {
+		return 0, 0, 0, fmt.Errorf("line must be >= 1")
+	}
+	if !samePath(file, m.sourcePath) {
+		return 0, 0, 0, fmt.Errorf("source map does not cover %q", file)
+	}
+	target, ok := m.pageForLine(line)
+	if !ok {
+		return 0, 0, 0, fmt.Errorf("line %d is out of range", line)
+	}
+	span := target.endLine - target.startLine + 1
+	if span < 1 {
+		return target.number, defaultPDFXOffset, 0, nil
+	}
+	offset := line - target.startLine
+	y = (float64(offset) / float64(span)) * m.pageHeight
+	return target.number, defaultPDFXOffset, y, nil
+}
+
+func (m *PandocSourceMap) page(number int) (pandocPage, bool) {
+	for _, page := range m.pages {
+		if page.number == number {
+			return page, true
+		}
+	}
+	return pandocPage{}, false
+}
+
+func (m *PandocSourceMap) pageForLine(line int) (pandocPage, bool) {
+	for _, page := range m.pages {
+		if line >= page.startLine && line <= page.endLine {
+			return page, true
+		}
+	}
+	return pandocPage{}, false
+}
+
+func buildPandocPages(file *os.File, linesPerPage int) ([]pandocPage, error) {
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 1024), 1024*1024)
+	var pages []pandocPage
+	currentPage := 1
+	pageStart := 1
+	lineNumber := 0
+	visibleLines := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := scanner.Text()
+		if isPandocPageBreak(line) {
+			pages = appendPandocPage(pages, currentPage, pageStart, max(pageStart, lineNumber-1))
+			currentPage++
+			pageStart = lineNumber + 1
+			visibleLines = 0
+			continue
+		}
+		visibleLines++
+		if visibleLines >= linesPerPage {
+			pages = appendPandocPage(pages, currentPage, pageStart, lineNumber)
+			currentPage++
+			pageStart = lineNumber + 1
+			visibleLines = 0
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if lineNumber == 0 {
+		return []pandocPage{{number: 1, startLine: 1, endLine: 1}}, nil
+	}
+	if pageStart <= lineNumber {
+		pages = appendPandocPage(pages, currentPage, pageStart, lineNumber)
+	}
+	if len(pages) == 0 {
+		pages = append(pages, pandocPage{number: 1, startLine: 1, endLine: lineNumber})
+	}
+	return pages, nil
+}
+
+func appendPandocPage(pages []pandocPage, number, startLine, endLine int) []pandocPage {
+	if startLine > endLine {
+		return pages
+	}
+	return append(pages, pandocPage{number: number, startLine: startLine, endLine: endLine})
+}
+
+func isPandocPageBreak(line string) bool {
+	clean := strings.ToLower(strings.TrimSpace(line))
+	switch clean {
+	case "\\newpage", "\\pagebreak", "<div class=\"pagebreak\">", "<div style=\"page-break-after: always;\">", "::: pagebreak":
+		return true
+	default:
+		return false
+	}
+}
+
+func samePath(left, right string) bool {
+	cleanLeft := filepath.Clean(strings.TrimSpace(left))
+	cleanRight := filepath.Clean(strings.TrimSpace(right))
+	if cleanLeft == cleanRight {
+		return true
+	}
+	absLeft, errLeft := filepath.Abs(cleanLeft)
+	absRight, errRight := filepath.Abs(cleanRight)
+	return errLeft == nil && errRight == nil && absLeft == absRight
+}
+
+func clamp(value, minValue, maxValue float64) float64 {
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func max(left, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/internal/document/synctex.go
+++ b/internal/document/synctex.go
@@ -1,0 +1,340 @@
+package document
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrSyncTeXFormat        = errors.New("invalid synctex file")
+	ErrSyncTeXBinaryMissing = errors.New("synctex binary not found")
+	ErrSyncTeXResultMissing = errors.New("synctex result not found")
+)
+
+type SyncTeX struct {
+	path      string
+	directory string
+	outputPDF string
+	inputs    map[string]string
+}
+
+func ParseSyncTeX(path string) (*SyncTeX, error) {
+	cleanPath := strings.TrimSpace(path)
+	if cleanPath == "" {
+		return nil, fmt.Errorf("parse synctex: missing path")
+	}
+	absPath, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader, closeReader, err := openSyncTeXReader(file, absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer closeReader()
+
+	inputs, err := parseSyncTeXInputs(reader)
+	if err != nil {
+		return nil, err
+	}
+	outputPDF, err := syncTeXOutputPath(absPath)
+	if err != nil {
+		return nil, err
+	}
+	return &SyncTeX{
+		path:      absPath,
+		directory: filepath.Dir(absPath),
+		outputPDF: outputPDF,
+		inputs:    inputs,
+	}, nil
+}
+
+func (s *SyncTeX) SourceLocation(page int, x, y float64) (file string, line int, err error) {
+	if page < 1 {
+		return "", 0, fmt.Errorf("page must be >= 1")
+	}
+	output, err := s.run("edit", "-o", fmt.Sprintf("%d:%s:%s:%s", page, formatFloat(x), formatFloat(y), s.outputPDF), "-d", s.directory)
+	if err != nil {
+		return "", 0, err
+	}
+	result, err := parseSyncTeXEditResult(output)
+	if err != nil {
+		return "", 0, err
+	}
+	return s.normalizeReturnedInput(result.input), result.line, nil
+}
+
+func (s *SyncTeX) PDFLocation(file string, line int) (page int, x, y float64, err error) {
+	if line < 1 {
+		return 0, 0, 0, fmt.Errorf("line must be >= 1")
+	}
+	input := s.normalizeRequestedInput(file)
+	if input == "" {
+		return 0, 0, 0, fmt.Errorf("missing input file")
+	}
+	output, err := s.run("view", "-i", fmt.Sprintf("%d:0:%s", line, input), "-o", s.outputPDF, "-d", s.directory)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	result, err := parseSyncTeXViewResult(output)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return result.page, result.x, result.y, nil
+}
+
+func (s *SyncTeX) run(subcommand string, args ...string) (string, error) {
+	if _, err := exec.LookPath("synctex"); err != nil {
+		return "", ErrSyncTeXBinaryMissing
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "synctex", append([]string{subcommand}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("synctex %s failed: %s", subcommand, message)
+	}
+	return string(out), nil
+}
+
+func (s *SyncTeX) normalizeRequestedInput(file string) string {
+	clean := strings.TrimSpace(file)
+	if clean == "" {
+		return ""
+	}
+	if mapped, ok := s.inputs[clean]; ok {
+		return mapped
+	}
+	abs, err := filepath.Abs(clean)
+	if err == nil {
+		if mapped, ok := s.inputs[abs]; ok {
+			return mapped
+		}
+		if mapped, ok := s.inputs[filepath.Clean(abs)]; ok {
+			return mapped
+		}
+	}
+	if rel, err := filepath.Rel(s.directory, clean); err == nil {
+		rel = filepath.ToSlash(rel)
+		if mapped, ok := s.inputs[rel]; ok {
+			return mapped
+		}
+	}
+	return clean
+}
+
+func (s *SyncTeX) normalizeReturnedInput(file string) string {
+	clean := filepath.Clean(strings.TrimSpace(file))
+	if filepath.IsAbs(clean) {
+		return clean
+	}
+	return filepath.Clean(filepath.Join(s.directory, clean))
+}
+
+func openSyncTeXReader(file *os.File, path string) (io.Reader, func() error, error) {
+	if strings.HasSuffix(path, ".gz") {
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			return nil, nil, err
+		}
+		return gz, gz.Close, nil
+	}
+	return file, func() error { return nil }, nil
+}
+
+func parseSyncTeXInputs(reader io.Reader) (map[string]string, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 1024), 1024*1024)
+	inputs := map[string]string{}
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+		return nil, ErrSyncTeXFormat
+	}
+	if !strings.HasPrefix(scanner.Text(), "SyncTeX Version:") {
+		return nil, ErrSyncTeXFormat
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "Content:" {
+			break
+		}
+		raw, ok := strings.CutPrefix(line, "Input:")
+		if !ok {
+			continue
+		}
+		parts := strings.SplitN(raw, ":", 2)
+		if len(parts) != 2 {
+			return nil, ErrSyncTeXFormat
+		}
+		path := strings.TrimSpace(parts[1])
+		if path == "" {
+			continue
+		}
+		registerSyncTeXInput(inputs, path)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return inputs, nil
+}
+
+func registerSyncTeXInput(inputs map[string]string, path string) {
+	clean := filepath.Clean(strings.TrimSpace(path))
+	if clean == "" {
+		return
+	}
+	values := []string{
+		path,
+		clean,
+		filepath.ToSlash(clean),
+		filepath.Base(clean),
+	}
+	if abs, err := filepath.Abs(clean); err == nil {
+		values = append(values, abs, filepath.Clean(abs))
+	}
+	for _, key := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, exists := inputs[key]; !exists {
+			inputs[key] = path
+		}
+	}
+}
+
+func syncTeXOutputPath(path string) (string, error) {
+	switch {
+	case strings.HasSuffix(path, ".synctex.gz"):
+		return strings.TrimSuffix(path, ".synctex.gz") + ".pdf", nil
+	case strings.HasSuffix(path, ".synctex"):
+		return strings.TrimSuffix(path, ".synctex") + ".pdf", nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrSyncTeXFormat, path)
+	}
+}
+
+type syncTeXViewResult struct {
+	page int
+	x    float64
+	y    float64
+}
+
+func parseSyncTeXViewResult(raw string) (syncTeXViewResult, error) {
+	values := map[string]string{}
+	if err := collectSyncTeXResultValues(raw, values, "Page", "x", "y"); err != nil {
+		return syncTeXViewResult{}, err
+	}
+	page, err := strconv.Atoi(values["Page"])
+	if err != nil {
+		return syncTeXViewResult{}, err
+	}
+	x, err := strconv.ParseFloat(values["x"], 64)
+	if err != nil {
+		return syncTeXViewResult{}, err
+	}
+	y, err := strconv.ParseFloat(values["y"], 64)
+	if err != nil {
+		return syncTeXViewResult{}, err
+	}
+	return syncTeXViewResult{page: page, x: x, y: y}, nil
+}
+
+type syncTeXEditResult struct {
+	input string
+	line  int
+}
+
+func parseSyncTeXEditResult(raw string) (syncTeXEditResult, error) {
+	values := map[string]string{}
+	if err := collectSyncTeXResultValues(raw, values, "Input", "Line"); err != nil {
+		return syncTeXEditResult{}, err
+	}
+	line, err := strconv.Atoi(values["Line"])
+	if err != nil {
+		return syncTeXEditResult{}, err
+	}
+	return syncTeXEditResult{input: values["Input"], line: line}, nil
+}
+
+func collectSyncTeXResultValues(raw string, values map[string]string, keys ...string) error {
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	inResult := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch line {
+		case "SyncTeX result begin":
+			inResult = true
+			continue
+		case "SyncTeX result end":
+			if hasSyncTeXKeys(values, keys...) {
+				return nil
+			}
+			inResult = false
+			continue
+		}
+		if !inResult {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if !syncTeXKeyRequested(key, keys...) {
+			continue
+		}
+		values[key] = strings.TrimSpace(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if hasSyncTeXKeys(values, keys...) {
+		return nil
+	}
+	return ErrSyncTeXResultMissing
+}
+
+func hasSyncTeXKeys(values map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if strings.TrimSpace(values[key]) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func syncTeXKeyRequested(key string, keys ...string) bool {
+	for _, candidate := range keys {
+		if key == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func formatFloat(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}

--- a/internal/document/synctex_test.go
+++ b/internal/document/synctex_test.go
@@ -1,0 +1,134 @@
+package document
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSyncTeXRoundTripsSourceAndPDFLocation(t *testing.T) {
+	ensureCommands(t, "pdflatex", "synctex")
+	dir := t.TempDir()
+	texPath := filepath.Join(dir, "main.tex")
+	source := "\\documentclass{article}\n\\begin{document}\nHello world.\n\nSecond line.\n\\end{document}\n"
+	if err := os.WriteFile(texPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("WriteFile(main.tex): %v", err)
+	}
+	cmd := exec.Command("pdflatex", "-synctex=1", "-interaction=nonstopmode", "main.tex")
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("pdflatex: %v\n%s", err, output)
+	}
+
+	syncPath := filepath.Join(dir, "main.synctex.gz")
+	mapping, err := ParseSyncTeX(syncPath)
+	if err != nil {
+		t.Fatalf("ParseSyncTeX() error = %v", err)
+	}
+
+	page, x, y, err := mapping.PDFLocation(texPath, 3)
+	if err != nil {
+		t.Fatalf("PDFLocation() error = %v", err)
+	}
+	if page != 1 {
+		t.Fatalf("page = %d, want 1", page)
+	}
+	if x <= 0 || y <= 0 {
+		t.Fatalf("PDFLocation() = (%d, %f, %f), want positive coordinates", page, x, y)
+	}
+
+	file, line, err := mapping.SourceLocation(page, x, y)
+	if err != nil {
+		t.Fatalf("SourceLocation() error = %v", err)
+	}
+	if file != texPath {
+		t.Fatalf("file = %q, want %q", file, texPath)
+	}
+	if line != 3 {
+		t.Fatalf("line = %d, want 3", line)
+	}
+}
+
+func TestParseSyncTeXRejectsInvalidHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.synctex")
+	if err := os.WriteFile(path, []byte("not synctex\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+	if _, err := ParseSyncTeX(path); err == nil {
+		t.Fatal("ParseSyncTeX() error = nil, want error")
+	}
+}
+
+func TestParsePandocSourceMapTracksExplicitPageBreaks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "paper.md")
+	content := "# Heading\n\nAlpha\nBeta\n\\newpage\nGamma\nDelta\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	mapping, err := ParsePandocSourceMapWithOptions(path, 10)
+	if err != nil {
+		t.Fatalf("ParsePandocSourceMapWithOptions() error = %v", err)
+	}
+
+	page, x, y, err := mapping.PDFLocation(path, 6)
+	if err != nil {
+		t.Fatalf("PDFLocation() error = %v", err)
+	}
+	if page != 2 {
+		t.Fatalf("page = %d, want 2", page)
+	}
+	if x <= 0 || y < 0 {
+		t.Fatalf("PDFLocation() = (%d, %f, %f), want positive x and non-negative y", page, x, y)
+	}
+
+	file, line, err := mapping.SourceLocation(2, x, 1)
+	if err != nil {
+		t.Fatalf("SourceLocation() error = %v", err)
+	}
+	if file != path {
+		t.Fatalf("file = %q, want %q", file, path)
+	}
+	if line != 6 {
+		t.Fatalf("line = %d, want 6", line)
+	}
+}
+
+func TestParsePandocSourceMapUsesLineBucketsWithoutExplicitBreaks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.md")
+	content := "one\ntwo\nthree\nfour\nfive\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	mapping, err := ParsePandocSourceMapWithOptions(path, 2)
+	if err != nil {
+		t.Fatalf("ParsePandocSourceMapWithOptions() error = %v", err)
+	}
+
+	page, _, _, err := mapping.PDFLocation(path, 5)
+	if err != nil {
+		t.Fatalf("PDFLocation() error = %v", err)
+	}
+	if page != 3 {
+		t.Fatalf("page = %d, want 3", page)
+	}
+
+	_, line, err := mapping.SourceLocation(3, 0, 0)
+	if err != nil {
+		t.Fatalf("SourceLocation() error = %v", err)
+	}
+	if line != 5 {
+		t.Fatalf("line = %d, want 5", line)
+	}
+}
+
+func ensureCommands(t *testing.T, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if _, err := exec.LookPath(name); err != nil {
+			t.Skipf("%s not available", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/document` with a typed SyncTeX API for bidirectional LaTeX source/PDF lookups
- add a deterministic Pandoc markdown fallback that maps source lines to PDF pages when SyncTeX is unavailable
- cover the new mapping behavior with round-trip and fallback tests

## Verification
- Requirement: parse SyncTeX data and resolve source line -> PDF position for LaTeX.
  Evidence: `go test ./internal/document 2>&1 | tee /tmp/issue273-test.log`
  Test: `TestParseSyncTeXRoundTripsSourceAndPDFLocation`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/document	0.042s`
- Requirement: resolve PDF page/position -> source file/line for LaTeX.
  Evidence: `go test ./internal/document 2>&1 | tee /tmp/issue273-test.log`
  Test: `TestParseSyncTeXRoundTripsSourceAndPDFLocation`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/document	0.042s`
- Requirement: provide a Pandoc source-map fallback.
  Evidence: `go test ./internal/document 2>&1 | tee /tmp/issue273-test.log`
  Tests: `TestParsePandocSourceMapTracksExplicitPageBreaks`, `TestParsePandocSourceMapUsesLineBucketsWithoutExplicitBreaks`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/document	0.042s`
- Requirement: reject invalid SyncTeX input instead of silently accepting malformed files.
  Evidence: `go test ./internal/document 2>&1 | tee /tmp/issue273-test.log`
  Test: `TestParseSyncTeXRejectsInvalidHeader`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/document	0.042s`
