### PR TITLE
fix: import Evernote notes as Artifacts and extract tasks (fixes #261)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -17,6 +17,7 @@ const (
 	ArtifactKindGitHubIssue  ArtifactKind = "github_issue"
 	ArtifactKindGitHubPR     ArtifactKind = "github_pr"
 	ArtifactKindExternalTask ArtifactKind = "external_task"
+	ArtifactKindExternalNote ArtifactKind = "external_note"
 	ArtifactKindTranscript   ArtifactKind = "transcript"
 	ArtifactKindPlanNote     ArtifactKind = "plan_note"
 	ArtifactKindIdeaNote     ArtifactKind = "idea_note"

--- a/internal/store/external_binding_test.go
+++ b/internal/store/external_binding_test.go
@@ -83,6 +83,13 @@ func TestExternalBindingStoreCRUDAndQueries(t *testing.T) {
 	if got.ID != created.ID {
 		t.Fatalf("GetBindingByRemote() id = %d, want %d", got.ID, created.ID)
 	}
+	latestRemoteAt, err := s.LatestBindingRemoteUpdatedAt(account.ID, ExternalProviderGmail, "email")
+	if err != nil {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(created) error: %v", err)
+	}
+	if latestRemoteAt == nil || *latestRemoteAt != "2026-03-08T12:00:00Z" {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(created) = %v, want 2026-03-08T12:00:00Z", latestRemoteAt)
+	}
 
 	updatedRemoteAt := "2026-03-08T13:15:00Z"
 	updated, err := s.UpsertExternalBinding(ExternalBinding{
@@ -108,6 +115,13 @@ func TestExternalBindingStoreCRUDAndQueries(t *testing.T) {
 	}
 	if updated.LastSyncedAt == "" {
 		t.Fatal("expected updated last_synced_at")
+	}
+	latestRemoteAt, err = s.LatestBindingRemoteUpdatedAt(account.ID, ExternalProviderGmail, "email")
+	if err != nil {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(updated) error: %v", err)
+	}
+	if latestRemoteAt == nil || *latestRemoteAt != updatedRemoteAt {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(updated) = %v, want %q", latestRemoteAt, updatedRemoteAt)
 	}
 
 	otherRemoteAt := "2026-03-08T08:30:00Z"
@@ -160,6 +174,13 @@ func TestExternalBindingStoreCRUDAndQueries(t *testing.T) {
 	}
 	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderGmail, "email", "msg-1"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("GetBindingByRemote(deleted) error = %v, want sql.ErrNoRows", err)
+	}
+	latestRemoteAt, err = s.LatestBindingRemoteUpdatedAt(account.ID, ExternalProviderGmail, "email")
+	if err != nil {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(deleted) error: %v", err)
+	}
+	if latestRemoteAt != nil {
+		t.Fatalf("LatestBindingRemoteUpdatedAt(deleted) = %v, want nil", latestRemoteAt)
 	}
 }
 
@@ -215,6 +236,9 @@ func TestExternalBindingStoreRejectsInvalidInput(t *testing.T) {
 	}
 	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderIMAP, "", "msg-1"); err == nil {
 		t.Fatal("expected missing object_type lookup error")
+	}
+	if _, err := s.LatestBindingRemoteUpdatedAt(account.ID, ExternalProviderIMAP, ""); err == nil {
+		t.Fatal("expected missing object_type latest lookup error")
 	}
 	if _, err := s.GetBindingByRemote(account.ID, ExternalProviderIMAP, "email", ""); err == nil {
 		t.Fatal("expected missing remote_id lookup error")

--- a/internal/store/store_external_binding.go
+++ b/internal/store/store_external_binding.go
@@ -164,6 +164,41 @@ func (s *Store) GetBindingsByArtifact(artifactID int64) ([]ExternalBinding, erro
 	return scanExternalBindingRows(rows)
 }
 
+func (s *Store) LatestBindingRemoteUpdatedAt(accountID int64, provider, objectType string) (*string, error) {
+	if _, err := s.validateExternalBindingAccount(accountID, provider); err != nil {
+		return nil, err
+	}
+	cleanObjectType := normalizeExternalBindingObjectType(objectType)
+	if cleanObjectType == "" {
+		return nil, errors.New("external binding object_type is required")
+	}
+	var value sql.NullString
+	err := s.db.QueryRow(
+		`SELECT remote_updated_at
+		 FROM external_bindings
+		 WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_updated_at IS NOT NULL
+		 ORDER BY datetime(remote_updated_at) DESC, id DESC
+		 LIMIT 1`,
+		accountID,
+		normalizeExternalAccountProvider(provider),
+		cleanObjectType,
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !value.Valid {
+		return nil, nil
+	}
+	clean := strings.TrimSpace(value.String)
+	if clean == "" {
+		return nil, nil
+	}
+	return &clean, nil
+}
+
 func (s *Store) ListStaleBindings(provider string, olderThan time.Time) ([]ExternalBinding, error) {
 	cleanProvider := normalizeExternalAccountProvider(provider)
 	if cleanProvider == "" {

--- a/internal/web/chat_evernote.go
+++ b/internal/web/chat_evernote.go
@@ -1,0 +1,484 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/evernote"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const evernoteSyncPageSize = 100
+
+type evernoteAccountConfig struct {
+	BaseURL string `json:"base_url"`
+}
+
+type evernoteSyncResult struct {
+	NoteCount int
+	TaskCount int
+}
+
+func parseInlineEvernoteIntent(text string) *SystemAction {
+	if normalizeItemCommandText(text) != "sync evernote" {
+		return nil
+	}
+	return &SystemAction{Action: "sync_evernote", Params: map[string]interface{}{}}
+}
+
+func evernoteActionFailurePrefix(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "sync_evernote":
+		return "I couldn't sync Evernote: "
+	default:
+		return "I couldn't resolve the Evernote request: "
+	}
+}
+
+func decodeEvernoteAccountConfig(account store.ExternalAccount) (evernoteAccountConfig, error) {
+	var cfg evernoteAccountConfig
+	raw := strings.TrimSpace(account.ConfigJSON)
+	if raw == "" || raw == "{}" {
+		return cfg, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return evernoteAccountConfig{}, fmt.Errorf("decode evernote config: %w", err)
+	}
+	return cfg, nil
+}
+
+func evernoteClientForAccount(account store.ExternalAccount) (*evernote.Client, error) {
+	cfg, err := decodeEvernoteAccountConfig(account)
+	if err != nil {
+		return nil, err
+	}
+	opts := []evernote.Option{}
+	if strings.TrimSpace(cfg.BaseURL) != "" {
+		opts = append(opts, evernote.WithBaseURL(cfg.BaseURL))
+	}
+	return evernote.NewClientFromEnv(account.Label, opts...)
+}
+
+func (a *App) activeEvernoteAccounts() ([]store.ExternalAccount, error) {
+	accounts, err := a.store.ListExternalAccountsByProvider(store.ExternalProviderEvernote)
+	if err != nil {
+		return nil, err
+	}
+	activeSphere, err := a.store.ActiveSphere()
+	if err != nil {
+		return nil, err
+	}
+	enabled := todoistEnabledAccounts(accounts, activeSphere)
+	if len(enabled) > 0 {
+		return enabled, nil
+	}
+	enabled = todoistEnabledAccounts(accounts, "")
+	if len(enabled) == 0 {
+		return nil, errors.New("no enabled Evernote account is configured")
+	}
+	return enabled, nil
+}
+
+func evernoteNotebookNameByID(notebooks []evernote.Notebook) map[string]string {
+	out := make(map[string]string, len(notebooks))
+	for _, notebook := range notebooks {
+		id := strings.TrimSpace(notebook.ID)
+		if id == "" {
+			continue
+		}
+		out[id] = strings.TrimSpace(notebook.Name)
+	}
+	return out
+}
+
+func evernoteNotebookMapping(mappings []store.ExternalContainerMapping, notebookName string) *store.ExternalContainerMapping {
+	cleanName := strings.ToLower(strings.TrimSpace(notebookName))
+	if cleanName == "" {
+		return nil
+	}
+	for i := range mappings {
+		mapping := &mappings[i]
+		if !strings.EqualFold(mapping.Provider, store.ExternalProviderEvernote) {
+			continue
+		}
+		if !strings.EqualFold(mapping.ContainerType, "notebook") {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(mapping.ContainerRef), cleanName) {
+			return mapping
+		}
+	}
+	return nil
+}
+
+func (a *App) evernoteNotebookMappingForAccount(account store.ExternalAccount, mappings []store.ExternalContainerMapping, notebookName string) (*store.ExternalContainerMapping, error) {
+	mapping := evernoteNotebookMapping(mappings, notebookName)
+	if mapping == nil {
+		return nil, nil
+	}
+	if mapping.Sphere != nil && !strings.EqualFold(strings.TrimSpace(*mapping.Sphere), account.Sphere) {
+		return nil, nil
+	}
+	if mapping.WorkspaceID == nil {
+		return mapping, nil
+	}
+	workspace, err := a.store.GetWorkspace(*mapping.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(workspace.Sphere, account.Sphere) {
+		return nil, nil
+	}
+	return mapping, nil
+}
+
+func (a *App) evernoteProjectHintFromTags(tags []string) *string {
+	for _, tag := range tags {
+		project, err := a.hubFindProjectByName(tag)
+		if err != nil {
+			continue
+		}
+		projectID := project.ID
+		return &projectID
+	}
+	return nil
+}
+
+func evernoteNoteArtifactMeta(note evernote.Note, notebookName string) (*string, error) {
+	payload := map[string]any{
+		"notebook":         strings.TrimSpace(notebookName),
+		"tags":             append([]string(nil), note.TagNames...),
+		"updated_at":       strings.TrimSpace(note.UpdatedAt),
+		"created_at":       strings.TrimSpace(note.CreatedAt),
+		"content_text":     strings.TrimSpace(note.ContentText),
+		"content_markdown": strings.TrimSpace(note.ContentMarkdown),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func evernoteNoteRefURL(note evernote.Note) *string {
+	for _, key := range []string{"url", "web_url", "webUrl"} {
+		if value, ok := note.Raw[key]; ok {
+			text := strings.TrimSpace(fmt.Sprint(value))
+			if text != "" {
+				return &text
+			}
+		}
+	}
+	return nil
+}
+
+func evernoteTaskSourceRef(noteID string, index int) string {
+	return fmt.Sprintf("note:%s:task:%d", strings.TrimSpace(noteID), index)
+}
+
+func evernoteTaskState(task evernote.Task) string {
+	if task.Checked {
+		return store.ItemStateDone
+	}
+	return store.ItemStateInbox
+}
+
+func (a *App) upsertEvernoteArtifact(account store.ExternalAccount, note evernote.Note, notebookName string) (store.Artifact, error) {
+	metaJSON, err := evernoteNoteArtifactMeta(note, notebookName)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	title := strings.TrimSpace(note.Title)
+	refURL := evernoteNoteRefURL(note)
+	kind := store.ArtifactKindExternalNote
+
+	if binding, err := a.store.GetBindingByRemote(account.ID, store.ExternalProviderEvernote, "note", strings.TrimSpace(note.ID)); err == nil {
+		if binding.ArtifactID != nil {
+			err = a.store.UpdateArtifact(*binding.ArtifactID, store.ArtifactUpdate{
+				Kind:     &kind,
+				RefURL:   refURL,
+				Title:    optionalTrimmedString(title),
+				MetaJSON: metaJSON,
+			})
+			if err == nil {
+				if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+					AccountID:       account.ID,
+					Provider:        store.ExternalProviderEvernote,
+					ObjectType:      "note",
+					RemoteID:        strings.TrimSpace(note.ID),
+					ArtifactID:      binding.ArtifactID,
+					ContainerRef:    optionalStringPointer(notebookName),
+					RemoteUpdatedAt: optionalStringPointer(note.UpdatedAt),
+				}); err != nil {
+					return store.Artifact{}, err
+				}
+				return a.store.GetArtifact(*binding.ArtifactID)
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return store.Artifact{}, err
+			}
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Artifact{}, err
+	}
+
+	artifact, err := a.store.CreateArtifact(kind, nil, refURL, optionalTrimmedString(title), metaJSON)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderEvernote,
+		ObjectType:      "note",
+		RemoteID:        strings.TrimSpace(note.ID),
+		ArtifactID:      &artifact.ID,
+		ContainerRef:    optionalStringPointer(notebookName),
+		RemoteUpdatedAt: optionalStringPointer(note.UpdatedAt),
+	}); err != nil {
+		return store.Artifact{}, err
+	}
+	return artifact, nil
+}
+
+func evernoteTaskProjectID(mapping *store.ExternalContainerMapping, inferredProjectID *string) *string {
+	if mapping != nil && mapping.ProjectID != nil {
+		projectID := strings.TrimSpace(*mapping.ProjectID)
+		return &projectID
+	}
+	if inferredProjectID == nil {
+		return nil
+	}
+	projectID := strings.TrimSpace(*inferredProjectID)
+	if projectID == "" {
+		return nil
+	}
+	return &projectID
+}
+
+func mappedProjectUpdateWithFallback(mapping *store.ExternalContainerMapping, fallback *string) *string {
+	if mapping != nil {
+		if mapping.ProjectID != nil {
+			return mappedProjectUpdate(mapping)
+		}
+		if fallback == nil {
+			return nil
+		}
+		projectID := strings.TrimSpace(*fallback)
+		if projectID == "" {
+			return nil
+		}
+		return &projectID
+	}
+	if fallback == nil {
+		return nil
+	}
+	projectID := strings.TrimSpace(*fallback)
+	return &projectID
+}
+
+func (a *App) persistEvernoteTask(account store.ExternalAccount, artifact store.Artifact, task evernote.Task, sourceRef string, mapping *store.ExternalContainerMapping, inferredProjectID *string, remoteUpdatedAt *string) (store.Item, error) {
+	title := strings.TrimSpace(task.Text)
+	if title == "" {
+		return store.Item{}, errors.New("evernote task text is required")
+	}
+	desiredState := evernoteTaskState(task)
+	if existing, err := a.store.GetItemBySource(store.ExternalProviderEvernote, sourceRef); err == nil {
+		updates := store.ItemUpdate{
+			Title:      &title,
+			ArtifactID: &artifact.ID,
+		}
+		if mapping != nil {
+			updates.WorkspaceID = mappedWorkspaceUpdate(mapping)
+		}
+		if projectID := mappedProjectUpdateWithFallback(mapping, inferredProjectID); projectID != nil {
+			updates.ProjectID = projectID
+		}
+		if mapping == nil || mapping.WorkspaceID == nil {
+			sphere := account.Sphere
+			updates.Sphere = &sphere
+		}
+		if err := a.store.UpdateItem(existing.ID, updates); err != nil {
+			return store.Item{}, err
+		}
+		item, err := a.store.GetItem(existing.ID)
+		if err != nil {
+			return store.Item{}, err
+		}
+		switch {
+		case desiredState == store.ItemStateDone && item.State != store.ItemStateDone:
+			if err := a.store.CompleteItemBySource(store.ExternalProviderEvernote, sourceRef); err != nil {
+				return store.Item{}, err
+			}
+			item, err = a.store.GetItem(existing.ID)
+			if err != nil {
+				return store.Item{}, err
+			}
+		case desiredState == store.ItemStateInbox && item.State == store.ItemStateDone:
+			if err := a.store.SyncItemStateBySource(store.ExternalProviderEvernote, sourceRef, store.ItemStateInbox); err != nil {
+				return store.Item{}, err
+			}
+			item, err = a.store.GetItem(existing.ID)
+			if err != nil {
+				return store.Item{}, err
+			}
+		}
+		if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+			AccountID:       account.ID,
+			Provider:        store.ExternalProviderEvernote,
+			ObjectType:      "task",
+			RemoteID:        sourceRef,
+			ItemID:          &item.ID,
+			ArtifactID:      &artifact.ID,
+			RemoteUpdatedAt: remoteUpdatedAt,
+		}); err != nil {
+			return store.Item{}, err
+		}
+		return item, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Item{}, err
+	}
+
+	opts := store.ItemOptions{
+		State:      desiredState,
+		ProjectID:  evernoteTaskProjectID(mapping, inferredProjectID),
+		Sphere:     &account.Sphere,
+		ArtifactID: &artifact.ID,
+		Source:     optionalStringPointer(store.ExternalProviderEvernote),
+		SourceRef:  &sourceRef,
+	}
+	if mapping != nil && mapping.WorkspaceID != nil {
+		opts.WorkspaceID = mapping.WorkspaceID
+	}
+	item, err := a.store.CreateItem(title, opts)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderEvernote,
+		ObjectType:      "task",
+		RemoteID:        sourceRef,
+		ItemID:          &item.ID,
+		ArtifactID:      &artifact.ID,
+		RemoteUpdatedAt: remoteUpdatedAt,
+	}); err != nil {
+		return store.Item{}, err
+	}
+	return item, nil
+}
+
+func (a *App) persistEvernoteNote(account store.ExternalAccount, note evernote.Note, notebookName string, mappings []store.ExternalContainerMapping) (evernoteSyncResult, error) {
+	artifact, err := a.upsertEvernoteArtifact(account, note, notebookName)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	mapping, err := a.evernoteNotebookMappingForAccount(account, mappings, notebookName)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	inferredProjectID := a.evernoteProjectHintFromTags(note.TagNames)
+
+	result := evernoteSyncResult{NoteCount: 1}
+	remoteUpdatedAt := optionalStringPointer(note.UpdatedAt)
+	for i, task := range note.Tasks {
+		if strings.TrimSpace(task.Text) == "" {
+			continue
+		}
+		sourceRef := evernoteTaskSourceRef(note.ID, i+1)
+		if _, err := a.persistEvernoteTask(account, artifact, task, sourceRef, mapping, inferredProjectID, remoteUpdatedAt); err != nil {
+			return evernoteSyncResult{}, err
+		}
+		result.TaskCount++
+	}
+	return result, nil
+}
+
+func listAllEvernoteNotes(ctx context.Context, client *evernote.Client, updatedAfter string) ([]evernote.NoteSummary, error) {
+	var all []evernote.NoteSummary
+	offset := 0
+	for {
+		notes, err := client.ListNotes(ctx, "", evernote.ListNotesOptions{
+			UpdatedAfter: updatedAfter,
+			Limit:        evernoteSyncPageSize,
+			Offset:       offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, notes...)
+		if len(notes) < evernoteSyncPageSize {
+			return all, nil
+		}
+		offset += len(notes)
+	}
+}
+
+func (a *App) executeSyncEvernoteAction() (string, map[string]interface{}, error) {
+	accounts, err := a.activeEvernoteAccounts()
+	if err != nil {
+		return "", nil, err
+	}
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderEvernote)
+	if err != nil {
+		return "", nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result := evernoteSyncResult{}
+	for _, account := range accounts {
+		client, err := evernoteClientForAccount(account)
+		if err != nil {
+			return "", nil, err
+		}
+		notebooks, err := client.ListNotebooks(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		notebookNames := evernoteNotebookNameByID(notebooks)
+		updatedAfter := ""
+		if latest, err := a.store.LatestBindingRemoteUpdatedAt(account.ID, store.ExternalProviderEvernote, "note"); err != nil {
+			return "", nil, err
+		} else if latest != nil {
+			updatedAfter = *latest
+		}
+		notes, err := listAllEvernoteNotes(ctx, client, updatedAfter)
+		if err != nil {
+			return "", nil, err
+		}
+		for _, summary := range notes {
+			note, err := client.GetNote(ctx, summary.ID)
+			if err != nil {
+				return "", nil, err
+			}
+			notebookName := strings.TrimSpace(notebookNames[strings.TrimSpace(note.NotebookID)])
+			synced, err := a.persistEvernoteNote(account, note, notebookName, mappings)
+			if err != nil {
+				return "", nil, err
+			}
+			result.NoteCount += synced.NoteCount
+			result.TaskCount += synced.TaskCount
+		}
+	}
+
+	return fmt.Sprintf("Synced %d Evernote note(s) and %d task item(s).", result.NoteCount, result.TaskCount), map[string]interface{}{
+		"type":       "sync_evernote",
+		"note_count": result.NoteCount,
+		"task_count": result.TaskCount,
+	}, nil
+}
+
+func (a *App) executeEvernoteAction(_ store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	switch strings.ToLower(strings.TrimSpace(action.Action)) {
+	case "sync_evernote":
+		return a.executeSyncEvernoteAction()
+	default:
+		return "", nil, fmt.Errorf("unsupported evernote action: %s", action.Action)
+	}
+}

--- a/internal/web/chat_evernote_test.go
+++ b/internal/web/chat_evernote_test.go
@@ -1,0 +1,308 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineEvernoteIntent(t *testing.T) {
+	action := parseInlineEvernoteIntent("sync evernote")
+	if action == nil {
+		t.Fatal("expected evernote action")
+	}
+	if action.Action != "sync_evernote" {
+		t.Fatalf("action = %q, want sync_evernote", action.Action)
+	}
+	if parseInlineEvernoteIntent("sync todoist") != nil {
+		t.Fatal("did not expect evernote action for unrelated text")
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSyncEvernote(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/notebooks":
+			writeEvernoteJSON(t, w, map[string]any{
+				"notebooks": []map[string]any{{
+					"id":   "nb-1",
+					"name": "Research",
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/notes":
+			if got := r.URL.Query().Get("updated_after"); got != "" {
+				t.Fatalf("updated_after = %q, want empty on first sync", got)
+			}
+			writeEvernoteJSON(t, w, map[string]any{
+				"notes": []map[string]any{{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "Reading queue",
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/notes/note-1":
+			writeEvernoteJSON(t, w, map[string]any{
+				"note": map[string]any{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "Reading queue",
+					"created_at":  "2026-03-08T08:00:00Z",
+					"updated_at":  "2026-03-09T09:30:00Z",
+					"tag_names":   []string{"Tabura"},
+					"url":         "https://evernote.test/note-1",
+					"content_enml": `<en-note>` +
+						`<div><en-todo/>Review section 2</div>` +
+						`<div><en-todo checked="true"/>Check bibliography</div>` +
+						`</en-note>`,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	account := createEvernoteTestAccount(t, app, "Research Notes", server.URL)
+	workspace, err := app.store.CreateWorkspace("Research", filepath.Join(t.TempDir(), "research"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	targetProject, err := app.store.CreateProject("Tabura", "tabura", filepath.Join(t.TempDir(), "tabura"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderEvernote, "notebook", "Research", &workspace.ID, nil, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync evernote")
+	if !handled {
+		t.Fatal("expected sync command to be handled")
+	}
+	if message != "Synced 1 Evernote note(s) and 2 task item(s)." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "sync_evernote" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	firstItem, err := app.store.GetItemBySource(store.ExternalProviderEvernote, "note:note-1:task:1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(task1) error: %v", err)
+	}
+	if firstItem.WorkspaceID == nil || *firstItem.WorkspaceID != workspace.ID {
+		t.Fatalf("first item workspace_id = %v, want %d", firstItem.WorkspaceID, workspace.ID)
+	}
+	if firstItem.ProjectID == nil || *firstItem.ProjectID != targetProject.ID {
+		t.Fatalf("first item project_id = %v, want %q", firstItem.ProjectID, targetProject.ID)
+	}
+	if firstItem.State != store.ItemStateInbox {
+		t.Fatalf("first item state = %q, want inbox", firstItem.State)
+	}
+	if firstItem.ArtifactID == nil {
+		t.Fatal("expected first item artifact")
+	}
+	secondItem, err := app.store.GetItemBySource(store.ExternalProviderEvernote, "note:note-1:task:2")
+	if err != nil {
+		t.Fatalf("GetItemBySource(task2) error: %v", err)
+	}
+	if secondItem.State != store.ItemStateDone {
+		t.Fatalf("second item state = %q, want done", secondItem.State)
+	}
+	artifact, err := app.store.GetArtifact(*firstItem.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindExternalNote {
+		t.Fatalf("artifact kind = %q, want %q", artifact.Kind, store.ArtifactKindExternalNote)
+	}
+	if artifact.RefURL == nil || *artifact.RefURL != "https://evernote.test/note-1" {
+		t.Fatalf("artifact ref_url = %v, want note URL", artifact.RefURL)
+	}
+	var meta map[string]any
+	if artifact.MetaJSON == nil || json.Unmarshal([]byte(*artifact.MetaJSON), &meta) != nil {
+		t.Fatalf("artifact meta_json = %v, want valid JSON", artifact.MetaJSON)
+	}
+	if got := strFromAny(meta["notebook"]); got != "Research" {
+		t.Fatalf("artifact notebook = %q, want Research", got)
+	}
+	binding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderEvernote, "note", "note-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(note) error: %v", err)
+	}
+	if binding.ArtifactID == nil || *binding.ArtifactID != artifact.ID {
+		t.Fatalf("note binding artifact_id = %v, want %d", binding.ArtifactID, artifact.ID)
+	}
+	taskBinding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderEvernote, "task", "note:note-1:task:1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(task) error: %v", err)
+	}
+	if taskBinding.ItemID == nil || *taskBinding.ItemID != firstItem.ID {
+		t.Fatalf("task binding item_id = %v, want %d", taskBinding.ItemID, firstItem.ID)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSyncEvernoteUsesUpdatedAfterAndRemapsExistingItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	var updatedAfterSeen string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/notebooks":
+			writeEvernoteJSON(t, w, map[string]any{
+				"notebooks": []map[string]any{{
+					"id":   "nb-1",
+					"name": "Research",
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/notes":
+			updatedAfterSeen = r.URL.Query().Get("updated_after")
+			writeEvernoteJSON(t, w, map[string]any{
+				"notes": []map[string]any{{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "Reading queue",
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/notes/note-1":
+			writeEvernoteJSON(t, w, map[string]any{
+				"note": map[string]any{
+					"id":          "note-1",
+					"notebook_id": "nb-1",
+					"title":       "Reading queue updated",
+					"updated_at":  "2026-03-09T10:30:00Z",
+					"tag_names":   []string{"Tabura"},
+					"content_enml": `<en-note>` +
+						`<div><en-todo checked="true"/>Review section 2</div>` +
+						`</en-note>`,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	account := createEvernoteTestAccount(t, app, "Research Notes", server.URL)
+	source := store.ExternalProviderEvernote
+	artifactTitle := "Old note"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindExternalNote, nil, nil, &artifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Old task", store.ItemOptions{
+		Source:     &source,
+		SourceRef:  optionalStringPointer("note:note-1:task:1"),
+		ArtifactID: &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	remoteUpdatedAt := "2026-03-09T09:30:00Z"
+	if _, err := app.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderEvernote,
+		ObjectType:      "note",
+		RemoteID:        "note-1",
+		ArtifactID:      &artifact.ID,
+		RemoteUpdatedAt: &remoteUpdatedAt,
+	}); err != nil {
+		t.Fatalf("UpsertExternalBinding(note) error: %v", err)
+	}
+	if _, err := app.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderEvernote,
+		ObjectType:      "task",
+		RemoteID:        "note:note-1:task:1",
+		ItemID:          &item.ID,
+		ArtifactID:      &artifact.ID,
+		RemoteUpdatedAt: &remoteUpdatedAt,
+	}); err != nil {
+		t.Fatalf("UpsertExternalBinding(task) error: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Research", filepath.Join(t.TempDir(), "research"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderEvernote, "notebook", "Research", &workspace.ID, nil, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync evernote")
+	if !handled {
+		t.Fatal("expected sync command to be handled")
+	}
+	if message != "Synced 1 Evernote note(s) and 1 task item(s)." {
+		t.Fatalf("message = %q", message)
+	}
+	if updatedAfterSeen != remoteUpdatedAt {
+		t.Fatalf("updated_after = %q, want %q", updatedAfterSeen, remoteUpdatedAt)
+	}
+	updatedItem, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(updated) error: %v", err)
+	}
+	if updatedItem.Title != "Review section 2" {
+		t.Fatalf("updated title = %q, want Review section 2", updatedItem.Title)
+	}
+	if updatedItem.State != store.ItemStateDone {
+		t.Fatalf("updated state = %q, want done", updatedItem.State)
+	}
+	if updatedItem.WorkspaceID == nil || *updatedItem.WorkspaceID != workspace.ID {
+		t.Fatalf("updated workspace_id = %v, want %d", updatedItem.WorkspaceID, workspace.ID)
+	}
+	updatedArtifact, err := app.store.GetArtifact(artifact.ID)
+	if err != nil {
+		t.Fatalf("GetArtifact(updated) error: %v", err)
+	}
+	if updatedArtifact.Title == nil || *updatedArtifact.Title != "Reading queue updated" {
+		t.Fatalf("updated artifact title = %v, want Reading queue updated", updatedArtifact.Title)
+	}
+}
+
+func createEvernoteTestAccount(t *testing.T, app *App, label, baseURL string) store.ExternalAccount {
+	t.Helper()
+	t.Setenv("TABURA_EVERNOTE_TOKEN_RESEARCH_NOTES", "token-1")
+	account, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderEvernote, label, map[string]any{
+		"base_url": baseURL,
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	return account
+}
+
+func writeEvernoteJSON(t *testing.T, w http.ResponseWriter, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode evernote payload: %v", err)
+	}
+}

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, map_todoist_project, sync_todoist, create_todoist_task, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "map_todoist_project", "sync_todoist", "create_todoist_task":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -759,6 +759,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return todoistActionFailurePrefix(inlineTodoistAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	if inlineEvernoteAction := parseInlineEvernoteIntent(trimmedText); inlineEvernoteAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineEvernoteAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return evernoteActionFailurePrefix(inlineEvernoteAction.Action) + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -320,6 +320,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.executeFilteredItemViewAction(action)
 	case "map_todoist_project", "sync_todoist", "create_todoist_task":
 		return a.executeTodoistAction(session, action)
+	case "sync_evernote":
+		return a.executeEvernoteAction(session, action)
 	case "create_github_issue", "create_github_issue_split":
 		return a.createGitHubIssueFromConversation(sessionID, session, action)
 	case "shell":

--- a/internal/web/chat_items_filters.go
+++ b/internal/web/chat_items_filters.go
@@ -15,6 +15,8 @@ var itemFilterSourceCommands = map[string]string{
 	"show todoist items":      store.ExternalProviderTodoist,
 	"zeige todoist aufgaben":  store.ExternalProviderTodoist,
 	"zeige todoist items":     store.ExternalProviderTodoist,
+	"show evernote notes":     store.ExternalProviderEvernote,
+	"show evernote items":     store.ExternalProviderEvernote,
 	"show gmail messages":     store.ExternalProviderGmail,
 	"show gmail items":        store.ExternalProviderGmail,
 	"zeige gmail nachrichten": store.ExternalProviderGmail,

--- a/internal/web/chat_items_filters_test.go
+++ b/internal/web/chat_items_filters_test.go
@@ -26,6 +26,7 @@ func TestParseInlineItemIntentFilterCommands(t *testing.T) {
 		{text: "show all todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist, wantAll: true},
 		{text: "show my todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
 		{text: "zeige todoist aufgaben", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
+		{text: "show evernote notes", wantAction: "show_filtered_items", wantSource: store.ExternalProviderEvernote},
 		{text: "show unassigned items", wantAction: "show_filtered_items", wantNullWork: true},
 		{text: "zeige nicht zugeordnete items", wantAction: "show_filtered_items", wantNullWork: true},
 	}


### PR DESCRIPTION
## Summary
- add a `sync evernote` system action backed by Evernote external accounts and incremental remote-updated polling
- persist synced Evernote notes as `external_note` artifacts and materialize ENML checkboxes as Evernote-backed items
- apply notebook workspace mappings, tag-based project hints, and Evernote source filtering in the inbox UI flow

## Verification
- Incremental note polling: `go test ./internal/store ./internal/web -run 'TestExternalBindingStoreCRUDAndQueries|TestExternalBindingStoreRejectsInvalidInput|TestParseInlineItemIntentFilterCommands|TestClassifyAndExecuteSystemActionShowFilteredItems|TestParseInlineEvernoteIntent|TestClassifyAndExecuteSystemActionSyncEvernote|TestClassifyAndExecuteSystemActionSyncEvernoteUsesUpdatedAfterAndRemapsExistingItem' 2>&1 | tee /tmp/test-issue-261.log` -> `ok   github.com/krystophny/tabura/internal/store` and `ok   github.com/krystophny/tabura/internal/web`; `TestExternalBindingStoreCRUDAndQueries` and `TestClassifyAndExecuteSystemActionSyncEvernoteUsesUpdatedAfterAndRemapsExistingItem` assert the stored remote timestamp is reused as `updated_after`.
- Note import as artifacts: `TestClassifyAndExecuteSystemActionSyncEvernote` verifies note `note-1` becomes an `external_note` artifact with the Evernote URL plus notebook/tag metadata.
- Task extraction from Evernote checkboxes: `TestClassifyAndExecuteSystemActionSyncEvernote` verifies `note:note-1:task:1` and `note:note-1:task:2` items are created from ENML tasks with inbox/done state and linked back to the imported note artifact.
- Notebook mapping and tag-based project hints: `TestClassifyAndExecuteSystemActionSyncEvernote` verifies the `Research` notebook mapping assigns the synced task to the mapped workspace and the `Tabura` tag resolves to the matching project; `TestClassifyAndExecuteSystemActionSyncEvernoteUsesUpdatedAfterAndRemapsExistingItem` verifies the resync path updates an existing item.
- UI filtering for imported Evernote work: `TestParseInlineItemIntentFilterCommands` covers `show evernote notes` mapping to the Evernote source filter.
