### PR TITLE
fix: add generic sync engine for external providers (fixes #253)

### DIFF
--- a/internal/sync/store_sink.go
+++ b/internal/sync/store_sink.go
@@ -1,0 +1,394 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type StoreSink struct {
+	store *store.Store
+}
+
+func NewStoreSink(s *store.Store) *StoreSink {
+	return &StoreSink{store: s}
+}
+
+func (s *StoreSink) UpsertItem(_ context.Context, item store.Item, binding store.ExternalBinding) (store.Item, error) {
+	account, existingBinding, existingItem, assignment, err := s.resolveItemTarget(binding)
+	if err != nil {
+		return store.Item{}, err
+	}
+
+	if existingItem != nil {
+		update, err := s.itemUpdate(account, item, assignment)
+		if err != nil {
+			return store.Item{}, err
+		}
+		if err := s.store.UpdateItem(existingItem.ID, update); err != nil {
+			return store.Item{}, err
+		}
+		updated, err := s.store.GetItem(existingItem.ID)
+		if err != nil {
+			return store.Item{}, err
+		}
+		if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
+			AccountID:       account.ID,
+			Provider:        account.Provider,
+			ObjectType:      binding.ObjectType,
+			RemoteID:        binding.RemoteID,
+			ItemID:          &updated.ID,
+			ArtifactID:      existingBinding.ArtifactID,
+			ContainerRef:    normalizeContainerRef(binding.ContainerRef),
+			RemoteUpdatedAt: binding.RemoteUpdatedAt,
+		}); err != nil {
+			return store.Item{}, err
+		}
+		return updated, nil
+	}
+
+	options, err := s.itemCreateOptions(account, item, assignment)
+	if err != nil {
+		return store.Item{}, err
+	}
+	created, err := s.store.CreateItem(item.Title, options)
+	if err != nil {
+		return store.Item{}, err
+	}
+	artifactID := existingBinding.ArtifactID
+	if item.ArtifactID != nil {
+		artifactID = item.ArtifactID
+	}
+	if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      binding.ObjectType,
+		RemoteID:        binding.RemoteID,
+		ItemID:          &created.ID,
+		ArtifactID:      artifactID,
+		ContainerRef:    normalizeContainerRef(binding.ContainerRef),
+		RemoteUpdatedAt: binding.RemoteUpdatedAt,
+	}); err != nil {
+		return store.Item{}, err
+	}
+	return created, nil
+}
+
+func (s *StoreSink) UpsertArtifact(_ context.Context, artifact store.Artifact, binding store.ExternalBinding) (store.Artifact, error) {
+	account, existingBinding, existingArtifact, assignment, err := s.resolveArtifactTarget(binding)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+
+	if existingArtifact != nil {
+		update, err := artifactUpdate(artifact)
+		if err != nil {
+			return store.Artifact{}, err
+		}
+		if err := s.store.UpdateArtifact(existingArtifact.ID, update); err != nil {
+			return store.Artifact{}, err
+		}
+		updated, err := s.store.GetArtifact(existingArtifact.ID)
+		if err != nil {
+			return store.Artifact{}, err
+		}
+		if err := s.linkArtifactWorkspace(updated, assignment.WorkspaceID); err != nil {
+			return store.Artifact{}, err
+		}
+		if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
+			AccountID:       account.ID,
+			Provider:        account.Provider,
+			ObjectType:      binding.ObjectType,
+			RemoteID:        binding.RemoteID,
+			ItemID:          existingBinding.ItemID,
+			ArtifactID:      &updated.ID,
+			ContainerRef:    normalizeContainerRef(binding.ContainerRef),
+			RemoteUpdatedAt: binding.RemoteUpdatedAt,
+		}); err != nil {
+			return store.Artifact{}, err
+		}
+		return updated, nil
+	}
+
+	if strings.TrimSpace(string(artifact.Kind)) == "" {
+		return store.Artifact{}, errors.New("artifact kind is required")
+	}
+	created, err := s.store.CreateArtifact(artifact.Kind, artifact.RefPath, artifact.RefURL, artifact.Title, artifact.MetaJSON)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	if err := s.linkArtifactWorkspace(created, assignment.WorkspaceID); err != nil {
+		return store.Artifact{}, err
+	}
+	if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      binding.ObjectType,
+		RemoteID:        binding.RemoteID,
+		ItemID:          existingBinding.ItemID,
+		ArtifactID:      &created.ID,
+		ContainerRef:    normalizeContainerRef(binding.ContainerRef),
+		RemoteUpdatedAt: binding.RemoteUpdatedAt,
+	}); err != nil {
+		return store.Artifact{}, err
+	}
+	return created, nil
+}
+
+type assignment struct {
+	WorkspaceID *int64
+	ProjectID   *string
+	Sphere      *string
+}
+
+func (s *StoreSink) resolveItemTarget(binding store.ExternalBinding) (store.ExternalAccount, store.ExternalBinding, *store.Item, assignment, error) {
+	account, existingBinding, err := s.resolveBinding(binding)
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+	}
+	target, err := s.lookupAssignment(account.Provider, normalizeContainerRef(binding.ContainerRef))
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+	}
+	var item *store.Item
+	switch {
+	case existingBinding.ItemID != nil:
+		resolved, err := s.store.GetItem(*existingBinding.ItemID)
+		if err != nil {
+			return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+		}
+		item = &resolved
+	case binding.ItemID != nil:
+		resolved, err := s.store.GetItem(*binding.ItemID)
+		if err != nil {
+			return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+		}
+		item = &resolved
+	}
+	return account, existingBinding, item, target, nil
+}
+
+func (s *StoreSink) resolveArtifactTarget(binding store.ExternalBinding) (store.ExternalAccount, store.ExternalBinding, *store.Artifact, assignment, error) {
+	account, existingBinding, err := s.resolveBinding(binding)
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+	}
+	target, err := s.lookupAssignment(account.Provider, normalizeContainerRef(binding.ContainerRef))
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+	}
+	var artifact *store.Artifact
+	switch {
+	case existingBinding.ArtifactID != nil:
+		resolved, err := s.store.GetArtifact(*existingBinding.ArtifactID)
+		if err != nil {
+			return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+		}
+		artifact = &resolved
+	case binding.ArtifactID != nil:
+		resolved, err := s.store.GetArtifact(*binding.ArtifactID)
+		if err != nil {
+			return store.ExternalAccount{}, store.ExternalBinding{}, nil, assignment{}, err
+		}
+		artifact = &resolved
+	}
+	return account, existingBinding, artifact, target, nil
+}
+
+func (s *StoreSink) resolveBinding(binding store.ExternalBinding) (store.ExternalAccount, store.ExternalBinding, error) {
+	if binding.AccountID <= 0 {
+		return store.ExternalAccount{}, store.ExternalBinding{}, errors.New("external binding account_id is required")
+	}
+	account, err := s.store.GetExternalAccount(binding.AccountID)
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, err
+	}
+	if strings.TrimSpace(binding.Provider) == "" {
+		binding.Provider = account.Provider
+	}
+	if binding.Provider != account.Provider {
+		return store.ExternalAccount{}, store.ExternalBinding{}, errors.New("external binding provider must match account provider")
+	}
+	if strings.TrimSpace(binding.ObjectType) == "" {
+		return store.ExternalAccount{}, store.ExternalBinding{}, errors.New("external binding object_type is required")
+	}
+	if strings.TrimSpace(binding.RemoteID) == "" {
+		return store.ExternalAccount{}, store.ExternalBinding{}, errors.New("external binding remote_id is required")
+	}
+	existingBinding, err := s.store.GetBindingByRemote(binding.AccountID, binding.Provider, binding.ObjectType, binding.RemoteID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return account, store.ExternalBinding{}, nil
+	}
+	if err != nil {
+		return store.ExternalAccount{}, store.ExternalBinding{}, err
+	}
+	return account, existingBinding, nil
+}
+
+func (s *StoreSink) lookupAssignment(provider string, containerRef *string) (assignment, error) {
+	ref := strings.TrimSpace(stringFromPointer(containerRef))
+	if ref == "" {
+		return assignment{}, nil
+	}
+	for _, containerType := range []string{"project", "collection", "notebook", "tag", "label", "calendar", "folder"} {
+		mapping, err := s.store.GetContainerMapping(provider, containerType, ref)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return assignment{}, err
+		}
+		return assignment{
+			WorkspaceID: mapping.WorkspaceID,
+			ProjectID:   mapping.ProjectID,
+			Sphere:      mapping.Sphere,
+		}, nil
+	}
+	return assignment{}, nil
+}
+
+func (s *StoreSink) itemCreateOptions(account store.ExternalAccount, item store.Item, assignment assignment) (store.ItemOptions, error) {
+	if strings.TrimSpace(item.Title) == "" {
+		return store.ItemOptions{}, errors.New("item title is required")
+	}
+	opts := store.ItemOptions{
+		State:        item.State,
+		ArtifactID:   item.ArtifactID,
+		ActorID:      item.ActorID,
+		VisibleAfter: item.VisibleAfter,
+		FollowUpAt:   item.FollowUpAt,
+		Source:       item.Source,
+		SourceRef:    item.SourceRef,
+	}
+	opts.WorkspaceID = firstInt64(item.WorkspaceID, assignment.WorkspaceID)
+	opts.ProjectID = firstString(item.ProjectID, assignment.ProjectID)
+	if opts.WorkspaceID == nil {
+		sphere := strings.TrimSpace(item.Sphere)
+		if sphere == "" {
+			sphere = strings.TrimSpace(stringFromPointer(assignment.Sphere))
+		}
+		if sphere == "" {
+			sphere = account.Sphere
+		}
+		opts.Sphere = &sphere
+	}
+	return opts, nil
+}
+
+func (s *StoreSink) itemUpdate(account store.ExternalAccount, item store.Item, assignment assignment) (store.ItemUpdate, error) {
+	if strings.TrimSpace(item.Title) == "" {
+		return store.ItemUpdate{}, errors.New("item title is required")
+	}
+	update := store.ItemUpdate{
+		Title:        stringPointer(item.Title),
+		VisibleAfter: item.VisibleAfter,
+		FollowUpAt:   item.FollowUpAt,
+		Source:       item.Source,
+		SourceRef:    item.SourceRef,
+	}
+	if state := strings.TrimSpace(item.State); state != "" {
+		update.State = &state
+	}
+	if workspaceID := firstInt64(item.WorkspaceID, assignment.WorkspaceID); workspaceID != nil {
+		update.WorkspaceID = int64Pointer(*workspaceID)
+	}
+	if projectID := firstString(item.ProjectID, assignment.ProjectID); projectID != nil {
+		update.ProjectID = stringPointer(*projectID)
+	}
+	if update.WorkspaceID == nil {
+		sphere := strings.TrimSpace(item.Sphere)
+		if sphere == "" {
+			sphere = strings.TrimSpace(stringFromPointer(assignment.Sphere))
+		}
+		if sphere == "" {
+			sphere = account.Sphere
+		}
+		update.Sphere = &sphere
+	}
+	if item.ArtifactID != nil {
+		update.ArtifactID = int64Pointer(*item.ArtifactID)
+	}
+	if item.ActorID != nil {
+		update.ActorID = int64Pointer(*item.ActorID)
+	}
+	return update, nil
+}
+
+func artifactUpdate(artifact store.Artifact) (store.ArtifactUpdate, error) {
+	if strings.TrimSpace(string(artifact.Kind)) == "" && artifact.RefPath == nil && artifact.RefURL == nil && artifact.Title == nil && artifact.MetaJSON == nil {
+		return store.ArtifactUpdate{}, nil
+	}
+	update := store.ArtifactUpdate{
+		RefPath:  artifact.RefPath,
+		RefURL:   artifact.RefURL,
+		Title:    artifact.Title,
+		MetaJSON: artifact.MetaJSON,
+	}
+	if strings.TrimSpace(string(artifact.Kind)) != "" {
+		kind := artifact.Kind
+		update.Kind = &kind
+	}
+	return update, nil
+}
+
+func (s *StoreSink) linkArtifactWorkspace(artifact store.Artifact, workspaceID *int64) error {
+	if workspaceID == nil || *workspaceID <= 0 {
+		return nil
+	}
+	if err := s.store.LinkArtifactToWorkspace(*workspaceID, artifact.ID); err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "already belongs to workspace") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func normalizeContainerRef(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clean := strings.TrimSpace(*value)
+	if clean == "" {
+		return nil
+	}
+	return &clean
+}
+
+func stringFromPointer(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func firstInt64(values ...*int64) *int64 {
+	for _, value := range values {
+		if value != nil {
+			next := *value
+			return &next
+		}
+	}
+	return nil
+}
+
+func firstString(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && strings.TrimSpace(*value) != "" {
+			next := strings.TrimSpace(*value)
+			return &next
+		}
+	}
+	return nil
+}

