### PR TITLE
fix: for bug reports save user browser agent OS etc. details too (fixes #371)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -421,6 +421,11 @@ func bugReportIssueBody(bundle bugReportBundle, bundlePath string) string {
 			b.WriteString(line)
 		}
 	}
+	if deviceJSON := bugReportJSON(bundle.Device); deviceJSON != "" {
+		b.WriteString("\n## Device\n\n```json\n")
+		b.WriteString(deviceJSON)
+		b.WriteString("\n```\n")
+	}
 	if len(bundle.RecentEvents) > 0 {
 		b.WriteString("\n## Recent events\n\n")
 		for _, event := range bundle.RecentEvents {
@@ -451,6 +456,17 @@ func bugReportContextLine(label, value string) string {
 		return ""
 	}
 	return fmt.Sprintf("- %s: `%s`\n", label, clean)
+}
+
+func bugReportJSON(value any) string {
+	if value == nil {
+		return ""
+	}
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil || string(encoded) == "null" {
+		return ""
+	}
+	return string(encoded)
 }
 
 func decodeBugReportDataURL(raw string) (bugReportFile, error) {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -50,17 +50,26 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	}
 
 	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
-		"trigger":             "button",
-		"timestamp":           "2026-03-08T15:04:05Z",
-		"page_url":            "http://127.0.0.1:8420/",
-		"version":             "0.1.8",
-		"boot_id":             "boot-123",
-		"started_at":          "2026-03-08T14:00:00Z",
-		"active_mode":         "pen",
-		"canvas_state":        map[string]any{"has_artifact": true, "artifact_title": "README.md"},
-		"recent_events":       []string{"tap at (12,18)", "report bug"},
-		"browser_logs":        []string{"warn: render slow"},
-		"device":              map[string]any{"ua": "Playwright", "viewport": "1280x720"},
+		"trigger":       "button",
+		"timestamp":     "2026-03-08T15:04:05Z",
+		"page_url":      "http://127.0.0.1:8420/",
+		"version":       "0.1.8",
+		"boot_id":       "boot-123",
+		"started_at":    "2026-03-08T14:00:00Z",
+		"active_mode":   "pen",
+		"canvas_state":  map[string]any{"has_artifact": true, "artifact_title": "README.md"},
+		"recent_events": []string{"tap at (12,18)", "report bug"},
+		"browser_logs":  []string{"warn: render slow"},
+		"device": map[string]any{
+			"ua":                   "Mozilla/5.0 Example",
+			"platform":             "macOS",
+			"os_version":           "14.4.0",
+			"browser_version":      "123.0.6312.59",
+			"viewport":             "1280x720",
+			"screen":               "1440x900",
+			"timezone":             "Europe/Vienna",
+			"hardware_concurrency": float64(8),
+		},
 		"note":                "The indicator froze after the tap.",
 		"voice_transcript":    "it stops responding after the second tap",
 		"screenshot_data_url": testPNGDataURL,
@@ -110,6 +119,19 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	}
 	if got := strFromAny(bundle["voice_transcript"]); got != "it stops responding after the second tap" {
 		t.Fatalf("voice_transcript = %q, want transcript to round-trip", got)
+	}
+	device, ok := bundle["device"].(map[string]any)
+	if !ok {
+		t.Fatalf("device = %#v, want object", bundle["device"])
+	}
+	if got := strFromAny(device["platform"]); got != "macOS" {
+		t.Fatalf("device.platform = %q, want %q", got, "macOS")
+	}
+	if got := strFromAny(device["os_version"]); got != "14.4.0" {
+		t.Fatalf("device.os_version = %q, want %q", got, "14.4.0")
+	}
+	if got := strFromAny(device["timezone"]); got != "Europe/Vienna" {
+		t.Fatalf("device.timezone = %q, want %q", got, "Europe/Vienna")
 	}
 	if got := strFromAny(bundle["screenshot"]); got != screenshotPath {
 		t.Fatalf("bundle screenshot = %q, want %q", got, screenshotPath)
@@ -165,7 +187,10 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		"--label p0",
 		"--title Bug report: The indicator froze after the tap",
 		"## Evidence",
+		"## Device",
 		".tabura/artifacts/bugs/",
+		"\"platform\": \"macOS\"",
+		"\"os_version\": \"14.4.0\"",
 	} {
 		if !strings.Contains(createCall, needle) {
 			t.Fatalf("create call = %q, missing %q", createCall, needle)

--- a/internal/web/static/app-bug-report.js
+++ b/internal/web/static/app-bug-report.js
@@ -275,12 +275,78 @@ function buildCanvasState() {
   };
 }
 
-function buildDeviceState() {
+function cleanStringList(values) {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => safeText(value))
+    .filter(Boolean);
+}
+
+function normalizeBrandList(brands) {
+  if (!Array.isArray(brands)) return [];
+  return brands
+    .map((entry) => {
+      const brand = safeText(entry?.brand);
+      const version = safeText(entry?.version);
+      if (!brand && !version) return null;
+      return { brand, version };
+    })
+    .filter(Boolean);
+}
+
+async function readUserAgentData() {
+  const userAgentData = navigator.userAgentData;
+  if (!userAgentData || typeof userAgentData !== 'object') {
+    return {};
+  }
+  const device = {
+    mobile: Boolean(userAgentData.mobile),
+    brands: normalizeBrandList(userAgentData.brands),
+    platform: safeText(userAgentData.platform),
+  };
+  if (typeof userAgentData.getHighEntropyValues === 'function') {
+    try {
+      const detail = await userAgentData.getHighEntropyValues([
+        'architecture',
+        'fullVersionList',
+        'model',
+        'platformVersion',
+        'uaFullVersion',
+      ]);
+      device.architecture = safeText(detail?.architecture);
+      device.full_version_list = normalizeBrandList(detail?.fullVersionList);
+      device.model = safeText(detail?.model);
+      device.os_version = safeText(detail?.platformVersion);
+      device.browser_version = safeText(detail?.uaFullVersion);
+    } catch (_) {}
+  }
+  return device;
+}
+
+async function buildDeviceState() {
+  const uaData = await readUserAgentData();
+  const timeZone = safeText(Intl.DateTimeFormat().resolvedOptions?.().timeZone);
   return {
     ua: safeText(navigator.userAgent),
-    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    platform: safeText(uaData.platform || navigator.platform),
+    os_version: safeText(uaData.os_version),
+    architecture: safeText(uaData.architecture),
+    model: safeText(uaData.model),
+    mobile: Boolean(uaData.mobile),
+    brands: normalizeBrandList(uaData.brands),
+    full_version_list: normalizeBrandList(uaData.full_version_list),
+    browser_version: safeText(uaData.browser_version),
+    vendor: safeText(navigator.vendor),
     language: safeText(navigator.language),
+    languages: cleanStringList(navigator.languages),
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    screen: `${window.screen?.width || 0}x${window.screen?.height || 0}`,
+    color_depth: Number(window.screen?.colorDepth || 0),
     pixel_ratio: window.devicePixelRatio || 1,
+    timezone: timeZone,
+    hardware_concurrency: Number(navigator.hardwareConcurrency || 0),
+    device_memory_gb: Number(navigator.deviceMemory || 0),
+    max_touch_points: Number(navigator.maxTouchPoints || 0),
   };
 }
 
@@ -539,7 +605,7 @@ async function stopBugReportVoiceNote(cancel = false) {
   } catch (_) {}
 }
 
