### PR TITLE
fix: add Bear note importer and checklist promotion (fixes #263)

### DIFF
--- a/internal/bear/client.go
+++ b/internal/bear/client.go
@@ -1,0 +1,211 @@
+package bear
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const appleReferenceUnix = 978307200
+
+var (
+	ErrDatabaseNotFound = errors.New("bear database not found")
+
+	bearTagPattern       = regexp.MustCompile(`(?:^|[\s(])#([A-Za-z0-9_/-]+)`)
+	bearChecklistPattern = regexp.MustCompile(`(?m)^\s*(?:[-*+]|\d+[.)])\s+\[([ xX])\]\s+(.+?)\s*$`)
+)
+
+type Client struct {
+	dbPath string
+}
+
+type Note struct {
+	ID       string   `json:"id"`
+	Title    string   `json:"title,omitempty"`
+	Markdown string   `json:"markdown,omitempty"`
+	Created  string   `json:"created,omitempty"`
+	Modified string   `json:"modified,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+}
+
+type ChecklistItem struct {
+	Text    string `json:"text"`
+	Checked bool   `json:"checked"`
+}
+
+func DefaultDatabasePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(
+		home,
+		"Library",
+		"Group Containers",
+		"9K33E3U3T4.net.shinyfrog.bear",
+		"Application Data",
+		"database.sqlite",
+	)
+}
+
+func NewClient(dbPath string) (*Client, error) {
+	path := strings.TrimSpace(dbPath)
+	if path == "" {
+		path = DefaultDatabasePath()
+	}
+	if path == "" {
+		return nil, ErrDatabaseNotFound
+	}
+	return &Client{dbPath: path}, nil
+}
+
+func (c *Client) DatabasePath() string {
+	if c == nil {
+		return ""
+	}
+	return c.dbPath
+}
+
+func (c *Client) ListNotes(ctx context.Context) ([]Note, error) {
+	if c == nil || strings.TrimSpace(c.dbPath) == "" {
+		return nil, ErrDatabaseNotFound
+	}
+	if _, err := os.Stat(c.dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrDatabaseNotFound
+		}
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db, err := sql.Open("sqlite", c.dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  trim(COALESCE(ZUNIQUEIDENTIFIER, '')),
+  trim(COALESCE(ZTITLE, '')),
+  COALESCE(ZTEXT, ''),
+  ZCREATIONDATE,
+  ZMODIFICATIONDATE
+FROM ZSFNOTE
+WHERE COALESCE(ZTRASHED, 0) = 0
+  AND COALESCE(ZARCHIVED, 0) = 0
+ORDER BY COALESCE(ZMODIFICATIONDATE, ZCREATIONDATE) DESC, Z_PK DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	notes := []Note{}
+	for rows.Next() {
+		var (
+			note        Note
+			createdRaw  any
+			modifiedRaw any
+		)
+		if err := rows.Scan(&note.ID, &note.Title, &note.Markdown, &createdRaw, &modifiedRaw); err != nil {
+			return nil, err
+		}
+		note.ID = strings.TrimSpace(note.ID)
+		note.Title = strings.TrimSpace(note.Title)
+		note.Markdown = strings.TrimSpace(note.Markdown)
+		if note.ID == "" {
+			continue
+		}
+		note.Created = formatBearTimestamp(createdRaw)
+		note.Modified = formatBearTimestamp(modifiedRaw)
+		note.Tags = ExtractTags(note.Markdown)
+		notes = append(notes, note)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return notes, nil
+}
+
+func ExtractTags(markdown string) []string {
+	matches := bearTagPattern.FindAllStringSubmatch(strings.TrimSpace(markdown), -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	tags := make([]string, 0, len(matches))
+	for _, match := range matches {
+		tag := strings.TrimSpace(match[1])
+		if tag == "" {
+			continue
+		}
+		key := strings.ToLower(tag)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+func ExtractChecklist(markdown string) []ChecklistItem {
+	matches := bearChecklistPattern.FindAllStringSubmatch(strings.TrimSpace(markdown), -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	items := make([]ChecklistItem, 0, len(matches))
+	for _, match := range matches {
+		text := strings.TrimSpace(match[2])
+		if text == "" {
+			continue
+		}
+		items = append(items, ChecklistItem{
+			Text:    text,
+			Checked: strings.EqualFold(strings.TrimSpace(match[1]), "x"),
+		})
+	}
+	return items
+}
+
+func formatBearTimestamp(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case time.Time:
+		return typed.UTC().Format(time.RFC3339)
+	case string:
+		return strings.TrimSpace(typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	case int64:
+		return appleReferenceTime(float64(typed))
+	case float64:
+		return appleReferenceTime(typed)
+	case float32:
+		return appleReferenceTime(float64(typed))
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func appleReferenceTime(seconds float64) string {
+	if math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return ""
+	}
+	base := time.Unix(appleReferenceUnix, 0).UTC()
+	nanos := int64(seconds * float64(time.Second))
+	return base.Add(time.Duration(nanos)).Format(time.RFC3339)
+}

--- a/internal/bear/client_test.go
+++ b/internal/bear/client_test.go
@@ -1,0 +1,88 @@
+package bear
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestClientListNotesExtractsTagsAndChecklist(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "bear.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	if _, err := db.Exec(`
+CREATE TABLE ZSFNOTE (
+  Z_PK INTEGER PRIMARY KEY,
+  ZUNIQUEIDENTIFIER TEXT,
+  ZTITLE TEXT,
+  ZTEXT TEXT,
+  ZCREATIONDATE REAL,
+  ZMODIFICATIONDATE REAL,
+  ZTRASHED INTEGER DEFAULT 0,
+  ZARCHIVED INTEGER DEFAULT 0
+);
+INSERT INTO ZSFNOTE (ZUNIQUEIDENTIFIER, ZTITLE, ZTEXT, ZCREATIONDATE, ZMODIFICATIONDATE, ZTRASHED, ZARCHIVED)
+VALUES
+  ('note-1', 'Reading queue', '#Tabura' || char(10) || '- [ ] Review intro' || char(10) || '- [x] Fix refs', 788918400, 788922000, 0, 0),
+  ('note-2', 'Archived', '#Skip', 788918400, 788922000, 0, 1),
+  ('note-3', 'Trashed', '#Skip', 788918400, 788922000, 1, 0);
+`); err != nil {
+		t.Fatalf("seed bear schema: %v", err)
+	}
+
+	client, err := NewClient(dbPath)
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	notes, err := client.ListNotes(context.Background())
+	if err != nil {
+		t.Fatalf("ListNotes() error: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("ListNotes() len = %d, want 1", len(notes))
+	}
+	note := notes[0]
+	if note.ID != "note-1" {
+		t.Fatalf("note.ID = %q, want note-1", note.ID)
+	}
+	if note.Created != "2026-01-01T00:00:00Z" {
+		t.Fatalf("note.Created = %q, want 2026-01-01T00:00:00Z", note.Created)
+	}
+	if note.Modified != "2026-01-01T01:00:00Z" {
+		t.Fatalf("note.Modified = %q, want 2026-01-01T01:00:00Z", note.Modified)
+	}
+	if len(note.Tags) != 1 || note.Tags[0] != "Tabura" {
+		t.Fatalf("note.Tags = %#v, want [Tabura]", note.Tags)
+	}
+
+	checklist := ExtractChecklist(note.Markdown)
+	if len(checklist) != 2 {
+		t.Fatalf("ExtractChecklist() len = %d, want 2", len(checklist))
+	}
+	if checklist[0].Text != "Review intro" || checklist[0].Checked {
+		t.Fatalf("checklist[0] = %#v", checklist[0])
+	}
+	if checklist[1].Text != "Fix refs" || !checklist[1].Checked {
+		t.Fatalf("checklist[1] = %#v", checklist[1])
+	}
+}
+
+func TestClientListNotesMissingDatabase(t *testing.T) {
+	client, err := NewClient(filepath.Join(t.TempDir(), "missing.sqlite"))
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	_, err = client.ListNotes(context.Background())
+	if !errors.Is(err, ErrDatabaseNotFound) {
+		t.Fatalf("ListNotes() error = %v, want ErrDatabaseNotFound", err)
+	}
+}

--- a/internal/web/chat_bear.go
+++ b/internal/web/chat_bear.go
@@ -1,0 +1,512 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/bear"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type bearAccountConfig struct {
+	DBPath string `json:"db_path"`
+}
+
+type bearSyncResult struct {
+	NoteCount int
+	Skipped   int
+}
+
+type bearNoteMeta struct {
+	NoteID          string   `json:"note_id,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	Created         string   `json:"created,omitempty"`
+	Modified        string   `json:"modified,omitempty"`
+	ContentMarkdown string   `json:"content_markdown,omitempty"`
+}
+
+func parseInlineBearIntent(text string) *SystemAction {
+	switch normalizeItemCommandText(text) {
+	case "sync bear":
+		return &SystemAction{Action: "sync_bear", Params: map[string]interface{}{}}
+	case "create items from this bear note's checklist", "create items from this bear notes checklist":
+		return &SystemAction{Action: "promote_bear_checklist", Params: map[string]interface{}{}}
+	default:
+		return nil
+	}
+}
+
+func bearActionFailurePrefix(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "sync_bear":
+		return "I couldn't sync Bear: "
+	case "promote_bear_checklist":
+		return "I couldn't create Bear checklist items: "
+	default:
+		return "I couldn't resolve the Bear request: "
+	}
+}
+
+func decodeBearAccountConfig(account store.ExternalAccount) (bearAccountConfig, error) {
+	var cfg bearAccountConfig
+	raw := strings.TrimSpace(account.ConfigJSON)
+	if raw == "" || raw == "{}" {
+		return cfg, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return bearAccountConfig{}, fmt.Errorf("decode bear config: %w", err)
+	}
+	return cfg, nil
+}
+
+func bearClientForAccount(account store.ExternalAccount) (*bear.Client, error) {
+	cfg, err := decodeBearAccountConfig(account)
+	if err != nil {
+		return nil, err
+	}
+	return bear.NewClient(cfg.DBPath)
+}
+
+func (a *App) activeBearAccounts() ([]store.ExternalAccount, error) {
+	accounts, err := a.store.ListExternalAccountsByProvider(store.ExternalProviderBear)
+	if err != nil {
+		return nil, err
+	}
+	activeSphere, err := a.store.ActiveSphere()
+	if err != nil {
+		return nil, err
+	}
+	enabled := todoistEnabledAccounts(accounts, activeSphere)
+	if len(enabled) > 0 {
+		return enabled, nil
+	}
+	enabled = todoistEnabledAccounts(accounts, "")
+	if len(enabled) == 0 {
+		return nil, errors.New("no enabled Bear account is configured")
+	}
+	return enabled, nil
+}
+
+func bearTagMapping(mappings []store.ExternalContainerMapping, tag string) *store.ExternalContainerMapping {
+	cleanTag := strings.ToLower(strings.TrimSpace(tag))
+	if cleanTag == "" {
+		return nil
+	}
+	for i := range mappings {
+		mapping := &mappings[i]
+		if !strings.EqualFold(mapping.Provider, store.ExternalProviderBear) {
+			continue
+		}
+		if !strings.EqualFold(mapping.ContainerType, "tag") {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(mapping.ContainerRef), cleanTag) {
+			return mapping
+		}
+	}
+	return nil
+}
+
+func (a *App) bearTagMappingForAccount(account store.ExternalAccount, mappings []store.ExternalContainerMapping, tags []string) (*store.ExternalContainerMapping, error) {
+	for _, tag := range tags {
+		mapping := bearTagMapping(mappings, tag)
+		if mapping == nil {
+			continue
+		}
+		if mapping.Sphere != nil && !strings.EqualFold(strings.TrimSpace(*mapping.Sphere), account.Sphere) {
+			continue
+		}
+		if mapping.WorkspaceID == nil {
+			return mapping, nil
+		}
+		workspace, err := a.store.GetWorkspace(*mapping.WorkspaceID)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.EqualFold(workspace.Sphere, account.Sphere) {
+			continue
+		}
+		return mapping, nil
+	}
+	return nil, nil
+}
+
+func (a *App) bearProjectHintFromTags(tags []string) *string {
+	for _, tag := range tags {
+		project, err := a.hubFindProjectByName(tag)
+		if err != nil {
+			continue
+		}
+		projectID := project.ID
+		return &projectID
+	}
+	return nil
+}
+
+func bearNoteArtifactMeta(note bear.Note) (*string, error) {
+	payload := bearNoteMeta{
+		NoteID:          strings.TrimSpace(note.ID),
+		Tags:            append([]string(nil), note.Tags...),
+		Created:         strings.TrimSpace(note.Created),
+		Modified:        strings.TrimSpace(note.Modified),
+		ContentMarkdown: strings.TrimSpace(note.Markdown),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	text := string(raw)
+	return &text, nil
+}
+
+func parseBearNoteMeta(metaJSON *string) bearNoteMeta {
+	var meta bearNoteMeta
+	if metaJSON == nil || strings.TrimSpace(*metaJSON) == "" {
+		return meta
+	}
+	_ = json.Unmarshal([]byte(*metaJSON), &meta)
+	for i := range meta.Tags {
+		meta.Tags[i] = strings.TrimSpace(meta.Tags[i])
+	}
+	return meta
+}
+
+func bearNoteTitle(note bear.Note) string {
+	if title := strings.TrimSpace(note.Title); title != "" {
+		return title
+	}
+	for _, line := range strings.Split(note.Markdown, "\n") {
+		clean := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(line), "#"))
+		if clean != "" {
+			return clean
+		}
+	}
+	return fmt.Sprintf("Bear note %s", strings.TrimSpace(note.ID))
+}
+
+func (a *App) upsertBearArtifact(account store.ExternalAccount, note bear.Note, mapping *store.ExternalContainerMapping) (store.Artifact, error) {
+	metaJSON, err := bearNoteArtifactMeta(note)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	kind := store.ArtifactKindMarkdown
+	title := bearNoteTitle(note)
+	remoteID := strings.TrimSpace(note.ID)
+
+	if binding, err := a.store.GetBindingByRemote(account.ID, store.ExternalProviderBear, "note", remoteID); err == nil {
+		if binding.ArtifactID != nil {
+			err = a.store.UpdateArtifact(*binding.ArtifactID, store.ArtifactUpdate{
+				Kind:     &kind,
+				Title:    optionalTrimmedString(title),
+				MetaJSON: metaJSON,
+			})
+			if err == nil {
+				if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+					AccountID:       account.ID,
+					Provider:        store.ExternalProviderBear,
+					ObjectType:      "note",
+					RemoteID:        remoteID,
+					ArtifactID:      binding.ArtifactID,
+					ContainerRef:    firstBearTagPointer(note.Tags),
+					RemoteUpdatedAt: optionalStringPointer(note.Modified),
+				}); err != nil {
+					return store.Artifact{}, err
+				}
+				artifact, err := a.store.GetArtifact(*binding.ArtifactID)
+				if err != nil {
+					return store.Artifact{}, err
+				}
+				a.linkBearArtifactWorkspace(artifact.ID, mapping)
+				return artifact, nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return store.Artifact{}, err
+			}
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Artifact{}, err
+	}
+
+	artifact, err := a.store.CreateArtifact(kind, nil, nil, optionalTrimmedString(title), metaJSON)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderBear,
+		ObjectType:      "note",
+		RemoteID:        remoteID,
+		ArtifactID:      &artifact.ID,
+		ContainerRef:    firstBearTagPointer(note.Tags),
+		RemoteUpdatedAt: optionalStringPointer(note.Modified),
+	}); err != nil {
+		return store.Artifact{}, err
+	}
+	a.linkBearArtifactWorkspace(artifact.ID, mapping)
+	return artifact, nil
+}
+
+func firstBearTagPointer(tags []string) *string {
+	for _, tag := range tags {
+		if clean := strings.TrimSpace(tag); clean != "" {
+			return &clean
+		}
+	}
+	return nil
+}
+
+func (a *App) linkBearArtifactWorkspace(artifactID int64, mapping *store.ExternalContainerMapping) {
+	if mapping == nil || mapping.WorkspaceID == nil {
+		return
+	}
+	_ = a.store.LinkArtifactToWorkspace(*mapping.WorkspaceID, artifactID)
+}
+
+func bearChecklistSourceRef(noteID string, index int) string {
+	return fmt.Sprintf("note:%s:task:%d", strings.TrimSpace(noteID), index)
+}
+
+func bearChecklistState(item bear.ChecklistItem) string {
+	if item.Checked {
+		return store.ItemStateDone
+	}
+	return store.ItemStateInbox
+}
+
+func (a *App) persistBearChecklistItem(account store.ExternalAccount, artifact store.Artifact, checklistItem bear.ChecklistItem, sourceRef string, mapping *store.ExternalContainerMapping, inferredProjectID *string, remoteUpdatedAt *string) (store.Item, error) {
+	title := strings.TrimSpace(checklistItem.Text)
+	if title == "" {
+		return store.Item{}, errors.New("bear checklist item text is required")
+	}
+	desiredState := bearChecklistState(checklistItem)
+	if existing, err := a.store.GetItemBySource(store.ExternalProviderBear, sourceRef); err == nil {
+		updates := store.ItemUpdate{
+			Title:      &title,
+			ArtifactID: &artifact.ID,
+		}
+		if mapping != nil {
+			updates.WorkspaceID = mappedWorkspaceUpdate(mapping)
+		}
+		if projectID := mappedProjectUpdateWithFallback(mapping, inferredProjectID); projectID != nil {
+			updates.ProjectID = projectID
+		}
+		if mapping == nil || mapping.WorkspaceID == nil {
+			sphere := account.Sphere
+			updates.Sphere = &sphere
+		}
+		if err := a.store.UpdateItem(existing.ID, updates); err != nil {
+			return store.Item{}, err
+		}
+		item, err := a.store.GetItem(existing.ID)
+		if err != nil {
+			return store.Item{}, err
+		}
+		switch {
+		case desiredState == store.ItemStateDone && item.State != store.ItemStateDone:
+			if err := a.store.CompleteItemBySource(store.ExternalProviderBear, sourceRef); err != nil {
+				return store.Item{}, err
+			}
+			item, err = a.store.GetItem(existing.ID)
+			if err != nil {
+				return store.Item{}, err
+			}
+		case desiredState == store.ItemStateInbox && item.State == store.ItemStateDone:
+			if err := a.store.SyncItemStateBySource(store.ExternalProviderBear, sourceRef, store.ItemStateInbox); err != nil {
+				return store.Item{}, err
+			}
+			item, err = a.store.GetItem(existing.ID)
+			if err != nil {
+				return store.Item{}, err
+			}
+		}
+		if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+			AccountID:       account.ID,
+			Provider:        store.ExternalProviderBear,
+			ObjectType:      "task",
+			RemoteID:        sourceRef,
+			ItemID:          &item.ID,
+			ArtifactID:      &artifact.ID,
+			RemoteUpdatedAt: remoteUpdatedAt,
+		}); err != nil {
+			return store.Item{}, err
+		}
+		return item, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return store.Item{}, err
+	}
+
+	opts := store.ItemOptions{
+		State:      desiredState,
+		ProjectID:  evernoteTaskProjectID(mapping, inferredProjectID),
+		Sphere:     &account.Sphere,
+		ArtifactID: &artifact.ID,
+		Source:     optionalStringPointer(store.ExternalProviderBear),
+		SourceRef:  &sourceRef,
+	}
+	if mapping != nil && mapping.WorkspaceID != nil {
+		opts.WorkspaceID = mapping.WorkspaceID
+	}
+	item, err := a.store.CreateItem(title, opts)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if _, err := a.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        store.ExternalProviderBear,
+		ObjectType:      "task",
+		RemoteID:        sourceRef,
+		ItemID:          &item.ID,
+		ArtifactID:      &artifact.ID,
+		RemoteUpdatedAt: remoteUpdatedAt,
+	}); err != nil {
+		return store.Item{}, err
+	}
+	return item, nil
+}
+
+func (a *App) resolveActiveBearNoteArtifact(projectKey string) (*store.Artifact, bearNoteMeta, store.ExternalBinding, error) {
+	canvas := a.resolveCanvasContext(projectKey)
+	if canvas == nil || strings.TrimSpace(canvas.ArtifactTitle) == "" {
+		return nil, bearNoteMeta{}, store.ExternalBinding{}, errors.New("open the Bear note on canvas first")
+	}
+	title := strings.TrimSpace(canvas.ArtifactTitle)
+	artifacts, err := a.store.ListArtifactsByKind(store.ArtifactKindMarkdown)
+	if err != nil {
+		return nil, bearNoteMeta{}, store.ExternalBinding{}, err
+	}
+	for _, artifact := range artifacts {
+		if ideaNoteString(artifact.Title) != title {
+			continue
+		}
+		bindings, err := a.store.GetBindingsByArtifact(artifact.ID)
+		if err != nil {
+			return nil, bearNoteMeta{}, store.ExternalBinding{}, err
+		}
+		for _, binding := range bindings {
+			if !strings.EqualFold(binding.Provider, store.ExternalProviderBear) {
+				continue
+			}
+			if !strings.EqualFold(binding.ObjectType, "note") {
+				continue
+			}
+			meta := parseBearNoteMeta(artifact.MetaJSON)
+			candidate := artifact
+			return &candidate, meta, binding, nil
+		}
+	}
+	return nil, bearNoteMeta{}, store.ExternalBinding{}, errors.New("active canvas artifact is not a Bear note")
+}
+
+func (a *App) executeSyncBearAction() (string, map[string]interface{}, error) {
+	accounts, err := a.activeBearAccounts()
+	if err != nil {
+		return "", nil, err
+	}
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderBear)
+	if err != nil {
+		return "", nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result := bearSyncResult{}
+	for _, account := range accounts {
+		client, err := bearClientForAccount(account)
+		if err != nil {
+			if errors.Is(err, bear.ErrDatabaseNotFound) {
+				result.Skipped++
+				continue
+			}
+			return "", nil, err
+		}
+		notes, err := client.ListNotes(ctx)
+		if err != nil {
+			if errors.Is(err, bear.ErrDatabaseNotFound) {
+				result.Skipped++
+				continue
+			}
+			return "", nil, err
+		}
+		for _, note := range notes {
+			mapping, err := a.bearTagMappingForAccount(account, mappings, note.Tags)
+			if err != nil {
+				return "", nil, err
+			}
+			if _, err := a.upsertBearArtifact(account, note, mapping); err != nil {
+				return "", nil, err
+			}
+			result.NoteCount++
+		}
+	}
+
+	if result.NoteCount == 0 && result.Skipped > 0 {
+		return "Skipped Bear sync because no Bear database was found.", map[string]interface{}{
+			"type":             "sync_bear",
+			"note_count":       0,
+			"skipped_accounts": result.Skipped,
+		}, nil
+	}
+	return fmt.Sprintf("Synced %d Bear note(s).", result.NoteCount), map[string]interface{}{
+		"type":             "sync_bear",
+		"note_count":       result.NoteCount,
+		"skipped_accounts": result.Skipped,
+	}, nil
+}
+
+func (a *App) executePromoteBearChecklistAction(session store.ChatSession) (string, map[string]interface{}, error) {
+	artifact, meta, binding, err := a.resolveActiveBearNoteArtifact(session.ProjectKey)
+	if err != nil {
+		return "", nil, err
+	}
+	account, err := a.store.GetExternalAccount(binding.AccountID)
+	if err != nil {
+		return "", nil, err
+	}
+	checklist := bear.ExtractChecklist(meta.ContentMarkdown)
+	if len(checklist) == 0 {
+		return "", nil, errors.New("Bear note has no checklist items")
+	}
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderBear)
+	if err != nil {
+		return "", nil, err
+	}
+	mapping, err := a.bearTagMappingForAccount(account, mappings, meta.Tags)
+	if err != nil {
+		return "", nil, err
+	}
+	inferredProjectID := a.bearProjectHintFromTags(meta.Tags)
+	remoteUpdatedAt := optionalStringPointer(meta.Modified)
+	noteID := strings.TrimSpace(binding.RemoteID)
+	if noteID == "" {
+		noteID = strings.TrimSpace(meta.NoteID)
+	}
+	created := 0
+	for i, item := range checklist {
+		sourceRef := bearChecklistSourceRef(noteID, i+1)
+		if _, err := a.persistBearChecklistItem(account, *artifact, item, sourceRef, mapping, inferredProjectID, remoteUpdatedAt); err != nil {
+			return "", nil, err
+		}
+		created++
+	}
+	return fmt.Sprintf("Created %d item(s) from the Bear note checklist.", created), map[string]interface{}{
+		"type":        "bear_checklist_promoted",
+		"count":       created,
+		"artifact_id": artifact.ID,
+	}, nil
+}
+
+func (a *App) executeBearAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	switch strings.ToLower(strings.TrimSpace(action.Action)) {
+	case "sync_bear":
+		return a.executeSyncBearAction()
+	case "promote_bear_checklist":
+		return a.executePromoteBearChecklistAction(session)
+	default:
+		return "", nil, fmt.Errorf("unsupported bear action: %s", action.Action)
+	}
+}

