### PR TITLE
fix: add research mode that creates multi-artifact canvas output (fixes #297)

### DIFF
--- a/internal/web/chat_canvas.go
+++ b/internal/web/chat_canvas.go
@@ -138,10 +138,14 @@ func resolveCanvasFilePath(cwd, requested string) (absolutePath, canvasTitle str
 	return abs, filepath.ToSlash(rel), nil
 }
 
-func (a *App) executeFileBlocks(projectKey, canvasSessionID string, blocks []fileBlock) {
+func (a *App) executeFileBlocks(projectKey, canvasSessionID string, blocks []fileBlock) bool {
+	wroteAny := false
 	for _, block := range blocks {
-		_ = a.writeCanvasFileBlock(projectKey, canvasSessionID, block)
+		if a.writeCanvasFileBlock(projectKey, canvasSessionID, block) {
+			wroteAny = true
+		}
 	}
+	return wroteAny
 }
 
 func (a *App) writeCanvasFileBlock(projectKey, canvasSessionID string, block fileBlock) bool {

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -217,6 +217,35 @@ func TestBuildPromptFromHistoryForMode_SilentUsesToolOnlyPreamble(t *testing.T) 
 	}
 }
 
+func TestBuildPromptFromHistoryForSession_SilentResearchUsesArtifactContract(t *testing.T) {
+	prompt := buildPromptFromHistoryForSession("chat", "session-42", []store.ChatMessage{{
+		Role:         "user",
+		ContentPlain: "research bootstrap current modeling in stellarators",
+	}}, nil, turnOutputModeSilent, "")
+	if !strings.Contains(prompt, "Research Artifact Output") {
+		t.Fatal("silent research prompt should include research artifact contract")
+	}
+	if !strings.Contains(prompt, ".tabura/artifacts/research/session-42/summary.md") {
+		t.Fatalf("silent research prompt should pin the session research root, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "Produce multiple file-backed canvas artifacts") {
+		t.Fatal("silent research prompt should require multiple file-backed artifacts")
+	}
+}
+
+func TestBuildTurnPromptForSession_SilentResearchUsesArtifactContract(t *testing.T) {
+	prompt := buildTurnPromptForSession("session-42", []store.ChatMessage{{
+		Role:         "user",
+		ContentPlain: "find and summarize recent work on gyrokinetic turbulence",
+	}}, nil, turnOutputModeSilent, "")
+	if !strings.Contains(prompt, "Research Artifact Output") {
+		t.Fatal("silent research turn prompt should include research artifact contract")
+	}
+	if !strings.Contains(prompt, ".tabura/artifacts/research/session-42/summary.md") {
+		t.Fatalf("silent research turn prompt should pin the session research root, got %q", prompt)
+	}
+}
+
 func TestBuildPromptFromHistoryForMode_SparkOmitsModelSpecificHints(t *testing.T) {
 	prompt := buildPromptFromHistoryForMode("chat", nil, nil, turnOutputModeVoice, "spark")
 	if strings.Contains(prompt, "merge conflicts") {
@@ -541,6 +570,8 @@ type canvasMCPMock struct {
 	artifactText     string
 	lastShownTitle   string
 	lastShownContent string
+	shownTitles      []string
+	shownContents    []string
 	artifactShow     int32
 }
 
@@ -584,6 +615,8 @@ func (m *canvasMCPMock) setupServer(t *testing.T) *httptest.Server {
 			m.artifactText = content
 			m.lastShownTitle = title
 			m.lastShownContent = content
+			m.shownTitles = append(m.shownTitles, title)
+			m.shownContents = append(m.shownContents, content)
 			m.mu.Unlock()
 			structured = map[string]interface{}{"ok": true}
 		default:
@@ -789,5 +822,139 @@ func TestFinalizeAssistantResponse_SilentFallsBackWhenOverwritePathEscapesProjec
 	}
 	if strings.TrimSpace(mock.lastShownContent) != "fresh response" {
 		t.Fatalf("expected fallback scratch artifact content, got %q", mock.lastShownContent)
+	}
+}
+
+func TestFinalizeAssistantResponse_SilentResearchWritesMultipleArtifacts(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "research bootstrap current modeling in stellarators", "research bootstrap current modeling in stellarators", "markdown"); err != nil {
+		t.Fatalf("seed research user message: %v", err)
+	}
+
+	mock := &canvasMCPMock{}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	response := `Research bundle ready.
+
+:::file{path="summary.md"}
+# Summary
+
+- Citation: Example 2026
+:::
+
+:::file{path="sources.md"}
+# Sources
+
+- Example 2026
+:::`
+
+	var persistedID int64
+	var persistedText string
+	result := app.finalizeAssistantResponse(
+		session.ID,
+		project.ProjectKey,
+		response,
+		&persistedID,
+		&persistedText,
+		"",
+		"",
+		"",
+		turnOutputModeSilent,
+	)
+
+	if got := atomic.LoadInt32(&mock.artifactShow); got != 2 {
+		t.Fatalf("expected two canvas_artifact_show calls, got %d", got)
+	}
+	wantSummary := ".tabura/artifacts/research/" + session.ID + "/summary.md"
+	wantSources := ".tabura/artifacts/research/" + session.ID + "/sources.md"
+	mock.mu.Lock()
+	shownTitles := append([]string(nil), mock.shownTitles...)
+	mock.mu.Unlock()
+	if len(shownTitles) != 2 || shownTitles[0] != wantSummary || shownTitles[1] != wantSources {
+		t.Fatalf("shown titles = %#v, want [%q %q]", shownTitles, wantSummary, wantSources)
+	}
+	summaryBytes, err := os.ReadFile(filepath.Join(project.RootPath, filepath.FromSlash(wantSummary)))
+	if err != nil {
+		t.Fatalf("read summary artifact: %v", err)
+	}
+	if !strings.Contains(string(summaryBytes), "# Summary") {
+		t.Fatalf("summary artifact content = %q", string(summaryBytes))
+	}
+	sourcesBytes, err := os.ReadFile(filepath.Join(project.RootPath, filepath.FromSlash(wantSources)))
+	if err != nil {
+		t.Fatalf("read sources artifact: %v", err)
+	}
+	if !strings.Contains(string(sourcesBytes), "# Sources") {
+		t.Fatalf("sources artifact content = %q", string(sourcesBytes))
+	}
+	if strings.Contains(result, "[file:") {
+		t.Fatalf("final chat should strip file markers, got %q", result)
+	}
+	if strings.TrimSpace(result) != "Research bundle ready." {
+		t.Fatalf("final chat = %q, want %q", result, "Research bundle ready.")
+	}
+}
+
+func TestFinalizeAssistantResponse_SilentFileBlocksKeepExplicitPathsOutsideResearchTurns(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "show this diff on canvas", "show this diff on canvas", "markdown"); err != nil {
+		t.Fatalf("seed non-research user message: %v", err)
+	}
+
+	mock := &canvasMCPMock{}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	response := `Done.
+
+:::file{path=".tabura/artifacts/pr/pr-18.diff"}
+diff --git a/a.go b/a.go
+:::`
+
+	var persistedID int64
+	var persistedText string
+	_ = app.finalizeAssistantResponse(
+		session.ID,
+		project.ProjectKey,
+		response,
+		&persistedID,
+		&persistedText,
+		"",
+		"",
+		"",
+		turnOutputModeSilent,
+	)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.shownTitles) != 1 || mock.shownTitles[0] != ".tabura/artifacts/pr/pr-18.diff" {
+		t.Fatalf("shown titles = %#v, want explicit PR artifact path", mock.shownTitles)
 	}
 }

