### PR TITLE
fix: add canvas PDF annotation to source edit workflow (fixes #275)

### DIFF
--- a/internal/web/chat_canvas.go
+++ b/internal/web/chat_canvas.go
@@ -197,18 +197,27 @@ func resolveArtifactFilePath(cwd, title string) string {
 	return abs
 }
 
-// canvasFileTarget holds the resolved file-to-canvas binding for refresh.
-type canvasFileTarget struct {
-	sessionID string
-	port      int
-	title     string
-	filePath  string
+const (
+	canvasRefreshKindText        = "text"
+	canvasRefreshKindDocumentPDF = "document_pdf"
+)
+
+// canvasRefreshTarget holds the resolved disk binding for an active canvas
+// artifact that can be refreshed from source changes.
+type canvasRefreshTarget struct {
+	sessionID       string
+	port            int
+	title           string
+	kind            string
+	sourcePath      string
+	renderedPath    string
+	renderedAbsPath string
 }
 
-// resolveCanvasFileTarget resolves the active canvas artifact to a disk file.
-// Returns nil if the artifact is not a text file or the title doesn't map to
-// an existing file on disk.
-func (a *App) resolveCanvasFileTarget(projectKey string) *canvasFileTarget {
+// resolveCanvasRefreshTarget resolves the active canvas artifact to a source on
+// disk. It supports plain text artifacts and document-source PDFs rendered via
+// open_file_canvas.
+func (a *App) resolveCanvasRefreshTarget(projectKey string) *canvasRefreshTarget {
 	key := strings.TrimSpace(projectKey)
 	if key == "" {
 		return nil
@@ -230,35 +239,67 @@ func (a *App) resolveCanvasFileTarget(projectKey string) *canvasFileTarget {
 	if active == nil {
 		return nil
 	}
-	kind, _ := active["kind"].(string)
-	if kind != "text_artifact" && kind != "text" {
-		return nil
-	}
 	title, _ := active["title"].(string)
 	title = strings.TrimSpace(title)
 	if title == "" {
 		return nil
 	}
 	cwd := a.cwdForProjectKey(key)
-	filePath := resolveArtifactFilePath(cwd, title)
-	if filePath == "" {
+	kind, _ := active["kind"].(string)
+	switch strings.TrimSpace(kind) {
+	case "text_artifact", "text":
+		filePath := resolveArtifactFilePath(cwd, title)
+		if filePath == "" {
+			return nil
+		}
+		return &canvasRefreshTarget{
+			sessionID:  sid,
+			port:       port,
+			title:      title,
+			kind:       canvasRefreshKindText,
+			sourcePath: filePath,
+		}
+	case "pdf_artifact", "pdf":
+		sourcePath := resolveArtifactFilePath(cwd, title)
+		if sourcePath == "" || !shouldRenderDocumentArtifact(cwd, sourcePath) {
+			return nil
+		}
+		renderedPath, _ := active["path"].(string)
+		renderedPath = strings.TrimSpace(renderedPath)
+		renderedAbsPath := resolveArtifactFilePath(cwd, renderedPath)
+		return &canvasRefreshTarget{
+			sessionID:       sid,
+			port:            port,
+			title:           title,
+			kind:            canvasRefreshKindDocumentPDF,
+			sourcePath:      sourcePath,
+			renderedPath:    renderedPath,
+			renderedAbsPath: renderedAbsPath,
+		}
+	default:
 		return nil
 	}
-	return &canvasFileTarget{sessionID: sid, port: port, title: title, filePath: filePath}
 }
 
 // refreshCanvasFromDisk does a single check: reads the file, compares with
 // the canvas text, and pushes if different. Returns true if an update was pushed.
 func (a *App) refreshCanvasFromDisk(projectKey string) bool {
-	t := a.resolveCanvasFileTarget(projectKey)
+	t := a.resolveCanvasRefreshTarget(projectKey)
 	if t == nil {
 		return false
 	}
-	return a.pushCanvasFileIfChanged(projectKey, t)
+	switch t.kind {
+	case canvasRefreshKindText:
+		return a.pushCanvasFileIfChanged(projectKey, t)
+	case canvasRefreshKindDocumentPDF:
+		return a.pushCanvasDocumentIfChanged(projectKey, t)
+	default:
+		return false
+	}
 }
 
-func (a *App) pushCanvasFileIfChanged(projectKey string, t *canvasFileTarget) bool {
-	diskBytes, err := os.ReadFile(t.filePath)
+func (a *App) pushCanvasFileIfChanged(projectKey string, t *canvasRefreshTarget) bool {
+	diskBytes, err := os.ReadFile(t.sourcePath)
 	if err != nil {
 		return false
 	}
@@ -285,11 +326,52 @@ func (a *App) pushCanvasFileIfChanged(projectKey string, t *canvasFileTarget) bo
 	return true
 }
 
+func canvasDocumentNeedsRefresh(sourcePath, renderedAbsPath string) bool {
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil || sourceInfo.IsDir() {
+		return false
+	}
+	if strings.TrimSpace(renderedAbsPath) == "" {
+		return true
+	}
+	renderedInfo, err := os.Stat(renderedAbsPath)
+	if err != nil || renderedInfo.IsDir() {
+		return true
+	}
+	return sourceInfo.ModTime().After(renderedInfo.ModTime())
+}
+
+func (a *App) pushCanvasDocumentIfChanged(projectKey string, t *canvasRefreshTarget) bool {
+	if t == nil || t.kind != canvasRefreshKindDocumentPDF {
+		return false
+	}
+	projectRoot := strings.TrimSpace(a.cwdForProjectKey(projectKey))
+	if projectRoot == "" || !canvasDocumentNeedsRefresh(t.sourcePath, t.renderedAbsPath) {
+		return false
+	}
+	renderedPath, err := a.renderDocumentArtifact(projectRoot, t.sourcePath)
+	if err != nil {
+		return false
+	}
+	if _, err := a.mcpToolsCall(t.port, "canvas_artifact_show", map[string]interface{}{
+		"session_id": t.sessionID,
+		"kind":       "pdf",
+		"title":      t.title,
+		"path":       renderedPath,
+	}); err != nil {
+		return false
+	}
+	t.renderedPath = renderedPath
+	t.renderedAbsPath = resolveArtifactFilePath(projectRoot, renderedPath)
+	a.markProjectOutput(projectKey)
+	return true
+}
+
 // watchCanvasFile uses fsnotify to watch the disk file backing the active
 // canvas artifact. On every write, it reads the new content and pushes it
 // to the canvas via MCP. Blocks until ctx is cancelled.
 func (a *App) watchCanvasFile(ctx context.Context, projectKey string) {
-	t := a.resolveCanvasFileTarget(projectKey)
+	t := a.resolveCanvasRefreshTarget(projectKey)
 	if t == nil {
 		return
 	}
@@ -298,14 +380,19 @@ func (a *App) watchCanvasFile(ctx context.Context, projectKey string) {
 		return
 	}
 	defer watcher.Close()
-	dir := filepath.Dir(t.filePath)
+	dir := filepath.Dir(t.sourcePath)
 	if err := watcher.Add(dir); err != nil {
 		return
 	}
-	base := filepath.Base(t.filePath)
+	base := filepath.Base(t.sourcePath)
 	lastContent := ""
-	if b, err := os.ReadFile(t.filePath); err == nil {
-		lastContent = string(b)
+	lastModTime := time.Time{}
+	if t.kind == canvasRefreshKindText {
+		if b, err := os.ReadFile(t.sourcePath); err == nil {
+			lastContent = string(b)
+		}
+	} else if info, err := os.Stat(t.sourcePath); err == nil {
+		lastModTime = info.ModTime()
 	}
 	for {
 		select {
@@ -321,22 +408,35 @@ func (a *App) watchCanvasFile(ctx context.Context, projectKey string) {
 			if ev.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
 				continue
 			}
-			b, err := os.ReadFile(t.filePath)
-			if err != nil {
-				continue
+			switch t.kind {
+			case canvasRefreshKindText:
+				b, err := os.ReadFile(t.sourcePath)
+				if err != nil {
+					continue
+				}
+				content := string(b)
+				if content == lastContent {
+					continue
+				}
+				lastContent = content
+				_, _ = a.mcpToolsCall(t.port, "canvas_artifact_show", map[string]interface{}{
+					"session_id":       t.sessionID,
+					"kind":             "text",
+					"title":            t.title,
+					"markdown_or_text": content,
+				})
+				a.markProjectOutput(projectKey)
+			case canvasRefreshKindDocumentPDF:
+				info, err := os.Stat(t.sourcePath)
+				if err != nil || info.IsDir() {
+					continue
+				}
+				if !info.ModTime().After(lastModTime) {
+					continue
+				}
+				lastModTime = info.ModTime()
+				_ = a.pushCanvasDocumentIfChanged(projectKey, t)
 			}
-			content := string(b)
-			if content == lastContent {
-				continue
-			}
-			lastContent = content
-			_, _ = a.mcpToolsCall(t.port, "canvas_artifact_show", map[string]interface{}{
-				"session_id":       t.sessionID,
-				"kind":             "text",
-				"title":            t.title,
-				"markdown_or_text": content,
-			})
-			a.markProjectOutput(projectKey)
 		case _, ok := <-watcher.Errors:
 			if !ok {
 				return

--- a/internal/web/document_canvas_refresh_test.go
+++ b/internal/web/document_canvas_refresh_test.go
@@ -1,0 +1,241 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type documentCanvasMCPMock struct {
+	mu            sync.Mutex
+	artifactTitle string
+	artifactKind  string
+	artifactPath  string
+	showCalls     int32
+	lastShown     map[string]interface{}
+}
+
+func (m *documentCanvasMCPMock) setupServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || strings.TrimSpace(r.URL.Path) != "/mcp" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		params, _ := payload["params"].(map[string]interface{})
+		name := strings.TrimSpace(fmt.Sprint(params["name"]))
+		args, _ := params["arguments"].(map[string]interface{})
+
+		var structured map[string]interface{}
+		switch name {
+		case "canvas_status":
+			m.mu.Lock()
+			active := map[string]interface{}{
+				"title": m.artifactTitle,
+				"kind":  m.artifactKind,
+				"path":  m.artifactPath,
+			}
+			m.mu.Unlock()
+			structured = map[string]interface{}{"active_artifact": active}
+		case "canvas_artifact_show":
+			atomic.AddInt32(&m.showCalls, 1)
+			copied := map[string]interface{}{}
+			for key, value := range args {
+				copied[key] = value
+			}
+			m.mu.Lock()
+			m.artifactTitle = strings.TrimSpace(fmt.Sprint(args["title"]))
+			m.artifactKind = strings.TrimSpace(fmt.Sprint(args["kind"]))
+			m.artifactPath = strings.TrimSpace(fmt.Sprint(args["path"]))
+			m.lastShown = copied
+			m.mu.Unlock()
+			structured = map[string]interface{}{"ok": true}
+		default:
+			http.Error(w, "unknown tool", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      payload["id"],
+			"result": map[string]interface{}{
+				"structuredContent": structured,
+				"isError":           false,
+			},
+		})
+	}))
+}
+
+func writePandocEchoStub(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	stub := `#!/bin/sh
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+  fi
+  prev="$arg"
+done
+cat "$1" > "$out"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "pandoc"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("write pandoc stub: %v", err)
+	}
+	return binDir
+}
+
+func TestRefreshCanvasFromDisk_RebuildsRenderedDocumentPDF(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	docPath := filepath.Join(project.RootPath, "docs", "brief.md")
+	if err := os.MkdirAll(filepath.Dir(docPath), 0o755); err != nil {
+		t.Fatalf("mkdir docs dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project.RootPath, ".tabura"), 0o755); err != nil {
+		t.Fatalf("mkdir .tabura: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project.RootPath, ".tabura", "document.json"), []byte(`{"builder":"pandoc","main_file":"docs/brief.md"}`), 0o644); err != nil {
+		t.Fatalf("write document config: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("version one\n"), 0o644); err != nil {
+		t.Fatalf("write initial doc: %v", err)
+	}
+	binDir := writePandocEchoStub(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	renderedPath, err := app.renderDocumentArtifact(project.RootPath, docPath)
+	if err != nil {
+		t.Fatalf("renderDocumentArtifact() error = %v", err)
+	}
+	renderedAbs := filepath.Join(project.RootPath, filepath.FromSlash(renderedPath))
+
+	mock := &documentCanvasMCPMock{
+		artifactTitle: "docs/brief.md",
+		artifactKind:  "pdf",
+		artifactPath:  renderedPath,
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	time.Sleep(20 * time.Millisecond)
+	if err := os.WriteFile(docPath, []byte("version two\n"), 0o644); err != nil {
+		t.Fatalf("write updated doc: %v", err)
+	}
+
+	if !app.refreshCanvasFromDisk(project.ProjectKey) {
+		t.Fatal("expected rendered document PDF refresh")
+	}
+	if got := atomic.LoadInt32(&mock.showCalls); got != 1 {
+		t.Fatalf("canvas_artifact_show calls = %d, want 1", got)
+	}
+
+	mock.mu.Lock()
+	lastShown := mock.lastShown
+	mock.mu.Unlock()
+	if strings.TrimSpace(fmt.Sprint(lastShown["kind"])) != "pdf" {
+		t.Fatalf("shown kind = %v, want pdf", lastShown["kind"])
+	}
+	if strings.TrimSpace(fmt.Sprint(lastShown["title"])) != "docs/brief.md" {
+		t.Fatalf("shown title = %v, want docs/brief.md", lastShown["title"])
+	}
+	if strings.TrimSpace(fmt.Sprint(lastShown["path"])) != renderedPath {
+		t.Fatalf("shown path = %v, want %s", lastShown["path"], renderedPath)
+	}
+	renderedBytes, err := os.ReadFile(renderedAbs)
+	if err != nil {
+		t.Fatalf("read rendered artifact: %v", err)
+	}
+	if string(renderedBytes) != "version two\n" {
+		t.Fatalf("rendered artifact = %q", string(renderedBytes))
+	}
+}
+
+func TestWatchCanvasFile_RebuildsRenderedDocumentPDFOnSourceWrite(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	docPath := filepath.Join(project.RootPath, "docs", "brief.md")
+	if err := os.MkdirAll(filepath.Dir(docPath), 0o755); err != nil {
+		t.Fatalf("mkdir docs dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project.RootPath, ".tabura"), 0o755); err != nil {
+		t.Fatalf("mkdir .tabura: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project.RootPath, ".tabura", "document.json"), []byte(`{"builder":"pandoc","main_file":"docs/brief.md"}`), 0o644); err != nil {
+		t.Fatalf("write document config: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("draft one\n"), 0o644); err != nil {
+		t.Fatalf("write initial doc: %v", err)
+	}
+	binDir := writePandocEchoStub(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	renderedPath, err := app.renderDocumentArtifact(project.RootPath, docPath)
+	if err != nil {
+		t.Fatalf("renderDocumentArtifact() error = %v", err)
+	}
+	renderedAbs := filepath.Join(project.RootPath, filepath.FromSlash(renderedPath))
+
+	mock := &documentCanvasMCPMock{
+		artifactTitle: "docs/brief.md",
+		artifactKind:  "pdf",
+		artifactPath:  renderedPath,
+	}
+	server := mock.setupServer(t)
+	defer server.Close()
+	port, err := extractPort(server.URL)
+	if err != nil {
+		t.Fatalf("extract port: %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go app.watchCanvasFile(ctx, project.ProjectKey)
+
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(docPath, []byte("draft two\n"), 0o644); err != nil {
+		t.Fatalf("write updated doc: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&mock.showCalls) == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&mock.showCalls); got == 0 {
+		t.Fatal("expected canvas_artifact_show after source write")
+	}
+	renderedBytes, err := os.ReadFile(renderedAbs)
+	if err != nil {
+		t.Fatalf("read rendered artifact: %v", err)
+	}
+	if string(renderedBytes) != "draft two\n" {
+		t.Fatalf("rendered artifact = %q", string(renderedBytes))
+	}
+}


### PR DESCRIPTION
## Summary
- refreshable canvas targets now include document-source PDFs opened through `open_file_canvas`
- source edits rebuild the rendered PDF and push a fresh `canvas_artifact_show` update instead of leaving the canvas stale
- added focused tests for one-shot refresh and fsnotify-driven rebuilds

## Verification
- Document rebuild after source edit: `go test ./internal/web -run 'Test(OpenFileCanvasBuildsMarkdownDocumentAsPDF|RefreshCanvasFromDisk_RebuildsRenderedDocumentPDF|WatchCanvasFile_RebuildsRenderedDocumentPDFOnSourceWrite)$' 2>&1 | tee /tmp/tabula-issue-275-test.log` -> `ok   github.com/krystophny/tabura/internal/web	0.127s`
- Canvas refresh output: `TestRefreshCanvasFromDisk_RebuildsRenderedDocumentPDF` rewrites `docs/brief.md`, verifies `canvas_artifact_show` is called with `kind=pdf`, `title=docs/brief.md`, and the rendered artifact path under `.tabura/artifacts/documents/`, then asserts the rebuilt artifact content changes to `version two`
- Watcher-driven rebuild: `TestWatchCanvasFile_RebuildsRenderedDocumentPDFOnSourceWrite` rewrites the document source while `watchCanvasFile` is active, waits for the PDF refresh event, and verifies the rendered artifact file content changes to `draft two`
- Existing document open flow: `TestOpenFileCanvasBuildsMarkdownDocumentAsPDF` still verifies markdown document rendering to PDF and canvas display via `open_file_canvas`
