### PR TITLE
fix: epic: Bear notes integration (fixes #262)

### DIFF
--- a/internal/web/chat_bear.go
+++ b/internal/web/chat_bear.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -189,6 +190,15 @@ func bearNoteTitle(note bear.Note) string {
 	return fmt.Sprintf("Bear note %s", strings.TrimSpace(note.ID))
 }
 
+func bearNoteRefURL(note bear.Note) *string {
+	noteID := strings.TrimSpace(note.ID)
+	if noteID == "" {
+		return nil
+	}
+	value := "bear://x-callback-url/open-note?id=" + url.QueryEscape(noteID)
+	return &value
+}
+
 func (a *App) upsertBearArtifact(account store.ExternalAccount, note bear.Note, mapping *store.ExternalContainerMapping) (store.Artifact, error) {
 	metaJSON, err := bearNoteArtifactMeta(note)
 	if err != nil {
@@ -196,12 +206,14 @@ func (a *App) upsertBearArtifact(account store.ExternalAccount, note bear.Note, 
 	}
 	kind := store.ArtifactKindMarkdown
 	title := bearNoteTitle(note)
+	refURL := bearNoteRefURL(note)
 	remoteID := strings.TrimSpace(note.ID)
 
 	if binding, err := a.store.GetBindingByRemote(account.ID, store.ExternalProviderBear, "note", remoteID); err == nil {
 		if binding.ArtifactID != nil {
 			err = a.store.UpdateArtifact(*binding.ArtifactID, store.ArtifactUpdate{
 				Kind:     &kind,
+				RefURL:   refURL,
 				Title:    optionalTrimmedString(title),
 				MetaJSON: metaJSON,
 			})
@@ -232,7 +244,7 @@ func (a *App) upsertBearArtifact(account store.ExternalAccount, note bear.Note, 
 		return store.Artifact{}, err
 	}
 
-	artifact, err := a.store.CreateArtifact(kind, nil, nil, optionalTrimmedString(title), metaJSON)
+	artifact, err := a.store.CreateArtifact(kind, nil, refURL, optionalTrimmedString(title), metaJSON)
 	if err != nil {
 		return store.Artifact{}, err
 	}

--- a/internal/web/chat_bear_test.go
+++ b/internal/web/chat_bear_test.go
@@ -7,10 +7,24 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/krystophny/tabura/internal/bear"
 	"github.com/krystophny/tabura/internal/store"
 
 	_ "modernc.org/sqlite"
 )
+
+func TestBearNoteRefURL(t *testing.T) {
+	noteURL := bearNoteRefURL(bear.Note{ID: "note id/1"})
+	if noteURL == nil {
+		t.Fatal("bearNoteRefURL() = nil, want URL")
+	}
+	if *noteURL != "bear://x-callback-url/open-note?id=note+id%2F1" {
+		t.Fatalf("bearNoteRefURL() = %q", *noteURL)
+	}
+	if bearNoteRefURL(bear.Note{}) != nil {
+		t.Fatal("bearNoteRefURL() for empty id should be nil")
+	}
+}
 
 func TestParseInlineBearIntent(t *testing.T) {
 	action := parseInlineBearIntent("sync bear")
@@ -86,6 +100,9 @@ func TestClassifyAndExecuteSystemActionSyncBear(t *testing.T) {
 	}
 	if artifact.Kind != store.ArtifactKindMarkdown {
 		t.Fatalf("artifact.Kind = %q, want markdown", artifact.Kind)
+	}
+	if artifact.RefURL == nil || *artifact.RefURL != "bear://x-callback-url/open-note?id=note-1" {
+		t.Fatalf("artifact.RefURL = %v, want Bear open-note callback", artifact.RefURL)
 	}
 	var meta bearNoteMeta
 	if artifact.MetaJSON == nil || json.Unmarshal([]byte(*artifact.MetaJSON), &meta) != nil {


### PR DESCRIPTION
## Summary
- add Bear x-callback URLs to synced Bear note artifacts so notes can reopen in Bear
- preserve the existing Bear sync and checklist-promotion flow while covering the callback URL in tests

## Verification
- Bear notes sync as artifacts without auto-creating items: `go test ./internal/web -run 'TestBearNoteRefURL|TestClassifyAndExecuteSystemActionSyncBear|TestClassifyAndExecuteSystemActionPromoteBearChecklist' -count=1` -> `ok   github.com/krystophny/tabura/internal/web 0.038s`.
  `TestClassifyAndExecuteSystemActionSyncBear` asserts the synced artifact is `markdown`, carries `bear://x-callback-url/open-note?id=note-1`, links to the mapped workspace, and leaves item count at `0` until explicit promotion.
- Checklist promotion stays user-initiated: same command/output above.
  `TestClassifyAndExecuteSystemActionPromoteBearChecklist` verifies items are created only after the explicit `create items from this Bear note's checklist` command and that the created items bind back to the Bear note artifact.
- Bear open-note callback is available and correctly encoded: same command/output above.
  `TestBearNoteRefURL` covers Bear callback URL generation and escaping, and `TestClassifyAndExecuteSystemActionSyncBear` verifies the callback URL is persisted on the synced artifact.
