### PR TITLE
fix: add email thread artifact model and action extraction (fixes #266)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -12,6 +12,7 @@ const (
 	ActorKindAgent = "agent"
 
 	ArtifactKindEmail        ArtifactKind = "email"
+	ArtifactKindEmailThread  ArtifactKind = "email_thread"
 	ArtifactKindDocument     ArtifactKind = "document"
 	ArtifactKindPDF          ArtifactKind = "pdf"
 	ArtifactKindMarkdown     ArtifactKind = "markdown"

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -309,7 +309,7 @@ var MCPTools = []Tool{
 			"kind": {
 				Type:        "string",
 				Description: "Optional artifact kind filter.",
-				Enum:        []string{"email", "document", "pdf", "markdown", "image", "github_issue", "github_pr", "external_task", "transcript", "plan_note", "idea_note"},
+				Enum:        []string{"email", "email_thread", "document", "pdf", "markdown", "image", "github_issue", "github_pr", "external_task", "transcript", "plan_note", "idea_note"},
 			},
 			"workspace_id": {
 				Type:        "integer",

--- a/internal/web/items_email.go
+++ b/internal/web/items_email.go
@@ -332,14 +332,22 @@ func emailArtifactMetaJSON(message *providerdata.EmailMessage) (string, error) {
 	return string(raw), nil
 }
 
-func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, message *providerdata.EmailMessage, followUp bool) (bool, error) {
+func copyInt64Pointer(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
+}
+
+func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, message *providerdata.EmailMessage, followUp bool) (emailPersistedMessage, error) {
 	if message == nil || strings.TrimSpace(message.ID) == "" {
-		return false, nil
+		return emailPersistedMessage{}, nil
 	}
 	title := emailMessageTitle(message)
 	metaJSON, err := emailArtifactMetaJSON(message)
 	if err != nil {
-		return false, err
+		return emailPersistedMessage{}, err
 	}
 	binding := store.ExternalBinding{
 		AccountID:       account.ID,
@@ -355,23 +363,27 @@ func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, accoun
 		MetaJSON: &metaJSON,
 	}, binding)
 	if err != nil {
-		return false, err
+		return emailPersistedMessage{}, err
 	}
-	if !followUp {
-		return false, nil
+	persisted := emailPersistedMessage{
+		Message:  message,
+		Artifact: artifact,
 	}
-
 	existingBinding, err := a.store.GetBindingByRemote(account.ID, account.Provider, emailBindingObjectType, strings.TrimSpace(message.ID))
 	if err != nil {
-		return false, err
+		return emailPersistedMessage{}, err
+	}
+	persisted.ItemID = copyInt64Pointer(existingBinding.ItemID)
+	if !followUp {
+		return persisted, nil
 	}
 	if existingBinding.ItemID != nil {
 		item, err := a.store.GetItem(*existingBinding.ItemID)
 		if err != nil {
-			return false, err
+			return emailPersistedMessage{}, err
 		}
 		if item.State == store.ItemStateDone {
-			return false, nil
+			return persisted, nil
 		}
 	}
 
@@ -386,9 +398,15 @@ func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, accoun
 		SourceRef:  &sourceRef,
 	}, binding)
 	if err != nil {
-		return false, err
+		return emailPersistedMessage{}, err
 	}
-	return true, nil
+	updatedBinding, err := a.store.GetBindingByRemote(account.ID, account.Provider, emailBindingObjectType, strings.TrimSpace(message.ID))
+	if err != nil {
+		return emailPersistedMessage{}, err
+	}
+	persisted.ItemID = copyInt64Pointer(updatedBinding.ItemID)
+	persisted.FollowUpItem = true
+	return persisted, nil
 }
 
 func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.ExternalAccount, provider emailSyncProvider) (emailSyncResult, error) {
@@ -426,18 +444,27 @@ func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.Ex
 	}
 	sink := tabsync.NewStoreSink(a.store)
 	result := emailSyncResult{}
