### PR TITLE
fix: Epic: Batch orchestration and review dispatch for Items (fixes #171)

### DIFF
--- a/internal/web/static/app-chat-transport.js
+++ b/internal/web/static/app-chat-transport.js
@@ -228,6 +228,91 @@ export function isVoiceOutputModePayload(payload) {
   return String(payload?.output_mode || '').trim().toLowerCase() === 'voice';
 }
 
+function batchItemLabel(item) {
+  const titled = String(item?.item_title || '').trim();
+  if (titled) return titled;
+  const itemID = Number(item?.item_id || 0);
+  if (itemID > 0) return `item ${itemID}`;
+  return 'item';
+}
+
+function batchItemCounts(items) {
+  const counts = { total: 0, running: 0, completed: 0, failed: 0 };
+  if (!Array.isArray(items)) return counts;
+  items.forEach((item) => {
+    counts.total += 1;
+    const status = String(item?.status || '').trim().toLowerCase();
+    if (status === 'completed') counts.completed += 1;
+    else if (status === 'failed') counts.failed += 1;
+    else if (status === 'running') counts.running += 1;
+  });
+  return counts;
+}
+
+function batchSummaryLabel(batch, items, fallbackCount = 0) {
+  const batchStatus = String(batch?.status || '').trim().toLowerCase();
+  const counts = batchItemCounts(items);
+  const total = counts.total || Math.max(0, Number(fallbackCount || 0));
+  if (batchStatus === 'running') {
+    if (total > 0) return `batch running: ${total} item(s)`;
+    return 'batch running';
+  }
+  if (batchStatus === 'completed') {
+    if (counts.total > 0) return `batch completed: ${counts.completed} completed, ${counts.failed} failed`;
+    return 'batch completed';
+  }
+  if (batchStatus === 'failed') {
+    if (counts.total > 0) return `batch failed: ${counts.completed} completed, ${counts.failed} failed`;
+    return 'batch failed';
+  }
+  if (total === 0) return 'no matching batch items';
+  return 'batch status updated';
+}
+
+function batchProgressMessage(payload) {
+  const batch = payload?.batch && typeof payload.batch === 'object' ? payload.batch : {};
+  const item = payload?.item && typeof payload.item === 'object' ? payload.item : null;
+  if (item) {
+    const label = batchItemLabel(item);
+    const status = String(item?.status || '').trim().toLowerCase() || 'updated';
+    if (status === 'completed') {
+      return `Batch update: ${label} completed.`;
+    }
+    if (status === 'failed') {
+      const errorMsg = String(item?.error_msg || '').trim();
+      if (errorMsg) return `Batch update: ${label} failed: ${errorMsg}.`;
+      return `Batch update: ${label} failed.`;
+    }
+    if (status === 'running') {
+      return `Batch update: ${label} started.`;
+    }
+    return `Batch update: ${label} ${status}.`;
+  }
+  return `Batch update: ${batchSummaryLabel(batch, payload?.items, payload?.item_count)}.`;
+}
+
+function batchStatusIsActive(payload) {
+  const batchStatus = String(payload?.batch?.status || '').trim().toLowerCase();
+  if (batchStatus === 'running') return true;
+  return payload?.status?.active === true;
+}
+
+function applyBatchStatus(payload) {
+  const label = batchSummaryLabel(payload?.batch, payload?.items, payload?.item_count);
+  state.batchStatusLabel = label;
+  state.batchStatusActive = batchStatusIsActive(payload);
+  showStatus(label);
+  refreshBatchItemSidebar();
+}
+
+function refreshBatchItemSidebar() {
+  if (state.fileSidebarMode === 'items' && state.prReviewDrawerOpen) {
+    void loadItemSidebarView(state.itemSidebarView);
+    return;
+  }
+  void refreshItemSidebarCounts().catch(() => {});
+}
+
 export function handleChatEvent(payload) {
   const type = String(payload?.type || '').trim();
   if (!type) return;
@@ -345,6 +430,8 @@ export function handleChatEvent(payload) {
       }
     } else if (actionType === 'print_item') {
       openPrintView(String(action?.url || '').trim());
+    } else if (actionType === 'batch_status') {
+      applyBatchStatus(action);
     } else if (actionType === 'toggle_live_dialogue' || actionType === 'toggle_conversation') {
       const next = state.liveSessionActive ? '' : LIVE_SESSION_MODE_DIALOGUE;
       const action = next
@@ -361,6 +448,13 @@ export function handleChatEvent(payload) {
           showStatus(`live toggle failed: ${message}`);
         });
     }
+    return;
+  }
+
+  if (type === 'batch_progress') {
+    const message = batchProgressMessage(payload);
+    if (message) appendPlainMessage('system', message);
+    applyBatchStatus(payload);
     return;
   }
 
