### PR TITLE
fix: bump version and release after external providers milestone (fixes #276)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "tabura",
-  "version": "v0.1.8",
+  "version": "v0.1.9-dev",
   "description": "Tabura is a local-first MCP canvas and review runtime that defines and implements an object-scoped intent interface. The model centers AI invocation on selected UI objects via long press, mode-aware intent capture (voice, silent prompt, comment), explicit human approval controls (accept, edit, reject), and annotation-first review flows with commit-controlled persistence. This publication also includes integrated handoff protocol specifications, schemas, and conformance examples in the same repository to keep interaction and transport contracts citable together. The project emphasizes low-motion, low-redraw interaction behavior suitable for e-ink and high-latency display contexts while keeping API surfaces and runtime interfaces reproducible.",
   "license": "MIT",
   "upload_type": "software",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
   - family-names: Albert
     given-names: Christopher
 license: MIT
-version: v0.1.8
-date-released: 2026-03-06
+version: v0.1.9-dev
+date-released: 2026-03-10
 repository-code: https://github.com/krystophny/tabura
 url: https://github.com/krystophny/tabura
 abstract: >-

--- a/cmd/tabura/main.go
+++ b/cmd/tabura/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/krystophny/tabura/internal/web"
 )
 
-const defaultBinaryVersion = "0.1.8"
+const defaultBinaryVersion = "0.1.9-dev"
 
 var (
 	version   = defaultBinaryVersion

--- a/internal/appserver/client.go
+++ b/internal/appserver/client.go
@@ -157,7 +157,7 @@ func (c *Client) SendPromptStream(ctx context.Context, req PromptRequest, onEven
 			"clientInfo": map[string]interface{}{
 				"name":    "tabura-web",
 				"title":   "Tabura Web",
-				"version": "0.1.8",
+				"version": "0.1.9-dev",
 			},
 			"capabilities": map[string]interface{}{
 				"experimentalApi": true,

--- a/internal/appserver/session.go
+++ b/internal/appserver/session.go
@@ -104,7 +104,7 @@ func (s *Session) handshake(ctx context.Context) error {
 			"clientInfo": map[string]interface{}{
 				"name":    "tabura-web",
 				"title":   "Tabura Web",
-				"version": "0.1.8",
+				"version": "0.1.9-dev",
 			},
 			"capabilities": map[string]interface{}{
 				"experimentalApi": true,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	ServerName             = "tabura"
-	ServerVersion          = "0.1.8"
+	ServerVersion          = "0.1.9-dev"
 	LatestProtocolVersion  = "2025-03-26"
 	defaultProducerMCPURL  = "http://127.0.0.1:8090/mcp"
 	handoffKindFile        = "file"

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -244,7 +244,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	}
 	extensionHost, err := extensions.New(extensions.Options{
 		Dir:            resolvedExtensionsDir,
-		RuntimeVersion: "0.1.8",
+		RuntimeVersion: "0.1.9-dev",
 		Logf: func(format string, args ...interface{}) {
 			log.Printf("extensions: "+format, args...)
 		},
@@ -499,7 +499,7 @@ func (a *App) handleRuntime(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]interface{}{
 		"boot_id":                     a.bootID,
 		"started_at":                  a.startedAt,
-		"version":                     "0.1.8",
+		"version":                     "0.1.9-dev",
 		"dev_mode":                    a.devRuntime,
 		"local_mcp_url":               a.localMCPURL,
 		"app_server_url":              a.appServerURL,


### PR DESCRIPTION
## Summary
- create the missing `v0.1.8` GitHub release from the existing release-version HEAD
- bump all tracked version strings forward to `v0.1.9-dev` per the repo version policy

## Verification
- Release cut: `git push origin v0.1.8`; `gh release create v0.1.8 --title v0.1.8 --generate-notes`
  Release URL: https://github.com/krystophny/tabura/releases/tag/v0.1.8
- Next `-dev` bump applied in tracked version files: `rg -n '0\.1\.9-dev|v0\.1\.9-dev' .zenodo.json CITATION.cff cmd/tabura/main.go internal/mcp/server.go internal/web/server.go internal/appserver/client.go internal/appserver/session.go`
  Output excerpts:
  - `.zenodo.json:3:  "version": "v0.1.9-dev",`
  - `CITATION.cff:9:version: v0.1.9-dev`
  - `cmd/tabura/main.go:30:const defaultBinaryVersion = "0.1.9-dev"`
  - `internal/mcp/server.go:24:ServerVersion          = "0.1.9-dev"`
  - `internal/web/server.go:247:RuntimeVersion: "0.1.9-dev"`
  - `internal/appserver/client.go:160:                "version": "0.1.9-dev",`
  - `internal/appserver/session.go:107:                "version": "0.1.9-dev",`
- Version consistency: `scripts/check-version-consistency.sh`
  Result: exit 0
- Surface inventory check: `./scripts/sync-surface.sh --check`
  Result: exit 0
- Go test suite: `go test ./... 2>&1 | tee /tmp/tabura-issue-276-go-test.log`
  Output excerpt:
  - `ok   github.com/krystophny/tabura/internal/web 7.258s`
  - `ok   github.com/krystophny/tabura/tests/services (cached)`
- Playwright suite: `./scripts/playwright.sh 2>&1 | tee /tmp/tabura-issue-276-playwright.log`
  Output excerpt: `260 passed (2.6m)`, `1 failed`
  Failing test: `tests/playwright/ui-system.spec.ts:560` (`floating tool palette › text note tool creates sticky notes on PDF positions`)
  Repro rerun: `npx playwright test tests/playwright/ui-system.spec.ts --project=chromium -g 'text note tool creates sticky notes on PDF positions' 2>&1 | tee /tmp/tabura-issue-276-playwright-rerun.log`
  Rerun result: same timeout on `page.locator('#annotation-note-save').click()`
- Inference from the diff: the Playwright failure appears unrelated to this PR because this branch only changes version strings in 7 tracked files and does not modify frontend behavior.