+	persistedMessages := make([]emailPersistedMessage, 0, len(messages))
 	for _, message := range messages {
 		if message == nil || strings.TrimSpace(message.ID) == "" {
 			continue
 		}
-		createdItem, err := a.persistEmailMessage(ctx, sink, account, message, hasEmailMessageID(followUpIDs, message.ID))
+		persisted, err := a.persistEmailMessage(ctx, sink, account, message, hasEmailMessageID(followUpIDs, message.ID))
 		if err != nil {
 			return emailSyncResult{}, err
 		}
+		persistedMessages = append(persistedMessages, persisted)
 		result.MessageCount++
-		if createdItem {
+		if persisted.FollowUpItem {
 			result.ItemCount++
 		}
+	}
+	threads, err := a.persistEmailThreads(ctx, sink, account, persistedMessages)
+	if err != nil {
+		return emailSyncResult{}, err
+	}
+	if err := a.persistEmailActionItems(account, threads); err != nil {
+		return emailSyncResult{}, err
 	}
 	return result, nil
 }

--- a/internal/web/items_email_actions.go
+++ b/internal/web/items_email_actions.go
@@ -1,0 +1,250 @@
+package web
+
+import (
+	"database/sql"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type extractedEmailAction struct {
+	Title      string
+	SourceRef  string
+	FollowUpAt *string
+}
+
+var (
+	emailActionDatePhrasePattern = regexp.MustCompile(`(?i)\b(?:by|before|due|deadline:?|no later than)\s+([A-Za-z]{3,9}\s+\d{1,2}(?:,\s*\d{4})?|\d{4}-\d{2}-\d{2}|tomorrow)\b`)
+	emailActionSentenceRequest   = regexp.MustCompile(`(?i)\b(?:please|kindly|can you|could you|would you|need you to|i need you to|we need to|let's|let us|can we|could we|would we)\s+(.+)$`)
+	emailActionMeetingPattern    = regexp.MustCompile(`(?i)\b(schedule|meeting|meet|call|availability|calendar)\b`)
+)
+
+func (a *App) persistEmailActionItems(account store.ExternalAccount, threads []emailThreadRecord) error {
+	now := time.Now().UTC()
+	if a != nil && a.calendarNow != nil {
+		now = a.calendarNow().UTC()
+	}
+	for _, thread := range threads {
+		actions := extractEmailThreadActions(now, thread)
+		for _, action := range actions {
+			if err := a.upsertEmailActionItem(account, thread.Artifact.ID, action); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func extractEmailThreadActions(now time.Time, thread emailThreadRecord) []extractedEmailAction {
+	seen := make(map[string]struct{})
+	out := make([]extractedEmailAction, 0)
+	for _, persisted := range thread.Messages {
+		if persisted.Message == nil {
+			continue
+		}
+		base := now
+		if !persisted.Message.Date.IsZero() {
+			base = persisted.Message.Date.UTC()
+		}
+		for _, candidate := range emailActionCandidatesForMessage(persisted) {
+			action, ok := parseEmailActionCandidate(candidate, cleanEmailThreadSubject(persisted.Message), base, thread.ThreadID)
+			if !ok {
+				continue
+			}
+			key := strings.ToLower(action.Title)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, action)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].SourceRef < out[j].SourceRef
+	})
+	return out
+}
+
+func emailActionCandidatesForMessage(persisted emailPersistedMessage) []string {
+	message := persisted.Message
+	if message == nil {
+		return nil
+	}
+	candidates := []string{}
+	if message.BodyText != nil {
+		candidates = append(candidates, splitMeetingSummaryCandidates(*message.BodyText)...)
+	}
+	if len(candidates) == 0 && strings.TrimSpace(message.Snippet) != "" {
+		candidates = append(candidates, splitMeetingSummaryCandidates(message.Snippet)...)
+	}
+	if len(candidates) == 0 && strings.TrimSpace(message.Subject) != "" {
+		candidates = append(candidates, strings.TrimSpace(message.Subject))
+	}
+	return candidates
+}
+
+func parseEmailActionCandidate(raw, subject string, base time.Time, threadID string) (extractedEmailAction, bool) {
+	text := strings.Join(strings.Fields(strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(raw, ""))), " ")
+	if text == "" {
+		return extractedEmailAction{}, false
+	}
+
+	clause := text
+	if match := emailActionSentenceRequest.FindStringSubmatch(text); len(match) == 2 {
+		clause = strings.TrimSpace(match[1])
+	} else if !looksLikeMeetingAction(text) {
+		return extractedEmailAction{}, false
+	}
+
+	followUpAt := parseEmailFollowUpAt(base, text)
+	trimmedClause := strings.TrimSpace(emailActionDatePhrasePattern.ReplaceAllString(clause, ""))
+	trimmedClause = strings.Trim(trimmedClause, " \t\r\n,.;:!?")
+	if trimmedClause == "" {
+		trimmedClause = clause
+	}
+
+	title := normalizeMeetingItemTitle(trimmedClause)
+	if title == "" {
+		return extractedEmailAction{}, false
+	}
+	if emailActionMeetingPattern.MatchString(text) && !strings.HasPrefix(strings.ToLower(title), "schedule") {
+		if cleanSubject := strings.TrimSpace(subject); cleanSubject != "" {
+			title = normalizeMeetingItemTitle("Schedule meeting about " + cleanSubject)
+		}
+	}
+	if title == "" {
+		return extractedEmailAction{}, false
+	}
+
+	return extractedEmailAction{
+		Title:      title,
+		SourceRef:  emailActionSourceRef(threadID, title),
+		FollowUpAt: followUpAt,
+	}, true
+}
+
+func emailActionSourceRef(threadID, title string) string {
+	return "thread:" + strings.TrimSpace(threadID) + ":action:" + slugifyEmailActionTitle(title)
+}
+
+func slugifyEmailActionTitle(title string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(title)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash:
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func parseEmailFollowUpAt(base time.Time, text string) *string {
+	match := emailActionDatePhrasePattern.FindStringSubmatch(text)
+	if len(match) != 2 {
+		return nil
+	}
+	target := strings.TrimSpace(match[1])
+	if target == "" {
+		return nil
+	}
+	normalized := strings.ToLower(target)
+	var due time.Time
+	switch normalized {
+	case "tomorrow":
+		if base.IsZero() {
+			base = time.Now().UTC()
+		}
+		due = time.Date(base.Year(), base.Month(), base.Day(), 9, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
+	default:
+		if parsed, ok := parseEmailFollowUpDate(base, target); ok {
+			due = parsed
+		}
+	}
+	if due.IsZero() {
+		return nil
+	}
+	value := due.UTC().Format(time.RFC3339)
+	return &value
+}
+
+func parseEmailFollowUpDate(base time.Time, value string) (time.Time, bool) {
+	if base.IsZero() {
+		base = time.Now().UTC()
+	}
+	if parsed, err := time.Parse("2006-01-02", value); err == nil {
+		return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 9, 0, 0, 0, time.UTC), true
+	}
+	for _, layout := range []string{"January 2, 2006", "Jan 2, 2006", "January 2", "Jan 2"} {
+		parsed, err := time.Parse(layout, value)
+		if err != nil {
+			continue
+		}
+		year := parsed.Year()
+		if year == 0 {
+			year = base.Year()
+			if parsed.Month() < base.Month() || (parsed.Month() == base.Month() && parsed.Day() < base.Day()) {
+				year++
+			}
+		}
+		return time.Date(year, parsed.Month(), parsed.Day(), 9, 0, 0, 0, time.UTC), true
+	}
+	return time.Time{}, false
+}
+
+func (a *App) upsertEmailActionItem(account store.ExternalAccount, artifactID int64, action extractedEmailAction) error {
+	source := account.Provider
+	sourceRef := strings.TrimSpace(action.SourceRef)
+	if sourceRef == "" {
+		return nil
+	}
+	existing, err := a.store.GetItemBySource(source, sourceRef)
+	switch {
+	case err == nil:
+		if existing.State == store.ItemStateDone {
+			return nil
+		}
+		title := action.Title
+		targetArtifactID := artifactID
+		followUpAt := ""
+		if action.FollowUpAt != nil {
+			followUpAt = strings.TrimSpace(*action.FollowUpAt)
+		}
+		return a.store.UpdateItem(existing.ID, store.ItemUpdate{
+			Title:      &title,
+			ArtifactID: &targetArtifactID,
+			FollowUpAt: &followUpAt,
+		})
+	case !errorsIsNoRows(err):
+		return err
+	}
+
+	return createEmailActionItem(a.store, source, sourceRef, artifactID, action)
+}
+
+func createEmailActionItem(s *store.Store, source, sourceRef string, artifactID int64, action extractedEmailAction) error {
+	sourceValue := source
+	sourceRefValue := sourceRef
+	opts := store.ItemOptions{
+		State:      store.ItemStateInbox,
+		ArtifactID: &artifactID,
+		Source:     &sourceValue,
+		SourceRef:  &sourceRefValue,
+	}
+	if action.FollowUpAt != nil {
+		opts.FollowUpAt = action.FollowUpAt
+	}
+	_, err := s.CreateItem(action.Title, opts)
+	return err
+}
+
+func errorsIsNoRows(err error) bool {
+	return err == sql.ErrNoRows
+}

--- a/internal/web/items_email_test.go
+++ b/internal/web/items_email_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,8 +162,14 @@ func TestSourceSyncRunnerPollsGmailAndIMAPAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListItemArtifacts(gmail) error: %v", err)
 	}
-	if len(itemArtifacts) != 1 {
-		t.Fatalf("len(gmail item artifacts) = %d, want 1", len(itemArtifacts))
+	if len(itemArtifacts) != 2 {
+		t.Fatalf("len(gmail item artifacts) = %d, want 2", len(itemArtifacts))
+	}
+	if itemArtifacts[0].Artifact.Kind != store.ArtifactKindEmail {
+		t.Fatalf("gmail primary artifact kind = %q, want email", itemArtifacts[0].Artifact.Kind)
+	}
+	if itemArtifacts[1].Artifact.Kind != store.ArtifactKindEmailThread || itemArtifacts[1].Role != "related" {
+		t.Fatalf("gmail related thread artifact = %+v, want related email_thread", itemArtifacts[1])
 	}
 
 	var gmailMeta map[string]any
@@ -299,6 +306,181 @@ func TestSyncEmailAccountLeavesDoneItemsClosed(t *testing.T) {
 	}
 	if item.State != store.ItemStateDone {
 		t.Fatalf("item state after resync = %q, want done", item.State)
+	}
+}
+
+func TestSyncEmailAccountCreatesThreadArtifactsAndLinksEmailItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"gmail-1"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-1", "gmail-2"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-1": {
+				ID:         "gmail-1",
+				ThreadID:   "thread-contract",
+				Subject:    "Re: Contract review",
+				Sender:     "Ada <ada@example.com>",
+				Recipients: []string{"legal@example.com"},
+				Date:       time.Date(2026, time.March, 9, 10, 0, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+			},
+			"gmail-2": {
+				ID:         "gmail-2",
+				ThreadID:   "thread-contract",
+				Subject:    "Contract review",
+				Sender:     "Bob <bob@example.com>",
+				Recipients: []string{"legal@example.com"},
+				Date:       time.Date(2026, time.March, 8, 9, 0, 0, 0, time.UTC),
+				Labels:     []string{"Archive"},
+				IsRead:     true,
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("syncEmailAccount() error: %v", err)
+	}
+
+	threads, err := app.store.ListArtifactsByKind(store.ArtifactKindEmailThread)
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind(email_thread) error: %v", err)
+	}
+	if len(threads) != 1 {
+		t.Fatalf("len(email_thread artifacts) = %d, want 1", len(threads))
+	}
+
+	var threadMeta map[string]any
+	if err := json.Unmarshal([]byte(strFromPointer(threads[0].MetaJSON)), &threadMeta); err != nil {
+		t.Fatalf("Unmarshal(thread meta) error: %v", err)
+	}
+	if got := strFromAny(threadMeta["thread_id"]); got != "thread-contract" {
+		t.Fatalf("thread_id = %q, want thread-contract", got)
+	}
+	if got := int(threadMeta["message_count"].(float64)); got != 2 {
+		t.Fatalf("message_count = %d, want 2", got)
+	}
+	if got := strFromAny(threadMeta["subject"]); got != "Contract review" {
+		t.Fatalf("subject = %q, want Contract review", got)
+	}
+
+	item, err := app.store.GetItemBySource(store.ExternalProviderGmail, "message:gmail-1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(message) error: %v", err)
+	}
+	itemArtifacts, err := app.store.ListItemArtifacts(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemArtifacts() error: %v", err)
+	}
+	if len(itemArtifacts) != 2 {
+		t.Fatalf("len(item artifacts) = %d, want 2", len(itemArtifacts))
+	}
+	if itemArtifacts[0].Artifact.Kind != store.ArtifactKindEmail {
+		t.Fatalf("primary artifact kind = %q, want email", itemArtifacts[0].Artifact.Kind)
+	}
+	if itemArtifacts[1].Artifact.Kind != store.ArtifactKindEmailThread || itemArtifacts[1].Role != "related" {
+		t.Fatalf("thread artifact link = %+v, want related email_thread", itemArtifacts[1])
+	}
+}
+
+func TestSyncEmailAccountExtractsThreadActionItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.calendarNow = func() time.Time {
+		return time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	}
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+
+	body := strings.Join([]string{
+		"Please send the draft contract by 2026-03-12.",
+		"Please schedule the contract review meeting.",
+	}, "\n")
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"gmail-action"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-action"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-action": {
+				ID:         "gmail-action",
+				ThreadID:   "thread-action",
+				Subject:    "Contract review",
+				Sender:     "Ada <ada@example.com>",
+				Recipients: []string{"legal@example.com"},
+				Date:       time.Date(2026, time.March, 9, 7, 30, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+				BodyText:   &body,
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("syncEmailAccount() error: %v", err)
+	}
+
+	sendItem, err := app.store.GetItemBySource(store.ExternalProviderGmail, "thread:thread-action:action:send-the-draft-contract")
+	if err != nil {
+		t.Fatalf("GetItemBySource(send) error: %v", err)
+	}
+	if sendItem.Title != "Send the draft contract" {
+		t.Fatalf("send item title = %q, want Send the draft contract", sendItem.Title)
+	}
+	if sendItem.FollowUpAt == nil || *sendItem.FollowUpAt != "2026-03-12T09:00:00Z" {
+		t.Fatalf("send item follow_up_at = %v, want 2026-03-12T09:00:00Z", sendItem.FollowUpAt)
+	}
+
+	meetingItem, err := app.store.GetItemBySource(store.ExternalProviderGmail, "thread:thread-action:action:schedule-the-contract-review-meeting")
+	if err != nil {
+		t.Fatalf("GetItemBySource(meeting) error: %v", err)
+	}
+	if meetingItem.Title != "Schedule the contract review meeting" {
+		t.Fatalf("meeting item title = %q, want Schedule the contract review meeting", meetingItem.Title)
+	}
+	if meetingItem.FollowUpAt != nil {
+		t.Fatalf("meeting item follow_up_at = %v, want nil", meetingItem.FollowUpAt)
+	}
+
+	threads, err := app.store.ListArtifactsByKind(store.ArtifactKindEmailThread)
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind(email_thread) error: %v", err)
+	}
+	if len(threads) != 1 {
+		t.Fatalf("len(email_thread artifacts) = %d, want 1", len(threads))
+	}
+	if sendItem.ArtifactID == nil || meetingItem.ArtifactID == nil || *sendItem.ArtifactID != threads[0].ID || *meetingItem.ArtifactID != threads[0].ID {
+		t.Fatalf("action artifact ids = %v and %v, want thread artifact %d", sendItem.ArtifactID, meetingItem.ArtifactID, threads[0].ID)
 	}
 }
 

