### PR TITLE
fix: Bridge existing project model to Workspace (fixes #176)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -290,11 +290,17 @@ func (s *Store) migrateProjectColumns() error {
 		SQL   string
 	}
 	columns := []colDef{
+		{Table: "projects", Name: "project_key", SQL: `ALTER TABLE projects ADD COLUMN project_key TEXT NOT NULL DEFAULT ''`},
+		{Table: "projects", Name: "root_path", SQL: `ALTER TABLE projects ADD COLUMN root_path TEXT NOT NULL DEFAULT ''`},
+		{Table: "projects", Name: "kind", SQL: `ALTER TABLE projects ADD COLUMN kind TEXT NOT NULL DEFAULT 'managed'`},
 		{Table: "projects", Name: "mcp_url", SQL: `ALTER TABLE projects ADD COLUMN mcp_url TEXT NOT NULL DEFAULT ''`},
 		{Table: "projects", Name: "canvas_session_id", SQL: `ALTER TABLE projects ADD COLUMN canvas_session_id TEXT NOT NULL DEFAULT ''`},
 		{Table: "projects", Name: "chat_model", SQL: `ALTER TABLE projects ADD COLUMN chat_model TEXT NOT NULL DEFAULT ''`},
 		{Table: "projects", Name: "chat_model_reasoning_effort", SQL: `ALTER TABLE projects ADD COLUMN chat_model_reasoning_effort TEXT NOT NULL DEFAULT ''`},
 		{Table: "projects", Name: "companion_config_json", SQL: `ALTER TABLE projects ADD COLUMN companion_config_json TEXT NOT NULL DEFAULT '{}'`},
+		{Table: "projects", Name: "is_default", SQL: `ALTER TABLE projects ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0`},
+		{Table: "projects", Name: "created_at", SQL: `ALTER TABLE projects ADD COLUMN created_at INTEGER NOT NULL DEFAULT 0`},
+		{Table: "projects", Name: "updated_at", SQL: `ALTER TABLE projects ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`},
 		{Table: "projects", Name: "last_opened_at", SQL: `ALTER TABLE projects ADD COLUMN last_opened_at INTEGER NOT NULL DEFAULT 0`},
 		{Table: "chat_messages", Name: "thread_key", SQL: `ALTER TABLE chat_messages ADD COLUMN thread_key TEXT NOT NULL DEFAULT ''`},
 	}
@@ -321,6 +327,21 @@ func (s *Store) migrateProjectColumns() error {
 		}
 	}
 
+	if _, err := s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_project_key_nonempty
+		ON projects(project_key)
+		WHERE trim(project_key) <> ''`); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_root_path_nonempty
+		ON projects(root_path)
+		WHERE trim(root_path) <> ''`); err != nil {
+		return err
+	}
+
+	_, _ = s.db.Exec(`UPDATE projects SET project_key = id WHERE trim(project_key) = ''`)
+	_, _ = s.db.Exec(`UPDATE projects SET kind = 'managed' WHERE trim(kind) = ''`)
+	_, _ = s.db.Exec(`UPDATE projects SET created_at = CAST(strftime('%s', 'now') AS INTEGER) WHERE created_at = 0`)
+	_, _ = s.db.Exec(`UPDATE projects SET updated_at = created_at WHERE updated_at = 0`)
 	_, _ = s.db.Exec(`UPDATE projects SET canvas_session_id = 'local' WHERE is_default <> 0 AND trim(canvas_session_id) = ''`)
 	_, _ = s.db.Exec(`UPDATE projects SET canvas_session_id = id WHERE trim(canvas_session_id) = ''`)
 	_, _ = s.db.Exec(`UPDATE projects SET chat_model = lower(trim(chat_model))`)

--- a/internal/store/store_project_workspace_bridge.go
+++ b/internal/store/store_project_workspace_bridge.go
@@ -77,6 +77,9 @@ func (s *Store) migrateProjectWorkspaces() error {
 
 	var activeWorkspaceID int64
 	for _, project := range projects {
+		if strings.TrimSpace(project.ID) == "" || normalizeProjectPath(project.RootPath) == "" {
+			continue
+		}
 		workspace, err := s.ensureWorkspaceForProject(project)
 		if err != nil {
 			return err

--- a/internal/store/workspace_project_bridge_test.go
+++ b/internal/store/workspace_project_bridge_test.go
@@ -175,3 +175,53 @@ INSERT INTO workspaces (id, name, dir_path, project_id, sphere, is_active) VALUE
 		t.Fatal("workspace is_active = false, want true")
 	}
 }
+
+func TestStoreMigrationToleratesProjectsWithoutWorkspaceFields(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "tabura.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+
+	legacySchema := `
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+INSERT INTO projects (id, name) VALUES ('proj-legacy', 'Legacy Project');
+`
+	if _, err := db.Exec(legacySchema); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	project, err := s.GetProject("proj-legacy")
+	if err != nil {
+		t.Fatalf("GetProject() error: %v", err)
+	}
+	if project.ProjectKey != "proj-legacy" {
+		t.Fatalf("project_key = %q, want %q", project.ProjectKey, "proj-legacy")
+	}
+	if project.RootPath != "" {
+		t.Fatalf("root_path = %q, want empty", project.RootPath)
+	}
+
+	workspaces, err := s.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces() error: %v", err)
+	}
+	if len(workspaces) != 0 {
+		t.Fatalf("ListWorkspaces() len = %d, want 0", len(workspaces))
+	}
+}


### PR DESCRIPTION
## Summary
- materialize workspace rows for legacy project records during store migration
- reuse existing workspace rows by path and attach the legacy project id instead of creating duplicates
- preserve the active project selection as the active workspace during migration

## Verification
- Legacy project rows become linked workspaces: `go test ./internal/store -run 'TestStoreMigratesLegacyProjectsIntoWorkspaces|TestStoreMigrationReusesExistingWorkspaceForProjectPath|TestWorkspaceProjectInferenceFromPathAndRemote|TestActiveWorkspaceReturnsCurrentSelection' 2>&1 | tee /tmp/tabura-issue-176-store.log`
  - `TestStoreMigratesLegacyProjectsIntoWorkspaces` seeds legacy `projects` + `app_state` rows and verifies `GetWorkspaceByPath()` returns workspace rows linked to `proj-alpha` and `proj-beta`.
- Active project maps to the active workspace: same command
  - `TestStoreMigratesLegacyProjectsIntoWorkspaces` asserts `ActiveWorkspace()` resolves the workspace linked to `active_project_id=proj-beta`.
- Existing workspace rows are reused instead of duplicated: same command
  - `TestStoreMigrationReusesExistingWorkspaceForProjectPath` seeds a pre-existing workspace on the legacy project path and verifies migration preserves the workspace id/name while attaching `project_id=proj-existing` and marking it active.
- Output excerpt: `ok  \tgithub.com/krystophny/tabura/internal/store\t0.043s`