### PR TITLE
fix: add LaTeX and Pandoc build pipeline (fixes #274)

### DIFF
--- a/internal/document/build.go
+++ b/internal/document/build.go
@@ -1,0 +1,504 @@
+package document
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const buildConfigRelPath = ".tabura/document.json"
+
+type Builder interface {
+	Build(ctx context.Context, sourceDir string, mainFile string) (pdfPath string, err error)
+	SupportsSource(path string) bool
+}
+
+type BuildConfig struct {
+	Builder      string `json:"builder,omitempty"`
+	MainFile     string `json:"main_file,omitempty"`
+	Engine       string `json:"engine,omitempty"`
+	Bibliography string `json:"bibliography,omitempty"`
+	CSL          string `json:"csl,omitempty"`
+	Template     string `json:"template,omitempty"`
+}
+
+type BuildResult struct {
+	PDFPath  string
+	MainFile string
+	Builder  string
+}
+
+type latexBuilder struct {
+	cfg BuildConfig
+}
+
+type pandocBuilder struct {
+	cfg BuildConfig
+}
+
+func BuildWorkspaceDocument(ctx context.Context, sourceDir, requestedPath string) (BuildResult, error) {
+	root, err := filepath.Abs(strings.TrimSpace(sourceDir))
+	if err != nil {
+		return BuildResult{}, err
+	}
+	if strings.TrimSpace(root) == "" {
+		return BuildResult{}, errors.New("source directory is required")
+	}
+	cfg, err := LoadBuildConfig(root)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	mainFile, builderName, builder, err := resolveBuilder(root, strings.TrimSpace(requestedPath), cfg)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	builtPDF, err := builder.Build(ctx, root, mainFile)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	artifactPath, err := documentArtifactOutputPath(root, mainFile)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		return BuildResult{}, err
+	}
+	if err := copyFile(builtPDF, artifactPath); err != nil {
+		return BuildResult{}, err
+	}
+	return BuildResult{
+		PDFPath:  artifactPath,
+		MainFile: filepath.ToSlash(mainFile),
+		Builder:  builderName,
+	}, nil
+}
+
+func LoadBuildConfig(sourceDir string) (BuildConfig, error) {
+	root := strings.TrimSpace(sourceDir)
+	if root == "" {
+		return BuildConfig{}, errors.New("source directory is required")
+	}
+	path := filepath.Join(root, buildConfigRelPath)
+	bytes, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return BuildConfig{}, nil
+	}
+	if err != nil {
+		return BuildConfig{}, err
+	}
+	var cfg BuildConfig
+	if err := json.Unmarshal(bytes, &cfg); err != nil {
+		return BuildConfig{}, fmt.Errorf("decode %s: %w", buildConfigRelPath, err)
+	}
+	cfg.Builder = normalizeBuilderName(cfg.Builder)
+	cfg.MainFile = filepath.ToSlash(strings.TrimSpace(cfg.MainFile))
+	cfg.Engine = normalizeLatexEngine(cfg.Engine)
+	cfg.Bibliography = strings.TrimSpace(cfg.Bibliography)
+	cfg.CSL = strings.TrimSpace(cfg.CSL)
+	cfg.Template = strings.TrimSpace(cfg.Template)
+	return cfg, nil
+}
+
+func resolveBuilder(sourceDir, requestedPath string, cfg BuildConfig) (string, string, Builder, error) {
+	builders := map[string]Builder{
+		"latex":  latexBuilder{cfg: cfg},
+		"pandoc": pandocBuilder{cfg: cfg},
+	}
+	if requestedPath != "" {
+		mainFile, err := normalizeMainFile(sourceDir, requestedPath)
+		if err != nil {
+			return "", "", nil, err
+		}
+		for name, builder := range builders {
+			if builder.SupportsSource(mainFile) {
+				return mainFile, name, builder, nil
+			}
+		}
+		return "", "", nil, fmt.Errorf("unsupported document source: %s", filepath.Base(mainFile))
+	}
+	if cfg.MainFile != "" {
+		mainFile, err := normalizeMainFile(sourceDir, cfg.MainFile)
+		if err != nil {
+			return "", "", nil, err
+		}
+		builderName, builder, err := builderForFile(mainFile, cfg, builders)
+		if err != nil {
+			return "", "", nil, err
+		}
+		return mainFile, builderName, builder, nil
+	}
+	candidates, err := discoverDocumentCandidates(sourceDir)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if len(candidates) == 0 {
+		return "", "", nil, errors.New("no supported document source found in workspace")
+	}
+	if cfg.Builder != "" {
+		filtered := candidates[:0]
+		for _, candidate := range candidates {
+			if builder, ok := builders[cfg.Builder]; ok && builder.SupportsSource(candidate) {
+				filtered = append(filtered, candidate)
+			}
+		}
+		candidates = filtered
+	}
+	if len(candidates) == 0 {
+		return "", "", nil, fmt.Errorf("no %s document source found in workspace", cfg.Builder)
+	}
+	mainFile := candidates[0]
+	builderName, builder, err := builderForFile(mainFile, cfg, builders)
+	if err != nil {
+		return "", "", nil, err
+	}
+	return mainFile, builderName, builder, nil
+}
+
+func builderForFile(mainFile string, cfg BuildConfig, builders map[string]Builder) (string, Builder, error) {
+	if cfg.Builder != "" {
+		builder, ok := builders[cfg.Builder]
+		if !ok {
+			return "", nil, fmt.Errorf("unsupported builder %q", cfg.Builder)
+		}
+		if !builder.SupportsSource(mainFile) {
+			return "", nil, fmt.Errorf("%s does not support %s", cfg.Builder, filepath.Base(mainFile))
+		}
+		return cfg.Builder, builder, nil
+	}
+	for name, builder := range builders {
+		if builder.SupportsSource(mainFile) {
+			return name, builder, nil
+		}
+	}
+	return "", nil, fmt.Errorf("unsupported document source: %s", filepath.Base(mainFile))
+}
+
+func normalizeMainFile(sourceDir, requestedPath string) (string, error) {
+	rootAbs, err := filepath.Abs(strings.TrimSpace(sourceDir))
+	if err != nil {
+		return "", err
+	}
+	raw := strings.TrimSpace(requestedPath)
+	if raw == "" {
+		return "", errors.New("document main file is required")
+	}
+	var abs string
+	if filepath.IsAbs(raw) {
+		abs = filepath.Clean(raw)
+	} else {
+		abs = filepath.Clean(filepath.Join(rootAbs, raw))
+	}
+	rel, err := filepath.Rel(rootAbs, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("document source escapes workspace: %s", requestedPath)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("document source %q is a directory", requestedPath)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func discoverDocumentCandidates(sourceDir string) ([]string, error) {
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	var candidates []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		switch {
+		case strings.EqualFold(filepath.Ext(name), ".tex"):
+			candidates = append(candidates, filepath.ToSlash(name))
+		case isPandocSourcePath(name):
+			candidates = append(candidates, filepath.ToSlash(name))
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		leftRank := documentCandidateRank(candidates[i])
+		rightRank := documentCandidateRank(candidates[j])
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return strings.ToLower(candidates[i]) < strings.ToLower(candidates[j])
+	})
+	return candidates, nil
+}
+
+func documentCandidateRank(path string) int {
+	base := strings.ToLower(strings.TrimSpace(filepath.Base(path)))
+	switch base {
+	case "main.tex", "paper.tex", "thesis.tex", "article.tex", "main.md", "readme.md", "index.md":
+		return 0
+	default:
+		switch strings.ToLower(filepath.Ext(base)) {
+		case ".tex":
+			return 1
+		default:
+			return 2
+		}
+	}
+}
+
+func normalizeBuilderName(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "auto":
+		return ""
+	case "latex", "pdflatex", "xelatex", "lualatex":
+		return "latex"
+	case "pandoc", "markdown", "md":
+		return "pandoc"
+	default:
+		return strings.ToLower(strings.TrimSpace(name))
+	}
+}
+
+func (b latexBuilder) SupportsSource(path string) bool {
+	return strings.EqualFold(strings.TrimSpace(filepath.Ext(path)), ".tex")
+}
+
+func (b latexBuilder) Build(ctx context.Context, sourceDir string, mainFile string) (string, error) {
+	engine := detectLatexEngine(filepath.Join(sourceDir, filepath.FromSlash(mainFile)), b.cfg.Engine)
+	if engine == "" {
+		engine = "pdflatex"
+	}
+	args := []string{"-synctex=1", "-interaction=nonstopmode", mainFile}
+	if _, err := runCommand(ctx, sourceDir, engine, args...); err != nil {
+		return "", err
+	}
+	if needsBibTeX(sourceDir, mainFile, b.cfg) {
+		auxBase := strings.TrimSuffix(mainFile, filepath.Ext(mainFile))
+		if _, err := runCommand(ctx, sourceDir, "bibtex", auxBase); err != nil {
+			return "", err
+		}
+	}
+	if _, err := runCommand(ctx, sourceDir, engine, args...); err != nil {
+		return "", err
+	}
+	if _, err := runCommand(ctx, sourceDir, engine, args...); err != nil {
+		return "", err
+	}
+	output := filepath.Join(sourceDir, strings.TrimSuffix(filepath.FromSlash(mainFile), filepath.Ext(mainFile))+".pdf")
+	if _, err := os.Stat(output); err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func normalizeLatexEngine(engine string) string {
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case "xelatex":
+		return "xelatex"
+	case "lualatex":
+		return "lualatex"
+	case "pdflatex":
+		return "pdflatex"
+	default:
+		return ""
+	}
+}
+
+func detectLatexEngine(sourcePath, configured string) string {
+	if normalized := normalizeLatexEngine(configured); normalized != "" {
+		return normalized
+	}
+	bytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return "pdflatex"
+	}
+	for _, line := range strings.Split(string(bytes), "\n") {
+		lower := strings.ToLower(strings.TrimSpace(line))
+		switch {
+		case strings.Contains(lower, "xelatex"):
+			return "xelatex"
+		case strings.Contains(lower, "lualatex"):
+			return "lualatex"
+		case strings.Contains(lower, "pdflatex"):
+			return "pdflatex"
+		}
+	}
+	return "pdflatex"
+}
+
+func needsBibTeX(sourceDir, mainFile string, cfg BuildConfig) bool {
+	if strings.TrimSpace(cfg.Bibliography) != "" {
+		return true
+	}
+	matches, err := filepath.Glob(filepath.Join(sourceDir, "*.bib"))
+	if err != nil {
+		return false
+	}
+	if len(matches) > 0 {
+		return true
+	}
+	sourceBytes, err := os.ReadFile(filepath.Join(sourceDir, filepath.FromSlash(mainFile)))
+	if err != nil {
+		return false
+	}
+	lower := strings.ToLower(string(sourceBytes))
+	return strings.Contains(lower, "\\bibliography{") || strings.Contains(lower, "\\addbibresource{")
+}
+
+func (b pandocBuilder) SupportsSource(path string) bool {
+	return isPandocSourcePath(path)
+}
+
+func isPandocSourcePath(path string) bool {
+	switch strings.ToLower(strings.TrimSpace(filepath.Ext(path))) {
+	case ".md", ".markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+func (b pandocBuilder) Build(ctx context.Context, sourceDir string, mainFile string) (string, error) {
+	output := filepath.Join(sourceDir, strings.TrimSuffix(filepath.FromSlash(mainFile), filepath.Ext(mainFile))+".pdf")
+	args := []string{mainFile, "-o", output}
+	if requiresPandocCiteproc(filepath.Join(sourceDir, filepath.FromSlash(mainFile)), b.cfg) {
+		args = append(args, "--citeproc")
+	}
+	if strings.TrimSpace(b.cfg.Bibliography) != "" {
+		args = append(args, "--bibliography="+strings.TrimSpace(b.cfg.Bibliography))
+	}
+	if strings.TrimSpace(b.cfg.CSL) != "" {
+		args = append(args, "--csl="+strings.TrimSpace(b.cfg.CSL))
+	}
+	if strings.TrimSpace(b.cfg.Template) != "" {
+		args = append(args, "--template="+strings.TrimSpace(b.cfg.Template))
+	}
+	if _, err := runCommand(ctx, sourceDir, "pandoc", args...); err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(output); err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func requiresPandocCiteproc(sourcePath string, cfg BuildConfig) bool {
+	if strings.TrimSpace(cfg.Bibliography) != "" || strings.TrimSpace(cfg.CSL) != "" {
+		return true
+	}
+	frontMatter, ok := readYAMLFrontMatter(sourcePath)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{"bibliography:", "references:", "csl:", "nocite:"} {
+		if strings.Contains(frontMatter, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func readYAMLFrontMatter(path string) (string, bool) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	text := string(bytes)
+	if !strings.HasPrefix(text, "---\n") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(text, "---\n")
+	idx := strings.Index(rest, "\n---\n")
+	if idx < 0 {
+		return "", false
+	}
+	return strings.ToLower(rest[:idx]), true
+}
+
+func runCommand(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	if _, err := exec.LookPath(name); err != nil {
+		return nil, fmt.Errorf("%s is not installed", name)
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s failed: %s", name, message)
+	}
+	return output, nil
+}
+
+func documentArtifactOutputPath(sourceDir, mainFile string) (string, error) {
+	rootAbs, err := filepath.Abs(strings.TrimSpace(sourceDir))
+	if err != nil {
+		return "", err
+	}
+	rel := filepath.ToSlash(strings.TrimSpace(mainFile))
+	if rel == "" {
+		return "", errors.New("document main file is required")
+	}
+	sum := sha256.Sum256([]byte(rel))
+	name := sanitizeDocumentArtifactName(mainFile)
+	return filepath.Join(rootAbs, ".tabura", "artifacts", "documents", fmt.Sprintf("%s-%x.pdf", name, sum[:6])), nil
+}
+
+func sanitizeDocumentArtifactName(path string) string {
+	base := strings.TrimSpace(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))
+	if base == "" {
+		return "document"
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(base) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			lastDash = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	name := strings.Trim(b.String(), "-")
+	if name == "" {
+		return "document"
+	}
+	return name
+}
+
+func copyFile(srcPath, dstPath string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return err
+	}
+	return dst.Close()
+}

--- a/internal/document/build_test.go
+++ b/internal/document/build_test.go
@@ -1,0 +1,170 @@
+package document
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildWorkspaceDocumentDetectsLatexMainFileAndWritesArtifact(t *testing.T) {
+	sourceDir := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "commands.log")
+	writeExecutable(t, filepath.Join(binDir, "xelatex"), `#!/bin/sh
+echo "xelatex $*" >> "$TEST_LOG"
+for last; do true; done
+base="${last%.tex}"
+printf 'PDF via xelatex\n' > "${base}.pdf"
+printf 'aux\n' > "${base}.aux"
+`)
+	writeExecutable(t, filepath.Join(binDir, "bibtex"), `#!/bin/sh
+echo "bibtex $*" >> "$TEST_LOG"
+`)
+	t.Setenv("TEST_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := os.MkdirAll(filepath.Join(sourceDir, ".tabura"), 0o755); err != nil {
+		t.Fatalf("mkdir .tabura: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, buildConfigRelPath), []byte(`{"builder":"latex","main_file":"paper.tex","engine":"xelatex"}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "paper.tex"), []byte("\\documentclass{article}\n\\begin{document}\nHello\n\\end{document}\n"), 0o644); err != nil {
+		t.Fatalf("write paper.tex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "refs.bib"), []byte("@book{demo,title={Demo}}\n"), 0o644); err != nil {
+		t.Fatalf("write refs.bib: %v", err)
+	}
+
+	result, err := BuildWorkspaceDocument(context.Background(), sourceDir, "")
+	if err != nil {
+		t.Fatalf("BuildWorkspaceDocument() error = %v", err)
+	}
+	if result.Builder != "latex" {
+		t.Fatalf("builder = %q, want latex", result.Builder)
+	}
+	if result.MainFile != "paper.tex" {
+		t.Fatalf("main file = %q, want paper.tex", result.MainFile)
+	}
+	if !strings.Contains(filepath.ToSlash(result.PDFPath), "/.tabura/artifacts/documents/") {
+		t.Fatalf("pdf path = %q", result.PDFPath)
+	}
+	bytes, err := os.ReadFile(result.PDFPath)
+	if err != nil {
+		t.Fatalf("read artifact pdf: %v", err)
+	}
+	if string(bytes) != "PDF via xelatex\n" {
+		t.Fatalf("artifact pdf = %q", string(bytes))
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	logText := string(logBytes)
+	if strings.Count(logText, "xelatex ") != 3 {
+		t.Fatalf("xelatex calls = %d, want 3\n%s", strings.Count(logText, "xelatex "), logText)
+	}
+	if strings.Count(logText, "bibtex ") != 1 {
+		t.Fatalf("bibtex calls = %d, want 1\n%s", strings.Count(logText, "bibtex "), logText)
+	}
+}
+
+func TestBuildWorkspaceDocumentAutoDetectsPreferredWorkspaceSource(t *testing.T) {
+	sourceDir := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "pdflatex"), `#!/bin/sh
+for last; do true; done
+base="${last%.tex}"
+printf 'PDF via pdflatex\n' > "${base}.pdf"
+printf 'aux\n' > "${base}.aux"
+`)
+	writeExecutable(t, filepath.Join(binDir, "bibtex"), "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := os.WriteFile(filepath.Join(sourceDir, "main.tex"), []byte("\\documentclass{article}\n\\begin{document}\nHello\n\\end{document}\n"), 0o644); err != nil {
+		t.Fatalf("write main.tex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "README.md"), []byte("# Notes\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+
+	result, err := BuildWorkspaceDocument(context.Background(), sourceDir, "")
+	if err != nil {
+		t.Fatalf("BuildWorkspaceDocument() error = %v", err)
+	}
+	if result.Builder != "latex" {
+		t.Fatalf("builder = %q, want latex", result.Builder)
+	}
+	if result.MainFile != "main.tex" {
+		t.Fatalf("main file = %q, want main.tex", result.MainFile)
+	}
+}
+
+func TestBuildWorkspaceDocumentUsesPandocForMarkdownWithFrontMatter(t *testing.T) {
+	sourceDir := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "pandoc.log")
+	writeExecutable(t, filepath.Join(binDir, "pandoc"), `#!/bin/sh
+echo "pandoc $*" >> "$TEST_LOG"
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+  fi
+  prev="$arg"
+done
+printf 'PDF via pandoc\n' > "$out"
+`)
+	t.Setenv("TEST_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	content := strings.Join([]string{
+		"---",
+		"bibliography: refs.bib",
+		"csl: ieee.csl",
+		"---",
+		"",
+		"# Notes",
+		"",
+		"[@demo]",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(sourceDir, "notes.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write notes.md: %v", err)
+	}
+
+	result, err := BuildWorkspaceDocument(context.Background(), sourceDir, "notes.md")
+	if err != nil {
+		t.Fatalf("BuildWorkspaceDocument() error = %v", err)
+	}
+	if result.Builder != "pandoc" {
+		t.Fatalf("builder = %q, want pandoc", result.Builder)
+	}
+	if result.MainFile != "notes.md" {
+		t.Fatalf("main file = %q, want notes.md", result.MainFile)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	logText := string(logBytes)
+	if !strings.Contains(logText, "--citeproc") {
+		t.Fatalf("pandoc log = %q, want --citeproc", logText)
+	}
+	bytes, err := os.ReadFile(result.PDFPath)
+	if err != nil {
+		t.Fatalf("read built artifact: %v", err)
+	}
+	if string(bytes) != "PDF via pandoc\n" {
+		t.Fatalf("artifact pdf = %q", string(bytes))
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -448,6 +448,26 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 				"rendered_path": renderedPath,
 			}, nil
 		}
+		if shouldRenderDocumentArtifact(cwd, absPath) {
+			renderedPath, err := a.renderDocumentArtifact(cwd, absPath)
+			if err != nil {
+				return "", nil, err
+			}
+			if _, err := a.mcpToolsCall(port, "canvas_artifact_show", map[string]interface{}{
+				"session_id": canvasSessionID,
+				"kind":       "pdf",
+				"title":      canvasTitle,
+				"path":       renderedPath,
+			}); err != nil {
+				return "", nil, err
+			}
+			return fmt.Sprintf("Opened %s on canvas as PDF.", canvasTitle), map[string]interface{}{
+				"type":          "open_file_canvas",
+				"path":          canvasTitle,
+				"project_id":    targetProject.ID,
+				"rendered_path": renderedPath,
+			}, nil
+		}
 		if isPDFFilePath(absPath) {
 			if _, err := a.mcpToolsCall(port, "canvas_artifact_show", map[string]interface{}{
 				"session_id": canvasSessionID,

--- a/internal/web/document_render.go
+++ b/internal/web/document_render.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/document"
+)
+
+const documentRenderTimeout = 90 * time.Second
+
+func isDocumentSourceFilePath(path string) bool {
+	switch strings.ToLower(strings.TrimSpace(filepath.Ext(path))) {
+	case ".tex":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldRenderDocumentArtifact(projectRoot, inputPath string) bool {
+	if isDocumentSourceFilePath(inputPath) {
+		return true
+	}
+	if !isPandocDocumentSourcePath(inputPath) {
+		return false
+	}
+	cfg, err := document.LoadBuildConfig(projectRoot)
+	if err == nil {
+		if strings.TrimSpace(cfg.MainFile) != "" {
+			mainFile, mainErr := filepath.Abs(filepath.Join(projectRoot, filepath.FromSlash(cfg.MainFile)))
+			if mainErr == nil && sameDocumentPath(mainFile, inputPath) {
+				return true
+			}
+		}
+		if cfg.Builder == "pandoc" && strings.TrimSpace(cfg.MainFile) == "" {
+			return true
+		}
+	}
+	return markdownHasFrontMatter(inputPath)
+}
+
+func isPandocDocumentSourcePath(path string) bool {
+	switch strings.ToLower(strings.TrimSpace(filepath.Ext(path))) {
+	case ".md", ".markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+func markdownHasFrontMatter(path string) bool {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(string(bytes), "---\n")
+}
+
+func sameDocumentPath(left, right string) bool {
+	cleanLeft := filepath.Clean(strings.TrimSpace(left))
+	cleanRight := filepath.Clean(strings.TrimSpace(right))
+	if cleanLeft == cleanRight {
+		return true
+	}
+	absLeft, errLeft := filepath.Abs(cleanLeft)
+	absRight, errRight := filepath.Abs(cleanRight)
+	return errLeft == nil && errRight == nil && absLeft == absRight
+}
+
+func (a *App) renderDocumentArtifact(projectRoot, inputPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), documentRenderTimeout)
+	defer cancel()
+	result, err := document.BuildWorkspaceDocument(ctx, projectRoot, inputPath)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(projectRoot, result.PDFPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}

--- a/internal/web/document_render_test.go
+++ b/internal/web/document_render_test.go
@@ -1,0 +1,151 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenFileCanvasBuildsMarkdownDocumentAsPDF(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	docPath := filepath.Join(project.RootPath, "docs", "brief.md")
+	if err := os.MkdirAll(filepath.Dir(docPath), 0o755); err != nil {
+		t.Fatalf("mkdir docs dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project.RootPath, ".tabura"), 0o755); err != nil {
+		t.Fatalf("mkdir .tabura: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project.RootPath, ".tabura", "document.json"), []byte(`{"builder":"pandoc","main_file":"docs/brief.md"}`), 0o644); err != nil {
+		t.Fatalf("write document config: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("# Brief\n"), 0o644); err != nil {
+		t.Fatalf("write brief.md: %v", err)
+	}
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "pandoc.log")
+	if err := os.WriteFile(filepath.Join(binDir, "pandoc"), []byte(`#!/bin/sh
+echo "pandoc $*" >> "$TEST_LOG"
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+  fi
+  prev="$arg"
+done
+printf '%%PDF-1.4\n' > "$out"
+`), 0o755); err != nil {
+		t.Fatalf("write pandoc stub: %v", err)
+	}
+	t.Setenv("TEST_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	showCalls := 0
+	var observed map[string]interface{}
+	server := setupMockCanvasShowServer(t, &showCalls, &observed)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract mock port: %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	msg, payload, err := app.executeSystemAction(session.ID, session, &SystemAction{
+		Action: "open_file_canvas",
+		Params: map[string]interface{}{
+			"path": "docs/brief.md",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute open_file_canvas: %v", err)
+	}
+	if msg != "Opened docs/brief.md on canvas as PDF." {
+		t.Fatalf("message = %q", msg)
+	}
+	if payload == nil {
+		t.Fatal("expected payload")
+	}
+	renderedPath := strings.TrimSpace(strFromAny(payload["rendered_path"]))
+	if !strings.HasPrefix(renderedPath, ".tabura/artifacts/documents/") {
+		t.Fatalf("rendered_path = %q", renderedPath)
+	}
+	renderedAbs := filepath.Join(project.RootPath, filepath.FromSlash(renderedPath))
+	renderedBytes, err := os.ReadFile(renderedAbs)
+	if err != nil {
+		t.Fatalf("read rendered pdf: %v", err)
+	}
+	if string(renderedBytes) != "%PDF-1.4\n" {
+		t.Fatalf("rendered pdf = %q", string(renderedBytes))
+	}
+	if showCalls < 1 {
+		t.Fatalf("canvas_artifact_show calls = %d, want >= 1", showCalls)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["kind"])); got != "pdf" {
+		t.Fatalf("canvas kind = %q, want pdf", got)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["title"])); got != "docs/brief.md" {
+		t.Fatalf("canvas title = %q, want docs/brief.md", got)
+	}
+	if got := strings.TrimSpace(strFromAny(observed["path"])); got != renderedPath {
+		t.Fatalf("canvas path = %q, want %q", got, renderedPath)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read pandoc log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "pandoc ") {
+		t.Fatalf("pandoc log = %q", string(logBytes))
+	}
+}
+
+func TestRenderDocumentArtifactUsesWorkspaceConfigMainFile(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project.RootPath, ".tabura"), 0o755); err != nil {
+		t.Fatalf("mkdir .tabura: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project.RootPath, ".tabura", "document.json"), []byte(`{"main_file":"paper.tex","builder":"latex"}`), 0o644); err != nil {
+		t.Fatalf("write document config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project.RootPath, "paper.tex"), []byte("\\documentclass{article}\n\\begin{document}\nHi\n\\end{document}\n"), 0o644); err != nil {
+		t.Fatalf("write paper.tex: %v", err)
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "pdflatex"), []byte(`#!/bin/sh
+for last; do true; done
+base="${last%.tex}"
+printf '%%PDF-1.4\n' > "${base}.pdf"
+printf 'aux\n' > "${base}.aux"
+`), 0o755); err != nil {
+		t.Fatalf("write pdflatex stub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "bibtex"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write bibtex stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	renderedPath, err := app.renderDocumentArtifact(project.RootPath, "")
+	if err != nil {
+		t.Fatalf("renderDocumentArtifact() error = %v", err)
+	}
+	if !strings.HasPrefix(renderedPath, ".tabura/artifacts/documents/") {
+		t.Fatalf("renderedPath = %q", renderedPath)
+	}
+	renderedAbs := filepath.Join(project.RootPath, filepath.FromSlash(renderedPath))
+	if _, err := os.Stat(renderedAbs); err != nil {
+		t.Fatalf("stat rendered artifact: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a real `internal/document` build pipeline with LaTeX and Pandoc builders, workspace config via `.tabura/document.json`, source auto-detection, and PDF artifacts under `.tabura/artifacts/documents/`
- route configured markdown documents, markdown with YAML front matter, and `.tex` sources through the existing `open_file_canvas` flow so canvas opens the built PDF instead of raw source
- keep ordinary markdown file opens as text to avoid regressing README/notes canvas behavior, and cover the new paths with focused tests

## Verification
- Builder interface, workspace detection, and artifact output: `go test ./internal/document ./internal/web 2>&1 | tee /tmp/tabura-issue-274-test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/document`, `ok   github.com/krystophny/tabura/internal/web 5.268s`
  Tests: `TestBuildWorkspaceDocumentDetectsLatexMainFileAndWritesArtifact`, `TestBuildWorkspaceDocumentAutoDetectsPreferredWorkspaceSource`, `TestBuildWorkspaceDocumentUsesPandocForMarkdownWithFrontMatter`
- Canvas build-and-open path for source documents: same command/output as above
  Tests: `TestOpenFileCanvasBuildsMarkdownDocumentAsPDF`, `TestRenderDocumentArtifactUsesWorkspaceConfigMainFile`
  Artifact path: `.tabura/artifacts/documents/<name>-<hash>.pdf`
- Regression protection for existing markdown opens: same `internal/web` package pass above after narrowing document rendering to configured/front-matter markdown and `.tex` sources