### PR TITLE
fix: epic: live bug reporting and behavior-driven review (fixes #292)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -31,6 +31,7 @@ type bugReportRequest struct {
 	BootID           string          `json:"boot_id"`
 	StartedAt        string          `json:"started_at"`
 	ActiveMode       string          `json:"active_mode"`
+	ActiveSphere     string          `json:"active_sphere"`
 	CanvasState      json.RawMessage `json:"canvas_state"`
 	RecentEvents     []string        `json:"recent_events"`
 	BrowserLogs      []string        `json:"browser_logs"`
@@ -76,6 +77,7 @@ type bugReportWorkspace struct {
 	Name    string
 	DirPath string
 	ID      *int64
+	Sphere  string
 }
 
 type gitHubLabelName struct {
@@ -110,6 +112,9 @@ func (a *App) handleBugReportCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
+	if sphere := normalizeBugReportSphere(req.ActiveSphere); sphere != "" {
+		workspace.Sphere = sphere
+	}
 	reportDir, reportID, err := createBugReportDir(workspace.DirPath, req.Timestamp)
 	if err != nil {
 		http.Error(w, "create bug report dir failed", http.StatusInternalServerError)
@@ -139,7 +144,7 @@ func (a *App) handleBugReportCreate(w http.ResponseWriter, r *http.Request) {
 		GitSHA:           resolveGitSHA(workspace.DirPath),
 		ActiveMode:       strings.TrimSpace(req.ActiveMode),
 		ActiveWorkspace:  workspace.Name,
-		ActiveSphere:     "",
+		ActiveSphere:     workspace.Sphere,
 		CanvasState:      normalizeBugReportRawJSON(req.CanvasState),
 		RecentEvents:     cleanBugReportLines(req.RecentEvents),
 		BrowserLogs:      cleanBugReportLines(req.BrowserLogs),
@@ -203,7 +208,7 @@ func (a *App) resolveBugReportWorkspace() (bugReportWorkspace, error) {
 	for _, workspace := range workspaces {
 		if workspace.IsActive {
 			id := workspace.ID
-			return bugReportWorkspace{Name: workspace.Name, DirPath: workspace.DirPath, ID: &id}, nil
+			return bugReportWorkspace{Name: workspace.Name, DirPath: workspace.DirPath, ID: &id, Sphere: workspace.Sphere}, nil
 		}
 	}
 	if root := strings.TrimSpace(a.localProjectDir); root != "" {
@@ -275,12 +280,31 @@ func (a *App) ensureBugReportWorkspaceID(workspace bugReportWorkspace) (*int64, 
 	case err != nil && !errors.Is(err, sql.ErrNoRows):
 		return nil, err
 	}
+	if sphere := normalizeBugReportSphere(workspace.Sphere); sphere != "" {
+		created, err := a.store.CreateWorkspace(workspace.Name, workspace.DirPath, sphere)
+		if err != nil {
+			return nil, err
+		}
+		id := created.ID
+		return &id, nil
+	}
 	created, err := a.store.CreateWorkspace(workspace.Name, workspace.DirPath)
 	if err != nil {
 		return nil, err
 	}
 	id := created.ID
 	return &id, nil
+}
+
+func normalizeBugReportSphere(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case store.SphereWork:
+		return store.SphereWork
+	case store.SpherePrivate:
+		return store.SpherePrivate
+	default:
+		return ""
+	}
 }
 
 func (a *App) ensureGitHubLabels(cwd string, wanted map[string]struct {
@@ -401,6 +425,7 @@ func bugReportIssueBody(bundle bugReportBundle, bundlePath string) string {
 	for _, line := range []string{
 		bugReportContextLine("Trigger", bundle.Trigger),
 		bugReportContextLine("Active mode", bundle.ActiveMode),
+		bugReportContextLine("Sphere", bundle.ActiveSphere),
 		bugReportContextLine("Workspace", bundle.ActiveWorkspace),
 		bugReportContextLine("Page", bundle.PageURL),
 		bugReportContextLine("Version", bundle.Version),

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -20,7 +20,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	workspaceDir := t.TempDir()
 	initGitRepo(t, workspaceDir)
 	addGitRemote(t, workspaceDir, "https://github.com/owner/tabula.git")
-	workspace, err := app.store.CreateWorkspace("Tabura", workspaceDir)
+	workspace, err := app.store.CreateWorkspace("Tabura", workspaceDir, store.SphereWork)
 	if err != nil {
 		t.Fatalf("CreateWorkspace() error: %v", err)
 	}
@@ -57,6 +57,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		"boot_id":       "boot-123",
 		"started_at":    "2026-03-08T14:00:00Z",
 		"active_mode":   "pen",
+		"active_sphere": store.SphereWork,
 		"canvas_state":  map[string]any{"has_artifact": true, "artifact_title": "README.md"},
 		"recent_events": []string{"tap at (12,18)", "report bug"},
 		"browser_logs":  []string{"warn: render slow"},
@@ -110,6 +111,9 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	}
 	if got := strFromAny(bundle["active_workspace"]); got != "Tabura" {
 		t.Fatalf("active_workspace = %q, want %q", got, "Tabura")
+	}
+	if got := strFromAny(bundle["active_sphere"]); got != store.SphereWork {
+		t.Fatalf("active_sphere = %q, want %q", got, store.SphereWork)
 	}
 	if got := strFromAny(bundle["active_mode"]); got != "pen" {
 		t.Fatalf("active_mode = %q, want %q", got, "pen")
@@ -187,6 +191,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		"--label p0",
 		"--title Bug report: The indicator froze after the tap",
 		"## Evidence",
+		"Sphere",
 		"## Device",
 		".tabura/artifacts/bugs/",
 		"\"platform\": \"macOS\"",
@@ -195,6 +200,57 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		if !strings.Contains(createCall, needle) {
 			t.Fatalf("create call = %q, missing %q", createCall, needle)
 		}
+	}
+}
+
+func TestHandleBugReportCreateFallsBackToWorkspaceSphere(t *testing.T) {
+	app := newAuthedTestApp(t)
+	workspaceDir := t.TempDir()
+	initGitRepo(t, workspaceDir)
+	addGitRemote(t, workspaceDir, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Tabura", workspaceDir, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		if cwd != workspaceDir {
+			t.Fatalf("gh cwd = %q, want %q", cwd, workspaceDir)
+		}
+		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
+			return `[{"name":"bug"},{"name":"p0"}]`, nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/owner/tabula/issues/88\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":88,"title":"Bug report: Sphere fallback","url":"https://github.com/owner/tabula/issues/88","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
+		"note":                "Sphere fallback.",
+		"screenshot_data_url": testPNGDataURL,
+	})
+	if rr.Code != 200 {
+		t.Fatalf("POST /api/bugs/report status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	bundlePath := strFromAny(payload["bundle_path"])
+	bundleBytes, err := os.ReadFile(filepath.Join(workspaceDir, filepath.FromSlash(bundlePath)))
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	var bundle map[string]any
+	if err := json.Unmarshal(bundleBytes, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	if got := strFromAny(bundle["active_sphere"]); got != store.SphereWork {
+		t.Fatalf("active_sphere = %q, want %q", got, store.SphereWork)
 	}
 }
 
@@ -244,6 +300,7 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	}
 
 	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
+		"active_sphere":       store.SphereWork,
 		"note":                "Local project fallback.",
 		"screenshot_data_url": testPNGDataURL,
 	})
@@ -253,6 +310,9 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	workspace, err := app.store.GetWorkspaceByPath(localProjectDir)
 	if err != nil {
 		t.Fatalf("GetWorkspaceByPath() error: %v", err)
+	}
+	if workspace.Sphere != store.SphereWork {
+		t.Fatalf("workspace.Sphere = %q, want %q", workspace.Sphere, store.SphereWork)
 	}
 	item, err := app.store.GetItemBySource("bug_report", "issue:91")
 	if err != nil {


### PR DESCRIPTION
## Summary
Preserve `active_sphere` throughout the bug-report pipeline so the captured bundle, fallback workspace creation, and generated GitHub issue all keep the user's sphere context.

## Verification
- Bug-report bundle now stores `active_sphere` from the request and includes it in the generated issue context.
  Evidence: `go test -v ./internal/web -run 'TestHandleBugReportCreate'` -> `TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts` passed and asserts `bundle["active_sphere"] == "work"`, plus the `gh issue create` payload includes `Sphere`.
- Active workspace sphere is used when the client omits `active_sphere`.
  Evidence: `go test -v ./internal/web -run 'TestHandleBugReportCreate'` -> `TestHandleBugReportCreateFallsBackToWorkspaceSphere` passed and verifies the saved bundle under `.tabura/artifacts/bugs/.../bundle.json` records `work`.
- Local-project fallback keeps the requested sphere when it auto-creates the workspace.
  Evidence: `go test -v ./internal/web -run 'TestHandleBugReportCreate'` -> `TestHandleBugReportCreateUsesLocalProjectFallback` passed and verifies the created workspace sphere is `work`.
- Existing workspace-context guard still holds.
  Evidence: `go test -v ./internal/web -run 'TestHandleBugReportCreate'` -> `TestHandleBugReportCreateRequiresWorkspaceContext` passed.

Command output excerpt:
```text
=== RUN   TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts
=== RUN   TestHandleBugReportCreateFallsBackToWorkspaceSphere
=== RUN   TestHandleBugReportCreateRequiresWorkspaceContext
=== RUN   TestHandleBugReportCreateUsesLocalProjectFallback
PASS
ok   github.com/krystophny/tabura/internal/web	0.070s
```