--- a/internal/web/chat_bear_test.go
+++ b/internal/web/chat_bear_test.go
@@ -1,0 +1,302 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestParseInlineBearIntent(t *testing.T) {
+	action := parseInlineBearIntent("sync bear")
+	if action == nil {
+		t.Fatal("expected bear sync action")
+	}
+	if action.Action != "sync_bear" {
+		t.Fatalf("action = %q, want sync_bear", action.Action)
+	}
+	checklist := parseInlineBearIntent("create items from this Bear note's checklist")
+	if checklist == nil || checklist.Action != "promote_bear_checklist" {
+		t.Fatalf("checklist action = %#v, want promote_bear_checklist", checklist)
+	}
+	if parseInlineBearIntent("sync evernote") != nil {
+		t.Fatal("did not expect bear action for unrelated text")
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSyncBear(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	dbPath := seedBearTestDatabase(t, []bearSeedNote{{
+		ID:       "note-1",
+		Title:    "Reading queue",
+		Markdown: "#Tabura\n- [ ] Review intro\n- [x] Fix refs",
+		Created:  788918400,
+		Modified: 788922000,
+	}})
+	account := createBearTestAccount(t, app, dbPath)
+	workspace, err := app.store.CreateWorkspace("Research", filepath.Join(t.TempDir(), "research"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	targetProject, err := app.store.CreateProject("Tabura", "tabura", filepath.Join(t.TempDir(), "tabura"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderBear, "tag", "Tabura", &workspace.ID, &targetProject.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync bear")
+	if !handled {
+		t.Fatal("expected sync bear command to be handled")
+	}
+	if message != "Synced 1 Bear note(s)." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "sync_bear" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	artifactBindings, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderBear, "note", "note-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(note) error: %v", err)
+	}
+	if artifactBindings.ArtifactID == nil {
+		t.Fatal("expected bear note artifact binding")
+	}
+	artifact, err := app.store.GetArtifact(*artifactBindings.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+	if artifact.Kind != store.ArtifactKindMarkdown {
+		t.Fatalf("artifact.Kind = %q, want markdown", artifact.Kind)
+	}
+	var meta bearNoteMeta
+	if artifact.MetaJSON == nil || json.Unmarshal([]byte(*artifact.MetaJSON), &meta) != nil {
+		t.Fatalf("artifact.MetaJSON = %v, want valid bear note meta", artifact.MetaJSON)
+	}
+	if meta.NoteID != "note-1" {
+		t.Fatalf("meta.NoteID = %q, want note-1", meta.NoteID)
+	}
+	if meta.Created != "2026-01-01T00:00:00Z" || meta.Modified != "2026-01-01T01:00:00Z" {
+		t.Fatalf("meta timestamps = %#v", meta)
+	}
+	if len(meta.Tags) != 1 || meta.Tags[0] != "Tabura" {
+		t.Fatalf("meta.Tags = %#v, want [Tabura]", meta.Tags)
+	}
+	linked, err := app.store.ListLinkedArtifacts(workspace.ID)
+	if err != nil {
+		t.Fatalf("ListLinkedArtifacts() error: %v", err)
+	}
+	if len(linked) != 1 || linked[0].ID != artifact.ID {
+		t.Fatalf("linked artifacts = %#v, want artifact %d", linked, artifact.ID)
+	}
+	items, err := app.store.ListItems()
+	if err != nil {
+		t.Fatalf("ListItems() error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("sync bear should not create checklist items automatically, got %d", len(items))
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSyncBearSkipsMissingDatabase(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	createBearTestAccount(t, app, filepath.Join(t.TempDir(), "missing.sqlite"))
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync bear")
+	if !handled {
+		t.Fatal("expected sync bear command to be handled")
+	}
+	if message != "Skipped Bear sync because no Bear database was found." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || intFromAny(payloads[0]["skipped_accounts"], 0) != 1 {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionPromoteBearChecklist(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	dbPath := seedBearTestDatabase(t, []bearSeedNote{{
+		ID:       "note-1",
+		Title:    "Reading queue",
+		Markdown: "#Tabura\n- [ ] Review intro\n- [x] Fix refs",
+		Created:  788918400,
+		Modified: 788922000,
+	}})
+	account := createBearTestAccount(t, app, dbPath)
+	workspace, err := app.store.CreateWorkspace("Research", filepath.Join(t.TempDir(), "research"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	targetProject, err := app.store.CreateProject("Tabura", "tabura", filepath.Join(t.TempDir(), "tabura"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderBear, "tag", "Tabura", &workspace.ID, &targetProject.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	if _, _, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync bear"); !handled {
+		t.Fatal("expected sync bear command to be handled")
+	}
+
+	binding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderBear, "note", "note-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(note) error: %v", err)
+	}
+	artifact, err := app.store.GetArtifact(*binding.ArtifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact() error: %v", err)
+	}
+
+	mock := &canvasMCPMock{
+		artifactTitle: ideaNoteString(artifact.Title),
+		artifactKind:  "text_artifact",
+		artifactText:  "#Tabura\n- [ ] Review intro\n- [x] Fix refs",
+	}
+	server := mock.setupServer(t)
+	t.Cleanup(server.Close)
+	port := serverPort(t, server.Listener.Addr())
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create items from this Bear note's checklist")
+	if !handled {
+		t.Fatal("expected bear checklist command to be handled")
+	}
+	if message != "Created 2 item(s) from the Bear note checklist." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "bear_checklist_promoted" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+
+	firstItem, err := app.store.GetItemBySource(store.ExternalProviderBear, "note:note-1:task:1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(task1) error: %v", err)
+	}
+	if firstItem.State != store.ItemStateInbox {
+		t.Fatalf("first item state = %q, want inbox", firstItem.State)
+	}
+	if firstItem.WorkspaceID == nil || *firstItem.WorkspaceID != workspace.ID {
+		t.Fatalf("first item workspace_id = %v, want %d", firstItem.WorkspaceID, workspace.ID)
+	}
+	if firstItem.ProjectID == nil || *firstItem.ProjectID != targetProject.ID {
+		t.Fatalf("first item project_id = %v, want %q", firstItem.ProjectID, targetProject.ID)
+	}
+	if firstItem.ArtifactID == nil || *firstItem.ArtifactID != artifact.ID {
+		t.Fatalf("first item artifact_id = %v, want %d", firstItem.ArtifactID, artifact.ID)
+	}
+
+	secondItem, err := app.store.GetItemBySource(store.ExternalProviderBear, "note:note-1:task:2")
+	if err != nil {
+		t.Fatalf("GetItemBySource(task2) error: %v", err)
+	}
+	if secondItem.State != store.ItemStateDone {
+		t.Fatalf("second item state = %q, want done", secondItem.State)
+	}
+	taskBinding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderBear, "task", "note:note-1:task:1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(task) error: %v", err)
+	}
+	if taskBinding.ItemID == nil || *taskBinding.ItemID != firstItem.ID {
+		t.Fatalf("task binding item_id = %v, want %d", taskBinding.ItemID, firstItem.ID)
+	}
+}
+
+type bearSeedNote struct {
+	ID       string
+	Title    string
+	Markdown string
+	Created  float64
+	Modified float64
+}
+
+func seedBearTestDatabase(t *testing.T, notes []bearSeedNote) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "bear.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	if _, err := db.Exec(`
+CREATE TABLE ZSFNOTE (
+  Z_PK INTEGER PRIMARY KEY,
+  ZUNIQUEIDENTIFIER TEXT,
+  ZTITLE TEXT,
+  ZTEXT TEXT,
+  ZCREATIONDATE REAL,
+  ZMODIFICATIONDATE REAL,
+  ZTRASHED INTEGER DEFAULT 0,
+  ZARCHIVED INTEGER DEFAULT 0
+);`); err != nil {
+		t.Fatalf("create bear schema: %v", err)
+	}
+	for _, note := range notes {
+		if _, err := db.Exec(`
+INSERT INTO ZSFNOTE (ZUNIQUEIDENTIFIER, ZTITLE, ZTEXT, ZCREATIONDATE, ZMODIFICATIONDATE, ZTRASHED, ZARCHIVED)
+VALUES (?, ?, ?, ?, ?, 0, 0)`,
+			note.ID,
+			note.Title,
+			note.Markdown,
+			note.Created,
+			note.Modified,
+		); err != nil {
+			t.Fatalf("insert bear note %s: %v", note.ID, err)
+		}
+	}
+	return dbPath
+}
+
+func createBearTestAccount(t *testing.T, app *App, dbPath string) store.ExternalAccount {
+	t.Helper()
+	account, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderBear, "Reading Notes", map[string]any{
+		"db_path": dbPath,
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	return account
+}

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, map_todoist_project, sync_todoist, create_todoist_task, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -770,6 +770,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return evernoteActionFailurePrefix(inlineEvernoteAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	if inlineBearAction := parseInlineBearIntent(trimmedText); inlineBearAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineBearAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return bearActionFailurePrefix(inlineBearAction.Action) + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -322,6 +322,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.executeTodoistAction(session, action)
 	case "sync_evernote":
 		return a.executeEvernoteAction(session, action)
+	case "sync_bear", "promote_bear_checklist":
+		return a.executeBearAction(session, action)
 	case "create_github_issue", "create_github_issue_split":
 		return a.createGitHubIssueFromConversation(sessionID, session, action)
 	case "shell":


### PR DESCRIPTION
## Summary
- add `internal/bear` as a local SQLite-backed Bear note reader with tag and checklist extraction
- add `sync bear` and `create items from this Bear note's checklist` chat actions
- persist Bear note/task bindings and apply Bear tag container mappings when promoting checklist items

## Verification
- Bear SQLite note import: `go test -v ./internal/bear ./internal/web -run 'Test(ClientListNotesExtractsTagsAndChecklist|ClientListNotesMissingDatabase|ParseInlineBearIntent|ClassifyAndExecuteSystemActionSyncBear|ClassifyAndExecuteSystemActionSyncBearSkipsMissingDatabase|ClassifyAndExecuteSystemActionPromoteBearChecklist)$'`
  Output excerpt: `--- PASS: TestClientListNotesExtractsTagsAndChecklist` and `--- PASS: TestClassifyAndExecuteSystemActionSyncBear`
  Evidence: the sync test seeds a Bear-style SQLite database, runs `sync bear`, and asserts a `markdown` artifact with `tags`, `created`, and `modified` metadata plus an `external_bindings` note UUID entry.
- Checklist promotion is user-initiated only: same command
  Output excerpt: `--- PASS: TestClassifyAndExecuteSystemActionSyncBear` and `--- PASS: TestClassifyAndExecuteSystemActionPromoteBearChecklist`
  Evidence: sync creates zero items; the explicit checklist command then creates two artifact-linked items with inbox/done state derived from checkbox status.
- Tag container mapping drives workspace/project assignment: same command
  Output excerpt: `--- PASS: TestClassifyAndExecuteSystemActionPromoteBearChecklist`
  Evidence: the promoted checklist items inherit the mapped workspace and project for the `#Tabura` Bear tag.
- Missing databases are skipped cleanly: same command
  Output excerpt: `--- PASS: TestClientListNotesMissingDatabase` and `--- PASS: TestClassifyAndExecuteSystemActionSyncBearSkipsMissingDatabase`
  Evidence: a missing Bear DB path returns a handled skip message instead of failing the sync action.
