### PR TITLE
fix: Add pull-based source polling for ingesting Items from external (fixes #202)

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -108,6 +108,14 @@ func (e *Engine) Register(provider Provider) {
 }
 
 func (e *Engine) RunOnce(ctx context.Context) (RunResult, error) {
+	return e.run(ctx, false)
+}
+
+func (e *Engine) RunNow(ctx context.Context) (RunResult, error) {
+	return e.run(ctx, true)
+}
+
+func (e *Engine) run(ctx context.Context, force bool) (RunResult, error) {
 	accounts, err := e.accounts.ListExternalAccounts("")
 	if err != nil {
 		return RunResult{}, err
@@ -134,7 +142,7 @@ func (e *Engine) RunOnce(ctx context.Context) (RunResult, error) {
 		}
 		interval := e.accountInterval(account)
 		lastRun, due := e.accountDue(account.ID, interval, now)
-		if !due {
+		if !force && !due {
 			remaining := interval - now.Sub(lastRun)
 			if remaining < 0 {
 				remaining = 0

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -176,3 +176,35 @@ func TestIntervalFromAccountConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestEngineRunNowIgnoresIntervals(t *testing.T) {
+	source := fakeAccountSource{
+		accounts: []store.ExternalAccount{
+			{ID: 1, Provider: store.ExternalProviderTodoist, Label: "todo-a", Enabled: true},
+		},
+	}
+	provider := &fakeProvider{name: store.ExternalProviderTodoist}
+	engine := NewEngine(source, &fakeCleaner{}, fakeSink{}, Options{
+		DefaultInterval: 10 * time.Minute,
+	})
+	now := time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	engine.sleep = func(_ context.Context, d time.Duration) error {
+		now = now.Add(d)
+		return nil
+	}
+	engine.Register(provider)
+
+	if _, err := engine.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error: %v", err)
+	}
+	if len(provider.calls) != 1 {
+		t.Fatalf("provider call count after RunOnce = %d, want 1", len(provider.calls))
+	}
+	if _, err := engine.RunNow(context.Background()); err != nil {
+		t.Fatalf("RunNow() error: %v", err)
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("provider call count after RunNow = %d, want 2", len(provider.calls))
+	}
+}

--- a/internal/web/chat_bear.go
+++ b/internal/web/chat_bear.go
@@ -407,41 +407,17 @@ func (a *App) executeSyncBearAction() (string, map[string]interface{}, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	mappings, err := a.store.ListContainerMappings(store.ExternalProviderBear)
-	if err != nil {
-		return "", nil, err
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	result := bearSyncResult{}
 	for _, account := range accounts {
-		client, err := bearClientForAccount(account)
+		synced, err := a.syncBearAccount(ctx, account)
 		if err != nil {
-			if errors.Is(err, bear.ErrDatabaseNotFound) {
-				result.Skipped++
-				continue
-			}
 			return "", nil, err
 		}
-		notes, err := client.ListNotes(ctx)
-		if err != nil {
-			if errors.Is(err, bear.ErrDatabaseNotFound) {
-				result.Skipped++
-				continue
-			}
-			return "", nil, err
-		}
-		for _, note := range notes {
-			mapping, err := a.bearTagMappingForAccount(account, mappings, note.Tags)
-			if err != nil {
-				return "", nil, err
-			}
-			if _, err := a.upsertBearArtifact(account, note, mapping); err != nil {
-				return "", nil, err
-			}
-			result.NoteCount++
-		}
+		result.NoteCount += synced.NoteCount
+		result.Skipped += synced.Skipped
 	}
 
 	if result.NoteCount == 0 && result.Skipped > 0 {
@@ -456,6 +432,39 @@ func (a *App) executeSyncBearAction() (string, map[string]interface{}, error) {
 		"note_count":       result.NoteCount,
 		"skipped_accounts": result.Skipped,
 	}, nil
+}
+
+func (a *App) syncBearAccount(ctx context.Context, account store.ExternalAccount) (bearSyncResult, error) {
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderBear)
+	if err != nil {
+		return bearSyncResult{}, err
+	}
+	client, err := bearClientForAccount(account)
+	if err != nil {
+		if errors.Is(err, bear.ErrDatabaseNotFound) {
+			return bearSyncResult{Skipped: 1}, nil
+		}
+		return bearSyncResult{}, err
+	}
+	notes, err := client.ListNotes(ctx)
+	if err != nil {
+		if errors.Is(err, bear.ErrDatabaseNotFound) {
+			return bearSyncResult{Skipped: 1}, nil
+		}
+		return bearSyncResult{}, err
+	}
+	result := bearSyncResult{}
+	for _, note := range notes {
+		mapping, err := a.bearTagMappingForAccount(account, mappings, note.Tags)
+		if err != nil {
+			return bearSyncResult{}, err
+		}
+		if _, err := a.upsertBearArtifact(account, note, mapping); err != nil {
+			return bearSyncResult{}, err
+		}
+		result.NoteCount++
+	}
+	return result, nil
 }
 
 func (a *App) executePromoteBearChecklistAction(session store.ChatSession) (string, map[string]interface{}, error) {

--- a/internal/web/chat_evernote.go
+++ b/internal/web/chat_evernote.go
@@ -424,47 +424,17 @@ func (a *App) executeSyncEvernoteAction() (string, map[string]interface{}, error
 	if err != nil {
 		return "", nil, err
 	}
-	mappings, err := a.store.ListContainerMappings(store.ExternalProviderEvernote)
-	if err != nil {
-		return "", nil, err
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	result := evernoteSyncResult{}
 	for _, account := range accounts {
-		client, err := evernoteClientForAccount(account)
+		synced, err := a.syncEvernoteAccount(ctx, account)
 		if err != nil {
 			return "", nil, err
 		}
-		notebooks, err := client.ListNotebooks(ctx)
-		if err != nil {
-			return "", nil, err
-		}
-		notebookNames := evernoteNotebookNameByID(notebooks)
-		updatedAfter := ""
-		if latest, err := a.store.LatestBindingRemoteUpdatedAt(account.ID, store.ExternalProviderEvernote, "note"); err != nil {
-			return "", nil, err
-		} else if latest != nil {
-			updatedAfter = *latest
-		}
-		notes, err := listAllEvernoteNotes(ctx, client, updatedAfter)
-		if err != nil {
-			return "", nil, err
-		}
-		for _, summary := range notes {
-			note, err := client.GetNote(ctx, summary.ID)
-			if err != nil {
-				return "", nil, err
-			}
-			notebookName := strings.TrimSpace(notebookNames[strings.TrimSpace(note.NotebookID)])
-			synced, err := a.persistEvernoteNote(account, note, notebookName, mappings)
-			if err != nil {
-				return "", nil, err
-			}
-			result.NoteCount += synced.NoteCount
-			result.TaskCount += synced.TaskCount
-		}
+		result.NoteCount += synced.NoteCount
+		result.TaskCount += synced.TaskCount
 	}
 
 	return fmt.Sprintf("Synced %d Evernote note(s) and %d task item(s).", result.NoteCount, result.TaskCount), map[string]interface{}{
@@ -481,4 +451,45 @@ func (a *App) executeEvernoteAction(_ store.ChatSession, action *SystemAction) (
 	default:
 		return "", nil, fmt.Errorf("unsupported evernote action: %s", action.Action)
 	}
+}
+
+func (a *App) syncEvernoteAccount(ctx context.Context, account store.ExternalAccount) (evernoteSyncResult, error) {
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderEvernote)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	client, err := evernoteClientForAccount(account)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	notebooks, err := client.ListNotebooks(ctx)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	notebookNames := evernoteNotebookNameByID(notebooks)
+	updatedAfter := ""
+	if latest, err := a.store.LatestBindingRemoteUpdatedAt(account.ID, store.ExternalProviderEvernote, "note"); err != nil {
+		return evernoteSyncResult{}, err
+	} else if latest != nil {
+		updatedAfter = *latest
+	}
+	notes, err := listAllEvernoteNotes(ctx, client, updatedAfter)
+	if err != nil {
+		return evernoteSyncResult{}, err
+	}
+	result := evernoteSyncResult{}
+	for _, summary := range notes {
+		note, err := client.GetNote(ctx, summary.ID)
+		if err != nil {
+			return evernoteSyncResult{}, err
+		}
+		notebookName := strings.TrimSpace(notebookNames[strings.TrimSpace(note.NotebookID)])
+		synced, err := a.persistEvernoteNote(account, note, notebookName, mappings)
+		if err != nil {
+			return evernoteSyncResult{}, err
+		}
+		result.NoteCount += synced.NoteCount
+		result.TaskCount += synced.TaskCount
+	}
+	return result, nil
 }

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -751,6 +751,17 @@ func (a *App) classifyAndExecuteSystemAction(ctx context.Context, sessionID stri
 	}
 
 	captureMode := a.chatCaptureModes.consume(sessionID)
+	if inlineSourceSyncAction := parseInlineSourceSyncIntent(trimmedText); inlineSourceSyncAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineSourceSyncAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return sourceSyncActionFailurePrefix(inlineSourceSyncAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
 	if inlineTodoistAction := parseInlineTodoistIntent(trimmedText); inlineTodoistAction != nil {
 		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineTodoistAction})
 		if len(enforced) == 0 {

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -318,6 +318,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		return a.executeSomedayAction(session, action)
 	case "show_filtered_items":
 		return a.executeFilteredItemViewAction(action)
+	case "sync_sources":
+		return a.executeSourceSyncAction(session, action)
 	case "map_todoist_project", "sync_todoist", "create_todoist_task":
 		return a.executeTodoistAction(session, action)
 	case "sync_evernote":

--- a/internal/web/chat_todoist.go
+++ b/internal/web/chat_todoist.go
@@ -448,40 +448,50 @@ func (a *App) executeSyncTodoistAction() (string, map[string]interface{}, error)
 	if err != nil {
 		return "", nil, err
 	}
-	mappings, err := a.store.ListContainerMappings(store.ExternalProviderTodoist)
-	if err != nil {
-		return "", nil, err
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	syncedCount := 0
 	for _, account := range accounts {
-		client, err := todoistClientForAccount(account)
+		count, err := a.syncTodoistAccount(ctx, account)
 		if err != nil {
 			return "", nil, err
 		}
-		projects, err := client.ListProjects(ctx)
-		if err != nil {
-			return "", nil, err
-		}
-		projectNames := todoistProjectNameByID(projects)
-		tasks, err := client.ListTasks(ctx, todoist.ListTasksOptions{})
-		if err != nil {
-			return "", nil, err
-		}
-		for _, task := range tasks {
-			if _, err := a.persistTodoistTask(account, task, mappings, projectNames); err != nil {
-				return "", nil, err
-			}
-			syncedCount++
-		}
+		syncedCount += count
 	}
 
 	return fmt.Sprintf("Synced %d Todoist task(s).", syncedCount), map[string]interface{}{
 		"type":  "sync_todoist",
 		"count": syncedCount,
 	}, nil
+}
+
+func (a *App) syncTodoistAccount(ctx context.Context, account store.ExternalAccount) (int, error) {
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderTodoist)
+	if err != nil {
+		return 0, err
+	}
+	client, err := todoistClientForAccount(account)
+	if err != nil {
+		return 0, err
+	}
+	projects, err := client.ListProjects(ctx)
+	if err != nil {
+		return 0, err
+	}
+	projectNames := todoistProjectNameByID(projects)
+	tasks, err := client.ListTasks(ctx, todoist.ListTasksOptions{})
+	if err != nil {
+		return 0, err
+	}
+	syncedCount := 0
+	for _, task := range tasks {
+		if _, err := a.persistTodoistTask(account, task, mappings, projectNames); err != nil {
+			return 0, err
+		}
+		syncedCount++
+	}
+	return syncedCount, nil
 }
 
 func parseTodoistTaskDraft(raw string) (string, string) {

--- a/internal/web/chat_zotero.go
+++ b/internal/web/chat_zotero.go
@@ -600,132 +600,20 @@ func (a *App) executeSyncZoteroAction() (string, map[string]interface{}, error) 
 	if err != nil {
 		return "", nil, err
 	}
-	mappings, err := a.store.ListContainerMappings(store.ExternalProviderZotero)
-	if err != nil {
-		return "", nil, err
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), zoteroSyncTimeout)
+	defer cancel()
 
 	result := zoteroSyncResult{}
 	for _, account := range accounts {
-		reader, cfg, err := zoteroReaderForAccount(account)
-		if errors.Is(err, zotero.ErrDatabaseNotFound) {
-			result.Skipped++
-			continue
-		}
+		synced, err := a.syncZoteroAccount(ctx, account)
 		if err != nil {
 			return "", nil, err
 		}
-
-		func() {
-			defer reader.Close()
-			ctx, cancel := context.WithTimeout(context.Background(), zoteroSyncTimeout)
-			defer cancel()
-
-			items, syncErr := reader.ListItems(ctx)
-			if syncErr != nil {
-				err = syncErr
-				return
-			}
-			if exportPath := strings.TrimSpace(cfg.CitationExportPath); exportPath != "" {
-				citationKeys, citationErr := reader.ResolveCitationKeys(exportPath)
-				if citationErr != nil && !errors.Is(citationErr, os.ErrNotExist) {
-					err = citationErr
-					return
-				}
-				for i := range items {
-					if key := strings.TrimSpace(citationKeys[items[i].Key]); key != "" {
-						items[i].CitationKey = key
-					}
-				}
-			}
-			collections, syncErr := reader.ListCollections(ctx)
-			if syncErr != nil {
-				err = syncErr
-				return
-			}
-			collectionNamesByKey := zoteroCollectionNamesByKey(collections)
-
-			for _, item := range items {
-				names := zoteroCollectionNames(item, collectionNamesByKey)
-				mapping, syncErr := a.zoteroCollectionMappingForAccount(account, mappings, names)
-				if syncErr != nil {
-					err = syncErr
-					return
-				}
-				inferredProjectID := a.zoteroProjectHintFromTags(item.Tags)
-				referenceArtifact, syncErr := a.upsertZoteroReferenceArtifact(account, item, names, mapping)
-				if syncErr != nil {
-					err = syncErr
-					return
-				}
-				result.ReferenceCount++
-
-				attachments, syncErr := reader.ListAttachments(ctx, item.Key)
-				if syncErr != nil {
-					err = syncErr
-					return
-				}
-				annotationByAttachment := map[string][]zotero.Annotation{}
-				for _, attachment := range attachments {
-					annotations, annErr := reader.ListAnnotations(ctx, attachment.Key)
-					if annErr != nil {
-						err = annErr
-						return
-					}
-					annotationByAttachment[strings.TrimSpace(attachment.Key)] = annotations
-				}
-
-				var readingItem *store.Item
-				if zoteroReadingItemWanted(item) {
-					allAnnotations := make([]zotero.Annotation, 0)
-					for _, annotations := range annotationByAttachment {
-						allAnnotations = append(allAnnotations, annotations...)
-					}
-					persisted, syncErr := a.persistZoteroReadingItem(account, referenceArtifact, item, mapping, inferredProjectID, allAnnotations)
-					if syncErr != nil {
-						err = syncErr
-						return
-					}
-					readingItem = &persisted
-					result.ReadingItemCount++
-				}
-
-				for _, attachment := range attachments {
-					if !strings.Contains(strings.ToLower(strings.TrimSpace(attachment.ContentType)), "pdf") {
-						continue
-					}
-					attachmentArtifact, syncErr := a.upsertZoteroAttachmentArtifact(account, reader, attachment, referenceArtifact.ID, item.Key, mapping)
-					if syncErr != nil {
-						err = syncErr
-						return
-					}
-					result.AttachmentCount++
-					if readingItem != nil {
-						if linkErr := a.store.LinkItemArtifact(readingItem.ID, attachmentArtifact.ID, "related"); linkErr != nil {
-							err = linkErr
-							return
-						}
-					}
-					for _, annotation := range annotationByAttachment[strings.TrimSpace(attachment.Key)] {
-						annotationArtifact, syncErr := a.upsertZoteroAnnotationArtifact(account, annotation, referenceArtifact.ID, item.Key, attachment.Key, mapping)
-						if syncErr != nil {
-							err = syncErr
-							return
-						}
-						result.AnnotationCount++
-						if readingItem != nil {
-							if linkErr := a.store.LinkItemArtifact(readingItem.ID, annotationArtifact.ID, "related"); linkErr != nil {
-								err = linkErr
-								return
-							}
-						}
-					}
-				}
-			}
-		}()
-		if err != nil {
-			return "", nil, err
-		}
+		result.ReferenceCount += synced.ReferenceCount
+		result.AttachmentCount += synced.AttachmentCount
+		result.AnnotationCount += synced.AnnotationCount
+		result.ReadingItemCount += synced.ReadingItemCount
+		result.Skipped += synced.Skipped
 	}
 
 	if result.ReferenceCount == 0 && result.Skipped > 0 {
@@ -752,6 +640,116 @@ func (a *App) executeSyncZoteroAction() (string, map[string]interface{}, error) 
 			"reading_items":    result.ReadingItemCount,
 			"skipped_accounts": result.Skipped,
 		}, nil
+}
+
+func (a *App) syncZoteroAccount(ctx context.Context, account store.ExternalAccount) (zoteroSyncResult, error) {
+	mappings, err := a.store.ListContainerMappings(store.ExternalProviderZotero)
+	if err != nil {
+		return zoteroSyncResult{}, err
+	}
+	reader, cfg, err := zoteroReaderForAccount(account)
+	if errors.Is(err, zotero.ErrDatabaseNotFound) {
+		return zoteroSyncResult{Skipped: 1}, nil
+	}
+	if err != nil {
+		return zoteroSyncResult{}, err
+	}
+	defer reader.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, zoteroSyncTimeout)
+	defer cancel()
+
+	items, err := reader.ListItems(ctx)
+	if err != nil {
+		return zoteroSyncResult{}, err
+	}
+	if exportPath := strings.TrimSpace(cfg.CitationExportPath); exportPath != "" {
+		citationKeys, err := reader.ResolveCitationKeys(exportPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return zoteroSyncResult{}, err
+		}
+		for i := range items {
+			if key := strings.TrimSpace(citationKeys[items[i].Key]); key != "" {
+				items[i].CitationKey = key
+			}
+		}
+	}
+	collections, err := reader.ListCollections(ctx)
+	if err != nil {
+		return zoteroSyncResult{}, err
+	}
+	collectionNamesByKey := zoteroCollectionNamesByKey(collections)
+
+	result := zoteroSyncResult{}
+	for _, item := range items {
+		names := zoteroCollectionNames(item, collectionNamesByKey)
+		mapping, err := a.zoteroCollectionMappingForAccount(account, mappings, names)
+		if err != nil {
+			return zoteroSyncResult{}, err
+		}
+		inferredProjectID := a.zoteroProjectHintFromTags(item.Tags)
+		referenceArtifact, err := a.upsertZoteroReferenceArtifact(account, item, names, mapping)
+		if err != nil {
+			return zoteroSyncResult{}, err
+		}
+		result.ReferenceCount++
+
+		attachments, err := reader.ListAttachments(ctx, item.Key)
+		if err != nil {
+			return zoteroSyncResult{}, err
+		}
+		annotationByAttachment := map[string][]zotero.Annotation{}
+		for _, attachment := range attachments {
+			annotations, err := reader.ListAnnotations(ctx, attachment.Key)
+			if err != nil {
+				return zoteroSyncResult{}, err
+			}
+			annotationByAttachment[strings.TrimSpace(attachment.Key)] = annotations
+		}
+
+		var readingItem *store.Item
+		if zoteroReadingItemWanted(item) {
+			allAnnotations := make([]zotero.Annotation, 0)
+			for _, annotations := range annotationByAttachment {
+				allAnnotations = append(allAnnotations, annotations...)
+			}
+			persisted, err := a.persistZoteroReadingItem(account, referenceArtifact, item, mapping, inferredProjectID, allAnnotations)
+			if err != nil {
+				return zoteroSyncResult{}, err
+			}
+			readingItem = &persisted
+			result.ReadingItemCount++
+		}
+
+		for _, attachment := range attachments {
+			if !strings.Contains(strings.ToLower(strings.TrimSpace(attachment.ContentType)), "pdf") {
+				continue
+			}
+			attachmentArtifact, err := a.upsertZoteroAttachmentArtifact(account, reader, attachment, referenceArtifact.ID, item.Key, mapping)
+			if err != nil {
+				return zoteroSyncResult{}, err
+			}
+			result.AttachmentCount++
+			if readingItem != nil {
+				if err := a.store.LinkItemArtifact(readingItem.ID, attachmentArtifact.ID, "related"); err != nil {
+					return zoteroSyncResult{}, err
+				}
+			}
+			for _, annotation := range annotationByAttachment[strings.TrimSpace(attachment.Key)] {
+				annotationArtifact, err := a.upsertZoteroAnnotationArtifact(account, annotation, referenceArtifact.ID, item.Key, attachment.Key, mapping)
+				if err != nil {
+					return zoteroSyncResult{}, err
+				}
+				result.AnnotationCount++
+				if readingItem != nil {
+					if err := a.store.LinkItemArtifact(readingItem.ID, annotationArtifact.ID, "related"); err != nil {
+						return zoteroSyncResult{}, err
+					}
+				}
+			}
+		}
+	}
+	return result, nil
 }
 
 func (a *App) executeZoteroAction(action *SystemAction) (string, map[string]interface{}, error) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -81,7 +81,8 @@ type App struct {
 	hookProviders                 []plugins.HookProvider
 	devRuntime                    bool
 
-	store *store.Store
+	store      *store.Store
+	sourceSync sourceSyncRunner
 
 	appServerClient *appserver.Client
 
@@ -267,6 +268,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		hookProviders:                 buildHookProviders(extensionHost, pluginManager),
 		devRuntime:                    devRuntime,
 		store:                         s,
+		sourceSync:                    nil,
 		appServerClient:               appServerClient,
 		upgrader:                      websocket.Upgrader{CheckOrigin: checkWSOrigin},
 		hub:                           newWSHub(),
@@ -299,7 +301,9 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		_ = s.Close()
 		return nil, err
 	}
+	app.sourceSync = app.newSourceSyncRunner()
 	app.startItemResurfacer()
+	app.startSourcePoller()
 	return app, nil
 }
 

--- a/internal/web/source_poller.go
+++ b/internal/web/source_poller.go
@@ -1,0 +1,274 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+	tabsync "github.com/krystophny/tabura/internal/sync"
+)
+
+const (
+	sourceSyncDefaultInterval = 5 * time.Minute
+	sourceSyncStaleAfter      = 24 * time.Hour
+	sourceSyncCommandTimeout  = 45 * time.Second
+)
+
+type sourceSyncRunner interface {
+	RunOnce(ctx context.Context) (tabsync.RunResult, error)
+	RunNow(ctx context.Context) (tabsync.RunResult, error)
+}
+
+type accountSyncProvider struct {
+	name        string
+	syncAccount func(context.Context, store.ExternalAccount) (int, error)
+	onSynced    func(store.ExternalAccount, int)
+}
+
+func (p *accountSyncProvider) Name() string {
+	return p.name
+}
+
+func (p *accountSyncProvider) Sync(ctx context.Context, account store.ExternalAccount, _ tabsync.Sink) error {
+	if p == nil || p.syncAccount == nil {
+		return nil
+	}
+	count, err := p.syncAccount(ctx, account)
+	if err != nil {
+		return err
+	}
+	if count > 0 && p.onSynced != nil {
+		p.onSynced(account, count)
+	}
+	return nil
+}
+
+func parseInlineSourceSyncIntent(text string) *SystemAction {
+	switch normalizeItemCommandText(text) {
+	case "sync now", "sync all", "sync everything", "sync all sources":
+		return &SystemAction{Action: "sync_sources", Params: map[string]interface{}{}}
+	default:
+		return nil
+	}
+}
+
+func sourceSyncActionFailurePrefix(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "sync_sources":
+		return "I couldn't sync external sources: "
+	default:
+		return "I couldn't sync external sources: "
+	}
+}
+
+func (a *App) newSourceSyncRunner() sourceSyncRunner {
+	if a == nil || a.store == nil {
+		return nil
+	}
+	engine := tabsync.NewEngine(a.store, a.store, nil, tabsync.Options{
+		DefaultInterval: sourceSyncDefaultInterval,
+		StaleAfter:      sourceSyncStaleAfter,
+	})
+	for _, provider := range []*accountSyncProvider{
+		{
+			name:        store.ExternalProviderTodoist,
+			syncAccount: a.syncTodoistAccount,
+			onSynced:    a.handleSourceSyncCount,
+		},
+		{
+			name: store.ExternalProviderEvernote,
+			syncAccount: func(ctx context.Context, account store.ExternalAccount) (int, error) {
+				result, err := a.syncEvernoteAccount(ctx, account)
+				return result.NoteCount + result.TaskCount, err
+			},
+			onSynced: a.handleSourceSyncCount,
+		},
+		{
+			name: store.ExternalProviderBear,
+			syncAccount: func(ctx context.Context, account store.ExternalAccount) (int, error) {
+				result, err := a.syncBearAccount(ctx, account)
+				return result.NoteCount, err
+			},
+			onSynced: a.handleSourceSyncCount,
+		},
+		{
+			name: store.ExternalProviderZotero,
+			syncAccount: func(ctx context.Context, account store.ExternalAccount) (int, error) {
+				result, err := a.syncZoteroAccount(ctx, account)
+				return result.ReferenceCount + result.AttachmentCount + result.AnnotationCount + result.ReadingItemCount, err
+			},
+			onSynced: a.handleSourceSyncCount,
+		},
+	} {
+		engine.Register(provider)
+	}
+	return engine
+}
+
+func (a *App) handleSourceSyncCount(account store.ExternalAccount, count int) {
+	if a == nil || count <= 0 {
+		return
+	}
+	a.broadcastItemsIngested(count, account.Provider)
+}
+
+func (a *App) startSourcePoller() {
+	if a == nil || a.shutdownCtx == nil || a.sourceSync == nil {
+		return
+	}
+	a.workerWG.Add(1)
+	go func() {
+		defer a.workerWG.Done()
+		a.runSourcePoller(a.shutdownCtx)
+	}()
+}
+
+func (a *App) runSourcePoller(ctx context.Context) {
+	if a == nil || a.sourceSync == nil {
+		return
+	}
+	for {
+		result, err := a.sourceSync.RunOnce(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("source poller: %v", err)
+			if err := sleepSourcePoller(ctx, sourceSyncDefaultInterval); err != nil {
+				return
+			}
+			continue
+		}
+		if err := sleepSourcePoller(ctx, nextSourceSyncDelay(result.NextDelay)); err != nil {
+			return
+		}
+	}
+}
+
+func nextSourceSyncDelay(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return sourceSyncDefaultInterval
+	}
+	return delay
+}
+
+func sleepSourcePoller(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (a *App) syncSourcesNow(ctx context.Context) (tabsync.RunResult, error) {
+	if a == nil || a.sourceSync == nil {
+		return tabsync.RunResult{}, fmt.Errorf("no external source poller is configured")
+	}
+	return a.sourceSync.RunNow(ctx)
+}
+
+func summarizeSourceSyncResult(result tabsync.RunResult) string {
+	if len(result.Accounts) == 0 {
+		return "No enabled external sources were configured."
+	}
+	synced := 0
+	skipped := 0
+	failed := 0
+	for _, account := range result.Accounts {
+		switch {
+		case account.Err != nil:
+			failed++
+		case account.Skipped:
+			skipped++
+		default:
+			synced++
+		}
+	}
+	message := fmt.Sprintf("Polled %d external source account(s)", len(result.Accounts))
+	message += fmt.Sprintf("; %d synced", synced)
+	if skipped > 0 {
+		message += fmt.Sprintf(", %d skipped", skipped)
+	}
+	if failed > 0 {
+		message += fmt.Sprintf(", %d failed", failed)
+	}
+	return message + "."
+}
+
+func sourceSyncResultPayload(result tabsync.RunResult) map[string]interface{} {
+	payload := map[string]interface{}{
+		"type":          "sync_sources",
+		"account_count": len(result.Accounts),
+	}
+	accounts := make([]map[string]interface{}, 0, len(result.Accounts))
+	synced := 0
+	skipped := 0
+	failed := 0
+	for _, account := range result.Accounts {
+		entry := map[string]interface{}{
+			"account_id": account.AccountID,
+			"provider":   account.Provider,
+			"label":      account.Label,
+			"skipped":    account.Skipped,
+		}
+		if account.Reason != "" {
+			entry["reason"] = account.Reason
+		}
+		if account.Err != nil {
+			entry["error"] = account.Err.Error()
+			failed++
+		} else if account.Skipped {
+			skipped++
+		} else {
+			synced++
+		}
+		accounts = append(accounts, entry)
+	}
+	payload["synced_accounts"] = synced
+	payload["skipped_accounts"] = skipped
+	payload["failed_accounts"] = failed
+	payload["accounts"] = accounts
+	return payload
+}
+
+func (a *App) executeSourceSyncAction(_ store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	switch strings.ToLower(strings.TrimSpace(action.Action)) {
+	case "sync_sources":
+		ctx, cancel := context.WithTimeout(context.Background(), sourceSyncCommandTimeout)
+		defer cancel()
+		result, err := a.syncSourcesNow(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		return summarizeSourceSyncResult(result), sourceSyncResultPayload(result), nil
+	default:
+		return "", nil, fmt.Errorf("unsupported source sync action: %s", action.Action)
+	}
+}
+
+func (a *App) broadcastItemsIngested(count int, source string) {
+	if a == nil || count <= 0 {
+		return
+	}
+	encoded, err := json.Marshal(map[string]interface{}{
+		"type":   "items_ingested",
+		"count":  count,
+		"source": strings.TrimSpace(source),
+	})
+	if err != nil {
+		return
+	}
+	a.hub.forEachChatConn(func(conn *chatWSConn) {
+		_ = conn.writeText(encoded)
+	})
+}

--- a/internal/web/source_poller_test.go
+++ b/internal/web/source_poller_test.go
@@ -1,0 +1,144 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	tabsync "github.com/krystophny/tabura/internal/sync"
+)
+
+type stubSourceSyncRunner struct {
+	runOnceCount  int
+	runNowCount   int
+	runOnceFn     func()
+	runOnceResult tabsync.RunResult
+	runNowResult  tabsync.RunResult
+	runOnceErr    error
+	runNowErr     error
+}
+
+func (s *stubSourceSyncRunner) RunOnce(context.Context) (tabsync.RunResult, error) {
+	s.runOnceCount++
+	if s.runOnceFn != nil {
+		s.runOnceFn()
+	}
+	return s.runOnceResult, s.runOnceErr
+}
+
+func (s *stubSourceSyncRunner) RunNow(context.Context) (tabsync.RunResult, error) {
+	s.runNowCount++
+	return s.runNowResult, s.runNowErr
+}
+
+func TestSourcePollerLoopRunsRunnerUntilCanceled(t *testing.T) {
+	app := newAuthedTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := &stubSourceSyncRunner{
+		runOnceResult: tabsync.RunResult{NextDelay: 10 * time.Millisecond},
+	}
+	runner.runOnceFn = func() {
+		if runner.runOnceCount >= 2 {
+			cancel()
+		}
+	}
+	app.sourceSync = runner
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.runSourcePoller(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runSourcePoller did not stop after cancel")
+	}
+	if runner.runOnceCount < 2 {
+		t.Fatalf("runOnceCount = %d, want at least 2", runner.runOnceCount)
+	}
+}
+
+func TestSyncNowCommandForcesImmediateRun(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	app.sourceSync = &stubSourceSyncRunner{
+		runNowResult: tabsync.RunResult{
+			Accounts: []tabsync.AccountResult{
+				{AccountID: 1, Provider: "todoist", Label: "main"},
+				{AccountID: 2, Provider: "bear", Label: "notes", Skipped: true, Reason: "interval"},
+			},
+		},
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "sync now")
+	if !handled {
+		t.Fatal("expected sync now to be handled")
+	}
+	if message != "Polled 2 external source account(s); 1 synced, 1 skipped." {
+		t.Fatalf("message = %q, want poll summary", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payload count = %d, want 1", len(payloads))
+	}
+	if got := strFromAny(payloads[0]["type"]); got != "sync_sources" {
+		t.Fatalf("payload type = %q, want sync_sources", got)
+	}
+	if got := intFromAny(payloads[0]["synced_accounts"], 0); got != 1 {
+		t.Fatalf("synced_accounts = %d, want 1", got)
+	}
+	if got := intFromAny(payloads[0]["skipped_accounts"], 0); got != 1 {
+		t.Fatalf("skipped_accounts = %d, want 1", got)
+	}
+	runner, _ := app.sourceSync.(*stubSourceSyncRunner)
+	if runner.runNowCount != 1 {
+		t.Fatalf("runNowCount = %d, want 1", runner.runNowCount)
+	}
+}
+
+func TestBroadcastItemsIngestedWebsocketNotification(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	app.broadcastItemsIngested(2, "todoist")
+
+	payload := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "items_ingested")
+	if got, ok := payload["count"].(float64); !ok || int(got) != 2 {
+		t.Fatalf("items_ingested count = %#v, want 2", payload["count"])
+	}
+	if got := strFromAny(payload["source"]); got != "todoist" {
+		t.Fatalf("items_ingested source = %q, want todoist", got)
+	}
+}
+
+func TestRouterRejectsIngestEndpoint(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/ingest", map[string]any{"items": []any{}})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("POST /api/ingest status = %d, want 404", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- wire the existing `internal/sync.Engine` into app startup as a background puller
- add `sync_sources` / `sync now` plus `items_ingested` websocket broadcasts
- refactor Todoist, Evernote, Bear, and Zotero sync into account-scoped helpers reused by scheduled and manual sync

## Verification
- Pull-based polling loop runs in the web app: `go test ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 5.838s`
  Coverage: `TestSourcePollerLoopRunsRunnerUntilCanceled`
- Force-poll bypasses interval gating: `go test ./internal/sync` and `go test ./internal/web`
  Excerpts: `ok   github.com/krystophny/tabura/internal/sync (cached)`, `ok   github.com/krystophny/tabura/internal/web 5.838s`
  Coverage: `TestEngineRunNowIgnoresIntervals`, `TestSyncNowCommandForcesImmediateRun`
- Poll intervals remain config-driven: `go test ./internal/sync`
  Excerpt: `ok   github.com/krystophny/tabura/internal/sync (cached)`
  Coverage: `TestIntervalFromAccountConfig`
- Pull dedup still reuses existing bindings/items instead of duplicating them: `go test ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 5.838s`
  Coverage: `TestClassifyAndExecuteSystemActionSyncTodoistRemapUpdatesExistingItem`
- No inbound ingest endpoint exists: `go test ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 5.838s`
  Coverage: `TestRouterRejectsIngestEndpoint`
- New-item notifications are pushed over websocket: `go test ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 5.838s`
  Coverage: `TestBroadcastItemsIngestedWebsocketNotification`
