### PR TITLE
fix: Replace single-tap live prompt with annotation accumulation laye (fixes #191)

### DIFF
--- a/internal/web/static/app-annotations.js
+++ b/internal/web/static/app-annotations.js
@@ -7,6 +7,7 @@ const sttStart = (...args) => refs.sttStart(...args);
 const sttSendBlob = (...args) => refs.sttSendBlob(...args);
 const sttStop = (...args) => refs.sttStop(...args);
 const sttCancel = (...args) => refs.sttCancel(...args);
+const submitMessage = (...args) => refs.submitMessage(...args);
 
 const ANNOTATION_STORAGE_KEY = 'tabura.annotations.v1';
 const HIGHLIGHT_COLOR = 'rgba(253, 230, 138, 0.72)';
@@ -140,6 +141,122 @@ function normalizeDescriptor(detail) {
     path: safeText(detail.path),
     event_id: safeText(detail.event_id || detail.eventId),
   };
+}
+
+function activeArtifactDescriptor() {
+  const current = state.currentCanvasArtifact || {};
+  return {
+    kind: safeText(activeDescriptor?.kind || current.kind),
+    title: safeText(activeDescriptor?.title || current.title),
+    path: safeText(activeDescriptor?.path || current.path),
+    event_id: safeText(activeDescriptor?.event_id || activeDescriptor?.eventId || current.event_id || current.eventId),
+  };
+}
+
+function activeArtifactLabel() {
+  const descriptor = activeArtifactDescriptor();
+  return descriptor.title || descriptor.path || descriptor.kind || 'current artifact';
+}
+
+function activeArtifactBundleInstruction() {
+  const descriptor = activeArtifactDescriptor();
+  const title = descriptor.title.toLowerCase();
+  const kind = descriptor.kind.toLowerCase();
+  if (state.prReviewMode || title.endsWith('.diff') || kind === 'pr_diff') {
+    return 'Draft review feedback for the current diff using these annotations.';
+  }
+  if (kind === 'email' || title.startsWith('re:') || title.startsWith('fw:')) {
+    return 'Draft an email reply using these annotations.';
+  }
+  if (kind === 'text_artifact' || kind === 'document' || kind === 'markdown') {
+    return 'Revise the current artifact using these annotations.';
+  }
+  return 'Use these annotations as instructions for the current artifact.';
+}
+
+function formatAnnotationTarget(annotation) {
+  if (annotation?.target === 'pdf') {
+    const page = Number.parseInt(safeText(annotation?.page), 10);
+    return Number.isFinite(page) && page > 0 ? `PDF page ${page}` : 'PDF selection';
+  }
+  return 'Text selection';
+}
+
+function formatAnnotationBundleText(annotations, options = {}) {
+  if (!Array.isArray(annotations) || annotations.length === 0) return '';
+  const immediate = options.immediate === true;
+  const lines = [
+    immediate
+      ? 'Handle this annotation immediately instead of waiting for a larger bundle.'
+      : activeArtifactBundleInstruction(),
+    `Artifact: ${activeArtifactLabel()}`,
+  ];
+  const descriptor = activeArtifactDescriptor();
+  if (descriptor.kind) {
+    lines.push(`Artifact kind: ${descriptor.kind}`);
+  }
+  annotations.forEach((annotation, index) => {
+    lines.push('');
+    lines.push(`Annotation ${index + 1}: ${formatAnnotationTarget(annotation)}`);
+    lines.push(`Selection: "${safeText(annotation?.text) || 'Untitled annotation'}"`);
+    const notes = Array.isArray(annotation?.notes) ? annotation.notes : [];
+    if (notes.length === 0) {
+      lines.push('Notes: none');
+      return;
+    }
+    lines.push('Notes:');
+    notes.forEach((note) => {
+      const kind = safeText(note?.kind) || 'text';
+      const content = safeText(note?.content) || '(empty)';
+      lines.push(`- ${kind}: ${content}`);
+    });
+  });
+  return lines.join('\n').trim();
+}
+
+async function submitAnnotationBundle(annotationID = '') {
+  const annotations = listActiveAnnotations();
+  if (annotations.length === 0) {
+    showStatus('no annotations to send');
+    return false;
+  }
+  const targetID = safeText(annotationID);
+  const selected = targetID
+    ? annotations.filter((annotation) => safeText(annotation?.id) === targetID)
+    : annotations;
+  if (selected.length === 0) {
+    showStatus('annotation missing');
+    return false;
+  }
+  const bundleText = formatAnnotationBundleText(selected, { immediate: Boolean(targetID) });
+  if (!bundleText) {
+    showStatus('annotation bundle empty');
+    return false;
+  }
+  const ok = await submitMessage(bundleText, {
+    kind: targetID ? 'annotation_immediate' : 'annotation_bundle',
+  });
+  if (!ok) return false;
+  if (targetID) {
+    saveActiveAnnotations(annotations.filter((annotation) => safeText(annotation?.id) !== targetID));
+  } else {
+    saveActiveAnnotations([]);
+  }
+  closeAnnotationBubble();
+  renderActiveAnnotations();
+  showStatus(targetID ? 'annotation sent' : 'annotation bundle sent');
+  return true;
+}
+
+function clearAllActiveAnnotations() {
+  if (listActiveAnnotations().length === 0) {
+    showStatus('no annotations to clear');
+    return;
+  }
+  saveActiveAnnotations([]);
+  closeAnnotationBubble();
+  renderActiveAnnotations();
+  showStatus('annotations cleared');
 }
 
 function annotationClientRects(annotation) {
@@ -326,6 +443,29 @@ function renderAnnotationBubble() {
   controls.appendChild(deleteButton);
 
   bubble.appendChild(controls);
+
+  const bundleControls = document.createElement('div');
+  bundleControls.className = 'annotation-bubble-controls';
+
+  const sendButton = document.createElement('button');
+  sendButton.id = 'annotation-bundle-send';
+  sendButton.type = 'button';
+  sendButton.textContent = listActiveAnnotations().length > 1 ? 'Send bundle' : 'Send annotation';
+  sendButton.addEventListener('click', () => {
+    void submitAnnotationBundle();
+  });
+  bundleControls.appendChild(sendButton);
+
+  const clearButton = document.createElement('button');
+  clearButton.id = 'annotation-bundle-clear';
+  clearButton.type = 'button';
+  clearButton.textContent = 'Clear all';
+  clearButton.addEventListener('click', () => {
+    clearAllActiveAnnotations();
+  });
+  bundleControls.appendChild(clearButton);
+
+  bubble.appendChild(bundleControls);
   bubble.hidden = false;
   bubble.style.left = `${Math.max(12, Math.min(window.innerWidth - 300, anchor.left))}px`;
   bubble.style.top = `${Math.max(12, Math.min(window.innerHeight - 220, anchor.top + anchor.height + 10))}px`;
@@ -347,6 +487,11 @@ function renderAnnotationBadge(root, annotation, width, height) {
     event.preventDefault();
     event.stopPropagation();
     openAnnotationBubble(annotation.id);
+  });
+  badge.addEventListener('dblclick', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void submitAnnotationBundle(annotation.id);
   });
   root.appendChild(badge);
 }