--- a/internal/sync/store_sink_test.go
+++ b/internal/sync/store_sink_test.go
@@ -1,0 +1,148 @@
+package sync_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
+	tabsync "github.com/krystophny/tabura/internal/sync"
+)
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.New(filepath.Join(t.TempDir(), "tabura.db"))
+	if err != nil {
+		t.Fatalf("store.New() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+	return s
+}
+
+func TestStoreSinkUpsertItemUsesContainerMappingAndBinding(t *testing.T) {
+	s := newTestStore(t)
+	sink := tabsync.NewStoreSink(s)
+
+	account, err := s.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "todo", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	workspace, err := s.CreateWorkspace("sync-target", filepath.Join(t.TempDir(), "workspace"), store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	project, err := s.CreateProject("Program", "program", filepath.Join(t.TempDir(), "program"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if _, err := s.SetContainerMapping(account.Provider, "project", "alpha", &workspace.ID, &project.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+
+	item, err := sink.UpsertItem(context.Background(), store.Item{
+		Title: "Follow up with provider",
+	}, store.ExternalBinding{
+		AccountID:    account.ID,
+		Provider:     account.Provider,
+		ObjectType:   "task",
+		RemoteID:     "remote-1",
+		ContainerRef: stringPtr("alpha"),
+	})
+	if err != nil {
+		t.Fatalf("UpsertItem(create) error: %v", err)
+	}
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("item.WorkspaceID = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.ProjectID == nil || *item.ProjectID != project.ID {
+		t.Fatalf("item.ProjectID = %v, want %q", item.ProjectID, project.ID)
+	}
+	if item.Sphere != store.SphereWork {
+		t.Fatalf("item.Sphere = %q, want %q", item.Sphere, store.SphereWork)
+	}
+
+	binding, err := s.GetBindingByRemote(account.ID, account.Provider, "task", "remote-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote() error: %v", err)
+	}
+	if binding.ItemID == nil || *binding.ItemID != item.ID {
+		t.Fatalf("binding.ItemID = %v, want %d", binding.ItemID, item.ID)
+	}
+
+	updated, err := sink.UpsertItem(context.Background(), store.Item{
+		Title: "Updated provider title",
+		State: store.ItemStateWaiting,
+	}, store.ExternalBinding{
+		AccountID:    account.ID,
+		Provider:     account.Provider,
+		ObjectType:   "task",
+		RemoteID:     "remote-1",
+		ContainerRef: stringPtr("alpha"),
+	})
+	if err != nil {
+		t.Fatalf("UpsertItem(update) error: %v", err)
+	}
+	if updated.ID != item.ID {
+		t.Fatalf("updated.ID = %d, want %d", updated.ID, item.ID)
+	}
+	if updated.Title != "Updated provider title" {
+		t.Fatalf("updated.Title = %q, want updated title", updated.Title)
+	}
+	if updated.State != store.ItemStateWaiting {
+		t.Fatalf("updated.State = %q, want %q", updated.State, store.ItemStateWaiting)
+	}
+}
+
+func TestStoreSinkUpsertArtifactLinksWorkspaceAndTracksBinding(t *testing.T) {
+	s := newTestStore(t)
+	sink := tabsync.NewStoreSink(s)
+
+	account, err := s.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderIMAP, "mail", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	workspace, err := s.CreateWorkspace("mailbox", filepath.Join(t.TempDir(), "mailbox"), store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if _, err := s.SetContainerMapping(account.Provider, "folder", "inbox", &workspace.ID, nil, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+
+	title := "Subject line"
+	artifact, err := sink.UpsertArtifact(context.Background(), store.Artifact{
+		Kind:  store.ArtifactKindEmail,
+		Title: &title,
+	}, store.ExternalBinding{
+		AccountID:    account.ID,
+		Provider:     account.Provider,
+		ObjectType:   "message",
+		RemoteID:     "msg-1",
+		ContainerRef: stringPtr("inbox"),
+	})
+	if err != nil {
+		t.Fatalf("UpsertArtifact() error: %v", err)
+	}
+
+	links, err := s.ListArtifactWorkspaceLinks(workspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactWorkspaceLinks() error: %v", err)
+	}
+	if len(links) != 1 || links[0].ArtifactID != artifact.ID {
+		t.Fatalf("workspace links = %#v, want artifact %d", links, artifact.ID)
+	}
+
+	binding, err := s.GetBindingByRemote(account.ID, account.Provider, "message", "msg-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote() error: %v", err)
+	}
+	if binding.ArtifactID == nil || *binding.ArtifactID != artifact.ID {
+		t.Fatalf("binding.ArtifactID = %v, want %d", binding.ArtifactID, artifact.ID)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,0 +1,333 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	stdsync "sync"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type Provider interface {
+	Name() string
+	Sync(ctx context.Context, account store.ExternalAccount, sink Sink) error
+}
+
+type Sink interface {
+	UpsertItem(ctx context.Context, item store.Item, binding store.ExternalBinding) (store.Item, error)
+	UpsertArtifact(ctx context.Context, artifact store.Artifact, binding store.ExternalBinding) (store.Artifact, error)
+}
+
+type AccountSource interface {
+	ListExternalAccounts(sphere string) ([]store.ExternalAccount, error)
+}
+
+type BindingCleaner interface {
+	ListStaleBindings(provider string, olderThan time.Time) ([]store.ExternalBinding, error)
+	DeleteBinding(id int64) error
+}
+
+type Options struct {
+	DefaultInterval time.Duration
+	ProviderLimits  map[string]time.Duration
+	StaleAfter      time.Duration
+}
+
+type AccountResult struct {
+	AccountID int64
+	Provider  string
+	Label     string
+	Skipped   bool
+	Reason    string
+	Err       error
+}
+
+type RunResult struct {
+	Accounts  []AccountResult
+	NextDelay time.Duration
+}
+
+type Engine struct {
+	accounts AccountSource
+	cleaner  BindingCleaner
+	sink     Sink
+
+	defaultInterval time.Duration
+	staleAfter      time.Duration
+
+	mu              stdsync.Mutex
+	lastAccountRun  map[int64]time.Time
+	lastProviderRun map[string]time.Time
+	providers       map[string]Provider
+	providerLimits  map[string]time.Duration
+
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+}
+
+func NewEngine(accounts AccountSource, cleaner BindingCleaner, sink Sink, opts Options) *Engine {
+	defaultInterval := opts.DefaultInterval
+	if defaultInterval <= 0 {
+		defaultInterval = 5 * time.Minute
+	}
+	engine := &Engine{
+		accounts:        accounts,
+		cleaner:         cleaner,
+		sink:            sink,
+		defaultInterval: defaultInterval,
+		staleAfter:      opts.StaleAfter,
+		lastAccountRun:  make(map[int64]time.Time),
+		lastProviderRun: make(map[string]time.Time),
+		providers:       make(map[string]Provider),
+		providerLimits:  make(map[string]time.Duration),
+		now:             time.Now,
+		sleep:           sleepContext,
+	}
+	for provider, limit := range opts.ProviderLimits {
+		if limit > 0 {
+			engine.providerLimits[provider] = limit
+		}
+	}
+	return engine
+}
+
+func (e *Engine) Register(provider Provider) {
+	if provider == nil {
+		return
+	}
+	name := provider.Name()
+	if name == "" {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.providers[name] = provider
+}
+
+func (e *Engine) RunOnce(ctx context.Context) (RunResult, error) {
+	accounts, err := e.accounts.ListExternalAccounts("")
+	if err != nil {
+		return RunResult{}, err
+	}
+	sort.Slice(accounts, func(i, j int) bool {
+		if accounts[i].Provider == accounts[j].Provider {
+			if accounts[i].Label == accounts[j].Label {
+				return accounts[i].ID < accounts[j].ID
+			}
+			return accounts[i].Label < accounts[j].Label
+		}
+		return accounts[i].Provider < accounts[j].Provider
+	})
+
+	result := RunResult{
+		Accounts: make([]AccountResult, 0, len(accounts)),
+	}
+	now := e.now()
+	nextDelay := time.Duration(-1)
+
+	for _, account := range accounts {
+		if !account.Enabled {
+			continue
+		}
+		interval := e.accountInterval(account)
+		lastRun, due := e.accountDue(account.ID, interval, now)
+		if !due {
+			remaining := interval - now.Sub(lastRun)
+			if remaining < 0 {
+				remaining = 0
+			}
+			nextDelay = minPositiveDuration(nextDelay, remaining)
+			result.Accounts = append(result.Accounts, AccountResult{
+				AccountID: account.ID,
+				Provider:  account.Provider,
+				Label:     account.Label,
+				Skipped:   true,
+				Reason:    "interval",
+			})
+			continue
+		}
+
+		provider := e.providerFor(account.Provider)
+		if provider == nil {
+			result.Accounts = append(result.Accounts, AccountResult{
+				AccountID: account.ID,
+				Provider:  account.Provider,
+				Label:     account.Label,
+				Skipped:   true,
+				Reason:    "provider_unregistered",
+			})
+			nextDelay = minPositiveDuration(nextDelay, interval)
+			continue
+		}
+
+		if err := e.waitForProvider(ctx, account.Provider); err != nil {
+			return result, err
+		}
+		runStarted := e.now()
+		runErr := provider.Sync(ctx, account, e.sink)
+		accountResult := AccountResult{
+			AccountID: account.ID,
+			Provider:  account.Provider,
+			Label:     account.Label,
+			Err:       runErr,
+		}
+		result.Accounts = append(result.Accounts, accountResult)
+		if runErr != nil {
+			nextDelay = minPositiveDuration(nextDelay, interval)
+			continue
+		}
+		e.markAccountRun(account.ID, runStarted)
+		nextDelay = minPositiveDuration(nextDelay, interval)
+		if err := e.cleanupStaleBindings(account); err != nil {
+			result.Accounts[len(result.Accounts)-1].Err = err
+		}
+	}
+
+	if nextDelay < 0 {
+		nextDelay = e.defaultInterval
+	}
+	result.NextDelay = nextDelay
+	return result, nil
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (e *Engine) providerFor(name string) Provider {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.providers[name]
+}
+
+func (e *Engine) accountDue(accountID int64, interval time.Duration, now time.Time) (time.Time, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	lastRun, ok := e.lastAccountRun[accountID]
+	if !ok {
+		return time.Time{}, true
+	}
+	return lastRun, now.Sub(lastRun) >= interval
+}
+
+func (e *Engine) markAccountRun(accountID int64, at time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.lastAccountRun[accountID] = at
+}
+
+func (e *Engine) waitForProvider(ctx context.Context, provider string) error {
+	e.mu.Lock()
+	limit := e.providerLimits[provider]
+	lastRun := e.lastProviderRun[provider]
+	now := e.now()
+	wait := time.Duration(0)
+	if limit > 0 && !lastRun.IsZero() {
+		wait = limit - now.Sub(lastRun)
+		if wait < 0 {
+			wait = 0
+		}
+	}
+	e.mu.Unlock()
+
+	if err := e.sleep(ctx, wait); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	e.lastProviderRun[provider] = e.now()
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *Engine) cleanupStaleBindings(account store.ExternalAccount) error {
+	if e.cleaner == nil || e.staleAfter <= 0 {
+		return nil
+	}
+	olderThan := e.now().Add(-e.staleAfter)
+	bindings, err := e.cleaner.ListStaleBindings(account.Provider, olderThan)
+	if err != nil {
+		return err
+	}
+	for _, binding := range bindings {
+		if binding.AccountID != account.ID {
+			continue
+		}
+		if err := e.cleaner.DeleteBinding(binding.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Engine) accountInterval(account store.ExternalAccount) time.Duration {
+	interval, err := intervalFromAccountConfig(account.ConfigJSON)
+	if err == nil && interval > 0 {
+		return interval
+	}
+	return e.defaultInterval
+}
+
+func intervalFromAccountConfig(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return 0, err
+	}
+	if value, ok := payload["sync_interval_seconds"]; ok {
+		seconds, ok := numberSeconds(value)
+		if !ok || seconds <= 0 {
+			return 0, errors.New("sync_interval_seconds must be positive")
+		}
+		return time.Duration(seconds) * time.Second, nil
+	}
+	if value, ok := payload["sync_interval"]; ok {
+		text, ok := value.(string)
+		if !ok {
+			return 0, errors.New("sync_interval must be a duration string")
+		}
+		return time.ParseDuration(text)
+	}
+	return 0, nil
+}
+
+func numberSeconds(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed), typed > 0 && float64(int64(typed)) == typed
+	case int:
+		return int64(typed), typed > 0
+	case int64:
+		return typed, typed > 0
+	case json.Number:
+		v, err := typed.Int64()
+		return v, err == nil && v > 0
+	default:
+		return 0, false
+	}
+}
+
+func minPositiveDuration(current, candidate time.Duration) time.Duration {
+	if candidate < 0 {
+		return current
+	}
+	if current < 0 || candidate < current {
+		return candidate
+	}
+	return current
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,0 +1,178 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type fakeAccountSource struct {
+	accounts []store.ExternalAccount
+}
+
+func (f fakeAccountSource) ListExternalAccounts(string) ([]store.ExternalAccount, error) {
+	out := make([]store.ExternalAccount, len(f.accounts))
+	copy(out, f.accounts)
+	return out, nil
+}
+
+type fakeCleaner struct {
+	staleByProvider map[string][]store.ExternalBinding
+	deleted         []int64
+}
+
+func (f *fakeCleaner) ListStaleBindings(provider string, _ time.Time) ([]store.ExternalBinding, error) {
+	out := make([]store.ExternalBinding, len(f.staleByProvider[provider]))
+	copy(out, f.staleByProvider[provider])
+	return out, nil
+}
+
+func (f *fakeCleaner) DeleteBinding(id int64) error {
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+type fakeSink struct{}
+
+func (fakeSink) UpsertItem(context.Context, store.Item, store.ExternalBinding) (store.Item, error) {
+	return store.Item{}, nil
+}
+
+func (fakeSink) UpsertArtifact(context.Context, store.Artifact, store.ExternalBinding) (store.Artifact, error) {
+	return store.Artifact{}, nil
+}
+
+type fakeProvider struct {
+	name  string
+	calls []int64
+	err   error
+}
+
+func (f *fakeProvider) Name() string {
+	return f.name
+}
+
+func (f *fakeProvider) Sync(_ context.Context, account store.ExternalAccount, _ Sink) error {
+	f.calls = append(f.calls, account.ID)
+	return f.err
+}
+
+func TestEngineRunOnceAppliesIntervalsRateLimitsCleanupAndErrorIsolation(t *testing.T) {
+	todoConfig, err := json.Marshal(map[string]any{"sync_interval_seconds": 600})
+	if err != nil {
+		t.Fatalf("Marshal(todoConfig) error: %v", err)
+	}
+	source := fakeAccountSource{
+		accounts: []store.ExternalAccount{
+			{ID: 3, Provider: store.ExternalProviderBear, Label: "bear", Enabled: true},
+			{ID: 1, Provider: store.ExternalProviderTodoist, Label: "todo-a", Enabled: true, ConfigJSON: string(todoConfig)},
+			{ID: 2, Provider: store.ExternalProviderTodoist, Label: "todo-b", Enabled: true},
+			{ID: 4, Provider: store.ExternalProviderICS, Label: "ics-off", Enabled: false},
+		},
+	}
+	cleaner := &fakeCleaner{
+		staleByProvider: map[string][]store.ExternalBinding{
+			store.ExternalProviderTodoist: {
+				{ID: 11, AccountID: 1, Provider: store.ExternalProviderTodoist},
+				{ID: 12, AccountID: 999, Provider: store.ExternalProviderTodoist},
+			},
+		},
+	}
+	todoProvider := &fakeProvider{name: store.ExternalProviderTodoist}
+	bearProvider := &fakeProvider{name: store.ExternalProviderBear, err: errors.New("bear failed")}
+
+	engine := NewEngine(source, cleaner, fakeSink{}, Options{
+		DefaultInterval: 5 * time.Minute,
+		ProviderLimits: map[string]time.Duration{
+			store.ExternalProviderTodoist: 2 * time.Second,
+		},
+		StaleAfter: time.Hour,
+	})
+
+	now := time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC)
+	var sleeps []time.Duration
+	engine.now = func() time.Time { return now }
+	engine.sleep = func(_ context.Context, d time.Duration) error {
+		sleeps = append(sleeps, d)
+		now = now.Add(d)
+		return nil
+	}
+	engine.Register(todoProvider)
+	engine.Register(bearProvider)
+
+	result, err := engine.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce() error: %v", err)
+	}
+	if !reflect.DeepEqual(todoProvider.calls, []int64{1, 2}) {
+		t.Fatalf("todoProvider.calls = %#v, want [1 2]", todoProvider.calls)
+	}
+	if !reflect.DeepEqual(bearProvider.calls, []int64{3}) {
+		t.Fatalf("bearProvider.calls = %#v, want [3]", bearProvider.calls)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{0, 0, 2 * time.Second}) {
+		t.Fatalf("sleep calls = %#v, want [0 0 2s]", sleeps)
+	}
+	if !reflect.DeepEqual(cleaner.deleted, []int64{11}) {
+		t.Fatalf("cleaner.deleted = %#v, want [11]", cleaner.deleted)
+	}
+	if len(result.Accounts) != 3 {
+		t.Fatalf("len(result.Accounts) = %d, want 3", len(result.Accounts))
+	}
+	if result.Accounts[0].Provider != store.ExternalProviderBear || result.Accounts[0].Err == nil {
+		t.Fatalf("bear result = %#v, want provider error", result.Accounts[0])
+	}
+	if result.NextDelay != 5*time.Minute {
+		t.Fatalf("result.NextDelay = %s, want %s", result.NextDelay, 5*time.Minute)
+	}
+
+	result, err = engine.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("second RunOnce() error: %v", err)
+	}
+	if len(todoProvider.calls) != 2 {
+		t.Fatalf("todoProvider second call count = %d, want 2", len(todoProvider.calls))
+	}
+	if len(bearProvider.calls) != 2 {
+		t.Fatalf("bearProvider second call count = %d, want 2", len(bearProvider.calls))
+	}
+	if result.Accounts[1].Reason != "interval" || !result.Accounts[1].Skipped {
+		t.Fatalf("todo account result = %#v, want interval skip", result.Accounts[1])
+	}
+}
+
+func TestIntervalFromAccountConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty", raw: "", want: 0},
+		{name: "seconds", raw: `{"sync_interval_seconds":300}`, want: 5 * time.Minute},
+		{name: "duration", raw: `{"sync_interval":"90s"}`, want: 90 * time.Second},
+		{name: "invalid", raw: `{"sync_interval_seconds":"fast"}`, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := intervalFromAccountConfig(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("intervalFromAccountConfig(%q) error = nil, want error", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("intervalFromAccountConfig(%q) error: %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("intervalFromAccountConfig(%q) = %s, want %s", tc.raw, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/sync` with a provider-agnostic engine, provider registration, per-account scheduling, per-provider rate limiting, and stale-binding cleanup hooks
- add a store-backed sink that upserts Items and Artifacts through existing external account, binding, and container-mapping primitives
- add focused tests for engine scheduling/error isolation and store sink assignment/linking behavior

## Verification
- Provider interface + engine loop: `go test ./internal/sync 2>&1 | tee /tmp/test.log`
  Output: `ok   github.com/krystophny/tabura/internal/sync 0.016s`
- Poll scheduling per account: covered by `TestEngineRunOnceAppliesIntervalsRateLimitsCleanupAndErrorIsolation`, including `sync_interval_seconds` parsing and interval skips on the second run
- Error isolation + per-provider rate limiting: covered by `TestEngineRunOnceAppliesIntervalsRateLimitsCleanupAndErrorIsolation`, which records a Bear failure without blocking both Todoist runs and asserts the inter-provider sleep sequence
- Stale binding cleanup: covered by `TestEngineRunOnceAppliesIntervalsRateLimitsCleanupAndErrorIsolation`, which deletes only stale bindings for the successfully synced account/provider pair
- Container mapping lookup + sphere inheritance: covered by `TestStoreSinkUpsertItemUsesContainerMappingAndBinding`, which creates a mapped Item with workspace/project assignment and `work` sphere inheritance
- Artifact upsert path: covered by `TestStoreSinkUpsertArtifactLinksWorkspaceAndTracksBinding`, which verifies workspace artifact linking and binding persistence
