### PR TITLE
fix: Standing policy: new domain model replaces legacy, breaking chan (fixes #196)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,20 @@ not for speculative compatibility.
 - Historical docs and release notes may remain as records, but they must not
   steer new design if they conflict with the current direction.
 
+## Domain Replacement Policy
+
+- The Workspace/Artifact/Item/Actor model replaces the older
+  project/session/message model. Treat coexistence as a migration step, not a
+  target architecture.
+- When the new model covers an old table, handler, route, or UI flow, delete
+  the old path instead of preserving both.
+- Do not add bridges, adapters, compatibility shims, or dual-write paths just
+  to keep legacy code alive. Those require explicit, concrete justification.
+- The final schema and API surface should get smaller and clearer over time, not
+  accumulate parallel legacy and replacement shapes.
+- Reviewer default: ask whether the old thing can be deleted now. If the answer
+  is yes, delete it instead of layering more compatibility around it.
+
 ## Primary Criteria
 
 The only standing criteria for change are:


### PR DESCRIPTION
## Summary
- codify the replacement-only domain policy in `CONTRIBUTING.md`
- make deletion-first review guidance explicit for ongoing domain-model migration work

## Verification
- Replacement, not coexistence: `nl -ba CONTRIBUTING.md | sed -n '1,34p'` shows lines 24-26, which now state that the Workspace/Artifact/Item/Actor model replaces the older project/session/message model and that coexistence is only a migration step.
- Breaking changes and no assumed compatibility obligations: the same command shows lines 8-18, which keep the standing rule that external compatibility must not be assumed and that breaking changes are allowed when they improve the product/codebase.
- No bridges, adapters, or shims: the same command shows lines 29-30, which now explicitly forbid bridges, adapters, compatibility shims, and dual-write paths unless they have concrete justification.
- Delete redundant legacy handlers/routes/UI flows: the same command shows lines 27-28, which now require deleting old tables, handlers, routes, and UI flows once the new model covers them.
- No schema/API accumulation: the same command shows lines 31-32, which now require the schema and API surface to get smaller and clearer instead of accumulating parallel legacy and replacement shapes.
- Reviewer enforcement: the same command shows lines 33-34, which now state the reviewer default: ask whether the old thing can be deleted now, and delete it when the answer is yes.

Policy issue only: no runtime code changed, so verification is the committed contributor-policy text itself.