### PR TITLE
fix: Automatic workspace and project assignment for Items (fixes #213)

### DIFF
--- a/internal/web/items_email.go
+++ b/internal/web/items_email.go
@@ -296,18 +296,50 @@ func emailMessageRemoteUpdatedAt(message *providerdata.EmailMessage) *string {
 	return &value
 }
 
-func emailMessageContainerRef(message *providerdata.EmailMessage) *string {
+func emailMessageLabelRefs(message *providerdata.EmailMessage) []string {
 	if message == nil {
 		return nil
 	}
+	seen := map[string]struct{}{}
+	refs := make([]string, 0, len(message.Labels))
 	for _, label := range message.Labels {
 		clean := strings.TrimSpace(label)
 		if clean == "" {
 			continue
 		}
-		return &clean
+		key := strings.ToLower(clean)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, clean)
 	}
-	return nil
+	return refs
+}
+
+func emailMessageContainerRef(message *providerdata.EmailMessage, mappings []store.ExternalContainerMapping) *string {
+	refs := emailMessageLabelRefs(message)
+	if len(refs) == 0 {
+		return nil
+	}
+	if len(mappings) == 0 {
+		return &refs[0]
+	}
+	mappedRefs := make(map[string]struct{}, len(mappings))
+	for _, mapping := range mappings {
+		ref := strings.TrimSpace(mapping.ContainerRef)
+		if ref == "" {
+			continue
+		}
+		mappedRefs[strings.ToLower(ref)] = struct{}{}
+	}
+	for _, ref := range refs {
+		if _, ok := mappedRefs[strings.ToLower(ref)]; ok {
+			return &ref
+		}
+	}
+	ref := refs[0]
+	return &ref
 }
 
 func emailArtifactMetaJSON(message *providerdata.EmailMessage, senderActor *store.Actor) (string, error) {
@@ -365,7 +397,7 @@ func (a *App) upsertMessageSenderActor(account store.ExternalAccount, message *p
 	return a.upsertContactActor(account, contact)
 }
 
-func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, message *providerdata.EmailMessage, followUp bool) (emailPersistedMessage, error) {
+func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, message *providerdata.EmailMessage, mappings []store.ExternalContainerMapping, followUp bool) (emailPersistedMessage, error) {
 	if message == nil || strings.TrimSpace(message.ID) == "" {
 		return emailPersistedMessage{}, nil
 	}
@@ -383,7 +415,7 @@ func (a *App) persistEmailMessage(ctx context.Context, sink tabsync.Sink, accoun
 		Provider:        account.Provider,
 		ObjectType:      emailBindingObjectType,
 		RemoteID:        strings.TrimSpace(message.ID),
-		ContainerRef:    emailMessageContainerRef(message),
+		ContainerRef:    emailMessageContainerRef(message, mappings),
 		RemoteUpdatedAt: emailMessageRemoteUpdatedAt(message),
 	}
 	artifact, err := sink.UpsertArtifact(ctx, store.Artifact{
@@ -448,6 +480,10 @@ func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.Ex
 	if err != nil {
 		return emailSyncResult{}, err
 	}
+	mappings, err := a.store.ListContainerMappings(account.Provider)
+	if err != nil {
+		return emailSyncResult{}, err
+	}
 
 	latestRemoteUpdatedAt, err := a.store.LatestBindingRemoteUpdatedAt(account.ID, account.Provider, emailBindingObjectType)
 	if err != nil {
@@ -483,7 +519,7 @@ func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.Ex
 		if message == nil || strings.TrimSpace(message.ID) == "" {
 			continue
 		}
-		persisted, err := a.persistEmailMessage(ctx, sink, account, message, hasEmailMessageID(followUpIDs, message.ID))
+		persisted, err := a.persistEmailMessage(ctx, sink, account, message, mappings, hasEmailMessageID(followUpIDs, message.ID))
 		if err != nil {
 			return emailSyncResult{}, err
 		}
@@ -493,7 +529,7 @@ func (a *App) syncEmailAccountWithProvider(ctx context.Context, account store.Ex
 			result.ItemCount++
 		}
 	}
-	threads, err := a.persistEmailThreads(ctx, sink, account, persistedMessages)
+	threads, err := a.persistEmailThreads(ctx, sink, account, mappings, persistedMessages)
 	if err != nil {
 		return emailSyncResult{}, err
 	}

--- a/internal/web/items_email_test.go
+++ b/internal/web/items_email_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -336,6 +337,94 @@ func TestSyncEmailAccountCreatesFollowUpItemsFromRules(t *testing.T) {
 	}
 	if item.Title != "contract review needed" {
 		t.Fatalf("rule item title = %q, want subject", item.Title)
+	}
+}
+
+func TestSyncEmailAccountUsesMappedNonPrimaryLabelForAssignment(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Legal Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	project, err := app.store.CreateProject("Contracts", "contracts", filepath.Join(t.TempDir(), "contracts"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Contracts", filepath.Join(t.TempDir(), "workspace", "contracts"), store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderGmail, "label", "Contracts", &workspace.ID, &project.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping() error: %v", err)
+	}
+
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			switch {
+			case opts.IsRead != nil && !*opts.IsRead:
+				return []string{"gmail-contracts"}, nil
+			case opts.IsFlagged != nil && *opts.IsFlagged:
+				return nil, nil
+			case !opts.Since.IsZero():
+				return []string{"gmail-contracts"}, nil
+			default:
+				return nil, nil
+			}
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-contracts": {
+				ID:         "gmail-contracts",
+				ThreadID:   "thread-contracts",
+				Subject:    "Review contract terms",
+				Sender:     "Counsel <counsel@example.com>",
+				Recipients: []string{"legal@example.com"},
+				Date:       time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC),
+				Labels:     []string{"INBOX", "Contracts"},
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	if _, err := app.syncEmailAccount(context.Background(), account); err != nil {
+		t.Fatalf("syncEmailAccount() error: %v", err)
+	}
+
+	item, err := app.store.GetItemBySource(store.ExternalProviderGmail, "message:gmail-contracts")
+	if err != nil {
+		t.Fatalf("GetItemBySource() error: %v", err)
+	}
+	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
+		t.Fatalf("item workspace_id = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+	if item.ProjectID == nil || *item.ProjectID != project.ID {
+		t.Fatalf("item project_id = %v, want %q", item.ProjectID, project.ID)
+	}
+
+	binding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderGmail, emailBindingObjectType, "gmail-contracts")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(email) error: %v", err)
+	}
+	if binding.ContainerRef == nil || *binding.ContainerRef != "Contracts" {
+		t.Fatalf("binding container_ref = %v, want Contracts", binding.ContainerRef)
+	}
+
+	artifacts, err := app.store.ListArtifactsForWorkspace(workspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactsForWorkspace() error: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("len(workspace artifacts) = %d, want 2", len(artifacts))
+	}
+
+	threadBinding, err := app.store.GetBindingByRemote(account.ID, store.ExternalProviderGmail, emailThreadBindingObjectType, "thread-contracts")
+	if err != nil {
+		t.Fatalf("GetBindingByRemote(thread) error: %v", err)
+	}
+	if threadBinding.ContainerRef == nil || *threadBinding.ContainerRef != "Contracts" {
+		t.Fatalf("thread binding container_ref = %v, want Contracts", threadBinding.ContainerRef)
 	}
 }
 

