### PR TITLE
fix: add calendar view on canvas for events and item deadlines (fixes #307)

### DIFF
--- a/internal/web/chat_calendar.go
+++ b/internal/web/chat_calendar.go
@@ -1,0 +1,851 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	tabcalendar "github.com/krystophny/tabura/internal/calendar"
+	"github.com/krystophny/tabura/internal/ics"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	calendarViewDay          = "day"
+	calendarViewWeek         = "week"
+	calendarViewAgenda       = "agenda"
+	calendarViewAvailability = "availability"
+	calendarBusyLabel        = "Busy (other sphere)"
+	calendarAvailabilityFrom = 8
+	calendarAvailabilityTo   = 18
+)
+
+var (
+	calendarForPattern     = regexp.MustCompile(`(?i)^\s*(?:show|display|open)\s+(?:my\s+)?calendar\s+for\s+(.+?)\s*$`)
+	calendarTokenSanitizer = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+)
+
+type googleCalendarReader interface {
+	ListCalendars(ctx context.Context) ([]providerdata.Calendar, error)
+	GetEvents(ctx context.Context, opts tabcalendar.GetEventsOptions) ([]providerdata.Event, error)
+}
+
+type icsCalendarReader interface {
+	ListCalendars() []providerdata.Calendar
+	GetEvents(calendarName string, timeMin, timeMax time.Time) ([]ics.ICSEvent, error)
+}
+
+type calendarActionRequest struct {
+	View  string
+	Date  time.Time
+	Query string
+}
+
+type calendarEventEntry struct {
+	Summary     string
+	Description string
+	Location    string
+	Attendees   []string
+	Source      string
+	Provider    string
+	Sphere      string
+	Start       time.Time
+	End         time.Time
+	AllDay      bool
+}
+
+type calendarDeadlineEntry struct {
+	Title     string
+	Sphere    string
+	Kind      string
+	When      time.Time
+	Workspace string
+	Project   string
+}
+
+func parseInlineCalendarIntent(text string, now time.Time) *SystemAction {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	normalized := normalizeItemCommandText(trimmed)
+	switch normalized {
+	case "show calendar", "show my calendar", "show my schedule", "show schedule":
+		return &SystemAction{
+			Action: "show_calendar",
+			Params: map[string]interface{}{"view": calendarViewDay},
+		}
+	case "what's today", "whats today", "what is today":
+		return &SystemAction{
+			Action: "show_calendar",
+			Params: map[string]interface{}{
+				"view": calendarViewAgenda,
+				"date": now.In(time.Local).Format("2006-01-02"),
+			},
+		}
+	case "what's this week", "whats this week", "what is this week":
+		return &SystemAction{
+			Action: "show_calendar",
+			Params: map[string]interface{}{
+				"view": calendarViewWeek,
+				"date": now.In(time.Local).Format("2006-01-02"),
+			},
+		}
+	case "when am i free tomorrow", "when am i available tomorrow":
+		return &SystemAction{
+			Action: "show_calendar",
+			Params: map[string]interface{}{
+				"view": calendarViewAvailability,
+				"date": now.In(time.Local).AddDate(0, 0, 1).Format("2006-01-02"),
+			},
+		}
+	}
+	if match := calendarForPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		query := strings.TrimSpace(match[1])
+		if query != "" {
+			return &SystemAction{
+				Action: "show_calendar",
+				Params: map[string]interface{}{
+					"view":  calendarViewDay,
+					"query": query,
+				},
+			}
+		}
+	}
+	return nil
+}
+
+func calendarActionFailurePrefix(string) string {
+	return "I couldn't build the calendar view: "
+}
+
+func (a *App) executeCalendarAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	if a == nil || action == nil {
+		return "", nil, fmt.Errorf("calendar action is required")
+	}
+	req, err := a.parseCalendarActionRequest(action)
+	if err != nil {
+		return "", nil, err
+	}
+	activeSphere, err := a.store.ActiveSphere()
+	if err != nil || strings.TrimSpace(activeSphere) == "" {
+		activeSphere = store.SpherePrivate
+	}
+
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	cwd := strings.TrimSpace(targetProject.RootPath)
+	if cwd == "" {
+		cwd = strings.TrimSpace(a.cwdForProjectKey(targetProject.ProjectKey))
+	}
+	if cwd == "" {
+		return "", nil, fmt.Errorf("calendar view cwd is not available")
+	}
+
+	events, warnings, err := a.collectCalendarEvents(context.Background(), req, activeSphere)
+	if err != nil {
+		return "", nil, err
+	}
+	deadlines, err := a.collectCalendarDeadlines(req)
+	if err != nil {
+		return "", nil, err
+	}
+	content := renderCalendarMarkdown(req, activeSphere, events, deadlines, warnings)
+
+	pathSeed := []string{req.Date.In(time.Local).Format("2006-01-02"), req.View}
+	if strings.TrimSpace(req.Query) != "" {
+		pathSeed = append(pathSeed, sanitizeCalendarFileToken(req.Query))
+	}
+	relativePath := filepath.ToSlash(filepath.Join(".tabura", "artifacts", "calendar", strings.Join(pathSeed, "-")+".md"))
+	absPath, canvasTitle, err := resolveCanvasFilePath(cwd, relativePath)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return "", nil, err
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		return "", nil, err
+	}
+
+	artifactTitle := calendarArtifactTitle(req)
+	metaJSON := calendarArtifactMeta(req, activeSphere, len(events), len(deadlines), warnings)
+	artifact, err := a.store.CreateArtifact(store.ArtifactKind("calendar_view"), &absPath, nil, &artifactTitle, &metaJSON)
+	if err != nil {
+		return "", nil, err
+	}
+	if workspace, workspaceErr := a.store.ActiveWorkspace(); workspaceErr == nil {
+		_ = a.store.LinkArtifactToWorkspace(workspace.ID, artifact.ID)
+	}
+
+	canvasSessionID := strings.TrimSpace(a.canvasSessionIDForProject(targetProject))
+	if canvasSessionID == "" {
+		return "", nil, fmt.Errorf("canvas session is not available")
+	}
+	port, ok := a.tunnels.getPort(canvasSessionID)
+	if !ok {
+		return "", nil, fmt.Errorf("no active MCP tunnel for project %q", targetProject.Name)
+	}
+	if _, err := a.mcpToolsCall(port, "canvas_artifact_show", map[string]interface{}{
+		"session_id":       canvasSessionID,
+		"kind":             "text",
+		"title":            canvasTitle,
+		"markdown_or_text": content,
+	}); err != nil {
+		return "", nil, err
+	}
+	a.markProjectOutput(targetProject.ProjectKey)
+
+	return fmt.Sprintf("Opened %s on canvas.", artifactTitle), map[string]interface{}{
+		"type":           "show_calendar",
+		"artifact_id":    artifact.ID,
+		"path":           canvasTitle,
+		"view":           req.View,
+		"date":           req.Date.In(time.Local).Format("2006-01-02"),
+		"query":          req.Query,
+		"event_count":    len(events),
+		"deadline_count": len(deadlines),
+		"warnings":       warnings,
+	}, nil
+}
+
+func (a *App) parseCalendarActionRequest(action *SystemAction) (calendarActionRequest, error) {
+	now := time.Now()
+	if a != nil && a.calendarNow != nil {
+		now = a.calendarNow()
+	}
+	req := calendarActionRequest{
+		View:  strings.ToLower(calendarOptionalParam(action.Params, "view")),
+		Date:  now.In(time.Local),
+		Query: calendarOptionalParam(action.Params, "query"),
+	}
+	switch req.View {
+	case "", calendarViewDay:
+		req.View = calendarViewDay
+	case calendarViewWeek, calendarViewAgenda, calendarViewAvailability:
+	default:
+		return calendarActionRequest{}, fmt.Errorf("unsupported calendar view %q", req.View)
+	}
+	if rawDate := calendarOptionalParam(action.Params, "date"); rawDate != "" {
+		parsed, err := time.ParseInLocation("2006-01-02", rawDate, time.Local)
+		if err != nil {
+			return calendarActionRequest{}, fmt.Errorf("calendar date must be YYYY-MM-DD")
+		}
+		req.Date = parsed
+	}
+	return req, nil
+}
+
+func (a *App) collectCalendarEvents(ctx context.Context, req calendarActionRequest, activeSphere string) ([]calendarEventEntry, []string, error) {
+	timeMin, timeMax := calendarTimeRange(req)
+	var (
+		events   []calendarEventEntry
+		warnings []string
+	)
+	googleEvents, googleWarnings, err := a.collectGoogleCalendarEvents(ctx, req, activeSphere, timeMin, timeMax)
+	if err != nil {
+		return nil, nil, err
+	}
+	events = append(events, googleEvents...)
+	warnings = append(warnings, googleWarnings...)
+	icsEvents, icsWarnings, err := a.collectICSEvents(req, activeSphere, timeMin, timeMax)
+	if err != nil {
+		return nil, nil, err
+	}
+	events = append(events, icsEvents...)
+	warnings = append(warnings, icsWarnings...)
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].Start.Equal(events[j].Start) {
+			if events[i].Sphere == events[j].Sphere {
+				return strings.ToLower(events[i].Summary) < strings.ToLower(events[j].Summary)
+			}
+			return events[i].Sphere < events[j].Sphere
+		}
+		return events[i].Start.Before(events[j].Start)
+	})
+	return events, warnings, nil
+}
+
+func (a *App) collectGoogleCalendarEvents(ctx context.Context, req calendarActionRequest, activeSphere string, timeMin, timeMax time.Time) ([]calendarEventEntry, []string, error) {
+	accounts, err := a.store.ListExternalAccountsByProvider(store.ExternalProviderGoogleCalendar)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(accounts) == 0 || a.newGoogleCalendarReader == nil {
+		return nil, nil, nil
+	}
+	reader, err := a.newGoogleCalendarReader(ctx)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("Google Calendar unavailable: %v", err)}, nil
+	}
+	calendars, err := reader.ListCalendars(ctx)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("Google Calendar list failed: %v", err)}, nil
+	}
+	var (
+		events   []calendarEventEntry
+		warnings []string
+	)
+	for _, cal := range calendars {
+		providerSphere := a.resolveCalendarSphere(store.ExternalProviderGoogleCalendar, cal.ID, cal.Name, activeSphere, accounts)
+		calEvents, eventErr := reader.GetEvents(ctx, tabcalendar.GetEventsOptions{
+			CalendarID: cal.ID,
+			TimeMin:    timeMin,
+			TimeMax:    timeMax,
+			MaxResults: 250,
+			Query:      strings.TrimSpace(req.Query),
+		})
+		if eventErr != nil {
+			warnings = append(warnings, fmt.Sprintf("Google Calendar %q failed: %v", cal.Name, eventErr))
+			continue
+		}
+		for _, event := range calEvents {
+			entry := calendarEventEntry{
+				Summary:     strings.TrimSpace(event.Summary),
+				Description: strings.TrimSpace(event.Description),
+				Location:    strings.TrimSpace(event.Location),
+				Attendees:   append([]string(nil), event.Attendees...),
+				Source:      firstNonEmptyCalendarValue(cal.Name, cal.ID, "Google Calendar"),
+				Provider:    store.ExternalProviderGoogleCalendar,
+				Sphere:      providerSphere,
+				Start:       event.Start.In(time.Local),
+				End:         event.End.In(time.Local),
+				AllDay:      event.AllDay,
+			}
+			if !matchesCalendarQuery(req.Query, entry, "") {
+				continue
+			}
+			events = append(events, entry)
+		}
+	}
+	return events, warnings, nil
+}
+
+func (a *App) collectICSEvents(req calendarActionRequest, activeSphere string, timeMin, timeMax time.Time) ([]calendarEventEntry, []string, error) {
+	if a == nil || a.newICSCalendarReader == nil {
+		return nil, nil, nil
+	}
+	reader, err := a.newICSCalendarReader()
+	if err != nil {
+		return nil, []string{fmt.Sprintf("ICS calendars unavailable: %v", err)}, nil
+	}
+	accounts, err := a.store.ListExternalAccountsByProvider(store.ExternalProviderICS)
+	if err != nil {
+		return nil, nil, err
+	}
+	var (
+		events   []calendarEventEntry
+		warnings []string
+	)
+	for _, cal := range reader.ListCalendars() {
+		providerSphere := a.resolveCalendarSphere(store.ExternalProviderICS, cal.ID, cal.Name, activeSphere, accounts)
+		calEvents, eventErr := reader.GetEvents(cal.Name, timeMin, timeMax)
+		if eventErr != nil {
+			warnings = append(warnings, fmt.Sprintf("ICS calendar %q failed: %v", cal.Name, eventErr))
+			continue
+		}
+		for _, event := range calEvents {
+			entry := calendarEventEntry{
+				Summary:     strings.TrimSpace(event.Summary),
+				Description: strings.TrimSpace(event.Description),
+				Location:    strings.TrimSpace(event.Location),
+				Source:      firstNonEmptyCalendarValue(cal.Name, cal.ID, "ICS"),
+				Provider:    store.ExternalProviderICS,
+				Sphere:      providerSphere,
+				Start:       event.Start.In(time.Local),
+				End:         event.End.In(time.Local),
+				AllDay:      event.AllDay,
+			}
+			if !matchesCalendarQuery(req.Query, entry, "") {
+				continue
+			}
+			events = append(events, entry)
+		}
+	}
+	return events, warnings, nil
+}
+
+func (a *App) resolveCalendarSphere(provider, calendarID, calendarName, fallback string, accounts []store.ExternalAccount) string {
+	for _, ref := range []string{calendarID, calendarName} {
+		if strings.TrimSpace(ref) == "" {
+			continue
+		}
+		mapping, err := a.store.GetContainerMapping(provider, "calendar", ref)
+		if err != nil {
+			continue
+		}
+		if mapping.Sphere != nil && strings.TrimSpace(*mapping.Sphere) != "" {
+			return strings.TrimSpace(*mapping.Sphere)
+		}
+		if mapping.WorkspaceID != nil {
+			workspace, workspaceErr := a.store.GetWorkspace(*mapping.WorkspaceID)
+			if workspaceErr == nil && strings.TrimSpace(workspace.Sphere) != "" {
+				return workspace.Sphere
+			}
+		}
+	}
+	for _, account := range accounts {
+		if strings.EqualFold(strings.TrimSpace(account.Label), strings.TrimSpace(calendarName)) ||
+			strings.EqualFold(strings.TrimSpace(account.Label), strings.TrimSpace(calendarID)) {
+			return account.Sphere
+		}
+	}
+	if len(accounts) == 1 && strings.TrimSpace(accounts[0].Sphere) != "" {
+		return accounts[0].Sphere
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return fallback
+	}
+	return store.SpherePrivate
+}
+
+func (a *App) collectCalendarDeadlines(req calendarActionRequest) ([]calendarDeadlineEntry, error) {
+	items, err := a.store.ListItems()
+	if err != nil {
+		return nil, err
+	}
+	timeMin, timeMax := calendarTimeRange(req)
+	workspaceNames := map[int64]string{}
+	projectNames := map[string]string{}
+	var deadlines []calendarDeadlineEntry
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item.State), store.ItemStateDone) {
+			continue
+		}
+		if item.FollowUpAt != nil {
+			when, parseErr := parseCalendarTimestamp(*item.FollowUpAt)
+			if parseErr == nil && !when.Before(timeMin) && when.Before(timeMax) {
+				entry := calendarDeadlineEntry{
+					Title:     item.Title,
+					Sphere:    item.Sphere,
+					Kind:      "Due",
+					When:      when.In(time.Local),
+					Workspace: calendarWorkspaceName(a, item.WorkspaceID, workspaceNames),
+					Project:   calendarProjectName(a, item.ProjectID, projectNames),
+				}
+				if matchesCalendarQuery(req.Query, calendarEventEntry{}, calendarDeadlineSearchText(entry)) {
+					deadlines = append(deadlines, entry)
+				}
+			}
+		}
+		if item.VisibleAfter != nil {
+			when, parseErr := parseCalendarTimestamp(*item.VisibleAfter)
+			if parseErr == nil && !when.Before(timeMin) && when.Before(timeMax) {
+				entry := calendarDeadlineEntry{
+					Title:     item.Title,
+					Sphere:    item.Sphere,
+					Kind:      "Resurface",
+					When:      when.In(time.Local),
+					Workspace: calendarWorkspaceName(a, item.WorkspaceID, workspaceNames),
+					Project:   calendarProjectName(a, item.ProjectID, projectNames),
+				}
+				if matchesCalendarQuery(req.Query, calendarEventEntry{}, calendarDeadlineSearchText(entry)) {
+					deadlines = append(deadlines, entry)
+				}
+			}
+		}
+	}
+	sort.Slice(deadlines, func(i, j int) bool {
+		if deadlines[i].When.Equal(deadlines[j].When) {
+			if deadlines[i].Kind == deadlines[j].Kind {
+				return strings.ToLower(deadlines[i].Title) < strings.ToLower(deadlines[j].Title)
+			}
+			return deadlines[i].Kind < deadlines[j].Kind
+		}
+		return deadlines[i].When.Before(deadlines[j].When)
+	})
+	return deadlines, nil
+}
+
+func renderCalendarMarkdown(req calendarActionRequest, activeSphere string, events []calendarEventEntry, deadlines []calendarDeadlineEntry, warnings []string) string {
+	switch req.View {
+	case calendarViewWeek:
+		return renderCalendarRangeMarkdown(req, activeSphere, events, deadlines, warnings, 7)
+	case calendarViewAgenda:
+		return renderCalendarRangeMarkdown(req, activeSphere, events, deadlines, warnings, 1)
+	case calendarViewAvailability:
+		return renderCalendarAvailabilityMarkdown(req, activeSphere, events, deadlines, warnings)
+	default:
+		return renderCalendarRangeMarkdown(req, activeSphere, events, deadlines, warnings, 1)
+	}
+}
+
+func renderCalendarRangeMarkdown(req calendarActionRequest, activeSphere string, events []calendarEventEntry, deadlines []calendarDeadlineEntry, warnings []string, days int) string {
+	start := req.Date.In(time.Local)
+	var b strings.Builder
+	title := "Calendar"
+	switch req.View {
+	case calendarViewWeek:
+		title = "Calendar Week"
+	case calendarViewAgenda:
+		title = "Calendar Agenda"
+	}
+	fmt.Fprintf(&b, "# %s\n\n", title)
+	fmt.Fprintf(&b, "- Active sphere: `%s`\n", activeSphere)
+	fmt.Fprintf(&b, "- Range: %s to %s\n", start.Format("Monday, January 2, 2006"), start.AddDate(0, 0, days-1).Format("Monday, January 2, 2006"))
+	if strings.TrimSpace(req.Query) != "" {
+		fmt.Fprintf(&b, "- Filter: `%s`\n", req.Query)
+	}
+	if len(warnings) > 0 {
+		fmt.Fprintf(&b, "- Source warnings: %d\n", len(warnings))
+	}
+	b.WriteString("\n")
+	for day := 0; day < days; day++ {
+		current := start.AddDate(0, 0, day)
+		dayEvents := eventsForDay(events, current)
+		dayDeadlines := deadlinesForDay(deadlines, current)
+		fmt.Fprintf(&b, "## %s\n\n", current.Format("Monday, January 2"))
+		if len(dayEvents) == 0 && len(dayDeadlines) == 0 {
+			b.WriteString("_No events or item deadlines._\n\n")
+			continue
+		}
+		if len(dayEvents) > 0 {
+			b.WriteString("### Events\n\n")
+			for _, event := range dayEvents {
+				fmt.Fprintf(&b, "- %s\n", renderCalendarEventLine(event, activeSphere))
+			}
+			b.WriteString("\n")
+		}
+		if len(dayDeadlines) > 0 {
+			b.WriteString("### Item Deadlines\n\n")
+			for _, deadline := range dayDeadlines {
+				fmt.Fprintf(&b, "- %s\n", renderCalendarDeadlineLine(deadline, activeSphere))
+			}
+			b.WriteString("\n")
+		}
+	}
+	if len(warnings) > 0 {
+		b.WriteString("## Source Warnings\n\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func renderCalendarAvailabilityMarkdown(req calendarActionRequest, activeSphere string, events []calendarEventEntry, deadlines []calendarDeadlineEntry, warnings []string) string {
+	dayStart := time.Date(req.Date.Year(), req.Date.Month(), req.Date.Day(), calendarAvailabilityFrom, 0, 0, 0, time.Local)
+	dayEnd := time.Date(req.Date.Year(), req.Date.Month(), req.Date.Day(), calendarAvailabilityTo, 0, 0, 0, time.Local)
+	freeSlots := computeCalendarAvailability(events, dayStart, dayEnd)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Availability for %s\n\n", req.Date.In(time.Local).Format("Monday, January 2, 2006"))
+	fmt.Fprintf(&b, "- Active sphere: `%s`\n", activeSphere)
+	fmt.Fprintf(&b, "- Window: %s to %s\n\n", dayStart.Format("15:04"), dayEnd.Format("15:04"))
+
+	b.WriteString("## Free Slots\n\n")
+	if len(freeSlots) == 0 {
+		b.WriteString("_No free slots in the default workday window._\n\n")
+	} else {
+		for _, slot := range freeSlots {
+			fmt.Fprintf(&b, "- %s to %s\n", slot[0].Format("15:04"), slot[1].Format("15:04"))
+		}
+		b.WriteString("\n")
+	}
+
+	dayEvents := eventsForDay(events, req.Date)
+	if len(dayEvents) > 0 {
+		b.WriteString("## Busy Blocks\n\n")
+		for _, event := range dayEvents {
+			fmt.Fprintf(&b, "- %s\n", renderCalendarEventLine(event, activeSphere))
+		}
+		b.WriteString("\n")
+	}
+
+	dayDeadlines := deadlinesForDay(deadlines, req.Date)
+	if len(dayDeadlines) > 0 {
+		b.WriteString("## Item Deadlines\n\n")
+		for _, deadline := range dayDeadlines {
+			fmt.Fprintf(&b, "- %s\n", renderCalendarDeadlineLine(deadline, activeSphere))
+		}
+		b.WriteString("\n")
+	}
+	if len(warnings) > 0 {
+		b.WriteString("## Source Warnings\n\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func renderCalendarEventLine(event calendarEventEntry, activeSphere string) string {
+	label := strings.TrimSpace(event.Summary)
+	if label == "" {
+		label = "(Untitled event)"
+	}
+	if !strings.EqualFold(strings.TrimSpace(event.Sphere), strings.TrimSpace(activeSphere)) {
+		label = calendarBusyLabel
+	}
+	parts := []string{calendarTimeLabel(event.Start, event.End, event.AllDay), label}
+	if strings.EqualFold(strings.TrimSpace(event.Sphere), strings.TrimSpace(activeSphere)) {
+		if strings.TrimSpace(event.Location) != "" {
+			parts = append(parts, "@ "+event.Location)
+		}
+		if len(event.Attendees) > 0 {
+			parts = append(parts, "with "+strings.Join(event.Attendees, ", "))
+		}
+	}
+	parts = append(parts, "["+firstNonEmptyCalendarValue(event.Source, event.Provider, "calendar")+"]")
+	return strings.Join(parts, " ")
+}
+
+func renderCalendarDeadlineLine(entry calendarDeadlineEntry, activeSphere string) string {
+	title := strings.TrimSpace(entry.Title)
+	if title == "" {
+		title = "(Untitled item)"
+	}
+	if !strings.EqualFold(strings.TrimSpace(entry.Sphere), strings.TrimSpace(activeSphere)) {
+		title = fmt.Sprintf("%s item (%s)", entry.Kind, "other sphere")
+	}
+	parts := []string{entry.Kind, entry.When.Format("15:04"), title}
+	if strings.EqualFold(strings.TrimSpace(entry.Sphere), strings.TrimSpace(activeSphere)) {
+		if strings.TrimSpace(entry.Workspace) != "" {
+			parts = append(parts, "["+entry.Workspace+"]")
+		} else if strings.TrimSpace(entry.Project) != "" {
+			parts = append(parts, "["+entry.Project+"]")
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func computeCalendarAvailability(events []calendarEventEntry, dayStart, dayEnd time.Time) [][2]time.Time {
+	intervals := make([][2]time.Time, 0, len(events))
+	for _, event := range events {
+		start := event.Start
+		end := event.End
+		if event.AllDay {
+			start = dayStart
+			end = dayEnd
+		}
+		if end.Before(dayStart) || !start.Before(dayEnd) {
+			continue
+		}
+		if start.Before(dayStart) {
+			start = dayStart
+		}
+		if end.After(dayEnd) {
+			end = dayEnd
+		}
+		if !start.Before(end) {
+			continue
+		}
+		intervals = append(intervals, [2]time.Time{start, end})
+	}
+	if len(intervals) == 0 {
+		return [][2]time.Time{{dayStart, dayEnd}}
+	}
+	sort.Slice(intervals, func(i, j int) bool {
+		if intervals[i][0].Equal(intervals[j][0]) {
+			return intervals[i][1].Before(intervals[j][1])
+		}
+		return intervals[i][0].Before(intervals[j][0])
+	})
+	merged := make([][2]time.Time, 0, len(intervals))
+	for _, interval := range intervals {
+		if len(merged) == 0 {
+			merged = append(merged, interval)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if interval[0].After(last[1]) {
+			merged = append(merged, interval)
+			continue
+		}
+		if interval[1].After(last[1]) {
+			last[1] = interval[1]
+		}
+	}
+	free := make([][2]time.Time, 0, len(merged)+1)
+	cursor := dayStart
+	for _, interval := range merged {
+		if cursor.Before(interval[0]) {
+			free = append(free, [2]time.Time{cursor, interval[0]})
+		}
+		if interval[1].After(cursor) {
+			cursor = interval[1]
+		}
+	}
+	if cursor.Before(dayEnd) {
+		free = append(free, [2]time.Time{cursor, dayEnd})
+	}
+	return free
+}
+
+func calendarTimeRange(req calendarActionRequest) (time.Time, time.Time) {
+	start := time.Date(req.Date.Year(), req.Date.Month(), req.Date.Day(), 0, 0, 0, 0, time.Local)
+	days := 1
+	switch req.View {
+	case calendarViewWeek:
+		days = 7
+	case calendarViewAvailability:
+		days = 1
+	case calendarViewAgenda:
+		days = 1
+	}
+	return start, start.AddDate(0, 0, days)
+}
+
+func matchesCalendarQuery(query string, event calendarEventEntry, extra string) bool {
+	cleanQuery := strings.ToLower(strings.TrimSpace(query))
+	if cleanQuery == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{
+		event.Summary,
+		event.Description,
+		event.Location,
+		strings.Join(event.Attendees, " "),
+		event.Source,
+		event.Provider,
+		extra,
+	}, " "))
+	return strings.Contains(haystack, cleanQuery)
+}
+
+func deadlinesForDay(deadlines []calendarDeadlineEntry, day time.Time) []calendarDeadlineEntry {
+	target := day.In(time.Local).Format("2006-01-02")
+	out := make([]calendarDeadlineEntry, 0, len(deadlines))
+	for _, deadline := range deadlines {
+		if deadline.When.In(time.Local).Format("2006-01-02") == target {
+			out = append(out, deadline)
+		}
+	}
+	return out
+}
+
+func eventsForDay(events []calendarEventEntry, day time.Time) []calendarEventEntry {
+	target := day.In(time.Local).Format("2006-01-02")
+	out := make([]calendarEventEntry, 0, len(events))
+	for _, event := range events {
+		if event.Start.In(time.Local).Format("2006-01-02") == target {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+func calendarArtifactTitle(req calendarActionRequest) string {
+	base := "Calendar"
+	switch req.View {
+	case calendarViewWeek:
+		base = "Calendar Week"
+	case calendarViewAgenda:
+		base = "Calendar Agenda"
+	case calendarViewAvailability:
+		base = "Availability"
+	}
+	return fmt.Sprintf("%s %s", base, req.Date.In(time.Local).Format("2006-01-02"))
+}
+
+func calendarArtifactMeta(req calendarActionRequest, activeSphere string, eventCount, deadlineCount int, warnings []string) string {
+	payload := map[string]interface{}{
+		"view":           req.View,
+		"date":           req.Date.In(time.Local).Format("2006-01-02"),
+		"query":          req.Query,
+		"active_sphere":  activeSphere,
+		"event_count":    eventCount,
+		"deadline_count": deadlineCount,
+		"warnings":       warnings,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func sanitizeCalendarFileToken(raw string) string {
+	clean := strings.TrimSpace(strings.ToLower(raw))
+	if clean == "" {
+		return "calendar"
+	}
+	clean = calendarTokenSanitizer.ReplaceAllString(clean, "-")
+	clean = strings.Trim(clean, "-.")
+	if clean == "" {
+		return "calendar"
+	}
+	return clean
+}
+
+func calendarTimeLabel(start, end time.Time, allDay bool) string {
+	if allDay {
+		return "All day"
+	}
+	if end.IsZero() || !start.Before(end) {
+		return start.Format("15:04")
+	}
+	return start.Format("15:04") + "-" + end.Format("15:04")
+}
+
+func parseCalendarTimestamp(raw string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+}
+
+func calendarWorkspaceName(a *App, workspaceID *int64, cache map[int64]string) string {
+	if a == nil || workspaceID == nil {
+		return ""
+	}
+	if cached, ok := cache[*workspaceID]; ok {
+		return cached
+	}
+	workspace, err := a.store.GetWorkspace(*workspaceID)
+	if err != nil {
+		cache[*workspaceID] = ""
+		return ""
+	}
+	cache[*workspaceID] = workspace.Name
+	return workspace.Name
+}
+
+func calendarProjectName(a *App, projectID *string, cache map[string]string) string {
+	if a == nil || projectID == nil {
+		return ""
+	}
+	cleanID := strings.TrimSpace(*projectID)
+	if cleanID == "" {
+		return ""
+	}
+	if cached, ok := cache[cleanID]; ok {
+		return cached
+	}
+	project, err := a.store.GetProject(cleanID)
+	if err != nil {
+		cache[cleanID] = ""
+		return ""
+	}
+	cache[cleanID] = project.Name
+	return project.Name
+}
+
+func calendarDeadlineSearchText(entry calendarDeadlineEntry) string {
+	return strings.Join([]string{entry.Title, entry.Workspace, entry.Project, entry.Kind}, " ")
+}
+
+func firstNonEmptyCalendarValue(values ...string) string {
+	for _, value := range values {
+		if clean := strings.TrimSpace(value); clean != "" {
+			return clean
+		}
+	}
+	return ""
+}
+
+func calendarOptionalParam(params map[string]interface{}, key string) string {
+	clean := strings.TrimSpace(fmt.Sprint(params[key]))
+	if clean == "" || clean == "<nil>" {
+		return ""
+	}
+	return clean
+}

--- a/internal/web/chat_calendar_test.go
+++ b/internal/web/chat_calendar_test.go
@@ -1,0 +1,322 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/calendar"
+	"github.com/krystophny/tabura/internal/ics"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type stubGoogleCalendarReader struct {
+	calendars []providerdata.Calendar
+	events    map[string][]providerdata.Event
+}
+
+func (s *stubGoogleCalendarReader) ListCalendars(context.Context) ([]providerdata.Calendar, error) {
+	return append([]providerdata.Calendar(nil), s.calendars...), nil
+}
+
+func (s *stubGoogleCalendarReader) GetEvents(_ context.Context, opts calendar.GetEventsOptions) ([]providerdata.Event, error) {
+	return append([]providerdata.Event(nil), s.events[opts.CalendarID]...), nil
+}
+
+type stubICSCalendarReader struct{}
+
+func (stubICSCalendarReader) ListCalendars() []providerdata.Calendar {
+	return nil
+}
+
+func (stubICSCalendarReader) GetEvents(string, time.Time, time.Time) ([]ics.ICSEvent, error) {
+	return nil, nil
+}
+
+func TestParseInlineCalendarIntent(t *testing.T) {
+	now := time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	cases := []struct {
+		text      string
+		wantView  string
+		wantDate  string
+		wantQuery string
+	}{
+		{text: "show calendar", wantView: calendarViewDay},
+		{text: "show my schedule", wantView: calendarViewDay},
+		{text: "what's today?", wantView: calendarViewAgenda, wantDate: "2026-03-09"},
+		{text: "what's this week?", wantView: calendarViewWeek, wantDate: "2026-03-09"},
+		{text: "when am I free tomorrow?", wantView: calendarViewAvailability, wantDate: "2026-03-10"},
+		{text: "show calendar for EUROfusion", wantView: calendarViewDay, wantQuery: "EUROfusion"},
+	}
+	for _, tc := range cases {
+		action := parseInlineCalendarIntent(tc.text, now)
+		if action == nil {
+			t.Fatalf("parseInlineCalendarIntent(%q) returned nil", tc.text)
+		}
+		if action.Action != "show_calendar" {
+			t.Fatalf("action = %q, want show_calendar", action.Action)
+		}
+		if got := strings.TrimSpace(systemActionStringParam(action.Params, "view")); got != tc.wantView {
+			t.Fatalf("view = %q, want %q", got, tc.wantView)
+		}
+		if tc.wantDate != "" {
+			if got := strings.TrimSpace(systemActionStringParam(action.Params, "date")); got != tc.wantDate {
+				t.Fatalf("date = %q, want %q", got, tc.wantDate)
+			}
+		}
+		if tc.wantQuery != "" {
+			if got := strings.TrimSpace(systemActionStringParam(action.Params, "query")); got != tc.wantQuery {
+				t.Fatalf("query = %q, want %q", got, tc.wantQuery)
+			}
+		}
+	}
+}
+
+func TestClassifyAndExecuteSystemActionShowCalendarRendersSphereAwareArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+	now := time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	app.calendarNow = func() time.Time { return now }
+	app.newICSCalendarReader = func() (icsCalendarReader, error) { return stubICSCalendarReader{}, nil }
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	workWorkspace, err := app.store.CreateWorkspace("Work", project.RootPath, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(work): %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workWorkspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(work): %v", err)
+	}
+	privateDir := filepath.Join(t.TempDir(), "private")
+	if err := os.MkdirAll(privateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(private): %v", err)
+	}
+	privateWorkspace, err := app.store.CreateWorkspace("Home", privateDir, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(private): %v", err)
+	}
+	if err := app.store.SetActiveSphere(store.SphereWork); err != nil {
+		t.Fatalf("SetActiveSphere(work): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGoogleCalendar, "Work Calendar", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(work calendar): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderGoogleCalendar, "Family", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(private calendar): %v", err)
+	}
+
+	workSphere := store.SphereWork
+	privateSphere := store.SpherePrivate
+	workDue := now.Add(8 * time.Hour).Format(time.RFC3339)
+	privateDue := now.Add(9 * time.Hour).Format(time.RFC3339)
+	workVisible := now.Add(2 * time.Hour).Format(time.RFC3339)
+	if _, err := app.store.CreateItem("Prepare brief", store.ItemOptions{
+		WorkspaceID: &workWorkspace.ID,
+		Sphere:      &workSphere,
+		FollowUpAt:  &workDue,
+	}); err != nil {
+		t.Fatalf("CreateItem(work due): %v", err)
+	}
+	if _, err := app.store.CreateItem("Review backlog", store.ItemOptions{
+		WorkspaceID:  &workWorkspace.ID,
+		Sphere:       &workSphere,
+		VisibleAfter: &workVisible,
+	}); err != nil {
+		t.Fatalf("CreateItem(work resurface): %v", err)
+	}
+	if _, err := app.store.CreateItem("Buy flowers", store.ItemOptions{
+		WorkspaceID: &privateWorkspace.ID,
+		Sphere:      &privateSphere,
+		FollowUpAt:  &privateDue,
+	}); err != nil {
+		t.Fatalf("CreateItem(private due): %v", err)
+	}
+
+	app.newGoogleCalendarReader = func(context.Context) (googleCalendarReader, error) {
+		return &stubGoogleCalendarReader{
+			calendars: []providerdata.Calendar{
+				{ID: "work", Name: "Work Calendar"},
+				{ID: "family", Name: "Family"},
+			},
+			events: map[string][]providerdata.Event{
+				"work": {
+					{
+						CalendarID: "work",
+						Summary:    "Work sync",
+						Location:   "Lab",
+						Attendees:  []string{"alice@example.com"},
+						Start:      now.Add(1 * time.Hour),
+						End:        now.Add(2 * time.Hour),
+					},
+				},
+				"family": {
+					{
+						CalendarID: "family",
+						Summary:    "Design review",
+						Start:      now.Add(4 * time.Hour),
+						End:        now.Add(5 * time.Hour),
+					},
+				},
+			},
+		}, nil
+	}
+
+	var (
+		showCalls int
+		observed  map[string]interface{}
+	)
+	canvasServer := setupMockCanvasShowServer(t, &showCalls, &observed)
+	defer canvasServer.Close()
+	port, err := extractPort(canvasServer.URL)
+	if err != nil {
+		t.Fatalf("extractPort(canvas): %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show calendar")
+	if !handled {
+		t.Fatal("expected show calendar to be handled")
+	}
+	if !strings.Contains(message, "Opened Calendar 2026-03-09 on canvas.") {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payload count = %d, want 1", len(payloads))
+	}
+	if got := strFromAny(payloads[0]["type"]); got != "show_calendar" {
+		t.Fatalf("payload type = %q, want show_calendar", got)
+	}
+	if got := strFromAny(payloads[0]["view"]); got != calendarViewDay {
+		t.Fatalf("payload view = %q, want %q", got, calendarViewDay)
+	}
+	if showCalls != 1 {
+		t.Fatalf("canvas_artifact_show calls = %d, want 1", showCalls)
+	}
+	path := strFromAny(payloads[0]["path"])
+	if !strings.HasPrefix(path, ".tabura/artifacts/calendar/2026-03-09-day") {
+		t.Fatalf("payload path = %q", path)
+	}
+	rendered, err := os.ReadFile(filepath.Join(project.RootPath, path))
+	if err != nil {
+		t.Fatalf("ReadFile(rendered): %v", err)
+	}
+	content := string(rendered)
+	for _, snippet := range []string{"Work sync", "Busy (other sphere)", "Prepare brief", "Review backlog"} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("calendar artifact missing %q:\n%s", snippet, content)
+		}
+	}
+	for _, hidden := range []string{"Design review", "Buy flowers"} {
+		if strings.Contains(content, hidden) {
+			t.Fatalf("calendar artifact leaked %q:\n%s", hidden, content)
+		}
+	}
+	if got := strFromAny(observed["title"]); got != path {
+		t.Fatalf("canvas title = %q, want %q", got, path)
+	}
+	artifacts, err := app.store.ListArtifactsByKind(store.ArtifactKind("calendar_view"))
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind(calendar_view): %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("calendar_view artifacts = %d, want 1", len(artifacts))
+	}
+}
+
+func TestClassifyAndExecuteSystemActionCalendarAvailabilityUsesAllBusyBlocks(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+	now := time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	app.calendarNow = func() time.Time { return now }
+	app.newICSCalendarReader = func() (icsCalendarReader, error) { return stubICSCalendarReader{}, nil }
+	if err := app.store.SetActiveSphere(store.SphereWork); err != nil {
+		t.Fatalf("SetActiveSphere(work): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGoogleCalendar, "Work Calendar", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(work calendar): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderGoogleCalendar, "Family", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(private calendar): %v", err)
+	}
+	app.newGoogleCalendarReader = func(context.Context) (googleCalendarReader, error) {
+		return &stubGoogleCalendarReader{
+			calendars: []providerdata.Calendar{
+				{ID: "work", Name: "Work Calendar"},
+				{ID: "family", Name: "Family"},
+			},
+			events: map[string][]providerdata.Event{
+				"work": {
+					{
+						CalendarID: "work",
+						Summary:    "Standup",
+						Start:      time.Date(2026, time.March, 10, 9, 0, 0, 0, time.Local),
+						End:        time.Date(2026, time.March, 10, 10, 0, 0, 0, time.Local),
+					},
+				},
+				"family": {
+					{
+						CalendarID: "family",
+						Summary:    "Dentist",
+						Start:      time.Date(2026, time.March, 10, 11, 0, 0, 0, time.Local),
+						End:        time.Date(2026, time.March, 10, 12, 0, 0, 0, time.Local),
+					},
+				},
+			},
+		}, nil
+	}
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	var showCalls int
+	canvasServer := setupMockCanvasShowServer(t, &showCalls, nil)
+	defer canvasServer.Close()
+	port, err := extractPort(canvasServer.URL)
+	if err != nil {
+		t.Fatalf("extractPort(canvas): %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	_, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "when am I free tomorrow?")
+	if !handled {
+		t.Fatal("expected availability query to be handled")
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payload count = %d, want 1", len(payloads))
+	}
+	rendered, err := os.ReadFile(filepath.Join(project.RootPath, strFromAny(payloads[0]["path"])))
+	if err != nil {
+		t.Fatalf("ReadFile(rendered): %v", err)
+	}
+	content := string(rendered)
+	for _, snippet := range []string{"08:00 to 09:00", "10:00 to 11:00", "12:00 to 18:00", "Standup", "Busy (other sphere)"} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("availability artifact missing %q:\n%s", snippet, content)
+		}
+	}
+	if strings.Contains(content, "Dentist") {
+		t.Fatalf("availability artifact leaked private title:\n%s", content)
+	}
+	if showCalls != 1 {
+		t.Fatalf("canvas_artifact_show calls = %d, want 1", showCalls)
+	}
+}

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, cancel_work, show_status, review_someday, toggle_someday_review_nudge, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, show_calendar, cancel_work, show_status, review_someday, toggle_someday_review_nudge, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -158,6 +158,7 @@ func TestParseSystemAction(t *testing.T) {
 		{name: "show status", raw: `{"action":"show_status"}`, wantAction: "show_status"},
 		{name: "shell", raw: `{"action":"shell","command":"ls -1"}`, wantAction: "shell"},
 		{name: "open file canvas", raw: `{"action":"open_file_canvas","path":"README.md"}`, wantAction: "open_file_canvas"},
+		{name: "show calendar", raw: `{"action":"show_calendar","view":"week"}`, wantAction: "show_calendar"},
 		{name: "multi action array", raw: `{"actions":[{"action":"shell","command":"ls -1"},{"action":"open_file_canvas","path":"README.md"}]}`, wantAction: "shell"},
 	}
 	for _, tc := range cases {

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, show_calendar, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_project", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero", "cursor_open_item", "cursor_triage_item", "cursor_open_path":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "show_calendar", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_project", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero", "cursor_open_item", "cursor_triage_item", "cursor_open_path":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -763,6 +763,21 @@ func (a *App) classifyAndExecuteSystemActionWithCursor(ctx context.Context, sess
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return sourceSyncActionFailurePrefix(inlineSourceSyncAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	now := time.Now().UTC()
+	if a != nil && a.calendarNow != nil {
+		now = a.calendarNow().UTC()
+	}
+	if inlineCalendarAction := parseInlineCalendarIntent(trimmedText, now); inlineCalendarAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineCalendarAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return calendarActionFailurePrefix(inlineCalendarAction.Action) + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -509,6 +509,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 			"path":       canvasTitle,
 			"project_id": targetProject.ID,
 		}, nil
+	case "show_calendar":
+		return a.executeCalendarAction(session, action)
 	case "print_item":
 		return a.executePrintItemAction(sessionID, session, action)
 	default:

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -18,7 +18,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/appserver"
+	tabcalendar "github.com/krystophny/tabura/internal/calendar"
 	"github.com/krystophny/tabura/internal/extensions"
+	"github.com/krystophny/tabura/internal/ics"
 	"github.com/krystophny/tabura/internal/modelprofile"
 	"github.com/krystophny/tabura/internal/plugins"
 	"github.com/krystophny/tabura/internal/serve"
@@ -84,7 +86,10 @@ type App struct {
 	store      *store.Store
 	sourceSync sourceSyncRunner
 
-	appServerClient *appserver.Client
+	appServerClient         *appserver.Client
+	calendarNow             func() time.Time
+	newGoogleCalendarReader func(context.Context) (googleCalendarReader, error)
+	newICSCalendarReader    func() (icsCalendarReader, error)
 
 	upgrader websocket.Upgrader
 
@@ -270,24 +275,31 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		store:                         s,
 		sourceSync:                    nil,
 		appServerClient:               appServerClient,
-		upgrader:                      websocket.Upgrader{CheckOrigin: checkWSOrigin},
-		hub:                           newWSHub(),
-		turns:                         newChatTurnTracker(),
-		companionTurns:                newCompanionPendingTurnTracker(),
-		companionRuntime:              newCompanionRuntimeTracker(),
-		chatCaptureModes:              newChatCaptureModeTracker(),
-		chatCursorContexts:            newChatCursorContextTracker(),
-		projectAttention:              newProjectAttentionTracker(),
-		tunnels:                       newTunnelRegistry(),
-		chatAppSessions:               map[string]*appserver.Session{},
-		pendingDanger:                 map[string]*pendingDangerousAction{},
-		pendingApprovals:              map[string]map[string]*pendingAppServerApproval{},
-		ghCommandRunner:               runGitHubCLI,
-		presentationRenderer:          renderPresentationToPDF,
-		shutdownCtx:                   shutdownCtx,
-		shutdownCancel:                shutdownCancel,
-		bootID:                        strconv.FormatInt(time.Now().UnixNano(), 16),
-		startedAt:                     time.Now().UTC().Format(time.RFC3339Nano),
+		calendarNow:                   time.Now,
+		newGoogleCalendarReader: func(ctx context.Context) (googleCalendarReader, error) {
+			return tabcalendar.New(ctx)
+		},
+		newICSCalendarReader: func() (icsCalendarReader, error) {
+			return ics.New()
+		},
+		upgrader:             websocket.Upgrader{CheckOrigin: checkWSOrigin},
+		hub:                  newWSHub(),
+		turns:                newChatTurnTracker(),
+		companionTurns:       newCompanionPendingTurnTracker(),
+		companionRuntime:     newCompanionRuntimeTracker(),
+		chatCaptureModes:     newChatCaptureModeTracker(),
+		chatCursorContexts:   newChatCursorContextTracker(),
+		projectAttention:     newProjectAttentionTracker(),
+		tunnels:              newTunnelRegistry(),
+		chatAppSessions:      map[string]*appserver.Session{},
+		pendingDanger:        map[string]*pendingDangerousAction{},
+		pendingApprovals:     map[string]map[string]*pendingAppServerApproval{},
+		ghCommandRunner:      runGitHubCLI,
+		presentationRenderer: renderPresentationToPDF,
+		shutdownCtx:          shutdownCtx,
+		shutdownCancel:       shutdownCancel,
+		bootID:               strconv.FormatInt(time.Now().UnixNano(), 16),
+		startedAt:            time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if _, err := app.ensureDefaultProjectRecord(); err != nil {
 		_ = s.Close()


### PR DESCRIPTION
## Summary
- add a `show_calendar` system action and inline dialogue parsing for day, week, agenda, availability, and filtered calendar requests
- render file-backed calendar artifacts under `.tabura/artifacts/calendar/` from Google Calendar or ICS events plus item `follow_up_at` and `visible_after` deadlines
- enforce sphere-aware output so the active sphere keeps full detail while the other sphere collapses to busy blocks, and availability merges busy time across both spheres

## Verification
- Canvas calendar artifact with events and item deadlines:
  `go test ./internal/web -run 'Test(ParseInlineCalendarIntent|ClassifyAndExecuteSystemActionShowCalendarRendersSphereAwareArtifact|ClassifyAndExecuteSystemActionCalendarAvailabilityUsesAllBusyBlocks|ParseSystemAction)$' 2>&1 | tee /tmp/test.log`
  Output: `ok   github.com/krystophny/tabura/internal/web  0.025s`
  Evidence: `TestClassifyAndExecuteSystemActionShowCalendarRendersSphereAwareArtifact` asserts `show calendar` writes `.tabura/artifacts/calendar/2026-03-09-day*.md`, creates a `calendar_view` artifact, includes active-sphere event details and item deadlines, and redacts other-sphere event and item titles to `Busy (other sphere)`.
- Dialogue command coverage:
  Same command and output as above.
  Evidence: `TestParseInlineCalendarIntent` covers `show calendar`, `show my schedule`, `what's today?`, `what's this week?`, `when am I free tomorrow?`, and `show calendar for EUROfusion`.
- Unified availability across spheres:
  Same command and output as above.
  Evidence: `TestClassifyAndExecuteSystemActionCalendarAvailabilityUsesAllBusyBlocks` asserts free slots `08:00 to 09:00`, `10:00 to 11:00`, and `12:00 to 18:00` are computed from both work and private busy blocks while hiding the private event title.