@@ -374,6 +519,11 @@ function renderTextAnnotations(annotations) {
           event.preventDefault();
           event.stopPropagation();
           openAnnotationBubble(annotation.id);
+        });
+        node.addEventListener('dblclick', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void submitAnnotationBundle(annotation.id);
         });
         layer.appendChild(node);
       });
@@ -404,6 +554,11 @@ function renderPdfAnnotations(annotations) {
           event.preventDefault();
           event.stopPropagation();
           openAnnotationBubble(annotation.id);
+        });
+        node.addEventListener('dblclick', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void submitAnnotationBundle(annotation.id);
         });
         layer.appendChild(node);
       });

--- a/internal/web/static/app-chat-submit.js
+++ b/internal/web/static/app-chat-submit.js
@@ -170,7 +170,7 @@ export async function submitMessage(text, options = {}) {
     if (submitKind === 'voice_transcript') {
       state.voiceTranscriptSubmitInFlight = false;
     }
-    return;
+    return false;
   }
   cancelLiveSessionListen();
   startVoiceLifecycleOp('submit-message');
@@ -191,7 +191,7 @@ export async function submitMessage(text, options = {}) {
     if (submitKind === 'voice_transcript') {
       state.voiceTranscriptSubmitInFlight = false;
     }
-    return;
+    return true;
   }
   let finalText = trimmed;
   const anchor = getInputAnchor();
@@ -242,7 +242,7 @@ export async function submitMessage(text, options = {}) {
       appendPlainMessage('system', `Send failed: ${detail}`);
       updateOverlay(`**Send failed:** ${detail}`);
       updateAssistantActivityIndicator();
-      return;
+      return false;
     }
     const payload = await resp.json();
     if (payload?.kind === 'command') {
@@ -254,6 +254,7 @@ export async function submitMessage(text, options = {}) {
         appendPlainMessage('system', String(payload.result.message));
       }
     }