-function snapshotBugReportContext(trigger, runtime) {
+async function snapshotBugReportContext(trigger, runtime) {
   return {
     trigger,
     timestamp: formatNow(),
@@ -551,7 +617,7 @@ function snapshotBugReportContext(trigger, runtime) {
     canvasState: buildCanvasState(),
     recentEvents: recentEvents.slice(),
     browserLogs: browserLogs.slice(),
-    device: buildDeviceState(),
+    device: await buildDeviceState(),
     screenshotDataURL: '',
     strokes: [],
     voiceTranscript: '',
@@ -561,7 +627,7 @@ function snapshotBugReportContext(trigger, runtime) {
 async function openBugReport(trigger) {
   ensureBugReportUi();
   const runtime = await fetchRuntimeMeta().catch(() => ({}));
-  const report = snapshotBugReportContext(trigger, runtime);
+  const report = await snapshotBugReportContext(trigger, runtime);
   report.screenshotDataURL = await captureViewportScreenshot();
   pendingReport = report;
   const { preview, note } = bugReportNodes();

--- a/tests/playwright/bug-report.spec.ts
+++ b/tests/playwright/bug-report.spec.ts
@@ -47,6 +47,12 @@ test.describe('bug report flow', () => {
     expect(Array.isArray(request.recent_events)).toBe(true);
     expect(request.recent_events.length).toBeGreaterThan(0);
     expect(Array.isArray(request.browser_logs)).toBe(true);
+    expect(String(request.device?.ua || '')).not.toBe('');
+    expect(String(request.device?.platform || '')).not.toBe('');
+    expect(String(request.device?.screen || '')).toMatch(/^\d+x\d+$/);
+    expect(String(request.device?.timezone || '')).not.toBe('');
+    expect(Number.isFinite(Number(request.device?.hardware_concurrency))).toBe(true);
+    expect(Number.isFinite(Number(request.device?.max_touch_points))).toBe(true);
     await expect(page.locator('#bug-report-sheet')).toBeHidden();
     await expect(page.locator('#canvas-text')).toContainText('Bug report filed');
     await expect(page.locator('#canvas-text')).toContainText('#77');


### PR DESCRIPTION
## Summary
- Capture richer browser/device metadata in bug-report payloads, including platform, OS version, screen, timezone, and hardware details.
- Persist that metadata in the saved bug bundle and include a `## Device` JSON block in the created GitHub issue body.
- Extend backend and Playwright coverage so the bug-report flow now proves those fields are captured and saved.

## Verification
- Browser agent/OS/device metadata capture: `./scripts/playwright.sh tests/playwright/bug-report.spec.ts` -> `✓ 1 [chromium] › tests/playwright/bug-report.spec.ts:18:7 › bug report flow › floating button captures a bundle with notes and annotations (408ms)`; this spec now asserts `request.device.ua`, `platform`, `screen`, `timezone`, `hardware_concurrency`, and `max_touch_points`.
- Saved bundle keeps the new details: `go test ./internal/web -run 'TestHandleBugReportCreate(WritesBundleUnderWorkspaceArtifacts|RequiresWorkspaceContext|UsesLocalProjectFallback)$'` -> `ok   github.com/krystophny/tabura/internal/web\t0.052s`; the test asserts the saved bundle path stays under `.tabura/artifacts/bugs/...` and that `device.platform`, `device.os_version`, and `device.timezone` round-trip into `bundle.json`.\n- GitHub issue evidence includes the device block: `go test ./internal/web -run 'TestHandleBugReportCreate(WritesBundleUnderWorkspaceArtifacts|RequiresWorkspaceContext|UsesLocalProjectFallback)$'` -> `ok   github.com/krystophny/tabura/internal/web\t0.052s`; the mocked `gh issue create` body is asserted to contain `## Device`, `"platform": "macOS"`, and `"os_version": "14.4.0"`.\n- Bug-report UI regression coverage stays green: `./scripts/playwright.sh tests/playwright/bug-report.spec.ts` -> `4 passed (2.6s)`.\n