@@ -505,7 +599,7 @@ export function handleChatEvent(payload) {
     const shouldSpeakTurn = isVoiceOutputModePayload(payload) || (turnID ? state.voiceTurns.has(turnID) : false) || isVoiceTurn();
     trackAssistantTurnFinished(turnID);
     state.assistantLastError = '';
-    showStatus('ready');
+    showStatus(state.batchStatusActive && state.batchStatusLabel ? state.batchStatusLabel : 'ready');
     updateAssistantActivityIndicator();
     void refreshAssistantActivity();
 

--- a/internal/web/static/app-context.js
+++ b/internal/web/static/app-context.js
@@ -230,6 +230,8 @@ export const state = {
   projectRunStatesInFlight: false,
   assistantSilentCancelInFlight: false,
   chatWsLastMessageAt: 0,
+  batchStatusLabel: '',
+  batchStatusActive: false,
   pendingRuntimeReloadContext: null,
   pendingRuntimeReloadStatus: '',
 };

--- a/tests/playwright/batch-orchestration.spec.ts
+++ b/tests/playwright/batch-orchestration.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    const wsOpen = (window as any).WebSocket.OPEN;
+    return s.chatWs?.readyState === wsOpen && s.canvasWs?.readyState === wsOpen;
+  }, null, { timeout: 8_000 });
+}
+
+async function clearLog(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__harnessLog.splice(0);
+  });
+}
+
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((eventPayload) => {
+    const app = (window as any)._taburaApp;
+    const sessionId = String(app?.getState?.().chatSessionId || '');
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string'
+      && ws.url.includes('/ws/chat/')
+      && (!sessionId || ws.url.includes(`/ws/chat/${sessionId}`)));
+    if (chatWs?.injectEvent) {
+      chatWs.injectEvent(eventPayload);
+    }
+  }, payload);
+}
+
+async function openInbox(page: Page) {
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+  await page.locator('.sidebar-tab', { hasText: 'Inbox' }).click();
+  await expect(page.locator('.sidebar-tab.is-active')).toContainText('Inbox');
+}
+
+test.describe('batch orchestration', () => {
+  test('dialogue-triggered batch status and progress are surfaced in the UI', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [{
+          id: 301,
+          title: 'Fix parser cleanup',
+          state: 'inbox',
+          sphere: 'private',
+          workspace_id: 11,
+          source: 'github',
+          source_ref: 'owner/tabula#12',
+          created_at: '2026-03-10 09:00:00',
+          updated_at: '2026-03-10 09:05:00',
+        }],
+        waiting: [],
+        someday: [],
+        done: [],
+      });
+    });
+
+    await openInbox(page);
+    await clearLog(page);
+
+    const input = page.locator('#chat-pane-input');
+    await input.fill('work through P0 issues');
+    await input.press('Enter');
+
+    await expect.poll(async () => {
+      const log = await page.evaluate(() => (window as any).__harnessLog || []);
+      return log.some((entry: any) => entry?.type === 'message_sent' && entry?.text === 'work through P0 issues');
+    }).toBe(true);
+
+    await clearLog(page);
+
+    await injectChatEvent(page, { type: 'turn_started', turn_id: 'batch-turn-1' });
+    await injectChatEvent(page, {
+      type: 'system_action',
+      action: {
+        type: 'batch_status',
+        workspace_id: 11,
+        item_count: 3,
+        batch: {
+          id: 7,
+          workspace_id: 11,
+          started_at: '2026-03-10T10:00:00Z',
+          status: 'running',
+          config_json: '{}',
+        },
+      },
+    });
+    await injectChatEvent(page, {
+      type: 'assistant_message',
+      turn_id: 'batch-turn-1',
+      message: 'Started batch for workspace Repo with 3 open item(s).',
+    });
+    await injectChatEvent(page, {
+      type: 'assistant_output',
+      role: 'assistant',
+      turn_id: 'batch-turn-1',
+      message: 'Started batch for workspace Repo with 3 open item(s).',
+    });
+
+    await expect(page.locator('#status-label')).toHaveText('batch running: 3 item(s)');
+    await expect(page.locator('#chat-history')).toContainText('Started batch for workspace Repo with 3 open item(s).');
+    await expect.poll(async () => {
+      const log = await page.evaluate(() => (window as any).__harnessLog || []);
+      return log.some((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'item_list' && String(entry?.payload?.view || '') === 'inbox');
+    }).toBe(true);
+
+    await clearLog(page);
+
+    await injectChatEvent(page, {
+      type: 'batch_progress',
+      batch_id: 7,
+      workspace_id: 11,
+      batch: {
+        id: 7,
+        workspace_id: 11,
+        started_at: '2026-03-10T10:00:00Z',
+        status: 'running',
+        config_json: '{}',
+      },
+      item: {
+        batch_id: 7,
+        item_id: 301,
+        item_title: 'Fix parser cleanup',
+        status: 'failed',
+        error_msg: 'tests failed',
+      },
+    });
+
+    await expect(page.locator('#chat-history')).toContainText('Batch update: Fix parser cleanup failed: tests failed.');
+    await expect(page.locator('#status-label')).toHaveText('batch running');
+    await expect.poll(async () => {
+      const log = await page.evaluate(() => (window as any).__harnessLog || []);
+      return log.some((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'item_list' && String(entry?.payload?.view || '') === 'inbox');
+    }).toBe(true);
+
+    await injectChatEvent(page, {
+      type: 'batch_progress',
+      batch_id: 7,
+      workspace_id: 11,
+      batch: {
+        id: 7,
+        workspace_id: 11,
+        started_at: '2026-03-10T10:00:00Z',
+        finished_at: '2026-03-10T10:04:00Z',
+        status: 'completed',
+        config_json: '{}',
+      },
+    });
+
+    await expect(page.locator('#status-label')).toHaveText('batch completed');
+    await expect(page.locator('#chat-history')).toContainText('Batch update: batch completed.');
+  });
+});