--- a/internal/web/items_email_thread.go
+++ b/internal/web/items_email_thread.go
@@ -1,0 +1,229 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+	tabsync "github.com/krystophny/tabura/internal/sync"
+)
+
+const emailThreadBindingObjectType = "email_thread"
+
+type emailPersistedMessage struct {
+	Message      *providerdata.EmailMessage
+	Artifact     store.Artifact
+	ItemID       *int64
+	FollowUpItem bool
+}
+
+type emailThreadRecord struct {
+	ThreadID string
+	Artifact store.Artifact
+	Messages []emailPersistedMessage
+}
+
+func emailThreadIDForMessage(message *providerdata.EmailMessage) string {
+	if message == nil {
+		return ""
+	}
+	threadID := strings.TrimSpace(message.ThreadID)
+	if threadID != "" {
+		return threadID
+	}
+	return strings.TrimSpace(message.ID)
+}
+
+func emailThreadTitle(messages []emailPersistedMessage) string {
+	for _, message := range sortEmailMessagesByDate(messages) {
+		subject := cleanEmailThreadSubject(message.Message)
+		if subject != "" {
+			return subject
+		}
+	}
+	if len(messages) > 0 {
+		if sender := strings.TrimSpace(messages[0].Message.Sender); sender != "" {
+			return sender
+		}
+	}
+	return "Email thread"
+}
+
+func cleanEmailThreadSubject(message *providerdata.EmailMessage) string {
+	if message == nil {
+		return ""
+	}
+	subject := strings.TrimSpace(message.Subject)
+	for subject != "" {
+		lower := strings.ToLower(subject)
+		switch {
+		case strings.HasPrefix(lower, "re:"):
+			subject = strings.TrimSpace(subject[3:])
+		case strings.HasPrefix(lower, "fw:"):
+			subject = strings.TrimSpace(subject[3:])
+		case strings.HasPrefix(lower, "fwd:"):
+			subject = strings.TrimSpace(subject[4:])
+		default:
+			return subject
+		}
+	}
+	return ""
+}
+
+func sortEmailMessagesByDate(messages []emailPersistedMessage) []emailPersistedMessage {
+	out := append([]emailPersistedMessage(nil), messages...)
+	sort.Slice(out, func(i, j int) bool {
+		left := time.Time{}
+		right := time.Time{}
+		if out[i].Message != nil {
+			left = out[i].Message.Date
+		}
+		if out[j].Message != nil {
+			right = out[j].Message.Date
+		}
+		switch {
+		case left.Equal(right):
+			leftID := ""
+			rightID := ""
+			if out[i].Message != nil {
+				leftID = strings.TrimSpace(out[i].Message.ID)
+			}
+			if out[j].Message != nil {
+				rightID = strings.TrimSpace(out[j].Message.ID)
+			}
+			return leftID < rightID
+		case left.IsZero():
+			return false
+		case right.IsZero():
+			return true
+		default:
+			return left.After(right)
+		}
+	})
+	return out
+}
+
+func emailThreadParticipants(messages []emailPersistedMessage) []string {
+	seen := make(map[string]string)
+	for _, persisted := range messages {
+		if persisted.Message == nil {
+			continue
+		}
+		for _, raw := range append([]string{persisted.Message.Sender}, persisted.Message.Recipients...) {
+			participant := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+			if participant == "" {
+				continue
+			}
+			key := strings.ToLower(participant)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = participant
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, participant := range seen {
+		out = append(out, participant)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i]) < strings.ToLower(out[j])
+	})
+	return out
+}
+
+func emailThreadRemoteUpdatedAt(messages []emailPersistedMessage) *string {
+	for _, persisted := range sortEmailMessagesByDate(messages) {
+		if persisted.Message == nil || persisted.Message.Date.IsZero() {
+			continue
+		}
+		value := persisted.Message.Date.UTC().Format(time.RFC3339)
+		return &value
+	}
+	return nil
+}
+
+func emailThreadContainerRef(messages []emailPersistedMessage) *string {
+	for _, persisted := range sortEmailMessagesByDate(messages) {
+		if ref := emailMessageContainerRef(persisted.Message); ref != nil {
+			return ref
+		}
+	}
+	return nil
+}
+
+func emailThreadMetaJSON(threadID string, messages []emailPersistedMessage) (string, error) {
+	payload := map[string]any{
+		"thread_id":     strings.TrimSpace(threadID),
+		"message_count": len(messages),
+		"participants":  emailThreadParticipants(messages),
+		"subject":       emailThreadTitle(messages),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (a *App) persistEmailThreads(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, messages []emailPersistedMessage) ([]emailThreadRecord, error) {
+	grouped := make(map[string][]emailPersistedMessage)
+	for _, persisted := range messages {
+		threadID := emailThreadIDForMessage(persisted.Message)
+		if threadID == "" {
+			continue
+		}
+		grouped[threadID] = append(grouped[threadID], persisted)
+	}
+	if len(grouped) == 0 {
+		return nil, nil
+	}
+
+	threadIDs := make([]string, 0, len(grouped))
+	for threadID := range grouped {
+		threadIDs = append(threadIDs, threadID)
+	}
+	sort.Strings(threadIDs)
+
+	out := make([]emailThreadRecord, 0, len(threadIDs))
+	for _, threadID := range threadIDs {
+		group := grouped[threadID]
+		title := emailThreadTitle(group)
+		metaJSON, err := emailThreadMetaJSON(threadID, group)
+		if err != nil {
+			return nil, err
+		}
+		artifact, err := sink.UpsertArtifact(ctx, store.Artifact{
+			Kind:     store.ArtifactKindEmailThread,
+			Title:    &title,
+			MetaJSON: &metaJSON,
+		}, store.ExternalBinding{
+			AccountID:       account.ID,
+			Provider:        account.Provider,
+			ObjectType:      emailThreadBindingObjectType,
+			RemoteID:        threadID,
+			ContainerRef:    emailThreadContainerRef(group),
+			RemoteUpdatedAt: emailThreadRemoteUpdatedAt(group),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, persisted := range group {
+			if persisted.ItemID == nil {
+				continue
+			}
+			if err := a.store.LinkItemArtifact(*persisted.ItemID, artifact.ID, "related"); err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, emailThreadRecord{
+			ThreadID: threadID,
+			Artifact: artifact,
+			Messages: sortEmailMessagesByDate(group),
+		})
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- add `email_thread` artifacts during email sync, with thread metadata and surfaced artifact filtering support
- link synced email items back to their thread artifact through `item_artifacts`
- run a post-import extraction pass that creates or updates thread-linked action items, including deadline-derived `follow_up_at`

## Verification
- Thread artifacts created from synced email threads: `bash -lc 'go test ./internal/web ./internal/store ./internal/surface && ./scripts/sync-surface.sh --check' 2>&1 | tee /tmp/test.log` -> `ok   github.com/krystophny/tabura/internal/web 6.051s`; `TestSyncEmailAccountCreatesThreadArtifactsAndLinksEmailItems` asserts `thread_id=thread-contract`, `message_count=2`, and `subject=Contract review` on the created `email_thread` artifact.
- Individual email items linked to their thread artifact: same command/output; `TestSyncEmailAccountCreatesThreadArtifactsAndLinksEmailItems` asserts `ListItemArtifacts(message:gmail-1)` returns a primary `email` artifact plus a related `email_thread` artifact.
- Action extraction runs as a post-import email sync step: same command/output; `TestSyncEmailAccountExtractsThreadActionItems` asserts sync creates `thread:thread-action:action:send-the-draft-contract` and `thread:thread-action:action:schedule-the-contract-review-meeting` from imported email content.
- Document request and deadline extraction preserved concrete task state: same command/output; `TestSyncEmailAccountExtractsThreadActionItems` asserts the extracted contract task has `follow_up_at=2026-03-12T09:00:00Z` and is linked to the thread artifact.
- New artifact kind stays on the published surface: same command/output; `./scripts/sync-surface.sh --check` passes after adding `email_thread` to the `artifact_list` kind enum.
