### PR TITLE
fix: Make AI aware of tap/point position on canvas for context (fixes #197)

### DIFF
--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -69,10 +69,11 @@ When user asks to show/open an existing file, do NOT paste file body into chat; 
 `
 
 type chatMessageRequest struct {
-	Text        string `json:"text"`
-	OutputMode  string `json:"output_mode"`
-	CaptureMode string `json:"capture_mode,omitempty"`
-	LocalOnly   bool   `json:"local_only,omitempty"`
+	Text        string             `json:"text"`
+	OutputMode  string             `json:"output_mode"`
+	CaptureMode string             `json:"capture_mode,omitempty"`
+	Cursor      *chatCursorContext `json:"cursor,omitempty"`
+	LocalOnly   bool               `json:"local_only,omitempty"`
 }
 
 type chatCommandRequest struct {
@@ -352,6 +353,7 @@ func (a *App) handleChatSessionMessage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	a.chatCursorContexts.enqueue(sessionID, req.Cursor)
 	a.broadcastChatEvent(sessionID, map[string]interface{}{
 		"type":    "message_accepted",
 		"role":    "user",

--- a/internal/web/chat_cursor.go
+++ b/internal/web/chat_cursor.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type chatCursorContext struct {
+	Title        string  `json:"title,omitempty"`
+	Page         int     `json:"page,omitempty"`
+	Line         int     `json:"line,omitempty"`
+	RelativeX    float64 `json:"relative_x,omitempty"`
+	RelativeY    float64 `json:"relative_y,omitempty"`
+	SelectedText string  `json:"selected_text,omitempty"`
+	Surrounding  string  `json:"surrounding_text,omitempty"`
+}
+
+type chatCursorContextTracker struct {
+	mu     sync.Mutex
+	queues map[string][]*chatCursorContext
+}
+
+func newChatCursorContextTracker() *chatCursorContextTracker {
+	return &chatCursorContextTracker{
+		queues: map[string][]*chatCursorContext{},
+	}
+}
+
+func normalizeChatCursorContext(raw *chatCursorContext) *chatCursorContext {
+	if raw == nil {
+		return nil
+	}
+	ctx := &chatCursorContext{
+		Title:        strings.TrimSpace(raw.Title),
+		Page:         raw.Page,
+		Line:         raw.Line,
+		RelativeX:    raw.RelativeX,
+		RelativeY:    raw.RelativeY,
+		SelectedText: strings.TrimSpace(raw.SelectedText),
+		Surrounding:  strings.TrimSpace(raw.Surrounding),
+	}
+	if ctx.Page < 0 {
+		ctx.Page = 0
+	}
+	if ctx.Line < 0 {
+		ctx.Line = 0
+	}
+	if ctx.RelativeX < 0 || ctx.RelativeX > 1 {
+		ctx.RelativeX = 0
+	}
+	if ctx.RelativeY < 0 || ctx.RelativeY > 1 {
+		ctx.RelativeY = 0
+	}
+	if ctx.Title == "" && ctx.Page == 0 && ctx.Line == 0 && ctx.RelativeX == 0 && ctx.RelativeY == 0 && ctx.SelectedText == "" && ctx.Surrounding == "" {
+		return nil
+	}
+	return ctx
+}
+
+func (t *chatCursorContextTracker) enqueue(sessionID string, raw *chatCursorContext) {
+	if t == nil {
+		return
+	}
+	cleanSessionID := strings.TrimSpace(sessionID)
+	if cleanSessionID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.queues[cleanSessionID] = append(t.queues[cleanSessionID], normalizeChatCursorContext(raw))
+}
+
+func (t *chatCursorContextTracker) consume(sessionID string) *chatCursorContext {
+	if t == nil {
+		return nil
+	}
+	cleanSessionID := strings.TrimSpace(sessionID)
+	if cleanSessionID == "" {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	queue := t.queues[cleanSessionID]
+	if len(queue) == 0 {
+		return nil
+	}
+	next := queue[0]
+	if len(queue) == 1 {
+		delete(t.queues, cleanSessionID)
+	} else {
+		t.queues[cleanSessionID] = queue[1:]
+	}
+	return next
+}
+
+func appendChatCursorPrompt(prompt string, cursor *chatCursorContext) string {
+	contextBlock := formatChatCursorPromptContext(cursor)
+	prompt = strings.TrimSpace(prompt)
+	if contextBlock == "" {
+		return prompt
+	}
+	if prompt == "" {
+		return contextBlock
+	}
+	return contextBlock + "\n\n" + prompt
+}
+
+func formatChatCursorPromptContext(cursor *chatCursorContext) string {
+	cursor = normalizeChatCursorContext(cursor)
+	if cursor == nil {
+		return ""
+	}
+
+	targetParts := make([]string, 0, 4)
+	if cursor.Page > 0 {
+		targetParts = append(targetParts, fmt.Sprintf("page %d", cursor.Page))
+	}
+	if cursor.Line > 0 {
+		targetParts = append(targetParts, fmt.Sprintf("line %d", cursor.Line))
+	}
+	if cursor.RelativeX > 0 || cursor.RelativeY > 0 {
+		targetParts = append(targetParts, fmt.Sprintf("point %.0f%%, %.0f%%", cursor.RelativeX*100, cursor.RelativeY*100))
+	}
+	target := strings.Join(targetParts, ", ")
+	if title := strings.TrimSpace(cursor.Title); title != "" {
+		if target != "" {
+			target += " of "
+		}
+		target += fmt.Sprintf("%q", title)
+	}
+	if target == "" {
+		target = "active artifact"
+	}
+
+	lines := []string{
+		"## Cursor Context",
+		"User is pointing at: " + target,
+	}
+	if text := strings.TrimSpace(cursor.SelectedText); text != "" {
+		lines = append(lines, "Selected text: "+quotePromptText(text, 220))
+	}
+	if text := strings.TrimSpace(cursor.Surrounding); text != "" {
+		lines = append(lines, "Surrounding text:")
+		lines = append(lines, limitPromptLines(text, 6, 420))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func quotePromptText(raw string, maxChars int) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return `""`
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if maxChars > 0 && len(runes) > maxChars {
+		text = string(runes[:maxChars]) + "..."
+	}
+	return fmt.Sprintf("%q", text)
+}
+
+func limitPromptLines(raw string, maxLines, maxChars int) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	if maxLines > 0 && len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	text = strings.TrimSpace(strings.Join(lines, "\n"))
+	runes := []rune(text)
+	if maxChars > 0 && len(runes) > maxChars {
+		text = string(runes[:maxChars]) + "..."
+	}
+	return text
+}

--- a/internal/web/chat_cursor_test.go
+++ b/internal/web/chat_cursor_test.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatChatCursorPromptContext_IncludesStructuredLocationAndContext(t *testing.T) {
+	ctx := &chatCursorContext{
+		Title:        "internal/web/items.go",
+		Page:         2,
+		Line:         42,
+		SelectedText: "if err != nil",
+		Surrounding:  "41: func main() {\n42: if err != nil {\n43:   return err\n44: }",
+	}
+	prompt := formatChatCursorPromptContext(ctx)
+	if !strings.Contains(prompt, `User is pointing at: page 2, line 42 of "internal/web/items.go"`) {
+		t.Fatalf("prompt missing target, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, `Selected text: "if err != nil"`) {
+		t.Fatalf("prompt missing selected text, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "42: if err != nil {") {
+		t.Fatalf("prompt missing surrounding text, got:\n%s", prompt)
+	}
+}
+
+func TestAppendChatCursorPrompt_PrependsContext(t *testing.T) {
+	prompt := appendChatCursorPrompt("Conversation transcript:\nUSER:\nfix this", &chatCursorContext{
+		Title: "test.txt",
+		Line:  3,
+	})
+	if !strings.HasPrefix(prompt, "## Cursor Context") {
+		t.Fatalf("prompt should start with cursor context, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, `line 3 of "test.txt"`) {
+		t.Fatalf("prompt missing line reference, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Conversation transcript:\nUSER:\nfix this") {
+		t.Fatalf("prompt missing original body, got:\n%s", prompt)
+	}
+}
+
+func TestChatCursorContextTracker_ConsumesInOrder(t *testing.T) {
+	tracker := newChatCursorContextTracker()
+	tracker.enqueue("session-1", &chatCursorContext{Title: "first.txt", Line: 1})
+	tracker.enqueue("session-1", nil)
+	tracker.enqueue("session-1", &chatCursorContext{Title: "third.txt", Line: 3})
+
+	first := tracker.consume("session-1")
+	if first == nil || first.Title != "first.txt" || first.Line != 1 {
+		t.Fatalf("first consume = %#v", first)
+	}
+	second := tracker.consume("session-1")
+	if second != nil {
+		t.Fatalf("second consume = %#v, want nil placeholder", second)
+	}
+	third := tracker.consume("session-1")
+	if third == nil || third.Title != "third.txt" || third.Line != 3 {
+		t.Fatalf("third consume = %#v", third)
+	}
+	if leftover := tracker.consume("session-1"); leftover != nil {
+		t.Fatalf("leftover consume = %#v, want nil", leftover)
+	}
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -24,6 +24,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
 		return
 	}
+	cursorCtx := a.chatCursorContexts.consume(sessionID)
 	userText := latestUserMessage(messages)
 	if project, projectErr := a.store.GetProjectByProjectKey(session.ProjectKey); projectErr == nil && isHubProject(project) {
 		a.runHubTurn(sessionID, session, messages, outputMode, localOnly)
@@ -52,7 +53,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 	profile = a.appServerProfileForChatSession(session, profile)
 	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
-		a.runAssistantTurnLegacy(sessionID, session, messages, outputMode, profile)
+		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, outputMode, profile)
 		return
 	}
 
@@ -65,6 +66,7 @@ func (a *App) runAssistantTurn(sessionID string, outputMode string, localOnly bo
 		prompt = buildPromptFromHistoryForSessionWithCompanion(session.Mode, sessionID, messages, canvasCtx, companionCtx, outputMode, profile.Alias)
 		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
 	}
+	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	if strings.TrimSpace(prompt) == "" {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
@@ -328,10 +330,11 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 
 // runAssistantTurnLegacy is the single-shot fallback when persistent session
 // fails to connect. Each call creates a new WS + thread.
-func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, outputMode string, profile appServerModelProfile) {
+func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, outputMode string, profile appServerModelProfile) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
 	prompt := buildPromptFromHistoryForSession(session.Mode, sessionID, messages, canvasCtx, outputMode, profile.Alias)
+	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	if strings.TrimSpace(prompt) == "" {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -99,6 +99,7 @@ type App struct {
 	companionTurns       *companionPendingTurnTracker
 	companionRuntime     *companionRuntimeTracker
 	chatCaptureModes     *chatCaptureModeTracker
+	chatCursorContexts   *chatCursorContextTracker
 	projectAttention     *projectAttentionTracker
 	tunnels              *tunnelRegistry
 	chatAppSessions      map[string]*appserver.Session
@@ -276,6 +277,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		companionTurns:                newCompanionPendingTurnTracker(),
 		companionRuntime:              newCompanionRuntimeTracker(),
 		chatCaptureModes:              newChatCaptureModeTracker(),
+		chatCursorContexts:            newChatCursorContextTracker(),
 		projectAttention:              newProjectAttentionTracker(),
 		tunnels:                       newTunnelRegistry(),
 		chatAppSessions:               map[string]*appserver.Session{},

--- a/internal/web/static/app-chat-submit.js
+++ b/internal/web/static/app-chat-submit.js
@@ -33,6 +33,28 @@ const maybeHandleInlineBugReport = (...args) => refs.maybeHandleInlineBugReport(
 const STOP_REQUEST_TIMEOUT_MS = 3500;
 const VOICE_TRANSCRIPT_SUBMIT_GUARD_MS = 220;
 
+function buildCursorPayload(anchor) {
+  if (!anchor || typeof anchor !== 'object') return null;
+  const payload = {
+    title: String(anchor.title || '').trim(),
+    page: Number.parseInt(String(anchor.page || ''), 10) || 0,
+    line: Number.parseInt(String(anchor.line || ''), 10) || 0,
+    relative_x: Number(anchor.relativeX),
+    relative_y: Number(anchor.relativeY),
+    selected_text: String(anchor.selectedText || '').trim(),
+    surrounding_text: String(anchor.surroundingText || '').trim(),
+  };
+  if (!Number.isFinite(payload.relative_x)) delete payload.relative_x;
+  if (!Number.isFinite(payload.relative_y)) delete payload.relative_y;
+  if (!payload.title) delete payload.title;
+  if (!payload.page) delete payload.page;
+  if (!payload.line) delete payload.line;
+  if (!payload.selected_text) delete payload.selected_text;
+  if (!payload.surrounding_text) delete payload.surrounding_text;
+  if (Object.keys(payload).length === 0) return null;
+  return payload;
+}
+
 export function setPendingSubmit(controller, kind = '') {
   state.pendingSubmitController = controller || null;
   state.pendingSubmitKind = String(kind || '').trim();
@@ -138,6 +160,10 @@ export async function submitMessage(text, options = {}) {
     output_mode: state.ttsSilent ? 'silent' : 'voice',
     capture_mode: submitKind === 'voice_transcript' ? 'voice' : 'text',
   };
+  const cursorPayload = buildCursorPayload(anchor);
+  if (cursorPayload) {
+    body.cursor = cursorPayload;
+  }
   try {
     if (submitKind === 'voice_transcript' && submitController) {
       await waitWithAbort(VOICE_TRANSCRIPT_SUBMIT_GUARD_MS, submitController.signal);

--- a/internal/web/static/canvas.js
+++ b/internal/web/static/canvas.js
@@ -914,6 +914,28 @@ function lineFromOffset(lines, charOffset) {
   return Math.max(1, lines.length);
 }
 
+function compactAnchorText(raw, maxChars = 240) {
+  const text = String(raw || '').trim();
+  if (!text) return '';
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= maxChars) return collapsed;
+  return `${collapsed.slice(0, maxChars)}...`;
+}
+
+function surroundingTextForLine(lines, line) {
+  const lineNumber = Number.parseInt(String(line || ''), 10);
+  if (!Array.isArray(lines) || lines.length === 0 || !Number.isFinite(lineNumber) || lineNumber <= 0) {
+    return '';
+  }
+  const start = Math.max(0, lineNumber - 2);
+  const end = Math.min(lines.length, lineNumber + 1);
+  return lines
+    .slice(start, end)
+    .map((entry, index) => `${start + index + 1}: ${String(entry || '')}`)
+    .join('\n')
+    .trim();
+}
+
 function textRangeFromClientPoint(clientX, clientY) {
   if (typeof document.caretRangeFromPoint === 'function') {
     return document.caretRangeFromPoint(clientX, clientY);
@@ -1126,6 +1148,7 @@ function getDiffAnchorContext(node) {
   return {
     line: resolvedLine,
     title: path || getActiveArtifactTitle(),
+    surroundingText: compactAnchorText(lineEl.textContent || ''),
   };
 }
 
@@ -1140,6 +1163,7 @@ function getMarkdownSourceAnchorContext(node) {
   return {
     line,
     title: getActiveArtifactTitle(),
+    surroundingText: compactAnchorText(sourceEl.textContent || ''),
   };
 }
 
@@ -1159,7 +1183,7 @@ export function getLocationFromPoint(clientX, clientY) {
       const lines = (e.text.textContent || '').split('\n');
       const line = lineFromOffset(lines, offset);
       const title = getActiveArtifactTitle();
-      return { line, title };
+      return { line, title, surroundingText: surroundingTextForLine(lines, line) };
     } catch (_) {
       return null;
     }
@@ -1169,7 +1193,12 @@ export function getLocationFromPoint(clientX, clientY) {
     if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
       const estimate = estimateTextLineAtPoint(e.text, clientY);
       if (estimate) {
-        return { line: estimate.line, title: getActiveArtifactTitle() };
+        const lines = (e.text.textContent || '').split('\n');
+        return {
+          line: estimate.line,
+          title: getActiveArtifactTitle(),
+          surroundingText: surroundingTextForLine(lines, estimate.line),
+        };
       }
     }
   }
@@ -1200,7 +1229,12 @@ function getTextSelectionLocation(e, selection, selectedText) {
   const lines = (e.text.textContent || '').split('\n');
   const line = lineFromOffset(lines, startOffset);
   const title = getActiveArtifactTitle();
-  return { line, selectedText, title };
+  return {
+    line,
+    selectedText,
+    title,
+    surroundingText: surroundingTextForLine(lines, line),
+  };
 }
 
 export function getLocationFromSelection() {

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -181,8 +181,15 @@ test('dialogue tap pins a cursor dot and scopes the next voice message without s
   await submitVoiceStyleMessage(page, 'fix this');
   await expect.poll(async () => {
     const nextLog = await getLog(page);
-    return nextLog.find((entry) => entry.type === 'message_sent')?.text || '';
-  }).toBe('[Line 3 of "test.txt"] fix this');
+    return nextLog.find((entry) => entry.type === 'message_sent') || null;
+  }).not.toBeNull();
+  const sentEntry = (await getLog(page)).find((entry) => entry.type === 'message_sent');
+
+  expect(sentEntry?.text).toBe('[Line 3 of "test.txt"] fix this');
+  expect(sentEntry?.cursor).toMatchObject({
+    title: 'test.txt',
+    line: 3,
+  });
 });
 
 test('meeting taps move the pinned cursor without starting a new recording', async ({ page }) => {

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1654,7 +1654,7 @@
         }
         try {
           const body = JSON.parse(opts.body);
-          window.__harnessLog.push({ type: 'message_sent', text: body.text });
+          window.__harnessLog.push({ type: 'message_sent', text: body.text, cursor: body.cursor || null });
         } catch (_) {}
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }


### PR DESCRIPTION
## Summary
- send structured cursor metadata with each submitted chat message
- prepend structured cursor context to the assistant prompt for the matching turn
- capture surrounding text for text, diff, and markdown anchors so "fix this" has local context
- extend the cursor Playwright harness assertion to verify the cursor payload is actually sent

## Verification
- Requirement: dialogue turns include current cursor context in the assistant prompt.
  Evidence: `go test ./internal/web -run 'TestFormatChatCursorPromptContext_IncludesStructuredLocationAndContext|TestAppendChatCursorPrompt_PrependsContext|TestChatCursorContextTracker_ConsumesInOrder' 2>&1 | tee /tmp/tabura-go-cursor.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.009s`
  Covered by: `TestFormatChatCursorPromptContext_IncludesStructuredLocationAndContext`, `TestAppendChatCursorPrompt_PrependsContext`.
- Requirement: tap-selected cursor data is carried with the submitted user turn, not just shown in the UI.
  Evidence: `./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts 2>&1 | tee /tmp/tabura-pw-cursor.log`
  Output excerpt: `✓  1 ... dialogue tap pins a cursor dot and scopes the next voice message without starting capture`
  Assertion added in the spec: the captured `message_sent` payload includes `cursor: { title: 'test.txt', line: 3 }` alongside the text `[Line 3 of "test.txt"] fix this`.
- Requirement: cursor context stays aligned to the matching assistant turn even when turns queue.
  Evidence: same focused Go test command above.
  Covered by: `TestChatCursorContextTracker_ConsumesInOrder`, which verifies per-session FIFO consumption including nil placeholders.
