### PR TITLE
fix: add daily briefing artifact - the silver tablet morning agenda (fixes #308)

### DIFF
--- a/internal/web/chat_briefing.go
+++ b/internal/web/chat_briefing.go
@@ -1,0 +1,555 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const briefingArtifactKind = store.ArtifactKind("briefing")
+
+type briefingRequest struct {
+	Date   time.Time
+	Sphere string
+}
+
+type briefingSnapshot struct {
+	Request          briefingRequest
+	GeneratedAt      time.Time
+	TodayEvents      []calendarEventEntry
+	TomorrowEvents   []calendarEventEntry
+	TodayDeadlines   []calendarDeadlineEntry
+	WeekDeadlines    []calendarDeadlineEntry
+	UrgentItems      []briefingOpenItem
+	UnreadEmailItems []briefingOpenItem
+	InFlightItems    []briefingOpenItem
+	ReviewPRItems    []briefingOpenItem
+	InboxCounts      map[string]int
+	Warnings         []string
+}
+
+type briefingOpenItem struct {
+	Title     string
+	Sphere    string
+	Workspace string
+	Project   string
+}
+
+func parseInlineBriefingIntent(text string, now time.Time) *SystemAction {
+	switch normalizeItemCommandText(text) {
+	case "show my day", "show me my day", "show briefing", "show my briefing", "update briefing", "refresh briefing", "was steht heute an":
+		return &SystemAction{
+			Action: "show_briefing",
+			Params: map[string]interface{}{
+				"date": now.In(time.Local).Format("2006-01-02"),
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func briefingActionFailurePrefix(string) string {
+	return "I couldn't build the daily briefing: "
+}
+
+func (a *App) executeBriefingAction(session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {
+	if a == nil || action == nil {
+		return "", nil, fmt.Errorf("briefing action is required")
+	}
+	req, err := a.parseBriefingRequest(action)
+	if err != nil {
+		return "", nil, err
+	}
+	targetProject, err := a.systemActionTargetProject(session)
+	if err != nil {
+		return "", nil, err
+	}
+	cwd := strings.TrimSpace(targetProject.RootPath)
+	if cwd == "" {
+		cwd = strings.TrimSpace(a.cwdForProjectKey(targetProject.ProjectKey))
+	}
+	if cwd == "" {
+		return "", nil, fmt.Errorf("briefing cwd is not available")
+	}
+
+	snapshot, err := a.collectBriefingSnapshot(req)
+	if err != nil {
+		return "", nil, err
+	}
+	content := renderBriefingMarkdown(snapshot)
+
+	relativePath := filepath.ToSlash(filepath.Join(".tabura", "artifacts", "briefing", req.Date.In(time.Local).Format("2006-01-02")+".md"))
+	absPath, canvasTitle, err := resolveCanvasFilePath(cwd, relativePath)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return "", nil, err
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		return "", nil, err
+	}
+
+	artifactTitle := fmt.Sprintf("Daily Briefing %s", req.Date.In(time.Local).Format("2006-01-02"))
+	metaJSON := briefingArtifactMeta(snapshot)
+	artifact, err := a.store.CreateArtifact(briefingArtifactKind, &absPath, nil, &artifactTitle, &metaJSON)
+	if err != nil {
+		return "", nil, err
+	}
+	if workspace, workspaceErr := a.store.ActiveWorkspace(); workspaceErr == nil {
+		_ = a.store.LinkArtifactToWorkspace(workspace.ID, artifact.ID)
+	}
+
+	canvasSessionID := strings.TrimSpace(a.canvasSessionIDForProject(targetProject))
+	if canvasSessionID == "" {
+		return "", nil, fmt.Errorf("canvas session is not available")
+	}
+	port, ok := a.tunnels.getPort(canvasSessionID)
+	if !ok {
+		return "", nil, fmt.Errorf("no active MCP tunnel for project %q", targetProject.Name)
+	}
+	if _, err := a.mcpToolsCall(port, "canvas_artifact_show", map[string]interface{}{
+		"session_id":       canvasSessionID,
+		"kind":             "text",
+		"title":            canvasTitle,
+		"markdown_or_text": content,
+	}); err != nil {
+		return "", nil, err
+	}
+	a.markProjectOutput(targetProject.ProjectKey)
+
+	return fmt.Sprintf("Opened %s on canvas.", artifactTitle), map[string]interface{}{
+		"type":                 "show_briefing",
+		"artifact_id":          artifact.ID,
+		"path":                 canvasTitle,
+		"date":                 req.Date.In(time.Local).Format("2006-01-02"),
+		"event_count":          len(snapshot.TodayEvents) + len(snapshot.TomorrowEvents),
+		"today_deadline_count": len(snapshot.TodayDeadlines),
+		"week_deadline_count":  len(snapshot.WeekDeadlines),
+		"warning_count":        len(snapshot.Warnings),
+	}, nil
+}
+
+func (a *App) parseBriefingRequest(action *SystemAction) (briefingRequest, error) {
+	now := time.Now()
+	if a != nil && a.calendarNow != nil {
+		now = a.calendarNow()
+	}
+	req := briefingRequest{
+		Date:   now.In(time.Local),
+		Sphere: normalizeBriefingSphere(calendarOptionalParam(action.Params, "sphere")),
+	}
+	if rawDate := calendarOptionalParam(action.Params, "date"); rawDate != "" {
+		parsed, err := time.ParseInLocation("2006-01-02", rawDate, time.Local)
+		if err != nil {
+			return briefingRequest{}, fmt.Errorf("briefing date must be YYYY-MM-DD")
+		}
+		req.Date = parsed
+	}
+	return req, nil
+}
+
+func normalizeBriefingSphere(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return ""
+	case store.SphereWork:
+		return store.SphereWork
+	case store.SpherePrivate:
+		return store.SpherePrivate
+	default:
+		return ""
+	}
+}
+
+func (a *App) collectBriefingSnapshot(req briefingRequest) (briefingSnapshot, error) {
+	todayReq := calendarActionRequest{View: calendarViewAgenda, Date: req.Date}
+	tomorrowReq := calendarActionRequest{View: calendarViewAgenda, Date: req.Date.AddDate(0, 0, 1)}
+	weekReq := calendarActionRequest{View: calendarViewWeek, Date: req.Date}
+
+	todayEvents, todayWarnings, err := a.collectCalendarEvents(context.Background(), todayReq, req.Sphere)
+	if err != nil {
+		return briefingSnapshot{}, err
+	}
+	tomorrowEvents, tomorrowWarnings, err := a.collectCalendarEvents(context.Background(), tomorrowReq, req.Sphere)
+	if err != nil {
+		return briefingSnapshot{}, err
+	}
+	todayDeadlines, err := a.collectCalendarDeadlines(todayReq)
+	if err != nil {
+		return briefingSnapshot{}, err
+	}
+	weekDeadlines, err := a.collectCalendarDeadlines(weekReq)
+	if err != nil {
+		return briefingSnapshot{}, err
+	}
+	items, err := a.store.ListItems()
+	if err != nil {
+		return briefingSnapshot{}, err
+	}
+	generatedAt := time.Now().UTC()
+	if a != nil && a.calendarNow != nil {
+		generatedAt = a.calendarNow().UTC()
+	}
+	inboxCounts := map[string]int{
+		store.SphereWork:    0,
+		store.SpherePrivate: 0,
+	}
+	workspaceNames := map[int64]string{}
+	projectNames := map[string]string{}
+	var (
+		urgentItems      []briefingOpenItem
+		unreadEmailItems []briefingOpenItem
+		inFlightItems    []briefingOpenItem
+		reviewPRItems    []briefingOpenItem
+	)
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item.State), store.ItemStateDone) {
+			continue
+		}
+		sphere := normalizeBriefingItemSphere(item.Sphere)
+		if req.Sphere != "" && !strings.EqualFold(req.Sphere, sphere) {
+			continue
+		}
+		openItem := briefingOpenItem{
+			Title:     strings.TrimSpace(item.Title),
+			Sphere:    sphere,
+			Workspace: calendarWorkspaceName(a, item.WorkspaceID, workspaceNames),
+			Project:   calendarProjectName(a, item.ProjectID, projectNames),
+		}
+		if item.State == store.ItemStateInbox {
+			inboxCounts[sphere]++
+		}
+		if briefingItemIsUrgent(item) {
+			urgentItems = append(urgentItems, openItem)
+		}
+		if briefingItemIsUnreadEmail(item) {
+			unreadEmailItems = append(unreadEmailItems, openItem)
+		}
+		if item.State == store.ItemStateWaiting {
+			inFlightItems = append(inFlightItems, openItem)
+		}
+		if briefingItemIsReviewPR(item) {
+			reviewPRItems = append(reviewPRItems, openItem)
+		}
+	}
+	sortBriefingItems(urgentItems)
+	sortBriefingItems(unreadEmailItems)
+	sortBriefingItems(inFlightItems)
+	sortBriefingItems(reviewPRItems)
+
+	return briefingSnapshot{
+		Request:          req,
+		GeneratedAt:      generatedAt,
+		TodayEvents:      todayEvents,
+		TomorrowEvents:   tomorrowEvents,
+		TodayDeadlines:   filterBriefingDeadlines(todayDeadlines, req),
+		WeekDeadlines:    filterBriefingUpcomingDeadlines(weekDeadlines, req),
+		UrgentItems:      urgentItems,
+		UnreadEmailItems: unreadEmailItems,
+		InFlightItems:    inFlightItems,
+		ReviewPRItems:    reviewPRItems,
+		InboxCounts:      inboxCounts,
+		Warnings:         dedupeBriefingWarnings(todayWarnings, tomorrowWarnings),
+	}, nil
+}
+
+func normalizeBriefingItemSphere(raw string) string {
+	if strings.EqualFold(strings.TrimSpace(raw), store.SphereWork) {
+		return store.SphereWork
+	}
+	return store.SpherePrivate
+}
+
+func briefingItemIsUrgent(item store.Item) bool {
+	haystack := strings.ToLower(strings.Join([]string{
+		item.Title,
+		stringFromPointer(item.Source),
+		stringFromPointer(item.SourceRef),
+	}, " "))
+	for _, token := range []string{"[p0]", " p0 ", "p0:", "urgent", "asap"} {
+		if strings.Contains(haystack, token) {
+			return true
+		}
+	}
+	return strings.HasPrefix(haystack, "p0 ")
+}
+
+func briefingItemIsUnreadEmail(item store.Item) bool {
+	source := strings.ToLower(strings.TrimSpace(stringFromPointer(item.Source)))
+	switch source {
+	case store.ExternalProviderGmail, store.ExternalProviderIMAP, store.ExternalProviderExchange:
+		return true
+	default:
+		return false
+	}
+}
+
+func briefingItemIsReviewPR(item store.Item) bool {
+	if !strings.EqualFold(strings.TrimSpace(stringFromPointer(item.Source)), "github") {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(strings.TrimSpace(stringFromPointer(item.SourceRef))), "#PR-")
+}
+
+func sortBriefingItems(items []briefingOpenItem) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Sphere == items[j].Sphere {
+			return strings.ToLower(items[i].Title) < strings.ToLower(items[j].Title)
+		}
+		return items[i].Sphere < items[j].Sphere
+	})
+}
+
+func filterBriefingDeadlines(deadlines []calendarDeadlineEntry, req briefingRequest) []calendarDeadlineEntry {
+	out := make([]calendarDeadlineEntry, 0, len(deadlines))
+	for _, entry := range deadlines {
+		if req.Sphere != "" && !strings.EqualFold(req.Sphere, normalizeBriefingItemSphere(entry.Sphere)) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func filterBriefingUpcomingDeadlines(deadlines []calendarDeadlineEntry, req briefingRequest) []calendarDeadlineEntry {
+	cutoff := req.Date.In(time.Local).Format("2006-01-02")
+	out := make([]calendarDeadlineEntry, 0, len(deadlines))
+	for _, entry := range deadlines {
+		if req.Sphere != "" && !strings.EqualFold(req.Sphere, normalizeBriefingItemSphere(entry.Sphere)) {
+			continue
+		}
+		if entry.When.In(time.Local).Format("2006-01-02") <= cutoff {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func dedupeBriefingWarnings(groups ...[]string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, group := range groups {
+		for _, warning := range group {
+			clean := strings.TrimSpace(warning)
+			if clean == "" {
+				continue
+			}
+			if _, ok := seen[clean]; ok {
+				continue
+			}
+			seen[clean] = struct{}{}
+			out = append(out, clean)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func renderBriefingMarkdown(snapshot briefingSnapshot) string {
+	var b strings.Builder
+	date := snapshot.Request.Date.In(time.Local)
+	fmt.Fprintf(&b, "# Daily Briefing\n\n")
+	fmt.Fprintf(&b, "- Date: %s\n", date.Format("Monday, January 2, 2006"))
+	fmt.Fprintf(&b, "- Generated: %s\n", snapshot.GeneratedAt.In(time.Local).Format(time.RFC3339))
+	if snapshot.Request.Sphere != "" {
+		fmt.Fprintf(&b, "- Sphere filter: `%s`\n", snapshot.Request.Sphere)
+	}
+	if len(snapshot.Warnings) > 0 {
+		fmt.Fprintf(&b, "- Source warnings: %d\n", len(snapshot.Warnings))
+	}
+	b.WriteString("\n## Schedule\n\n")
+	for _, sphere := range briefingSphereOrder(snapshot.Request.Sphere) {
+		fmt.Fprintf(&b, "### %s\n\n", briefingSphereTitle(sphere))
+		events := briefingEventsForSphere(snapshot.TodayEvents, sphere)
+		if len(events) == 0 {
+			b.WriteString("_No scheduled events._\n\n")
+			continue
+		}
+		for _, event := range events {
+			fmt.Fprintf(&b, "- %s\n", renderBriefingEventLine(event))
+		}
+		b.WriteString("\n")
+	}
+
+	dueToday, resurfaceToday := splitBriefingDeadlines(snapshot.TodayDeadlines)
+	fmt.Fprintf(&b, "## Attention Needed\n\n")
+	fmt.Fprintf(&b, "- Inbox items: work %d, private %d\n", snapshot.InboxCounts[store.SphereWork], snapshot.InboxCounts[store.SpherePrivate])
+	fmt.Fprintf(&b, "- P0/urgent items: %d\n", len(snapshot.UrgentItems))
+	fmt.Fprintf(&b, "- Items due today: %d\n", len(dueToday))
+	fmt.Fprintf(&b, "- Items resurfacing today: %d\n", len(resurfaceToday))
+	fmt.Fprintf(&b, "- Unread emails requiring action: %d\n\n", len(snapshot.UnreadEmailItems))
+	renderBriefingItemSection(&b, "Urgent items", snapshot.UrgentItems)
+	renderBriefingDeadlineSection(&b, "Due today", dueToday, false)
+	renderBriefingDeadlineSection(&b, "Resurfacing today", resurfaceToday, false)
+	renderBriefingItemSection(&b, "Unread email follow-ups", snapshot.UnreadEmailItems)
+
+	fmt.Fprintf(&b, "## Active Work\n\n")
+	fmt.Fprintf(&b, "- Watched workspaces: 0\n")
+	fmt.Fprintf(&b, "- Orchestrator items in flight: %d\n", len(snapshot.InFlightItems))
+	fmt.Fprintf(&b, "- PRs awaiting review: %d\n\n", len(snapshot.ReviewPRItems))
+	b.WriteString("### Watched workspaces\n\n")
+	b.WriteString("_No watched workspaces configured._\n\n")
+	renderBriefingItemSection(&b, "Items in flight", snapshot.InFlightItems)
+	renderBriefingItemSection(&b, "PRs awaiting review", snapshot.ReviewPRItems)
+
+	fmt.Fprintf(&b, "## Upcoming\n\n")
+	b.WriteString("### Tomorrow's key events\n\n")
+	if len(snapshot.TomorrowEvents) == 0 {
+		b.WriteString("_No events tomorrow._\n\n")
+	} else {
+		for _, event := range snapshot.TomorrowEvents {
+			fmt.Fprintf(&b, "- %s: %s\n", briefingSphereTitle(normalizeBriefingItemSphere(event.Sphere)), renderBriefingEventLine(event))
+		}
+		b.WriteString("\n")
+	}
+	renderBriefingDeadlineSection(&b, "Items due this week", snapshot.WeekDeadlines, true)
+	renderBriefingDeadlineSection(&b, "Deadlines approaching", snapshot.WeekDeadlines, true)
+
+	if len(snapshot.Warnings) > 0 {
+		b.WriteString("## Source Warnings\n\n")
+		for _, warning := range snapshot.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func briefingSphereOrder(filter string) []string {
+	if filter != "" {
+		return []string{filter}
+	}
+	return []string{store.SphereWork, store.SpherePrivate}
+}
+
+func briefingSphereTitle(sphere string) string {
+	if strings.EqualFold(strings.TrimSpace(sphere), store.SphereWork) {
+		return "Work"
+	}
+	return "Private"
+}
+
+func briefingEventsForSphere(events []calendarEventEntry, sphere string) []calendarEventEntry {
+	out := make([]calendarEventEntry, 0, len(events))
+	for _, event := range events {
+		if strings.EqualFold(normalizeBriefingItemSphere(event.Sphere), normalizeBriefingItemSphere(sphere)) {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+func renderBriefingEventLine(event calendarEventEntry) string {
+	label := strings.TrimSpace(event.Summary)
+	if label == "" {
+		label = "(Untitled event)"
+	}
+	parts := []string{calendarTimeLabel(event.Start, event.End, event.AllDay), label}
+	if strings.TrimSpace(event.Location) != "" {
+		parts = append(parts, "@ "+event.Location)
+	}
+	if len(event.Attendees) > 0 {
+		parts = append(parts, "with "+strings.Join(event.Attendees, ", "))
+	}
+	parts = append(parts, "["+firstNonEmptyCalendarValue(event.Source, event.Provider, "calendar")+"]")
+	return strings.Join(parts, " ")
+}
+
+func splitBriefingDeadlines(deadlines []calendarDeadlineEntry) ([]calendarDeadlineEntry, []calendarDeadlineEntry) {
+	var due []calendarDeadlineEntry
+	var resurface []calendarDeadlineEntry
+	for _, entry := range deadlines {
+		switch strings.ToLower(strings.TrimSpace(entry.Kind)) {
+		case "due":
+			due = append(due, entry)
+		case "resurface":
+			resurface = append(resurface, entry)
+		}
+	}
+	return due, resurface
+}
+
+func renderBriefingItemSection(b *strings.Builder, title string, items []briefingOpenItem) {
+	fmt.Fprintf(b, "### %s\n\n", title)
+	if len(items) == 0 {
+		b.WriteString("_None._\n\n")
+		return
+	}
+	for _, item := range items {
+		fmt.Fprintf(b, "- %s\n", renderBriefingItemLine(item))
+	}
+	b.WriteString("\n")
+}
+
+func renderBriefingItemLine(item briefingOpenItem) string {
+	parts := []string{strings.TrimSpace(item.Title)}
+	location := firstNonEmpty(item.Workspace, item.Project)
+	if location != "" {
+		parts = append(parts, "["+location+"]")
+	}
+	parts = append(parts, "("+briefingSphereTitle(item.Sphere)+")")
+	return strings.Join(parts, " ")
+}
+
+func renderBriefingDeadlineSection(b *strings.Builder, title string, deadlines []calendarDeadlineEntry, includeDate bool) {
+	fmt.Fprintf(b, "### %s\n\n", title)
+	if len(deadlines) == 0 {
+		b.WriteString("_None._\n\n")
+		return
+	}
+	for _, entry := range deadlines {
+		fmt.Fprintf(b, "- %s\n", renderBriefingDeadlineLine(entry, includeDate))
+	}
+	b.WriteString("\n")
+}
+
+func renderBriefingDeadlineLine(entry calendarDeadlineEntry, includeDate bool) string {
+	title := strings.TrimSpace(entry.Title)
+	if title == "" {
+		title = "(Untitled item)"
+	}
+	timeLabel := entry.When.In(time.Local).Format("15:04")
+	if includeDate {
+		timeLabel = entry.When.In(time.Local).Format("Mon 15:04")
+	}
+	parts := []string{timeLabel, title}
+	location := firstNonEmpty(entry.Workspace, entry.Project)
+	if location != "" {
+		parts = append(parts, "["+location+"]")
+	}
+	parts = append(parts, "("+briefingSphereTitle(entry.Sphere)+")")
+	return strings.Join(parts, " ")
+}
+
+func briefingArtifactMeta(snapshot briefingSnapshot) string {
+	payload := map[string]interface{}{
+		"date":                 snapshot.Request.Date.In(time.Local).Format("2006-01-02"),
+		"sphere":               snapshot.Request.Sphere,
+		"today_event_count":    len(snapshot.TodayEvents),
+		"tomorrow_event_count": len(snapshot.TomorrowEvents),
+		"today_deadline_count": len(snapshot.TodayDeadlines),
+		"week_deadline_count":  len(snapshot.WeekDeadlines),
+		"urgent_count":         len(snapshot.UrgentItems),
+		"unread_email_count":   len(snapshot.UnreadEmailItems),
+		"in_flight_count":      len(snapshot.InFlightItems),
+		"review_pending_count": len(snapshot.ReviewPRItems),
+		"inbox_work_count":     snapshot.InboxCounts[store.SphereWork],
+		"inbox_private_count":  snapshot.InboxCounts[store.SpherePrivate],
+		"warning_count":        len(snapshot.Warnings),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}

--- a/internal/web/chat_briefing_test.go
+++ b/internal/web/chat_briefing_test.go
@@ -1,0 +1,242 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestParseInlineBriefingIntent(t *testing.T) {
+	now := time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	cases := []string{
+		"show my day",
+		"show briefing",
+		"update briefing",
+		"was steht heute an?",
+	}
+	for _, text := range cases {
+		action := parseInlineBriefingIntent(text, now)
+		if action == nil {
+			t.Fatalf("parseInlineBriefingIntent(%q) returned nil", text)
+		}
+		if action.Action != "show_briefing" {
+			t.Fatalf("action = %q, want show_briefing", action.Action)
+		}
+		if got := strings.TrimSpace(systemActionStringParam(action.Params, "date")); got != "2026-03-09" {
+			t.Fatalf("date = %q, want 2026-03-09", got)
+		}
+	}
+}
+
+func TestClassifyAndExecuteSystemActionShowBriefingRendersArtifact(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+	now := time.Date(2026, time.March, 9, 8, 0, 0, 0, time.UTC)
+	app.calendarNow = func() time.Time { return now }
+	app.newICSCalendarReader = func() (icsCalendarReader, error) { return stubICSCalendarReader{}, nil }
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	workWorkspace, err := app.store.CreateWorkspace("Work", project.RootPath, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(work): %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workWorkspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(work): %v", err)
+	}
+	privateDir := filepath.Join(t.TempDir(), "private")
+	if err := os.MkdirAll(privateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(private): %v", err)
+	}
+	privateWorkspace, err := app.store.CreateWorkspace("Home", privateDir, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(private): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGoogleCalendar, "Work Calendar", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(work calendar): %v", err)
+	}
+	if _, err := app.store.CreateExternalAccount(store.SpherePrivate, store.ExternalProviderGoogleCalendar, "Family", map[string]any{}); err != nil {
+		t.Fatalf("CreateExternalAccount(private calendar): %v", err)
+	}
+
+	workSphere := store.SphereWork
+	privateSphere := store.SpherePrivate
+	dueToday := now.Add(2 * time.Hour).Format(time.RFC3339)
+	resurfaceToday := now.Add(-30 * time.Minute).Format(time.RFC3339)
+	dueThisWeek := now.Add(48 * time.Hour).Format(time.RFC3339)
+	if _, err := app.store.CreateItem("[P0] Ship fix", store.ItemOptions{
+		WorkspaceID: &workWorkspace.ID,
+		Sphere:      &workSphere,
+	}); err != nil {
+		t.Fatalf("CreateItem(urgent): %v", err)
+	}
+	if _, err := app.store.CreateItem("Prepare brief", store.ItemOptions{
+		WorkspaceID: &workWorkspace.ID,
+		Sphere:      &workSphere,
+		FollowUpAt:  &dueToday,
+	}); err != nil {
+		t.Fatalf("CreateItem(due today): %v", err)
+	}
+	if _, err := app.store.CreateItem("Review backlog", store.ItemOptions{
+		WorkspaceID:  &workWorkspace.ID,
+		Sphere:       &workSphere,
+		VisibleAfter: &resurfaceToday,
+	}); err != nil {
+		t.Fatalf("CreateItem(resurface today): %v", err)
+	}
+	if _, err := app.store.CreateItem("Reply to Carol", store.ItemOptions{
+		WorkspaceID: &privateWorkspace.ID,
+		Sphere:      &privateSphere,
+		Source:      existingStringPtr(store.ExternalProviderGmail),
+	}); err != nil {
+		t.Fatalf("CreateItem(email): %v", err)
+	}
+	if _, err := app.store.CreateItem("Review PR 42", store.ItemOptions{
+		State:       store.ItemStateWaiting,
+		WorkspaceID: &workWorkspace.ID,
+		Sphere:      &workSphere,
+		Source:      existingStringPtr("github"),
+		SourceRef:   existingStringPtr("owner/repo#PR-42"),
+	}); err != nil {
+		t.Fatalf("CreateItem(pr review): %v", err)
+	}
+	if _, err := app.store.CreateItem("Draft budget", store.ItemOptions{
+		WorkspaceID: &workWorkspace.ID,
+		Sphere:      &workSphere,
+		FollowUpAt:  &dueThisWeek,
+	}); err != nil {
+		t.Fatalf("CreateItem(due this week): %v", err)
+	}
+
+	app.newGoogleCalendarReader = func(context.Context) (googleCalendarReader, error) {
+		return &stubGoogleCalendarReader{
+			calendars: []providerdata.Calendar{
+				{ID: "work", Name: "Work Calendar"},
+				{ID: "family", Name: "Family"},
+			},
+			events: map[string][]providerdata.Event{
+				"work": {
+					{
+						CalendarID: "work",
+						Summary:    "Work sync",
+						Location:   "Lab",
+						Attendees:  []string{"alice@example.com"},
+						Start:      now.Add(1 * time.Hour),
+						End:        now.Add(2 * time.Hour),
+					},
+					{
+						CalendarID: "work",
+						Summary:    "Design sync",
+						Start:      now.Add(26 * time.Hour),
+						End:        now.Add(27 * time.Hour),
+					},
+				},
+				"family": {
+					{
+						CalendarID: "family",
+						Summary:    "Family holiday",
+						Start:      now.Add(12 * time.Hour),
+						End:        now.Add(36 * time.Hour),
+						AllDay:     true,
+					},
+				},
+			},
+		}, nil
+	}
+
+	var (
+		showCalls int
+		observed  map[string]interface{}
+	)
+	canvasServer := setupMockCanvasShowServer(t, &showCalls, &observed)
+	defer canvasServer.Close()
+	port, err := extractPort(canvasServer.URL)
+	if err != nil {
+		t.Fatalf("extractPort(canvas): %v", err)
+	}
+	app.tunnels.setPort(app.canvasSessionIDForProject(project), port)
+
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show my day")
+	if !handled {
+		t.Fatal("expected show my day to be handled")
+	}
+	if !strings.Contains(message, "Opened Daily Briefing 2026-03-09 on canvas.") {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payload count = %d, want 1", len(payloads))
+	}
+	if got := strFromAny(payloads[0]["type"]); got != "show_briefing" {
+		t.Fatalf("payload type = %q, want show_briefing", got)
+	}
+	if showCalls != 1 {
+		t.Fatalf("canvas_artifact_show calls = %d, want 1", showCalls)
+	}
+	path := strFromAny(payloads[0]["path"])
+	if path != ".tabura/artifacts/briefing/2026-03-09.md" {
+		t.Fatalf("payload path = %q", path)
+	}
+	rendered, err := os.ReadFile(filepath.Join(project.RootPath, path))
+	if err != nil {
+		t.Fatalf("ReadFile(rendered): %v", err)
+	}
+	content := string(rendered)
+	for _, snippet := range []string{
+		"# Daily Briefing",
+		"## Schedule",
+		"### Work",
+		"### Private",
+		"Work sync @ Lab with alice@example.com [Work Calendar]",
+		"All day Family holiday [Family]",
+		"## Attention Needed",
+		"Inbox items: work 4, private 1",
+		"P0/urgent items: 1",
+		"Unread emails requiring action: 1",
+		"Prepare brief [Work] (Work)",
+		"Review backlog [Work] (Work)",
+		"Reply to Carol [Home] (Private)",
+		"## Active Work",
+		"Watched workspaces: 0",
+		"Orchestrator items in flight: 1",
+		"PRs awaiting review: 1",
+		"Review PR 42 [Work] (Work)",
+		"## Upcoming",
+		"Tomorrow's key events",
+		"Design sync [Work Calendar]",
+		"Items due this week",
+		"Draft budget [Work] (Work)",
+		"Deadlines approaching",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("briefing artifact missing %q:\n%s", snippet, content)
+		}
+	}
+	if got := strFromAny(observed["title"]); got != path {
+		t.Fatalf("canvas title = %q, want %q", got, path)
+	}
+	artifacts, err := app.store.ListArtifactsByKind(briefingArtifactKind)
+	if err != nil {
+		t.Fatalf("ListArtifactsByKind(briefing): %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("briefing artifacts = %d, want 1", len(artifacts))
+	}
+}
+
+func existingStringPtr(value string) *string {
+	return &value
+}

--- a/internal/web/chat_hub.go
+++ b/internal/web/chat_hub.go
@@ -27,7 +27,7 @@ const (
 
 const hubSystemPrompt = `You are Tabura Hub, a fast coordinator.
 For system actions output JSON only: {"action":"<action>", ...params}.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, show_calendar, cancel_work, show_status, review_someday, toggle_someday_review_nudge, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, create_workspace_from_git, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, shell, open_file_canvas, show_calendar, show_briefing, cancel_work, show_status, review_someday, toggle_someday_review_nudge, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 You may return multi-step actions via {"actions":[...]}.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), MUST use chat and MUST NOT use shell.
 For uncertain open/show-file requests: shell search first, then open_file_canvas with path="$last_shell_path".

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -31,7 +31,7 @@ const (
 )
 
 const intentLLMSystemPrompt = `You are Tabura's local router. Output JSON only.
-Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, show_calendar, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
+Allowed actions: switch_project, switch_workspace, list_workspace_items, list_workspaces, create_workspace, create_workspace_from_git, rename_workspace, delete_workspace, show_workspace_details, assign_workspace_project, show_workspace_project, create_project, list_project_workspaces, link_workspace_artifact, list_linked_artifacts, switch_model, toggle_silent, toggle_live_dialogue, cancel_work, show_status, shell, open_file_canvas, show_calendar, show_briefing, make_item, delegate_item, snooze_item, split_items, reassign_workspace, reassign_project, clear_workspace, clear_project, capture_idea, refine_idea_note, promote_idea, apply_idea_promotion, create_github_issue, create_github_issue_split, print_item, review_someday, triage_someday, promote_someday, toggle_someday_review_nudge, show_filtered_items, sync_project, sync_sources, map_todoist_project, sync_todoist, create_todoist_task, sync_evernote, sync_bear, promote_bear_checklist, sync_zotero, chat.
 Use {"action":"chat"} unless user clearly requests a system action.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"action":"chat"} and MUST NOT use shell.
 For shell-like requests use {"action":"shell","command":"..."}.
@@ -318,7 +318,7 @@ func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "toggle_conversation":
 		return "toggle_live_dialogue"
-	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "show_calendar", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_project", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero", "cursor_open_item", "cursor_triage_item", "cursor_open_path":
+	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "show_calendar", "show_briefing", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_project", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero", "cursor_open_item", "cursor_triage_item", "cursor_open_path":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""
@@ -778,6 +778,17 @@ func (a *App) classifyAndExecuteSystemActionWithCursor(ctx context.Context, sess
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
 			return calendarActionFailurePrefix(inlineCalendarAction.Action) + err.Error(), nil, true
+		}
+		return message, payloads, true
+	}
+	if inlineBriefingAction := parseInlineBriefingIntent(trimmedText, now); inlineBriefingAction != nil {
+		enforced := enforceRoutingPolicy(trimmedText, []*SystemAction{inlineBriefingAction})
+		if len(enforced) == 0 {
+			return "", nil, false
+		}
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		if err != nil {
+			return briefingActionFailurePrefix(inlineBriefingAction.Action) + err.Error(), nil, true
 		}
 		return message, payloads, true
 	}

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -511,6 +511,8 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 		}, nil
 	case "show_calendar":
 		return a.executeCalendarAction(session, action)
+	case "show_briefing":
+		return a.executeBriefingAction(session, action)
 	case "print_item":
 		return a.executePrintItemAction(sessionID, session, action)
 	default:


### PR DESCRIPTION
## Summary

- add a file-backed `show_briefing` chat action that generates `.tabura/artifacts/briefing/YYYY-MM-DD.md` and renders it on canvas
- reuse the existing calendar/item data sources to populate Schedule, Attention Needed, Active Work, and Upcoming sections
- cover the new routing and artifact content with focused `internal/web` tests

## Verification

- Trigger coverage: `TestParseInlineBriefingIntent` verifies `show my day`, `show briefing`, `update briefing`, and `was steht heute an?` all resolve to `show_briefing`.
- Schedule content: `TestClassifyAndExecuteSystemActionShowBriefingRendersArtifact` verifies separate `### Work` and `### Private` sections plus event title, location, attendees, and all-day rendering inside `.tabura/artifacts/briefing/2026-03-09.md`.
- Attention needed: the same test verifies inbox counts, urgent/P0 detection, due-today and resurfacing-today entries, and unread email action reporting in the generated briefing artifact.
- Active work: the same test verifies the watched-workspace status line, in-flight item count, and PR-awaiting-review list in the artifact.
- Upcoming: the same test verifies tomorrow event rendering plus `Items due this week` and `Deadlines approaching` sections, and it checks the canvas payload path `.tabura/artifacts/briefing/2026-03-09.md`.
- Command: `go test ./internal/web -run 'Test(ParseInlineBriefingIntent|ClassifyAndExecuteSystemActionShowBriefingRendersArtifact|ParseInlineCalendarIntent|ClassifyAndExecuteSystemActionShowCalendarRendersSphereAwareArtifact)$' 2>&1 | tee /tmp/tabura_issue308_test.log`
- Output excerpt: `ok   github.com/krystophny/tabura/internal/web  0.030s`
