### PR TITLE
fix: epic: sphere model — work/private life-boundary separation (fixes #243)

### DIFF
--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -297,19 +297,46 @@ func (a *App) chooseActiveProject(projects []store.Project, defaultProject store
 	if len(projects) == 0 {
 		return store.Project{}, errors.New("no projects available")
 	}
+	activeSphere := a.runtimeActiveSphere()
 	activeID, err := a.store.ActiveProjectID()
 	if err != nil {
 		return store.Project{}, err
 	}
 	if activeID != "" {
 		for _, project := range projects {
-			if project.ID == activeID {
+			if project.ID != activeID {
+				continue
+			}
+			rank, err := a.projectSelectionRank(project, activeSphere)
+			if err != nil {
+				return store.Project{}, err
+			}
+			if rank < 4 {
 				return project, nil
 			}
 		}
 	}
+
+	bestIndex := -1
+	bestRank := 5
+	for i, project := range projects {
+		rank, err := a.projectSelectionRank(project, activeSphere)
+		if err != nil {
+			return store.Project{}, err
+		}
+		if rank >= 4 {
+			continue
+		}
+		if bestIndex == -1 || rank < bestRank {
+			bestIndex = i
+			bestRank = rank
+		}
+	}
+
 	fallback := defaultProject
-	if strings.TrimSpace(fallback.ID) == "" {
+	if bestIndex >= 0 {
+		fallback = projects[bestIndex]
+	} else if strings.TrimSpace(fallback.ID) == "" {
 		fallback = projects[0]
 	}
 	if err := a.store.SetActiveProjectID(fallback.ID); err != nil {

--- a/internal/web/projects_model.go
+++ b/internal/web/projects_model.go
@@ -75,6 +75,28 @@ func (a *App) projectSphere(project store.Project) (string, error) {
 	return workspace.Sphere, nil
 }
 
+func (a *App) projectSelectionRank(project store.Project, activeSphere string) (int, error) {
+	if isHubProject(project) {
+		return 3, nil
+	}
+	projectSphere, err := a.projectSphere(project)
+	if err != nil {
+		return 0, err
+	}
+	cleanProjectSphere := normalizeRuntimeActiveSphere(projectSphere)
+	cleanActiveSphere := normalizeRuntimeActiveSphere(activeSphere)
+	switch {
+	case cleanActiveSphere != "" && cleanProjectSphere == cleanActiveSphere:
+		return 0, nil
+	case cleanProjectSphere == "" && project.IsDefault:
+		return 1, nil
+	case cleanProjectSphere == "":
+		return 2, nil
+	default:
+		return 4, nil
+	}
+}
+
 func (a *App) buildProjectActivityItem(project store.Project) (projectActivityItem, error) {
 	session, err := a.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
@@ -244,6 +266,15 @@ func (a *App) activateProject(projectID string) (store.Project, error) {
 	if err != nil {
 		return store.Project{}, err
 	}
+	projectSphere, err := a.projectSphere(project)
+	if err != nil {
+		return store.Project{}, err
+	}
+	if cleanSphere := normalizeRuntimeActiveSphere(projectSphere); cleanSphere != "" && cleanSphere != a.runtimeActiveSphere() {
+		if err := a.store.SetActiveSphere(cleanSphere); err != nil {
+			return store.Project{}, err
+		}
+	}
 	if err := a.ensureProjectCanvasReady(project); err != nil {
 		return store.Project{}, err
 	}
@@ -285,6 +316,7 @@ func (a *App) handleProjectActivate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]interface{}{
 		"ok":                true,
 		"active_project_id": project.ID,
+		"active_sphere":     a.runtimeActiveSphere(),
 		"project":           item,
 	})
 }

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -230,6 +230,122 @@ func TestCreateActivateProjectAffectsChatSessionCreation(t *testing.T) {
 	}
 }
 
+func TestProjectsListRehomesActiveProjectIntoActiveSphere(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	privateRoot := filepath.Join(t.TempDir(), "private-root")
+	workRoot := filepath.Join(t.TempDir(), "work-root")
+	for _, dir := range []string{privateRoot, workRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error: %v", dir, err)
+		}
+	}
+	if _, err := app.store.CreateWorkspace("Private Root", privateRoot, store.SpherePrivate); err != nil {
+		t.Fatalf("CreateWorkspace(private) error: %v", err)
+	}
+	if _, err := app.store.CreateWorkspace("Work Root", workRoot, store.SphereWork); err != nil {
+		t.Fatalf("CreateWorkspace(work) error: %v", err)
+	}
+	privateProjectPath := filepath.Join(privateRoot, "notes")
+	workProjectPath := filepath.Join(workRoot, "tracker")
+	for _, dir := range []string{privateProjectPath, workProjectPath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error: %v", dir, err)
+		}
+	}
+	privateProject, err := app.store.CreateProject("Private Notes", "private-notes", privateProjectPath, "linked", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject(private) error: %v", err)
+	}
+	workProject, err := app.store.CreateProject("Work Tracker", "work-tracker", workProjectPath, "linked", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject(work) error: %v", err)
+	}
+	if err := app.store.SetActiveProjectID(workProject.ID); err != nil {
+		t.Fatalf("SetActiveProjectID(work) error: %v", err)
+	}
+	if err := app.store.SetActiveSphere(store.SpherePrivate); err != nil {
+		t.Fatalf("SetActiveSphere(private) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/projects", map[string]any{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list projects status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload projectsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.ActiveProjectID != privateProject.ID {
+		t.Fatalf("active_project_id = %q, want %q", payload.ActiveProjectID, privateProject.ID)
+	}
+	activeProjectID, err := app.store.ActiveProjectID()
+	if err != nil {
+		t.Fatalf("ActiveProjectID() error: %v", err)
+	}
+	if activeProjectID != privateProject.ID {
+		t.Fatalf("stored active project = %q, want %q", activeProjectID, privateProject.ID)
+	}
+}
+
+func TestProjectActivateUpdatesActiveSphere(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workRoot := filepath.Join(t.TempDir(), "work-root")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot) error: %v", err)
+	}
+	if _, err := app.store.CreateWorkspace("Work Root", workRoot, store.SphereWork); err != nil {
+		t.Fatalf("CreateWorkspace(work) error: %v", err)
+	}
+	projectPath := filepath.Join(workRoot, "tracker")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectPath) error: %v", err)
+	}
+	project, err := app.store.CreateProject("Work Tracker", "work-tracker", projectPath, "linked", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject(work) error: %v", err)
+	}
+	if err := app.store.SetActiveSphere(store.SpherePrivate); err != nil {
+		t.Fatalf("SetActiveSphere(private) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodPost,
+		"/api/projects/"+project.ID+"/activate",
+		map[string]any{},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("activate status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		OK              bool   `json:"ok"`
+		ActiveProjectID string `json:"active_project_id"`
+		ActiveSphere    string `json:"active_sphere"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode activate response: %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("expected ok=true")
+	}
+	if payload.ActiveProjectID != project.ID {
+		t.Fatalf("active_project_id = %q, want %q", payload.ActiveProjectID, project.ID)
+	}
+	if payload.ActiveSphere != store.SphereWork {
+		t.Fatalf("active_sphere = %q, want %q", payload.ActiveSphere, store.SphereWork)
+	}
+	activeSphere, err := app.store.ActiveSphere()
+	if err != nil {
+		t.Fatalf("ActiveSphere() error: %v", err)
+	}
+	if activeSphere != store.SphereWork {
+		t.Fatalf("stored active sphere = %q, want %q", activeSphere, store.SphereWork)
+	}
+}
+
 func TestProjectChatModelUpdate(t *testing.T) {
 	app := newAuthedTestApp(t)
 

--- a/internal/web/static/app-projects.js
+++ b/internal/web/static/app-projects.js
@@ -710,6 +710,11 @@ export async function activateProject(projectID) {
   }
   const payload = await resp.json();
   const project = payload?.project || {};
+  const activeSphere = normalizeActiveSphere(payload?.active_sphere || state.activeSphere);
+  if (activeSphere) {
+    state.activeSphere = activeSphere;
+    persistActiveSpherePreference(activeSphere);
+  }
   state.chatSessionId = String(project.chat_session_id || '');
   state.sessionId = String(project.canvas_session_id || 'local');
   setChatMode(project.chat_mode || 'chat');

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -995,6 +995,9 @@
           };
         }
         const project = cloneProject(activateId);
+        if (project.sphere === 'work' || project.sphere === 'private') {
+          runtimeState.active_sphere = project.sphere;
+        }
         window.__harnessLog.push({
           type: 'api_fetch',
           action: 'project_activate',
@@ -1003,6 +1006,9 @@
           payload: { project_id: project.id },
         });
         return new Response(JSON.stringify({
+          ok: true,
+          active_project_id: project.id,
+          active_sphere: runtimeState.active_sphere,
           project,
         }), { status: 200 });
       }

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -326,6 +326,24 @@ test.describe('inbox triage interactions', () => {
     await expect(page.locator('#pr-file-list')).toContainText('Private inbox item');
   });
 
+  test('switching directly to a project in another sphere syncs the active sphere', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+    await seedSphereScenario(page);
+
+    await page.evaluate(async () => {
+      const mod = await import('../../internal/web/static/app-chat-transport.js');
+      await mod.switchProject('work-tracker');
+    });
+
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as any).__getRuntimeState?.().active_sphere || '');
+    }).toBe('work');
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as any)._taburaApp?.getState?.().activeSphere || '');
+    }).toBe('work');
+  });
+
   test('tap opens the linked artifact on canvas', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitReady(page);


### PR DESCRIPTION
## Summary

- keep `/api/projects` from preserving an active project that falls outside the runtime active sphere
- update the runtime active sphere when a direct project activation crosses from `private` to `work` or back
- persist the sphere change in the browser state so project switching stays consistent end-to-end

## Verification

- Active project is re-homed into the active sphere: `go test ./internal/web -run 'TestProjectsListRehomesActiveProjectIntoActiveSphere|TestProjectActivateUpdatesActiveSphere'` -> `ok   github.com/krystophny/tabura/internal/web`
- Project activation updates the active sphere in the API response and store: covered by `TestProjectActivateUpdatesActiveSphere` in the same command above
- Browser project switching syncs the active sphere: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts --grep "switching directly to a project in another sphere syncs the active sphere"` -> `1 passed`
- Full regression run executed once: `./scripts/sync-surface.sh --check && go test ./... && ./scripts/playwright.sh` -> exit `0`, log `/tmp/tabura-issue-243-verify.log`, includes `ok   github.com/krystophny/tabura/internal/web 6.853s` and `254 passed (2.1m)`