--- a/internal/web/chat_prompt.go
+++ b/internal/web/chat_prompt.go
@@ -110,11 +110,20 @@ func buildPromptFromHistoryForMode(mode string, messages []store.ChatMessage, ca
 }
 
 func buildPromptFromHistoryForModeWithCompanion(mode string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
+	return buildPromptFromHistoryForSessionWithCompanion(mode, "", messages, canvas, companion, outputMode, modelAlias)
+}
+
+func buildPromptFromHistoryForSession(mode, sessionID string, messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
+	return buildPromptFromHistoryForSessionWithCompanion(mode, sessionID, messages, canvas, nil, outputMode, modelAlias)
+}
+
+func buildPromptFromHistoryForSessionWithCompanion(mode, sessionID string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
 	isVoiceMode := isVoiceOutputMode(outputMode)
 	const maxHistory = 80
 	if len(messages) > maxHistory {
 		messages = messages[len(messages)-maxHistory:]
 	}
+	userText := latestUserMessage(messages)
 	var b strings.Builder
 
 	promptTemplate := loadModePromptTemplate(outputMode, defaultVoiceHistoryPrompt, "")
@@ -140,6 +149,7 @@ func buildPromptFromHistoryForModeWithCompanion(mode string, messages []store.Ch
 		b.WriteString("Explain what you intend to do and why, then continue once the approval decision is available.\n")
 		b.WriteString("For research tasks, propose each retrieval step clearly and present findings as artifacts or concise chat updates.\n\n")
 	}
+	appendResearchArtifactPrompt(&b, outputMode, userText, researchArtifactRoot(sessionID))
 
 	appendCompanionPromptContext(&b, companion)
 	b.WriteString("Conversation transcript:\n")
@@ -177,18 +187,17 @@ func buildTurnPromptForMode(messages []store.ChatMessage, canvas *canvasContext,
 }
 
 func buildTurnPromptForModeWithCompanion(messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
+	return buildTurnPromptForSessionWithCompanion("", messages, canvas, companion, outputMode, modelAlias)
+}
+
+func buildTurnPromptForSession(sessionID string, messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
+	return buildTurnPromptForSessionWithCompanion(sessionID, messages, canvas, nil, outputMode, modelAlias)
+}
+
+func buildTurnPromptForSessionWithCompanion(sessionID string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
 	isVoiceMode := isVoiceOutputMode(outputMode)
 	_ = modelAlias
-	var lastUserMsg string
-	for i := len(messages) - 1; i >= 0; i-- {
-		if strings.EqualFold(strings.TrimSpace(messages[i].Role), "user") {
-			lastUserMsg = strings.TrimSpace(messages[i].ContentPlain)
-			if lastUserMsg == "" {
-				lastUserMsg = strings.TrimSpace(messages[i].ContentMarkdown)
-			}
-			break
-		}
-	}
+	lastUserMsg := latestUserMessage(messages)
 	if lastUserMsg == "" {
 		return ""
 	}
@@ -199,6 +208,7 @@ func buildTurnPromptForModeWithCompanion(messages []store.ChatMessage, canvas *c
 			fmt.Fprintf(&b, "[Active artifact tab: %q (kind: %s)]\n\n", canvas.ArtifactTitle, canvas.ArtifactKind)
 		}
 	}
+	appendResearchArtifactPrompt(&b, outputMode, lastUserMsg, researchArtifactRoot(sessionID))
 	appendCompanionPromptContext(&b, companion)
 	b.WriteString(lastUserMsg)
 	return b.String()

--- a/internal/web/chat_research.go
+++ b/internal/web/chat_research.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func isResearchQuery(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	strongSignals := []string{
+		"research ",
+		" research",
+		"find and summarize",
+		"find recent work",
+		"recent work",
+		"literature review",
+		"survey the literature",
+		"compare ",
+		"papers on",
+		"paper about",
+		"citations",
+	}
+	for _, signal := range strongSignals {
+		if strings.Contains(lower, signal) {
+			return true
+		}
+	}
+	return false
+}
+
+func researchArtifactRoot(sessionID string) string {
+	stem := strings.TrimSpace(sessionID)
+	if stem == "" {
+		return ""
+	}
+	stem = canvasTempFileStemRe.ReplaceAllString(stem, "-")
+	stem = strings.Trim(stem, "-.")
+	if stem == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Join(".tabura", "artifacts", "research", stem))
+}
+
+func appendResearchArtifactPrompt(b *strings.Builder, outputMode, userText, researchRoot string) {
+	if b == nil || normalizeTurnOutputMode(outputMode) != turnOutputModeSilent || !isResearchQuery(userText) {
+		return
+	}
+	root := strings.TrimSpace(researchRoot)
+	if root == "" {
+		root = filepath.ToSlash(filepath.Join(".tabura", "artifacts", "research", "current"))
+	}
+	b.WriteString("## Research Artifact Output\n")
+	b.WriteString("This is a research request. Produce multiple file-backed canvas artifacts instead of one long chat reply.\n")
+	fmt.Fprintf(b, "- Write every :::file block under %q.\n", root)
+	fmt.Fprintf(b, "- Include %q with the structured summary and citations.\n", filepath.ToSlash(filepath.Join(root, "summary.md")))
+	b.WriteString("- Add supporting artifacts such as sources.md, comparison.md, notes.md, or extracted snippets when useful.\n")
+	b.WriteString("- Keep any companion chat outside :::file blocks to one short sentence.\n\n")
+}
+
+func normalizeResearchFileBlocks(blocks []fileBlock, researchRoot string) []fileBlock {
+	root := filepath.ToSlash(strings.TrimSpace(researchRoot))
+	if root == "" || len(blocks) == 0 {
+		return blocks
+	}
+	out := make([]fileBlock, 0, len(blocks))
+	for i, block := range blocks {
+		path := filepath.ToSlash(strings.TrimSpace(block.Path))
+		if filepath.IsAbs(path) {
+			path = filepath.Base(path)
+		}
+		path = strings.TrimPrefix(path, "./")
+		path = filepath.ToSlash(filepath.Clean(path))
+		if path == "." || path == "" {
+			path = defaultResearchArtifactName(i)
+		}
+		if strings.HasPrefix(path, "../") {
+			path = defaultResearchArtifactName(i)
+		}
+		if strings.HasPrefix(path, ".tabura/") && !strings.HasPrefix(path, root+"/") {
+			path = filepath.Base(path)
+		}
+		if !strings.HasPrefix(path, root+"/") && path != root {
+			path = filepath.ToSlash(filepath.Join(root, path))
+		}
+		block.Path = path
+		out = append(out, block)
+	}
+	return out
+}
+
+func defaultResearchArtifactName(index int) string {
+	switch index {
+	case 0:
+		return "summary.md"
+	case 1:
+		return "sources.md"
+	case 2:
+		return "comparison.md"
+	default:
+		return fmt.Sprintf("artifact-%d.md", index+1)
+	}
+}
+
+func (a *App) isResearchTurn(sessionID string) bool {
+	if a == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	messages, err := a.store.ListChatMessages(sessionID, 12)
+	if err != nil {
+		return false
+	}
+	return isResearchQuery(latestUserMessage(messages))
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -60,9 +60,9 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 	companionCtx := a.loadCompanionPromptContext(session.ProjectKey)
 	var prompt string
 	if resumed {
-		prompt = buildTurnPromptForModeWithCompanion(messages, canvasCtx, companionCtx, outputMode, profile.Alias)
+		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, outputMode, profile.Alias)
 	} else {
-		prompt = buildPromptFromHistoryForModeWithCompanion(session.Mode, messages, canvasCtx, companionCtx, outputMode, profile.Alias)
+		prompt = buildPromptFromHistoryForSessionWithCompanion(session.Mode, sessionID, messages, canvasCtx, companionCtx, outputMode, profile.Alias)
 		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
 	}
 	if strings.TrimSpace(prompt) == "" {
@@ -331,7 +331,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, outputMode string, profile appServerModelProfile) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
-	prompt := buildPromptFromHistoryForMode(session.Mode, messages, canvasCtx, outputMode, profile.Alias)
+	prompt := buildPromptFromHistoryForSession(session.Mode, sessionID, messages, canvasCtx, outputMode, profile.Alias)
 	if strings.TrimSpace(prompt) == "" {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
@@ -570,7 +570,14 @@ func (a *App) finalizeAssistantResponse(
 	} else {
 		canvasCtx := a.resolveCanvasContext(projectKey)
 		content := strings.TrimSpace(text)
-		if content != "" && canvasSessionID != "" {
+		blocks, cleaned := parseFileBlocks(content)
+		if len(blocks) > 0 && canvasSessionID != "" {
+			if a.isResearchTurn(sessionID) {
+				blocks = normalizeResearchFileBlocks(blocks, researchArtifactRoot(sessionID))
+			}
+			renderOnCanvas = a.executeFileBlocks(projectKey, canvasSessionID, blocks)
+			text = cleaned
+		} else if content != "" && canvasSessionID != "" {
 			block := fileBlock{
 				Path:    "",
 				Content: content,
@@ -583,8 +590,9 @@ func (a *App) finalizeAssistantResponse(
 				block.Path = ""
 				autoCanvas = a.writeCanvasFileBlock(projectKey, canvasSessionID, block)
 			}
+			text = content
 		}
-		renderOnCanvas = autoCanvas
+		renderOnCanvas = renderOnCanvas || autoCanvas
 	}
 	text = stripLangTags(text)
 	chatMarkdown, chatPlain, renderFormat := assistantFinalChatContent(text, renderOnCanvas, autoCanvas)


### PR DESCRIPTION
## Summary
- add a silent research prompt contract that requires multiple `:::file` blocks under `.tabura/artifacts/research/<session-id>/`
- execute silent-mode file blocks directly instead of collapsing them into one temp artifact, while rebasing only research turns into the session research root
- cover research prompt shaping, multi-artifact writes, explicit non-research path preservation, and existing silent scratch fallback behavior with regression tests

## Verification
- Requirement: research queries instruct the model to emit multiple research artifacts under the session research root.
  Evidence: `go test ./internal/web -run 'Test(BuildPromptFromHistoryForSession_SilentResearchUsesArtifactContract|BuildTurnPromptForSession_SilentResearchUsesArtifactContract|FinalizeAssistantResponse_SilentResearchWritesMultipleArtifacts|FinalizeAssistantResponse_SilentFileBlocksKeepExplicitPathsOutsideResearchTurns|FinalizeAssistantResponse_SilentOverwritesScratchArtifact|FinalizeAssistantResponse_SilentFallsBackToScratchForWorkspaceArtifact|FinalizeAssistantResponse_SilentFallsBackWhenOverwritePathEscapesProject)$'`
  Output: `ok   github.com/krystophny/tabura/internal/web	0.047s`
  Tests: `TestBuildPromptFromHistoryForSession_SilentResearchUsesArtifactContract`, `TestBuildTurnPromptForSession_SilentResearchUsesArtifactContract`
- Requirement: silent research replies create multiple canvas artifacts instead of one temp blob.
  Evidence: same command and output above.
  Test: `TestFinalizeAssistantResponse_SilentResearchWritesMultipleArtifacts`
  Artifact paths: `.tabura/artifacts/research/<session-id>/summary.md`, `.tabura/artifacts/research/<session-id>/sources.md`
- Requirement: explicit non-research file-block paths remain unchanged.
  Evidence: same command and output above.
  Test: `TestFinalizeAssistantResponse_SilentFileBlocksKeepExplicitPathsOutsideResearchTurns`
  Artifact path: `.tabura/artifacts/pr/pr-18.diff`
- Requirement: existing silent scratch overwrite and fallback flows still work.
  Evidence: same command and output above.
  Tests: `TestFinalizeAssistantResponse_SilentOverwritesScratchArtifact`, `TestFinalizeAssistantResponse_SilentFallsBackToScratchForWorkspaceArtifact`, `TestFinalizeAssistantResponse_SilentFallsBackWhenOverwritePathEscapesProject`
