### PR TITLE
fix: Epic: Mobile capture mode and iPhone reliability (fixes #222)

### DIFF
--- a/docs/meeting-notes-privacy.md
+++ b/docs/meeting-notes-privacy.md
@@ -10,6 +10,7 @@ This document formalizes the audio privacy guarantees for Tabura's speech-to-tex
 
 - Captured voice memos follow the same RAM-only policy as meeting capture.
 - Uploaded audio is normalized and transcribed in memory, then discarded immediately.
+- Offline or retryable voice memos may stay in browser RAM for the current page session only; they must not be persisted to IndexedDB, disk, SQLite, or other durable browser storage.
 - Only transcript text may persist as an artifact or chat message. The original recording must not be stored for replay.
 - Oversized or invalid uploads must be rejected without creating multipart temp files on disk.
 

--- a/internal/web/server_security_test.go
+++ b/internal/web/server_security_test.go
@@ -183,6 +183,19 @@ func TestPrivacySchemaNoAudioColumns(t *testing.T) {
 	}
 }
 
+func TestPrivacyCapturePageDoesNotPersistVoiceAudio(t *testing.T) {
+	data, err := staticFiles.ReadFile("static/capture.js")
+	if err != nil {
+		t.Fatalf("ReadFile(static/capture.js): %v", err)
+	}
+	source := strings.ToLower(string(data))
+	for _, forbidden := range []string{"indexeddb", "queued locally", "saved locally"} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("capture.js contains forbidden persisted-audio marker %q", forbidden)
+		}
+	}
+}
+
 func TestPrivacySTTBufferCleanupOnCancel(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()

--- a/internal/web/static/capture.js
+++ b/internal/web/static/capture.js
@@ -17,8 +17,6 @@
 
   const testEnv = window.__taburaCaptureTestEnv || {};
   const microphonePermissionCacheKey = 'tabura.capture.microphone_permission';
-  const queueDatabaseName = String(testEnv.queueDatabaseName || 'tabura-capture');
-  const queueStoreName = 'voice-memos';
   const maxVoiceRetries = 3;
 
   const state = {
@@ -27,7 +25,6 @@
     recording: false,
     saving: false,
     transcribing: false,
-    drainingQueue: false,
     discardRecording: false,
     mediaStream: null,
     mediaRecorder: null,
@@ -113,8 +110,8 @@
       return;
     }
     if (cleanState === 'offline') {
-      recordLabel.textContent = 'Queued';
-      recordHint.textContent = 'Saved locally. It will upload when you are back online.';
+      recordLabel.textContent = 'Offline';
+      recordHint.textContent = 'Voice memo kept in memory until you reconnect.';
       return;
     }
     if (cleanState === 'success') {
@@ -373,119 +370,16 @@
     return !isOnline() || message.includes('failed to fetch') || message.includes('networkerror');
   }
 
-  function queueUnsupported() {
-    return !window.indexedDB;
-  }
-
-  function openQueueDB() {
-    return new Promise((resolve, reject) => {
-      if (queueUnsupported()) {
-        reject(new Error('IndexedDB unavailable'));
-        return;
-      }
-      const request = window.indexedDB.open(queueDatabaseName, 1);
-      request.onerror = () => {
-        reject(request.error || new Error('capture queue unavailable'));
-      };
-      request.onupgradeneeded = () => {
-        const db = request.result;
-        if (!db.objectStoreNames.contains(queueStoreName)) {
-          db.createObjectStore(queueStoreName, { keyPath: 'id', autoIncrement: true });
-        }
-      };
-      request.onsuccess = () => {
-        resolve(request.result);
-      };
-    });
-  }
-
-  function runQueueRequest(mode, action) {
-    return openQueueDB().then((db) => new Promise((resolve, reject) => {
-      const tx = db.transaction(queueStoreName, mode);
-      const store = tx.objectStore(queueStoreName);
-      let request;
-      try {
-        request = action(store);
-      } catch (error) {
-        db.close();
-        reject(error);
-        return;
-      }
-      tx.oncomplete = () => {
-        db.close();
-      };
-      tx.onerror = () => {
-        db.close();
-        reject(tx.error || new Error('capture queue transaction failed'));
-      };
-      request.onsuccess = () => {
-        resolve(request.result);
-      };
-      request.onerror = () => {
-        reject(request.error || new Error('capture queue request failed'));
-      };
-    }));
-  }
-
-  function enqueueVoiceMemo(blob, transcript) {
-    return runQueueRequest('readwrite', (store) => store.add({
-      createdAt: new Date().toISOString(),
-      blob,
-      transcript: String(transcript || '').trim(),
-    }));
-  }
-
-  function listQueuedVoiceMemos() {
-    return runQueueRequest('readonly', (store) => store.getAll()).then((items) => {
-      const out = Array.isArray(items) ? items : [];
-      out.sort((left, right) => Number(left.id || 0) - Number(right.id || 0));
-      return out;
-    });
-  }
-
-  function deleteQueuedVoiceMemo(id) {
-    return runQueueRequest('readwrite', (store) => store.delete(id));
-  }
-
-  async function queueCurrentVoiceMemo() {
+  function holdVoiceMemoInMemory(statusMessage) {
     if (!state.audioBlob) {
       return false;
     }
-    await enqueueVoiceMemo(state.audioBlob, state.pendingTranscript);
-    clearVoiceMemoState();
     setCaptureState('offline');
-    setStatus('Saved locally. It will upload when online.', '');
+    setStatus(
+      String(statusMessage || 'Offline. Voice memo kept in memory until you reconnect.'),
+      '',
+    );
     return true;
-  }
-
-  async function drainQueuedVoiceMemos() {
-    if (state.drainingQueue || !isOnline()) {
-      return;
-    }
-    state.drainingQueue = true;
-    try {
-      const queued = await listQueuedVoiceMemos();
-      for (const entry of queued) {
-        if (!isOnline()) {
-          break;
-        }
-        const transcript = normalizeNote(entry && entry.transcript)
-          || await transcribeVoiceMemo(entry && entry.blob ? entry.blob : null);
-        await saveVoiceMemo(transcript);
-        await deleteQueuedVoiceMemo(entry.id);
-        setCaptureState('success');
-        setStatus(`Saved: ${deriveItemTitle(transcript)}`, 'success');
-        scheduleStatusClear(1800);
-        scheduleCaptureStateReset(1800);
-      }
-    } catch (error) {
-      if (!isNetworkFailure(error)) {
-        setStatus(`Queued memo failed: ${String(error && error.message ? error.message : error)}`, 'error');
-      }
-    } finally {
-      state.drainingQueue = false;
-      updateSaveState();
-    }
   }
 
   async function readMicrophonePermission() {
@@ -537,15 +431,11 @@
     } catch (error) {
       const message = String(error && error.message ? error.message : error);
       if (isNetworkFailure(error)) {
-        try {
-          const queued = await queueCurrentVoiceMemo();
-          if (!queued) {
-            throw new Error('queue_unavailable');
-          }
-        } catch (queueError) {
-          setCaptureState('failed');
-          setStatus(`Upload failed: ${String(queueError && queueError.message ? queueError.message : queueError)}`, 'error');
-        }
+        holdVoiceMemoInMemory(
+          state.pendingTranscript
+            ? 'Offline. The transcript is kept in memory until you reconnect.'
+            : 'Offline. Voice memo kept in memory until you reconnect.',
+        );
       } else if (message === 'transcription_http_error') {
         state.voiceRetryCount += 1;
         state.fallbackVisible = state.voiceRetryCount >= maxVoiceRetries;
@@ -615,11 +505,7 @@
         finishRecording();
         if (state.audioBlob) {
           if (!isOnline()) {
-            void queueCurrentVoiceMemo().catch((error) => {
-              setCaptureState('failed');
-              setStatus(`Queue failed: ${String(error && error.message ? error.message : error)}`, 'error');
-              updateSaveState();
-            });
+            holdVoiceMemoInMemory();
             return;
           }
           void processVoiceMemo();
@@ -733,23 +619,25 @@
   fallbackButton.addEventListener('click', offerTextFallback);
   resetButton.addEventListener('click', resetCapture);
   window.addEventListener('online', () => {
+    if (!state.recording && !state.saving && !state.transcribing && state.audioBlob) {
+      void processVoiceMemo();
+      return;
+    }
     if (!state.recording && !state.saving && !state.transcribing) {
-      void drainQueuedVoiceMemos();
+      setCaptureState('idle');
+      setStatus('', '');
     }
   });
   window.addEventListener('offline', () => {
     if (!state.recording && !state.audioBlob) {
       setCaptureState('offline');
-      setStatus('Offline. New voice memos will queue until you reconnect.', '');
+      setStatus('Offline. Voice memos stay in memory only until you reconnect.', '');
     }
   });
 
   updateSaveState();
   applyCaptureAvailability();
   setCaptureState('idle');
-  if (isOnline()) {
-    void drainQueuedVoiceMemos();
-  }
   window.__taburaCapture = {
     deriveItemTitle,
     voiceMemoErrorMessage,

--- a/tests/playwright/capture-harness.html
+++ b/tests/playwright/capture-harness.html
@@ -51,6 +51,7 @@
       const searchParams = new URLSearchParams(window.location.search);
       let online = searchParams.get('online') !== '0';
       let permissionMode = searchParams.get('permission') || 'granted';
+      let indexedDBOpenCount = 0;
       let transcribeResponses = [
         { status: 200, body: { text: 'Voice memo from capture harness. Follow up tomorrow morning.' } },
       ];
@@ -59,13 +60,13 @@
         isSecureContext: searchParams.get('secure') !== '0',
         protocol: searchParams.get('protocol') || window.location.protocol,
         hostname: searchParams.get('host') || window.location.hostname,
-        queueDatabaseName: `tabura-capture-${Math.random().toString(16).slice(2)}`,
       };
 
       window.__captureRequests = itemRequests;
       window.__captureArtifactRequests = artifactRequests;
       window.__captureTranscribeRequests = transcribeRequests;
       window.__captureFetchRequests = fetchRequests;
+      window.__captureIndexedDBOpenCount = () => indexedDBOpenCount;
       window.__setCaptureOnline = (value) => {
         online = Boolean(value);
         window.dispatchEvent(new Event(online ? 'online' : 'offline'));
@@ -178,6 +179,16 @@
             addEventListener() {},
             removeEventListener() {},
           }),
+        },
+      });
+
+      Object.defineProperty(window, 'indexedDB', {
+        configurable: true,
+        value: {
+          open() {
+            indexedDBOpenCount += 1;
+            throw new Error('capture should not persist voice memos to IndexedDB');
+          },
         },
       });
 

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -114,7 +114,7 @@ test.describe('capture page', () => {
     await expect(page.locator('#capture-status')).toContainText('Microphone access is currently denied.');
   });
 
-  test('queues voice memos offline and uploads them on reconnect', async ({ page }) => {
+  test('keeps offline voice memos in memory and uploads them on reconnect', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/tests/playwright/capture-harness.html?online=0');
 
@@ -122,10 +122,12 @@ test.describe('capture page', () => {
     await page.locator('#capture-record').click({ force: true });
 
     await expect(page.locator('body')).toHaveAttribute('data-capture-state', 'offline');
-    await expect(page.locator('#capture-status')).toContainText('Saved locally');
+    await expect(page.locator('#capture-status')).toContainText('kept in memory');
 
     const transcribeRequestsBefore = await page.evaluate(() => (window as any).__captureTranscribeRequests);
     expect(transcribeRequestsBefore).toHaveLength(0);
+    const indexedDBOpenCountBefore = await page.evaluate(() => (window as any).__captureIndexedDBOpenCount());
+    expect(indexedDBOpenCountBefore).toBe(0);
 
     await page.evaluate(() => {
       (window as any).__setCaptureOnline(true);
@@ -136,6 +138,8 @@ test.describe('capture page', () => {
     expect(transcribeRequestsAfter).toHaveLength(1);
     const itemRequests = await page.evaluate(() => (window as any).__captureRequests);
     expect(itemRequests).toHaveLength(1);
+    const indexedDBOpenCountAfter = await page.evaluate(() => (window as any).__captureIndexedDBOpenCount());
+    expect(indexedDBOpenCountAfter).toBe(0);
   });
 
   test('offers a text fallback after repeated voice save failures', async ({ page }) => {


### PR DESCRIPTION
## Summary
- remove IndexedDB-backed voice memo queuing from `/capture` so offline and retryable audio stays RAM-only
- retry pending `/capture` voice memos from in-memory state on reconnect instead of durable browser storage
- document the RAM-only browser behavior and add privacy regression coverage alongside updated Playwright assertions

## Verification
- Requirement: `/capture` loads a blank capture-only page.
  Evidence: `go test ./internal/web -run "TestServeCaptureUsesStandaloneAssets|TestPrivacy"` -> `ok   github.com/krystophny/tabura/internal/web 0.096s`; `TestServeCaptureUsesStandaloneAssets` asserts `GET /capture` serves `#capture-page` and excludes `#workspace`, `#edge-left-tap`, and `./static/app.js`.
- Requirement: voice recording with STT transcription saves into the inbox.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... transcribes a voice memo and saves an artifact-backed inbox item`.
- Requirement: short text entry remains available as an alternative.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... saves a typed note and stays outside the canvas shell`.
- Requirement: successful saves reset the capture surface back toward blank state.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... saves a typed note and stays outside the canvas shell` and `✓ ... toggles record state with the large capture button`; those checks verify the note field clears, save is disabled again, and the capture button returns from recording to non-pressed state.
- Requirement: HTTPS requirement messaging works on insecure non-loopback origins.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... shows an actionable HTTPS warning on insecure non-loopback origins`.
- Requirement: microphone permission failures show recovery guidance.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... shows Safari recovery guidance when microphone access is denied`.
- Requirement: upload/transcription failure and retry states are handled.
  Evidence: `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... keeps the memo available for retry after transcription failure` and `✓ ... offers a text fallback after repeated voice save failures`.
- Requirement: captured audio retention follows the documented RAM-only policy.
  Evidence: `go test ./internal/web -run "TestServeCaptureUsesStandaloneAssets|TestPrivacy"` includes `TestPrivacyCapturePageDoesNotPersistVoiceAudio`; `./scripts/playwright.sh tests/playwright/capture.spec.ts` -> `✓ ... keeps offline voice memos in memory and uploads them on reconnect`, and that spec asserts the IndexedDB open count stays `0` before and after reconnect. `docs/meeting-notes-privacy.md` now explicitly states offline/retryable capture audio may stay only in browser RAM for the current page session.