--- a/internal/web/items_email_thread.go
+++ b/internal/web/items_email_thread.go
@@ -146,9 +146,9 @@ func emailThreadRemoteUpdatedAt(messages []emailPersistedMessage) *string {
 	return nil
 }
 
-func emailThreadContainerRef(messages []emailPersistedMessage) *string {
+func emailThreadContainerRef(messages []emailPersistedMessage, mappings []store.ExternalContainerMapping) *string {
 	for _, persisted := range sortEmailMessagesByDate(messages) {
-		if ref := emailMessageContainerRef(persisted.Message); ref != nil {
+		if ref := emailMessageContainerRef(persisted.Message, mappings); ref != nil {
 			return ref
 		}
 	}
@@ -169,7 +169,7 @@ func emailThreadMetaJSON(threadID string, messages []emailPersistedMessage) (str
 	return string(raw), nil
 }
 
-func (a *App) persistEmailThreads(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, messages []emailPersistedMessage) ([]emailThreadRecord, error) {
+func (a *App) persistEmailThreads(ctx context.Context, sink tabsync.Sink, account store.ExternalAccount, mappings []store.ExternalContainerMapping, messages []emailPersistedMessage) ([]emailThreadRecord, error) {
 	grouped := make(map[string][]emailPersistedMessage)
 	for _, persisted := range messages {
 		threadID := emailThreadIDForMessage(persisted.Message)
@@ -205,7 +205,7 @@ func (a *App) persistEmailThreads(ctx context.Context, sink tabsync.Sink, accoun
 			Provider:        account.Provider,
 			ObjectType:      emailThreadBindingObjectType,
 			RemoteID:        threadID,
-			ContainerRef:    emailThreadContainerRef(group),
+			ContainerRef:    emailThreadContainerRef(group, mappings),
 			RemoteUpdatedAt: emailThreadRemoteUpdatedAt(group),
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary
- prefer a mapped email label or folder when choosing the binding container ref instead of blindly taking the first message label
- apply the same mapped-label selection to derived email thread artifacts so workspace links stay consistent
- add a regression test covering a Gmail message whose mapped label appears after `INBOX`

## Verification
- Items inherit active workspace automatically: `go test ./internal/store ./internal/web -run 'TestInferWorkspaceForArtifact|TestCreateItemInfersWorkspaceFromArtifactWithoutOverridingExplicitWorkspace|TestClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext' 2>&1 | tee -a /tmp/tabura-issue-213-test.log` -> `ok   github.com/krystophny/tabura/internal/web`
- Artifact location infers workspace when possible: `go test ./internal/store ./internal/web -run 'TestInferWorkspaceForArtifact|TestCreateItemInfersWorkspaceFromArtifactWithoutOverridingExplicitWorkspace|TestClassifyAndExecuteSystemActionMakeItemCreatesInboxItemFromAssistantContext' 2>&1 | tee -a /tmp/tabura-issue-213-test.log` -> `ok   github.com/krystophny/tabura/internal/store`
- Project label optional on workspaces and items: `go test ./internal/store ./internal/web -run 'TestWorkspaceProjectInferenceFromPathAndRemote|TestWorkspaceProjectInferenceSkipsAmbiguousMatches|TestProjectAwareItemFilteringUsesWorkspaceProjectFallback|TestWorkspaceProjectAssignmentAndProjectScopeAPI|TestItemWorkspaceAndProjectReassignmentAPI|TestClassifyAndExecuteSystemActionAssignWorkspaceProject|TestClassifyAndExecuteSystemActionItemReassignment|TestSyncEmailAccountUsesMappedNonPrimaryLabelForAssignment' 2>&1 | tee /tmp/tabura-issue-213-test.log` -> `ok   github.com/krystophny/tabura/internal/store`
- Heuristics infer project from workspace path, repo, and email tags: `go test ./internal/store ./internal/web -run 'TestWorkspaceProjectInferenceFromPathAndRemote|TestWorkspaceProjectInferenceSkipsAmbiguousMatches|TestProjectAwareItemFilteringUsesWorkspaceProjectFallback|TestWorkspaceProjectAssignmentAndProjectScopeAPI|TestItemWorkspaceAndProjectReassignmentAPI|TestClassifyAndExecuteSystemActionAssignWorkspaceProject|TestClassifyAndExecuteSystemActionItemReassignment|TestSyncEmailAccountUsesMappedNonPrimaryLabelForAssignment' 2>&1 | tee /tmp/tabura-issue-213-test.log` -> `ok   github.com/krystophny/tabura/internal/store` and `ok   github.com/krystophny/tabura/internal/web`
- Manual reassignment overrides any automatic assignment: `go test ./internal/store ./internal/web -run 'TestWorkspaceProjectInferenceFromPathAndRemote|TestWorkspaceProjectInferenceSkipsAmbiguousMatches|TestProjectAwareItemFilteringUsesWorkspaceProjectFallback|TestWorkspaceProjectAssignmentAndProjectScopeAPI|TestItemWorkspaceAndProjectReassignmentAPI|TestClassifyAndExecuteSystemActionAssignWorkspaceProject|TestClassifyAndExecuteSystemActionItemReassignment|TestSyncEmailAccountUsesMappedNonPrimaryLabelForAssignment' 2>&1 | tee /tmp/tabura-issue-213-test.log` -> `ok   github.com/krystophny/tabura/internal/web`
- Full test coverage for inheritance, inference, and manual override: `rg -n 'FAIL|panic:|--- FAIL|error:' /tmp/tabura-issue-213-test.log || true` -> no matches