### PR DESCRIPTION
## Summary
- surface `batch_status` system actions and `batch_progress` websocket events in the web client
- keep active batch state visible in `#status-label` after the initiating assistant turn completes
- add Playwright coverage for the dialogue-triggered batch UI flow

## Verification
- Batch triggered from Dialogue with workspace-scoped selection:
  `go test ./internal/web -run 'TestParseInlineBatchIntent$|TestClassifyAndExecuteSystemActionBatchWorkUsesFiltersLimitAndStatus$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: `TestParseInlineBatchIntent` covers `work through P0 issues` and `work through 166-170`; `TestClassifyAndExecuteSystemActionBatchWorkUsesFiltersLimitAndStatus` starts a workspace-scoped batch and verifies the `show me progress` status payload.
- Items track state transitions visible to the inbox model:
  `go test ./internal/web -run 'TestClassifyAndExecuteSystemActionBatchWorkUsesFiltersLimitAndStatus$|TestItemReviewDispatchGitHubAPI$|TestItemReviewDispatchEmailAPI$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: batch work moves the processed item to `done`; review dispatch moves PR items to `waiting`.
- Review dispatch works for agent, GitHub, and email:
  `go test ./internal/web -run 'TestItemReviewDispatchGitHubAPI$|TestItemReviewDispatchEmailAPI$|TestItemReviewDispatchAgentRerouteCancelsInFlightWork$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: the targeted tests cover all three dispatch targets.
- Re-routing mid-flow works:
  `go test ./internal/web -run 'TestItemReviewDispatchAgentRerouteCancelsInFlightWork$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: verifies rerouting cancels in-flight agent review work before switching targets.
- Completed items produce result artifacts:
  `go test ./internal/web -run 'TestBatchAPIListDetailAndArtifact$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: verifies `/api/batches/{id}/artifact` renders batch markdown including PR/result data.
- Failed items produce diagnostic artifacts:
  `go test ./internal/web -run 'TestBatchProgressBroadcastsToConnectedClients$|TestBatchAPIListDetailAndArtifact$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: progress broadcasts include failed item payloads; artifact rendering includes notes/error cells for failed entries.
- Per-workspace worker/reviewer config persists:
  `go test ./internal/web -run 'TestClassifyAndExecuteSystemActionBatchConfigPersistsWorkspaceSettings$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: verifies worker, reviewer, limit, review policy, and workspace watch config persistence.
- Filtered batch execution and limits work:
  `go test ./internal/web -run 'TestParseInlineBatchIntent$|TestClassifyAndExecuteSystemActionBatchWorkUsesFiltersLimitAndStatus$'`
  Output: `ok   github.com/krystophny/tabura/internal/web`
  Evidence: label filtering (`P0`), explicit issue-range parsing (`166-170`), and limit enforcement (`stop after 1`) are covered.
- Progress is queryable mid-batch and surfaced in the UI:
  `./scripts/playwright.sh tests/playwright/batch-orchestration.spec.ts`
  Output: `1 passed`
  Evidence: [tests/playwright/batch-orchestration.spec.ts](/home/ert/code/assi/tabula/tests/playwright/batch-orchestration.spec.ts) sends a dialogue batch command, verifies `batch_status` reaches `#status-label`, verifies `batch_progress` appears in `#chat-history`, and confirms the inbox view refreshes while open.