+    return true;
   } catch (err) {
     if (err && (err.name === 'AbortError' || String(err?.message || '').toLowerCase().includes('aborted'))) {
       state.voiceAwaitingTurn = false;
@@ -262,7 +263,7 @@ export async function submitMessage(text, options = {}) {
       trackAssistantTurnFinished('');
       showStatus('stopped');
       updateAssistantActivityIndicator();
-      return;
+      return false;
     }
     state.voiceAwaitingTurn = false;
     const pending = takePendingRow('');
@@ -271,6 +272,7 @@ export async function submitMessage(text, options = {}) {
     appendPlainMessage('system', `Send failed: ${String(err?.message || err)}`);
     updateOverlay(`**Send failed:** ${String(err?.message || err)}`);
     updateAssistantActivityIndicator();
+    return false;
   } finally {
     clearPendingSubmit(submitController);
     if (submitKind === 'voice_transcript') {

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -536,6 +536,90 @@ test.describe('floating tool palette', () => {
     await expect(page.locator('#canvas-pdf .canvas-annotation-badge')).toHaveText('1');
   });
 
+  test('highlight annotations stay local until bundle send', async ({ page }) => {
+    await injectCanvasEvent(page, {
+      kind: 'text_artifact',
+      event_id: 'art-highlight-bundle-1',
+      title: 'bundle.md',
+      text: 'Alpha beta gamma delta',
+    });
+    await expect(page.locator('#canvas-text')).toBeVisible();
+    await page.locator('#surface-toggle').click();
+    await setInteractionTool(page, 'highlight');
+    await clearLog(page);
+
+    await page.evaluate(() => {
+      const textNode = document.querySelector('#canvas-text p')?.firstChild;
+      if (!(textNode instanceof Text)) {
+        throw new Error('text node unavailable for annotation bundle test');
+      }
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 5);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0 }));
+    });
+
+    await page.locator('#annotation-note-input').fill('Needs follow-up');
+    await page.locator('#annotation-note-save').click();
+    await expect(page.locator('#canvas-text .canvas-user-highlight.is-persistent')).toHaveCount(1);
+
+    let sentMessages = (await getLog(page)).filter((entry) => entry.type === 'message_sent');
+    expect(sentMessages).toHaveLength(0);
+
+    await page.locator('#annotation-bundle-send').click();
+    await waitForLogEntry(page, 'message_sent');
+
+    sentMessages = (await getLog(page)).filter((entry) => entry.type === 'message_sent');
+    expect(sentMessages).toHaveLength(1);
+    expect(String(sentMessages[0]?.text || '')).toContain('Revise the current artifact using these annotations.');
+    expect(String(sentMessages[0]?.text || '')).toContain('Selection: "Alpha"');
+    expect(String(sentMessages[0]?.text || '')).toContain('text: Needs follow-up');
+    await expect(page.locator('#canvas-text .canvas-user-highlight.is-persistent')).toHaveCount(0);
+  });
+
+  test('double-click on an annotation sends it immediately', async ({ page }) => {
+    await injectCanvasEvent(page, {
+      kind: 'text_artifact',
+      event_id: 'art-highlight-bundle-2',
+      title: 'immediate.md',
+      text: 'Alpha beta gamma delta',
+    });
+    await expect(page.locator('#canvas-text')).toBeVisible();
+    await page.locator('#surface-toggle').click();
+    await setInteractionTool(page, 'highlight');
+
+    await page.evaluate(() => {
+      const textNode = document.querySelector('#canvas-text p')?.firstChild;
+      if (!(textNode instanceof Text)) {
+        throw new Error('text node unavailable for immediate annotation test');
+      }
+      const range = document.createRange();
+      range.setStart(textNode, 6);
+      range.setEnd(textNode, 10);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0 }));
+    });
+
+    await page.locator('#annotation-note-input').fill('Ship this now');
+    await page.locator('#annotation-note-save').click();
+    await clearLog(page);
+
+    await page.locator('#canvas-text .canvas-user-highlight.is-persistent').dblclick();
+    await waitForLogEntry(page, 'message_sent');
+
+    const sentMessages = (await getLog(page)).filter((entry) => entry.type === 'message_sent');
+    expect(sentMessages).toHaveLength(1);
+    expect(String(sentMessages[0]?.text || '')).toContain('Handle this annotation immediately instead of waiting for a larger bundle.');
+    expect(String(sentMessages[0]?.text || '')).toContain('Selection: "beta"');
+    expect(String(sentMessages[0]?.text || '')).toContain('text: Ship this now');
+    await expect(page.locator('#canvas-text .canvas-user-highlight.is-persistent')).toHaveCount(0);
+  });
+
   test('email artifacts opened from the sidebar default to annotate surface', async ({ page }) => {
     await page.evaluate(() => {
       (window as any).__setItemSidebarData({


### PR DESCRIPTION
## Summary
- add explicit annotation bundle actions in the annotation bubble
- route bundled annotations through chat only after a successful submit, then clear dispatched highlights
- add a double-click immediate-send shortcut and targeted Playwright coverage

## Verification
- Requirement: annotations are not sent until an explicit bundle action.
  Evidence: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep "highlight annotations stay local until bundle send|double-click on an annotation sends it immediately"` -> `2 passed (2.3s)`
  Test: `highlight annotations stay local until bundle send` asserts zero `message_sent` events before clicking `#annotation-bundle-send`.
- Requirement: bundled annotations produce one contextual prompt and dispatched highlights are cleared.
  Evidence: same command/output above.
  Test: `highlight annotations stay local until bundle send` checks the sent message contains the selected text and note, then verifies `#canvas-text .canvas-user-highlight.is-persistent` count is `0`.
- Requirement: a power-user immediate-send escape hatch exists.
  Evidence: same command/output above.
  Test: `double-click on an annotation sends it immediately` verifies a double-click emits one `message_sent` event with immediate-send text and clears the highlight.
