### PR TITLE
fix: Epic: Add assignment, delegation, snooze, and resurfacing (fixes #169)

### DIFF
--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -79,6 +79,14 @@ func writeItemStoreError(w http.ResponseWriter, err error) {
 	writeAPIError(w, itemResponseErrorStatus(err), err.Error())
 }
 
+func (a *App) resurfaceDueItemsForRead(w http.ResponseWriter) bool {
+	if _, err := a.resurfaceDueItems(time.Now().UTC()); err != nil {
+		writeItemStoreError(w, err)
+		return false
+	}
+	return true
+}
+
 func parseItemListFilterQuery(r *http.Request) (store.ItemListFilter, error) {
 	filter := store.ItemListFilter{
 		Sphere: strings.TrimSpace(r.URL.Query().Get("sphere")),
@@ -121,6 +129,9 @@ func (a *App) handleItemList(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
+	if !a.resurfaceDueItemsForRead(w) {
+		return
+	}
 	state := strings.TrimSpace(r.URL.Query().Get("state"))
 	filter, err := parseItemListFilterQuery(r)
 	if err != nil {
@@ -154,6 +165,9 @@ func (a *App) handleItemInbox(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
+	if !a.resurfaceDueItemsForRead(w) {
+		return
+	}
 	filter, err := parseItemListFilterQuery(r)
 	if err != nil {
 		writeAPIError(w, http.StatusBadRequest, err.Error())
@@ -169,6 +183,9 @@ func (a *App) handleItemInbox(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleItemWaiting(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
+		return
+	}
+	if !a.resurfaceDueItemsForRead(w) {
 		return
 	}
 	filter, err := parseItemListFilterQuery(r)
@@ -188,6 +205,9 @@ func (a *App) handleItemSomeday(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
+	if !a.resurfaceDueItemsForRead(w) {
+		return
+	}
 	filter, err := parseItemListFilterQuery(r)
 	if err != nil {
 		writeAPIError(w, http.StatusBadRequest, err.Error())
@@ -203,6 +223,9 @@ func (a *App) handleItemSomeday(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleItemDone(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
+		return
+	}
+	if !a.resurfaceDueItemsForRead(w) {
 		return
 	}
 	filter, err := parseItemListFilterQuery(r)
@@ -229,6 +252,9 @@ func (a *App) handleItemDone(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleItemCounts(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
+		return
+	}
+	if !a.resurfaceDueItemsForRead(w) {
 		return
 	}
 	filter, err := parseItemListFilterQuery(r)
@@ -285,6 +311,9 @@ func (a *App) handleItemCreate(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleItemGet(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
+		return
+	}
+	if !a.resurfaceDueItemsForRead(w) {
 		return
 	}
 	itemID, err := parseItemIDParam(r)

--- a/internal/web/items_test.go
+++ b/internal/web/items_test.go
@@ -377,6 +377,111 @@ func TestItemStateViewAPI(t *testing.T) {
 	}
 }
 
+func TestItemStateViewAPIResurfacesDueWaitingItemsImmediately(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	past := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	future := time.Now().UTC().Add(time.Minute).Format(time.RFC3339)
+
+	dueVisible, err := app.store.CreateItem("Due visible_after", store.ItemOptions{
+		State:        store.ItemStateWaiting,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(due visible_after) error: %v", err)
+	}
+	dueFollowUp, err := app.store.CreateItem("Due follow_up_at", store.ItemOptions{
+		State:      store.ItemStateWaiting,
+		FollowUpAt: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(due follow_up_at) error: %v", err)
+	}
+	futureWaiting, err := app.store.CreateItem("Future waiting", store.ItemOptions{
+		State:        store.ItemStateWaiting,
+		VisibleAfter: &future,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(future waiting) error: %v", err)
+	}
+
+	rrInbox := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox", nil)
+	if rrInbox.Code != http.StatusOK {
+		t.Fatalf("inbox status = %d, want 200: %s", rrInbox.Code, rrInbox.Body.String())
+	}
+	inboxItems, ok := decodeJSONResponse(t, rrInbox)["items"].([]any)
+	if !ok || len(inboxItems) != 2 {
+		t.Fatalf("inbox payload = %#v", decodeJSONResponse(t, rrInbox))
+	}
+
+	inboxIDs := map[int64]bool{}
+	for _, raw := range inboxItems {
+		row, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("inbox row = %#v", raw)
+		}
+		inboxIDs[int64(row["id"].(float64))] = true
+	}
+	if !inboxIDs[dueVisible.ID] || !inboxIDs[dueFollowUp.ID] {
+		t.Fatalf("inbox ids = %#v, want %d and %d", inboxIDs, dueVisible.ID, dueFollowUp.ID)
+	}
+
+	rrList := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items?state=inbox", nil)
+	if rrList.Code != http.StatusOK {
+		t.Fatalf("list inbox status = %d, want 200: %s", rrList.Code, rrList.Body.String())
+	}
+	listItems, ok := decodeJSONDataResponse(t, rrList)["items"].([]any)
+	if !ok || len(listItems) != 2 {
+		t.Fatalf("list inbox payload = %#v", decodeJSONDataResponse(t, rrList))
+	}
+
+	rrWaiting := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/waiting", nil)
+	if rrWaiting.Code != http.StatusOK {
+		t.Fatalf("waiting status = %d, want 200: %s", rrWaiting.Code, rrWaiting.Body.String())
+	}
+	waitingItems, ok := decodeJSONResponse(t, rrWaiting)["items"].([]any)
+	if !ok || len(waitingItems) != 1 {
+		t.Fatalf("waiting payload = %#v", decodeJSONResponse(t, rrWaiting))
+	}
+	waitingRow, ok := waitingItems[0].(map[string]any)
+	if !ok || int64(waitingRow["id"].(float64)) != futureWaiting.ID {
+		t.Fatalf("waiting row = %#v, want id %d", waitingRow, futureWaiting.ID)
+	}
+
+	rrCounts := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/counts", nil)
+	if rrCounts.Code != http.StatusOK {
+		t.Fatalf("counts status = %d, want 200: %s", rrCounts.Code, rrCounts.Body.String())
+	}
+	counts, ok := decodeJSONResponse(t, rrCounts)["counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("counts payload = %#v", decodeJSONResponse(t, rrCounts))
+	}
+	if got := int(counts[store.ItemStateInbox].(float64)); got != 2 {
+		t.Fatalf("counts[inbox] = %d, want 2", got)
+	}
+	if got := int(counts[store.ItemStateWaiting].(float64)); got != 1 {
+		t.Fatalf("counts[waiting] = %d, want 1", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   int64
+		want string
+	}{
+		{name: "due visible_after", id: dueVisible.ID, want: store.ItemStateInbox},
+		{name: "due follow_up_at", id: dueFollowUp.ID, want: store.ItemStateInbox},
+		{name: "future waiting", id: futureWaiting.ID, want: store.ItemStateWaiting},
+	} {
+		item, err := app.store.GetItem(tc.id)
+		if err != nil {
+			t.Fatalf("GetItem(%s) error: %v", tc.name, err)
+		}
+		if item.State != tc.want {
+			t.Fatalf("%s state = %q, want %q", tc.name, item.State, tc.want)
+		}
+	}
+}
+
 func TestItemStateViewAPIFiltersBySphere(t *testing.T) {
 	app := newAuthedTestApp(t)
 


### PR DESCRIPTION
## Summary
- resurface due waiting items before item read and count handlers so `visible_after` and `follow_up_at` changes are reflected immediately instead of waiting for the 60-second worker tick
- add an API regression test that proves due waiting items move into inbox immediately across `/api/items/inbox`, `/api/items?state=inbox`, `/api/items/waiting`, and `/api/items/counts`

## Verification
- `Items assignable to actors`: existing automated coverage in `internal/web/items_test.go` (`TestItemAssignmentLifecycleAPI`) and `internal/store/domain_test.go` (`AssignItem`, `UnassignItem`, wrong-actor completion rejection at lines 517-566).
- `Items snoozable via visible_after, reappear on time`: `bash -lc "go test ./internal/web -run 'TestItemStateViewAPI$|TestItemStateViewAPIResurfacesDueWaitingItemsImmediately$|TestItemResurfacerTickerMovesDueItemsBackToInbox$|TestItemResurfaceBroadcastsWebsocketNotification$' -count=1 2>&1 | tee /tmp/tabula-issue-169-test.log"` -> `ok   github.com/krystophny/tabura/internal/web 0.078s`; immediate API resurfacing coverage in `internal/web/items_test.go:380`, read-path hook in `internal/web/items.go:82`, ticker coverage in `internal/web/items_resurface_test.go:11`.
- `Items with follow_up_at resurface`: same command/output; `follow_up_at` case asserted in `internal/web/items_test.go:393` and store-level resurfacing remains covered in `internal/store/domain_test.go:999`.
- `Items return to inbox when assignee finishes`: existing store coverage in `internal/store/domain_test.go:581` (`ReturnItemToInbox`) and the review dispatch retry path still calls it in `internal/web/items_review_dispatch.go:372`.
- `Inbox triage works from row without opening artifact`: existing browser coverage in `tests/playwright/inbox-triage.spec.ts:416` and `tests/playwright/inbox-triage.spec.ts:530`.
- `Swipe/gesture interactions work`: existing browser coverage in `tests/playwright/inbox-triage.spec.ts:416` and `tests/playwright/inbox-triage.spec.ts:607`.
- `Delegation moves to waiting`: existing API coverage in `internal/web/items_test.go:820` and store coverage in `internal/store/domain_test.go:540`.
- `Comprehensive test coverage: assignment lifecycle tests, resurfacing scheduler tests, gesture interaction Playwright specs, edge cases (reassign, unassign, complete-by-wrong-actor rejection)`: coverage remains in `internal/store/domain_test.go:517`, `internal/store/domain_test.go:999`, `internal/web/items_test.go:737`, `internal/web/items_resurface_test.go:11`, and `tests/playwright/inbox-triage.spec.ts:416`.
