### PR TITLE
fix: add email inbox polling via sync engine (fixes #264) (fixes #265)

### DIFF
--- a/internal/email/gmail.go
+++ b/internal/email/gmail.go
@@ -35,10 +35,12 @@ func tokenFile() string {
 
 // GmailClient provides access to Gmail API with rate limiting.
 type GmailClient struct {
-	rateLimiter *RateLimiter
-	config      *oauth2.Config
-	token       *oauth2.Token
-	mu          sync.Mutex
+	rateLimiter     *RateLimiter
+	config          *oauth2.Config
+	token           *oauth2.Token
+	credentialsPath string
+	tokenPath       string
+	mu              sync.Mutex
 }
 
 // Compile-time check that GmailClient implements EmailProvider.
@@ -47,9 +49,21 @@ var _ MessageActionProvider = (*GmailClient)(nil)
 
 // NewGmail creates a new Gmail client.
 func NewGmail() (*GmailClient, error) {
-	credBytes, err := os.ReadFile(credentialsFile())
+	return NewGmailWithFiles("", "")
+}
+
+// NewGmailWithFiles creates a Gmail client with explicit credential and token paths.
+func NewGmailWithFiles(credentialsPath, tokenPath string) (*GmailClient, error) {
+	if strings.TrimSpace(credentialsPath) == "" {
+		credentialsPath = credentialsFile()
+	}
+	if strings.TrimSpace(tokenPath) == "" {
+		tokenPath = tokenFile()
+	}
+
+	credBytes, err := os.ReadFile(credentialsPath)
 	if err != nil {
-		return nil, fmt.Errorf("configure Gmail credentials at %s first: %w", credentialsFile(), err)
+		return nil, fmt.Errorf("configure Gmail credentials at %s first: %w", credentialsPath, err)
 	}
 
 	config, err := google.ConfigFromJSON(credBytes, gmailScope)
@@ -58,12 +72,14 @@ func NewGmail() (*GmailClient, error) {
 	}
 
 	client := &GmailClient{
-		rateLimiter: NewRateLimiter(15000),
-		config:      config,
+		rateLimiter:     NewRateLimiter(15000),
+		config:          config,
+		credentialsPath: credentialsPath,
+		tokenPath:       tokenPath,
 	}
 
 	// Try to load existing token
-	if tokenBytes, err := os.ReadFile(tokenFile()); err == nil {
+	if tokenBytes, err := os.ReadFile(tokenPath); err == nil {
 		var token oauth2.Token
 		if json.Unmarshal(tokenBytes, &token) == nil {
 			client.token = &token
@@ -88,11 +104,11 @@ func (c *GmailClient) ExchangeCode(ctx context.Context, code string) error {
 	c.token = token
 
 	// Save token
-	if err := os.MkdirAll(configDir(), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(c.tokenPath), 0o755); err != nil {
 		return err
 	}
 	tokenBytes, _ := json.MarshalIndent(token, "", "  ")
-	return os.WriteFile(tokenFile(), tokenBytes, 0600)
+	return os.WriteFile(c.tokenPath, tokenBytes, 0o600)
 }
 
 func (c *GmailClient) getService(ctx context.Context) (*gmail.Service, error) {
@@ -100,7 +116,7 @@ func (c *GmailClient) getService(ctx context.Context) (*gmail.Service, error) {
 	defer c.mu.Unlock()
 
 	if c.token == nil {
-		return nil, fmt.Errorf("gmail is not authenticated; token file %s is missing", tokenFile())
+		return nil, fmt.Errorf("gmail is not authenticated; token file %s is missing", c.tokenPath)
 	}
 
 	// Refresh token if expired
@@ -113,7 +129,8 @@ func (c *GmailClient) getService(ctx context.Context) (*gmail.Service, error) {
 	if newToken.AccessToken != c.token.AccessToken {
 		c.token = newToken
 		tokenBytes, _ := json.MarshalIndent(newToken, "", "  ")
-		os.WriteFile(tokenFile(), tokenBytes, 0600)
+		_ = os.MkdirAll(filepath.Dir(c.tokenPath), 0o755)
+		_ = os.WriteFile(c.tokenPath, tokenBytes, 0o600)
 	}
 
 	return gmail.NewService(ctx, option.WithTokenSource(tokenSource))

--- a/internal/email/gmail_test.go
+++ b/internal/email/gmail_test.go
@@ -1,0 +1,51 @@
+package email
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewGmailWithFilesLoadsAccountToken(t *testing.T) {
+	dir := t.TempDir()
+	credentialsPath := filepath.Join(dir, "credentials.json")
+	tokenPath := filepath.Join(dir, "tokens", "work-gmail.json")
+
+	credentials := `{
+  "installed": {
+    "client_id": "client-id.apps.googleusercontent.com",
+    "project_id": "tabura-test",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "client_secret": "secret",
+    "redirect_uris": ["http://localhost"]
+  }
+}`
+	if err := os.WriteFile(credentialsPath, []byte(credentials), 0o600); err != nil {
+		t.Fatalf("WriteFile(credentials) error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(tokens) error: %v", err)
+	}
+	token := `{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expiry":"2030-01-01T00:00:00Z"}`
+	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+		t.Fatalf("WriteFile(token) error: %v", err)
+	}
+
+	client, err := NewGmailWithFiles(credentialsPath, tokenPath)
+	if err != nil {
+		t.Fatalf("NewGmailWithFiles() error: %v", err)
+	}
+	if client.credentialsPath != credentialsPath {
+		t.Fatalf("credentialsPath = %q, want %q", client.credentialsPath, credentialsPath)
+	}
+	if client.tokenPath != tokenPath {
+		t.Fatalf("tokenPath = %q, want %q", client.tokenPath, tokenPath)
+	}
+	if client.token == nil {
+		t.Fatal("expected token to be loaded from custom token path")
+	}
+	if client.token.AccessToken != "access-token" {
+		t.Fatalf("access token = %q, want access-token", client.token.AccessToken)
+	}
+}

--- a/internal/web/items_email.go
+++ b/internal/web/items_email.go
@@ -1,0 +1,466 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/email"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+	tabsync "github.com/krystophny/tabura/internal/sync"
+)
+
+const (
+	emailSyncDefaultRecentDays = 30
+	emailSyncDefaultMaxResults = 200
+	emailBindingObjectType     = "email"
+)
+
+type emailSyncProvider interface {
+	ListMessages(context.Context, email.SearchOptions) ([]string, error)
+	GetMessages(context.Context, []string, string) ([]*providerdata.EmailMessage, error)
+	Close() error
+}
+
+type emailFollowUpRuleConfig struct {
+	Text    string `json:"text"`
+	Subject string `json:"subject"`
+	From    string `json:"from"`
+	To      string `json:"to"`
+}
+
+func (r *emailFollowUpRuleConfig) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err == nil {
+		r.Text = strings.TrimSpace(text)
+		r.Subject = ""
+		r.From = ""
+		r.To = ""
+		return nil
+	}
+	type rawRule emailFollowUpRuleConfig
+	var raw rawRule
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = emailFollowUpRuleConfig{
+		Text:    strings.TrimSpace(raw.Text),
+		Subject: strings.TrimSpace(raw.Subject),
+		From:    strings.TrimSpace(raw.From),
+		To:      strings.TrimSpace(raw.To),
+	}
+	return nil
+}
+
+func (r emailFollowUpRuleConfig) empty() bool {
+	return r.Text == "" && r.Subject == "" && r.From == "" && r.To == ""
+}
+
+type emailSyncAccountConfig struct {
+	Host            string                    `json:"host"`
+	Port            int                       `json:"port"`
+	Username        string                    `json:"username"`
+	TLS             bool                      `json:"tls"`
+	StartTLS        bool                      `json:"starttls"`
+	TokenPath       string                    `json:"token_path"`
+	TokenFile       string                    `json:"token_file"`
+	CredentialsPath string                    `json:"credentials_path"`
+	CredentialsFile string                    `json:"credentials_file"`
+	SyncMaxResults  int64                     `json:"sync_max_results"`
+	SyncWindowDays  int                       `json:"sync_window_days"`
+	FollowUpRules   []emailFollowUpRuleConfig `json:"follow_up_rules"`
+}
+
+type emailSyncResult struct {
+	MessageCount int
+	ItemCount    int
+}
+
+func decodeEmailSyncAccountConfig(account store.ExternalAccount) (emailSyncAccountConfig, error) {
+	var cfg emailSyncAccountConfig
+	raw := strings.TrimSpace(account.ConfigJSON)
+	if raw == "" || raw == "{}" {
+		return cfg, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return emailSyncAccountConfig{}, fmt.Errorf("decode %s email sync config: %w", account.Provider, err)
+	}
+	cfg.Host = strings.TrimSpace(cfg.Host)
+	cfg.Username = strings.TrimSpace(cfg.Username)
+	cfg.TokenPath = strings.TrimSpace(cfg.TokenPath)
+	cfg.TokenFile = strings.TrimSpace(cfg.TokenFile)
+	cfg.CredentialsPath = strings.TrimSpace(cfg.CredentialsPath)
+	cfg.CredentialsFile = strings.TrimSpace(cfg.CredentialsFile)
+	filteredRules := make([]emailFollowUpRuleConfig, 0, len(cfg.FollowUpRules))
+	for _, rule := range cfg.FollowUpRules {
+		if rule.empty() {
+			continue
+		}
+		filteredRules = append(filteredRules, rule)
+	}
+	cfg.FollowUpRules = filteredRules
+	return cfg, nil
+}
+
+func emailSyncConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ".tabura"
+	}
+	return filepath.Join(home, ".config", "tabura")
+}
+
+func emailConfigPath(configDir, explicitPath, fileName string) string {
+	switch {
+	case strings.TrimSpace(explicitPath) != "":
+		clean := filepath.Clean(strings.TrimSpace(explicitPath))
+		if filepath.IsAbs(clean) {
+			return clean
+		}
+		return filepath.Join(configDir, clean)
+	case strings.TrimSpace(fileName) != "":
+		return filepath.Join(configDir, strings.TrimSpace(fileName))
+	default:
+		return ""
+	}
+}
+
+func gmailTokenPathForAccount(account store.ExternalAccount, cfg emailSyncAccountConfig) string {
+	configDir := emailSyncConfigDir()
+	if path := emailConfigPath(configDir, cfg.TokenPath, ""); path != "" {
+		return path
+	}
+	if strings.TrimSpace(cfg.TokenFile) != "" {
+		return filepath.Join(configDir, "tokens", strings.TrimSpace(cfg.TokenFile))
+	}
+	return store.ExternalAccountTokenPath(configDir, account.Provider, account.Label)
+}
+
+func gmailCredentialsPathForAccount(cfg emailSyncAccountConfig) string {
+	configDir := emailSyncConfigDir()
+	if path := emailConfigPath(configDir, cfg.CredentialsPath, cfg.CredentialsFile); path != "" {
+		return path
+	}
+	return filepath.Join(configDir, "gmail_credentials.json")
+}
+
+func (a *App) emailSyncProviderForAccount(ctx context.Context, account store.ExternalAccount, cfg emailSyncAccountConfig) (emailSyncProvider, error) {
+	if a != nil && a.newEmailSyncProvider != nil {
+		return a.newEmailSyncProvider(ctx, account)
+	}
+	switch account.Provider {
+	case store.ExternalProviderGmail:
+		return email.NewGmailWithFiles(gmailCredentialsPathForAccount(cfg), gmailTokenPathForAccount(account, cfg))
+	case store.ExternalProviderIMAP:
+		if cfg.Host == "" {
+			return nil, errors.New("imap host is required")
+		}
+		if cfg.Username == "" {
+			return nil, errors.New("imap username is required")
+		}
+		password, _, err := a.store.ResolveExternalAccountPasswordForAccount(ctx, account)
+		if err != nil {
+			return nil, err
+		}
+		useTLS := cfg.TLS || cfg.Port == 993
+		return email.NewIMAPClient(account.Label, cfg.Host, cfg.Port, cfg.Username, password, useTLS, cfg.StartTLS), nil
+	default:
+		return nil, fmt.Errorf("email sync does not support provider %s", account.Provider)
+	}
+}
+
+func emailSyncMaxResults(cfg emailSyncAccountConfig) int64 {
+	if cfg.SyncMaxResults > 0 {
+		return cfg.SyncMaxResults
+	}
+	return emailSyncDefaultMaxResults
+}
+
+func emailSyncSince(now time.Time, latestRemoteUpdatedAt *string, cfg emailSyncAccountConfig) time.Time {
+	days := cfg.SyncWindowDays
+	if days <= 0 {
+		days = emailSyncDefaultRecentDays
+	}
+	since := now.AddDate(0, 0, -days)
+	if latestRemoteUpdatedAt == nil || strings.TrimSpace(*latestRemoteUpdatedAt) == "" {
+		return since
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*latestRemoteUpdatedAt))
+	if err != nil {
+		return since
+	}
+	if parsed.Before(since) {
+		return since
+	}
+	return parsed.Add(-time.Minute)
+}
+
+func collectEmailMessageIDs(target map[string]struct{}, ids []string) {
+	for _, id := range ids {
+		clean := strings.TrimSpace(id)
+		if clean == "" {
+			continue
+		}
+		target[clean] = struct{}{}
+	}
+}
+
+func sortedEmailMessageIDs(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func listEmailMessagesWithFallback(ctx context.Context, provider emailSyncProvider, opts email.SearchOptions) ([]string, error) {
+	ids, err := provider.ListMessages(ctx, opts)
+	if err == nil || strings.TrimSpace(opts.Folder) == "" {
+		return ids, err
+	}
+	opts.Folder = ""
+	return provider.ListMessages(ctx, opts)
+}
+
+func followUpRuleSearchOptions(rule emailFollowUpRuleConfig, maxResults int64) email.SearchOptions {
+	opts := email.DefaultSearchOptions().WithMaxResults(maxResults)
+	if rule.Text != "" {
+		opts = opts.WithText(rule.Text)
+	}
+	if rule.Subject != "" {
+		opts = opts.WithSubject(rule.Subject)
+	}
+	if rule.From != "" {
+		opts = opts.WithFrom(rule.From)
+	}
+	if rule.To != "" {
+		opts = opts.WithTo(rule.To)
+	}
+	return opts
+}
+
+func emailFollowUpMessageIDs(ctx context.Context, provider emailSyncProvider, cfg emailSyncAccountConfig) (map[string]struct{}, error) {
+	maxResults := emailSyncMaxResults(cfg)
+	out := make(map[string]struct{})
+
+	unreadOpts := email.DefaultSearchOptions().
+		WithFolder("INBOX").
+		WithIsRead(false).
+		WithMaxResults(maxResults)
+	unreadIDs, err := listEmailMessagesWithFallback(ctx, provider, unreadOpts)
+	if err != nil {
+		return nil, err
+	}
+	collectEmailMessageIDs(out, unreadIDs)
+
+	flaggedIDs, err := provider.ListMessages(ctx, email.DefaultSearchOptions().WithIsFlagged(true).WithMaxResults(maxResults))
+	if err != nil {
+		return nil, err
+	}
+	collectEmailMessageIDs(out, flaggedIDs)
+
+	for _, rule := range cfg.FollowUpRules {
+		ruleIDs, err := provider.ListMessages(ctx, followUpRuleSearchOptions(rule, maxResults))
+		if err != nil {
+			return nil, err
+		}
+		collectEmailMessageIDs(out, ruleIDs)
+	}
+	return out, nil
+}
+
+func emailMessageTitle(message *providerdata.EmailMessage) string {
+	title := strings.TrimSpace(message.Subject)
+	if title != "" {
+		return title
+	}
+	if sender := strings.TrimSpace(message.Sender); sender != "" {
+		return sender
+	}
+	return "Email"
+}
+
+func emailMessageRemoteUpdatedAt(message *providerdata.EmailMessage) *string {
+	if message == nil || message.Date.IsZero() {
+		return nil
+	}
+	value := message.Date.UTC().Format(time.RFC3339)
+	return &value
+}
+
+func emailMessageContainerRef(message *providerdata.EmailMessage) *string {
+	if message == nil {
+		return nil
+	}
+	for _, label := range message.Labels {
+		clean := strings.TrimSpace(label)
+		if clean == "" {
+			continue
+		}
+		return &clean
+	}
+	return nil
+}
+
+func emailArtifactMetaJSON(message *providerdata.EmailMessage) (string, error) {
+	payload := map[string]any{
+		"thread_id":  strings.TrimSpace(message.ThreadID),
+		"subject":    strings.TrimSpace(message.Subject),
+		"sender":     strings.TrimSpace(message.Sender),
+		"recipients": append([]string(nil), message.Recipients...),
+		"labels":     append([]string(nil), message.Labels...),
+		"is_read":    message.IsRead,
+	}
+	if !message.Date.IsZero() {
+		payload["date"] = message.Date.UTC().Format(time.RFC3339)
+	}
+	if snippet := strings.TrimSpace(message.Snippet); snippet != "" {
+		payload["snippet"] = snippet
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, message *providerdata.EmailMessage, followUp bool) (bool, error) {
+	if message == nil || strings.TrimSpace(message.ID) == "" {
+		return false, nil
+	}
+	title := emailMessageTitle(message)
+	metaJSON, err := emailArtifactMetaJSON(message)
+	if err != nil {
+		return false, err
+	}
+	binding := store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      emailBindingObjectType,
+		RemoteID:        strings.TrimSpace(message.ID),
+		ContainerRef:    emailMessageContainerRef(message),
+		RemoteUpdatedAt: emailMessageRemoteUpdatedAt(message),
+	}
+	artifact, err := sink.UpsertArtifact(ctx, store.Artifact{
+		Kind:     store.ArtifactKindEmail,
+		Title:    &title,
+		MetaJSON: &metaJSON,
+	}, binding)
+	if err != nil {
+		return false, err
+	}
+	if !followUp {
+		return false, nil
+	}
+
+	existingBinding, err := a.store.GetBindingByRemote(account.ID, account.Provider, emailBindingObjectType, strings.TrimSpace(message.ID))
+	if err != nil {
+		return false, err
+	}
+	if existingBinding.ItemID != nil {
+		item, err := a.store.GetItem(*existingBinding.ItemID)
+		if err != nil {
+			return false, err
+		}
+		if item.State == store.ItemStateDone {
+			return false, nil
+		}
+	}
+
+	source := account.Provider
+	sourceRef := "message:" + strings.TrimSpace(message.ID)
+	artifactID := artifact.ID
+	_, err = sink.UpsertItem(ctx, store.Item{
+		Title:      title,
+		State:      store.ItemStateInbox,
+		ArtifactID: &artifactID,
+		Source:     &source,
+		SourceRef:  &sourceRef,
+	}, binding)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.ExternalAccount, provider emailSyncProvider) (emailSyncResult, error) {
+	cfg, err := decodeEmailSyncAccountConfig(account)
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+
+	latestRemoteUpdatedAt, err := a.store.LatestBindingRemoteUpdatedAt(account.ID, account.Provider, emailBindingObjectType)
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+	followUpIDs, err := emailFollowUpMessageIDs(ctx, provider, cfg)
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+	messageIDs := make(map[string]struct{}, len(followUpIDs))
+	for id := range followUpIDs {
+		messageIDs[id] = struct{}{}
+	}
+
+	since := emailSyncSince(time.Now().UTC(), latestRemoteUpdatedAt, cfg)
+	recentIDs, err := provider.ListMessages(ctx, email.DefaultSearchOptions().WithSince(since).WithMaxResults(emailSyncMaxResults(cfg)))
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+	collectEmailMessageIDs(messageIDs, recentIDs)
+	if len(messageIDs) == 0 {
+		return emailSyncResult{}, nil
+	}
+
+	messages, err := provider.GetMessages(ctx, sortedEmailMessageIDs(messageIDs), "full")
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+	sink := tabsync.NewStoreSink(a.store)
+	result := emailSyncResult{}
+	for _, message := range messages {
+		if message == nil || strings.TrimSpace(message.ID) == "" {
+			continue
+		}
+		createdItem, err := a.persistEmailMessage(ctx, sink, account, message, hasEmailMessageID(followUpIDs, message.ID))
+		if err != nil {
+			return emailSyncResult{}, err
+		}
+		result.MessageCount++
+		if createdItem {
+			result.ItemCount++
+		}
+	}
+	return result, nil
+}
+
+func hasEmailMessageID(values map[string]struct{}, id string) bool {
+	_, ok := values[strings.TrimSpace(id)]
+	return ok
+}
+
+func (a *App) syncEmailAccount(ctx context.Context, account store.ExternalAccount) (int, error) {
+	cfg, err := decodeEmailSyncAccountConfig(account)
+	if err != nil {
+		return 0, err
+	}
+	provider, err := a.emailSyncProviderForAccount(ctx, account, cfg)
+	if err != nil {
+		return 0, err
+	}
+	defer provider.Close()
+
+	result, err := a.syncEmailAccountWithProvider(ctx, account, provider)
+	if err != nil {
+		return 0, err
+	}
+	return result.MessageCount, nil
+}

--- a/internal/web/items_email_test.go
+++ b/internal/web/items_email_test.go
@@ -1,0 +1,310 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/email"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type fakeEmailSyncProvider struct {
+	listFunc  func(email.SearchOptions) ([]string, error)
+	messages  map[string]*providerdata.EmailMessage
+	listCalls []email.SearchOptions
+}
+
+func (f *fakeEmailSyncProvider) ListMessages(_ context.Context, opts email.SearchOptions) ([]string, error) {
+	f.listCalls = append(f.listCalls, opts)
+	if f.listFunc == nil {
+		return nil, nil
+	}
+	return f.listFunc(opts)
+}
+
+func (f *fakeEmailSyncProvider) GetMessages(_ context.Context, messageIDs []string, _ string) ([]*providerdata.EmailMessage, error) {
+	out := make([]*providerdata.EmailMessage, 0, len(messageIDs))
+	for _, id := range messageIDs {
+		if message, ok := f.messages[id]; ok {
+			out = append(out, message)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeEmailSyncProvider) Close() error {
+	return nil
+}
+
+func TestSourceSyncRunnerPollsGmailAndIMAPAccounts(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	gmailAccount, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(gmail) error: %v", err)
+	}
+	imapAccount, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderIMAP, "Private IMAP", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(imap) error: %v", err)
+	}
+
+	gmailProvider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"gmail-1"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-1"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-1": {
+				ID:         "gmail-1",
+				ThreadID:   "thread-gmail-1",
+				Subject:    "Review release notes",
+				Sender:     "Ada <ada@example.com>",
+				Recipients: []string{"team@example.com"},
+				Date:       time.Date(2026, time.March, 9, 10, 0, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+			},
+		},
+	}
+	imapProvider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"INBOX:7"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"INBOX:7"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"INBOX:7": {
+				ID:         "INBOX:7",
+				ThreadID:   "thread-imap-7",
+				Subject:    "Schedule site visit",
+				Sender:     "Bob <bob@example.com>",
+				Recipients: []string{"ops@example.com"},
+				Date:       time.Date(2026, time.March, 9, 11, 0, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(_ context.Context, account store.ExternalAccount) (emailSyncProvider, error) {
+		switch account.ID {
+		case gmailAccount.ID:
+			return gmailProvider, nil
+		case imapAccount.ID:
+			return imapProvider, nil
+		default:
+			t.Fatalf("unexpected account id: %d", account.ID)
+			return nil, nil
+		}
+	}
+	app.sourceSync = app.newSourceSyncRunner()
+
+	result, err := app.syncSourcesNow(context.Background())
+	if err != nil {
+		t.Fatalf("syncSourcesNow() error: %v", err)
+	}
+	if len(result.Accounts) != 2 {
+		t.Fatalf("len(result.Accounts) = %d, want 2", len(result.Accounts))
+	}
+	for _, account := range result.Accounts {
+		if account.Skipped {
+			t.Fatalf("account %#v was skipped, want sync", account)
+		}
+		if account.Err != nil {
+			t.Fatalf("account %#v returned error", account)
+		}
+	}
+
+	gmailItem, err := app.store.GetItemBySource(store.ExternalProviderGmail, "message:gmail-1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(gmail) error: %v", err)
+	}
+	if gmailItem.State != store.ItemStateInbox {
+		t.Fatalf("gmail item state = %q, want inbox", gmailItem.State)
+	}
+	if gmailItem.Sphere != store.SphereWork {
+		t.Fatalf("gmail item sphere = %q, want work", gmailItem.Sphere)
+	}
+
+	imapItem, err := app.store.GetItemBySource(store.ExternalProviderIMAP, "message:INBOX:7")
+	if err != nil {
+		t.Fatalf("GetItemBySource(imap) error: %v", err)
+	}
+	if imapItem.Sphere != store.SpherePrivate {
+		t.Fatalf("imap item sphere = %q, want private", imapItem.Sphere)
+	}
+
+	artifacts, err := app.store.ListArtifactsByKind(store.ArtifactKindEmail)
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind(email) error: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("len(email artifacts) = %d, want 2", len(artifacts))
+	}
+
+	itemArtifacts, err := app.store.ListItemArtifacts(gmailItem.ID)
+	if err != nil {
+		t.Fatalf("ListItemArtifacts(gmail) error: %v", err)
+	}
+	if len(itemArtifacts) != 1 {
+		t.Fatalf("len(gmail item artifacts) = %d, want 1", len(itemArtifacts))
+	}
+
+	var gmailMeta map[string]any
+	if err := json.Unmarshal([]byte(strFromPointer(itemArtifacts[0].Artifact.MetaJSON)), &gmailMeta); err != nil {
+		t.Fatalf("Unmarshal(gmail meta) error: %v", err)
+	}
+	if got := strFromAny(gmailMeta["thread_id"]); got != "thread-gmail-1" {
+		t.Fatalf("gmail thread_id = %q, want thread-gmail-1", got)
+	}
+	if got := strFromAny(gmailMeta["sender"]); got != "Ada <ada@example.com>" {
+		t.Fatalf("gmail sender = %q, want Ada <ada@example.com>", got)
+	}
+
+	gmailBinding, err := app.store.GetBindingByRemote(gmailAccount.ID, store.ExternalProviderGmail, "email", "gmail-1")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(gmail) error: %v", err)
+	}
+	if gmailBinding.ItemID == nil || gmailBinding.ArtifactID == nil {
+		t.Fatalf("gmail binding = %#v, want item and artifact ids", gmailBinding)
+	}
+}
+
+func TestSyncEmailAccountCreatesFollowUpItemsFromRules(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Legal Gmail", map[string]any{
+		"follow_up_rules": []any{
+			map[string]any{"subject": "contract"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.Subject == "contract":
+				return []string{"gmail-contract"}, nil
+			case opts.IsRead != nil && !*opts.IsRead:
+				return nil, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-contract"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-contract": {
+				ID:         "gmail-contract",
+				ThreadID:   "thread-contract",
+				Subject:    "contract review needed",
+				Sender:     "Counsel <counsel@example.com>",
+				Recipients: []string{"legal@example.com"},
+				Date:       time.Date(2026, time.March, 8, 16, 0, 0, 0, time.UTC),
+				Labels:     []string{"Archive"},
+				IsRead:     true,
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("syncEmailAccount() error: %v", err)
+	}
+
+	item, err := app.store.GetItemBySource(store.ExternalProviderGmail, "message:gmail-contract")
+	if err != nil {
+		t.Fatalf("GetItemBySource(rule) error: %v", err)
+	}
+	if item.Title != "contract review needed" {
+		t.Fatalf("rule item title = %q, want subject", item.Title)
+	}
+}
+
+func TestSyncEmailAccountLeavesDoneItemsClosed(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Done Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"gmail-done"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-done"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-done": {
+				ID:         "gmail-done",
+				ThreadID:   "thread-done",
+				Subject:    "Already handled",
+				Sender:     "Ops <ops@example.com>",
+				Recipients: []string{"team@example.com"},
+				Date:       time.Date(2026, time.March, 9, 9, 0, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("first syncEmailAccount() error: %v", err)
+	}
+	item, err := app.store.GetItemBySource(store.ExternalProviderGmail, "message:gmail-done")
+	if err != nil {
+		t.Fatalf("GetItemBySource(first) error: %v", err)
+	}
+	if err := app.store.UpdateItemState(item.ID, store.ItemStateDone); err != nil {
+		t.Fatalf("UpdateItemState(done) error: %v", err)
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("second syncEmailAccount() error: %v", err)
+	}
+	item, err = app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(second) error: %v", err)
+	}
+	if item.State != store.ItemStateDone {
+		t.Fatalf("item state after resync = %q, want done", item.State)
+	}
+}
+
+func strFromPointer(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -90,6 +90,7 @@ type App struct {
 	calendarNow             func() time.Time
 	newGoogleCalendarReader func(context.Context) (googleCalendarReader, error)
 	newICSCalendarReader    func() (icsCalendarReader, error)
+	newEmailSyncProvider    func(context.Context, store.ExternalAccount) (emailSyncProvider, error)
 
 	upgrader websocket.Upgrader
 

--- a/internal/web/source_poller.go
+++ b/internal/web/source_poller.go
@@ -75,6 +75,16 @@ func (a *App) newSourceSyncRunner() sourceSyncRunner {
 	})
 	for _, provider := range []*accountSyncProvider{
 		{
+			name:        store.ExternalProviderGmail,
+			syncAccount: a.syncEmailAccount,
+			onSynced:    a.handleSourceSyncCount,
+		},
+		{
+			name:        store.ExternalProviderIMAP,
+			syncAccount: a.syncEmailAccount,
+			onSynced:    a.handleSourceSyncCount,
+		},
+		{
 			name:        store.ExternalProviderTodoist,
 			syncAccount: a.syncTodoistAccount,
 			onSynced:    a.handleSourceSyncCount,


### PR DESCRIPTION
## Summary
- register Gmail and IMAP external accounts with the source poller
- persist synced messages as `email` artifacts plus follow-up items backed by shared external bindings
- load Gmail tokens per account and cover the flow with focused email/web tests

## Verification
- Poll configured email accounts at interval
  - `go test ./internal/email ./internal/web 2>&1 | tee /tmp/tabura-issue265-test.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/email 0.012s`, `ok   github.com/krystophny/tabura/internal/web 6.062s`
  - Evidence: `TestSourceSyncRunnerPollsGmailAndIMAPAccounts` drives `app.syncSourcesNow()` through `newSourceSyncRunner()` for one Gmail account and one IMAP account.
- New emails become `email` artifacts with the required metadata
  - Evidence: `TestSourceSyncRunnerPollsGmailAndIMAPAccounts` asserts `ListArtifactsByKind(email) == 2` and unmarshals artifact `meta_json` with `thread_id` and `sender` values for the synced Gmail message.
- Emails requiring follow-up become source-linked items
  - Evidence: `TestSourceSyncRunnerPollsGmailAndIMAPAccounts` asserts created items at `source=gmail|imap`, `source_ref=message:<id>`, and `state=inbox`.
- External bindings track the synced messages and keep sphere from the account binding
  - Evidence: `TestSourceSyncRunnerPollsGmailAndIMAPAccounts` asserts `GetBindingByRemote(..., "email", ...)` returns both `item_id` and `artifact_id`; the synced Gmail and IMAP items retain `work` and `private` spheres from their accounts.
- User-defined follow-up rules create items beyond unread/starred heuristics
  - Evidence: `TestSyncEmailAccountCreatesFollowUpItemsFromRules` syncs a read archived Gmail message via `follow_up_rules.subject=contract` and asserts item creation at `source_ref=message:gmail-contract`.
- Account-specific Gmail token files are respected during client creation
  - Evidence: `TestNewGmailWithFilesLoadsAccountToken` loads a custom token file path and asserts the client uses that token.