### PR TITLE
fix: Bug report: dialogue mode does not work at all (fixes #393)

### DIFF
--- a/internal/web/static/hotword.js
+++ b/internal/web/static/hotword.js
@@ -1,10 +1,19 @@
 import { staticURL } from './paths.js';
 
 const ORT_LOCAL_URL = staticURL('vad/ort.min.mjs');
+const ORT_WASM_MODULE_URL = staticURL('vad/ort-wasm-simd-threaded.mjs');
+const ORT_WASM_BINARY_URL = staticURL('vad/ort-wasm-simd-threaded.wasm');
 let ort = null;
 async function loadOrt() {
   if (!ort) ort = await import(ORT_LOCAL_URL);
   return ort;
+}
+
+export function resolveOrtWasmPaths() {
+  return {
+    mjs: ORT_WASM_MODULE_URL,
+    wasm: ORT_WASM_BINARY_URL,
+  };
 }
 
 const HOTWORD_VENDOR_BASE = staticURL('vendor/openwakeword');
@@ -400,7 +409,7 @@ async function startOnnxMonitor(stream) {
 async function initOnnxModel() {
   await loadOrt();
   if (ort.env?.wasm) {
-    ort.env.wasm.wasmPaths = staticURL('vad/');
+    ort.env.wasm.wasmPaths = resolveOrtWasmPaths();
     ort.env.wasm.numThreads = 1;
   }
 

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -146,6 +146,18 @@ test('hotword detection starts recording directly', async ({ page }) => {
   })).toBe(true);
 });
 
+test('hotword runtime pins explicit ONNX wasm asset URLs', async ({ page }) => {
+  await waitReady(page);
+
+  const paths = await page.evaluate(async () => {
+    const mod = await import('/internal/web/static/hotword.js');
+    return mod.resolveOrtWasmPaths();
+  });
+
+  expect(new URL(paths.mjs).pathname).toContain('/static/vad/ort-wasm-simd-threaded.mjs');
+  expect(new URL(paths.wasm).pathname).toContain('/static/vad/ort-wasm-simd-threaded.wasm');
+});
+
 test('hotword plus speech starts recording', async ({ page }) => {
   await waitReady(page);
   await setConversationListenWindowMs(page, 2_500);


### PR DESCRIPTION
## Summary
Pin the hotword ONNX Runtime wasm module and binary to the vendored `ort-wasm-simd-threaded.*` assets so dialogue mode no longer falls back to the missing default `ort-wasm-simd-threaded.jsep.mjs` path.

## Verification
- Issue symptom: dialogue-mode wake-word activation no longer depends on the missing default `*.jsep.mjs` asset.
  Evidence: `./scripts/playwright.sh tests/playwright/hotword.spec.ts -g "hotword runtime pins explicit ONNX wasm asset URLs"`
  Output excerpt: `1 passed (1.3s)`
- Issue requirement: saying the wake word in dialogue mode should still start recording after the asset-path change.
  Evidence: `./scripts/playwright.sh tests/playwright/hotword.spec.ts -g "hotword detection starts recording directly|hotword runtime pins explicit ONNX wasm asset URLs|meeting mode hotword still starts direct recording"`
  Output excerpt: `3 passed (2.2s)` including `hotword detection starts recording directly` and `meeting mode hotword still starts direct recording`
