### PR TITLE
fix: Epic: Integrate GitHub issues and reviews into the Item model (fixes #170)

### DIFF
--- a/internal/web/chat_items_github.go
+++ b/internal/web/chat_items_github.go
@@ -294,17 +294,20 @@ func (a *App) createGitHubIssueInWorkspace(cwd, title, body string, labels, assi
 
 func conversationItemCandidateScore(item store.Item, ctx conversationItemContext) int {
 	score := 0
+	matched := false
 	if ctx.ArtifactID != nil && item.ArtifactID != nil && *ctx.ArtifactID == *item.ArtifactID {
 		score += 100
+		matched = true
 	}
 	if strings.EqualFold(strings.TrimSpace(item.Title), strings.TrimSpace(ctx.Title)) {
 		score += 40
+		matched = true
+	}
+	if !matched {
+		return -1
 	}
 	if ctx.WorkspaceID != nil && item.WorkspaceID != nil && *ctx.WorkspaceID == *item.WorkspaceID {
 		score += 20
-	}
-	if score == 0 {
-		return -1
 	}
 	return score
 }
@@ -330,8 +333,10 @@ func stringFromPointer(value *string) string {
 }
 
 func (a *App) findConversationPromotionItem(ctx conversationItemContext) (*store.Item, error) {
-	var best *store.Item
-	bestScore := -1
+	var bestLinked *store.Item
+	bestLinkedScore := -1
+	var bestUnlinked *store.Item
+	bestUnlinkedScore := -1
 	for _, state := range []string{
 		store.ItemStateInbox,
 		store.ItemStateWaiting,
@@ -347,20 +352,31 @@ func (a *App) findConversationPromotionItem(ctx conversationItemContext) (*store
 			if score < 0 {
 				continue
 			}
-			if best == nil || score > bestScore || (score == bestScore && item.ID > best.ID) {
+			source := linkedItemSourceDescription(item)
+			if source != "" {
+				if bestLinked == nil || score > bestLinkedScore || (score == bestLinkedScore && item.ID > bestLinked.ID) {
+					candidate := item
+					bestLinked = &candidate
+					bestLinkedScore = score
+				}
+				continue
+			}
+			if bestUnlinked == nil || score > bestUnlinkedScore || (score == bestUnlinkedScore && item.ID > bestUnlinked.ID) {
 				candidate := item
-				best = &candidate
-				bestScore = score
+				bestUnlinked = &candidate
+				bestUnlinkedScore = score
 			}
 		}
 	}
-	if best == nil {
+	if bestLinked != nil && bestLinkedScore >= bestUnlinkedScore {
+		if source := linkedItemSourceDescription(*bestLinked); source != "" {
+			return nil, fmt.Errorf("item is already linked to %s", source)
+		}
+	}
+	if bestUnlinked == nil {
 		return nil, nil
 	}
-	if source := linkedItemSourceDescription(*best); source != "" {
-		return nil, fmt.Errorf("item is already linked to %s", source)
-	}
-	return best, nil
+	return bestUnlinked, nil
 }
 
 func (a *App) createGitHubIssueFromConversation(sessionID string, session store.ChatSession, action *SystemAction) (string, map[string]interface{}, error) {

--- a/internal/web/chat_items_github_test.go
+++ b/internal/web/chat_items_github_test.go
@@ -331,3 +331,87 @@ func TestClassifyAndExecuteSystemActionCreateGitHubIssueSurfacesCreateFailure(t 
 		t.Fatalf("message = %q", message)
 	}
 }
+
+func TestClassifyAndExecuteSystemActionCreateGitHubIssueRejectsDuplicateLinkedItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	app.intentClassifierURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	initGitHubWorkspaceRepo(t, project.RootPath, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Default", project.RootPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	assistantText := "Parser panic when config file is missing\n\n1. Reproduce with an empty config.\n2. Observe the nil pointer panic."
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", assistantText, assistantText, "markdown"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	source := "github"
+	sourceRef := "owner/tabula#77"
+	linkedItem, err := app.store.CreateItem("Parser panic when config file is missing", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Source:      &source,
+		SourceRef:   &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(linked) error: %v", err)
+	}
+	duplicateItem, err := app.store.CreateItem("Parser panic when config file is missing", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(duplicate) error: %v", err)
+	}
+
+	ghCalls := 0
+	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
+		ghCalls++
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "create a GitHub issue from this")
+	if !handled {
+		t.Fatal("expected duplicate command to be handled")
+	}
+	if ghCalls != 0 {
+		t.Fatalf("gh call count = %d, want 0", ghCalls)
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+	if message != "I couldn't create the GitHub issue: item is already linked to github owner/tabula#77" {
+		t.Fatalf("message = %q", message)
+	}
+
+	gotLinked, err := app.store.GetItem(linkedItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(linked) error: %v", err)
+	}
+	if gotLinked.SourceRef == nil || *gotLinked.SourceRef != sourceRef {
+		t.Fatalf("linked source_ref = %v, want %q", gotLinked.SourceRef, sourceRef)
+	}
+	gotDuplicate, err := app.store.GetItem(duplicateItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem(duplicate) error: %v", err)
+	}
+	if gotDuplicate.SourceRef != nil {
+		t.Fatalf("duplicate source_ref = %v, want nil", gotDuplicate.SourceRef)
+	}
+	items, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("ListItemsByState(inbox) error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListItemsByState(inbox) len = %d, want 2", len(items))
+	}
+}


### PR DESCRIPTION
## Summary
- stop GitHub issue promotion from treating workspace-only item collisions as a match
- prefer an already-linked GitHub item over a newer unlinked duplicate when promotion candidates tie
- add regression coverage proving duplicate dialogue promotions do not call `gh issue create`

## Verification
- Duplicate prevention for dialogue-to-GitHub promotion: `go test ./internal/web -run 'Test(GitHubIssueSyncAPI|GitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote|GitHubPRReviewSyncAPI|GitHubPRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote|ClassifyAndExecuteSystemActionCreateGitHubIssue.*)$' 2>&1 | tee /tmp/test.log` -> `ok   github.com/krystophny/tabura/internal/web	0.144s`
- Existing GitHub issue sync + state mapping still pass in the same command via `TestGitHubIssueSyncAPI` and `TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote` -> `ok   github.com/krystophny/tabura/internal/web	0.144s`
- Existing PR review item sync still passes in the same command via `TestGitHubPRReviewSyncAPI` and `TestGitHubPRReviewSyncAPIRejectsWorkspaceWithoutGitHubRemote` -> `ok   github.com/krystophny/tabura/internal/web	0.144s`
