### PR TITLE
fix: Bug report: new mail button and reply button do nothing (fixes #410)

### DIFF
--- a/internal/web/chat_dictation.go
+++ b/internal/web/chat_dictation.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	dictationTargetDocumentSection = "document_section"
+	dictationTargetEmailDraft      = "email_draft"
 	dictationTargetEmailReply      = "email_reply"
 	dictationTargetReviewComment   = "review_comment"
 )
@@ -73,6 +74,8 @@ func (t *dictationSessionTracker) delete(sessionID string) {
 
 func normalizeDictationTargetKind(raw string) string {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case dictationTargetEmailDraft:
+		return dictationTargetEmailDraft
 	case dictationTargetEmailReply:
 		return dictationTargetEmailReply
 	case dictationTargetReviewComment:
@@ -84,6 +87,8 @@ func normalizeDictationTargetKind(raw string) string {
 
 func dictationTargetLabel(kind string) string {
 	switch normalizeDictationTargetKind(kind) {
+	case dictationTargetEmailDraft:
+		return "Email Draft"
 	case dictationTargetEmailReply:
 		return "Email Reply"
 	case dictationTargetReviewComment:
@@ -98,8 +103,10 @@ func inferDictationTargetKind(prompt, artifactTitle string) string {
 	switch {
 	case strings.Contains(combined, "review"), strings.Contains(combined, "pull request"), strings.Contains(combined, ".diff"), strings.Contains(combined, "pr "):
 		return dictationTargetReviewComment
-	case strings.Contains(combined, "reply"), strings.Contains(combined, "email"), strings.Contains(combined, "thread"), strings.Contains(combined, "letter"):
+	case strings.Contains(combined, "reply"), strings.Contains(combined, "thread"):
 		return dictationTargetEmailReply
+	case strings.Contains(combined, "email"), strings.Contains(combined, "letter"):
+		return dictationTargetEmailDraft
 	default:
 		return dictationTargetDocumentSection
 	}
@@ -136,6 +143,8 @@ func shapeDictationDraft(targetKind, artifactTitle, transcript string) string {
 	parts := dictationParagraphs(transcript)
 	if len(parts) == 0 {
 		switch kind {
+		case dictationTargetEmailDraft:
+			return "# Email Draft\n\nStart speaking to build the message."
 		case dictationTargetEmailReply:
 			return "# Email Reply Draft\n\nStart speaking to build the reply."
 		case dictationTargetReviewComment:
@@ -146,6 +155,12 @@ func shapeDictationDraft(targetKind, artifactTitle, transcript string) string {
 	}
 	var b strings.Builder
 	switch kind {
+	case dictationTargetEmailDraft:
+		b.WriteString("# Email Draft\n\n")
+		if title != "" {
+			fmt.Fprintf(&b, "Subject: %s\n\n", title)
+		}
+		b.WriteString(strings.Join(parts, "\n\n"))
 	case dictationTargetEmailReply:
 		b.WriteString("# Email Reply Draft\n\n")
 		if title != "" {

--- a/internal/web/chat_dictation_test.go
+++ b/internal/web/chat_dictation_test.go
@@ -17,7 +17,7 @@ func TestInferDictationTargetKind(t *testing.T) {
 		want          string
 	}{
 		{name: "review prompt", prompt: "write my review", want: dictationTargetReviewComment},
-		{name: "email reply prompt", prompt: "take a letter", want: dictationTargetEmailReply},
+		{name: "email draft prompt", prompt: "take a letter", want: dictationTargetEmailDraft},
 		{name: "email artifact", prompt: "dictate", artifactTitle: "Email Thread", want: dictationTargetEmailReply},
 		{name: "fallback document", prompt: "dictate", artifactTitle: "notes.md", want: dictationTargetDocumentSection},
 	}
@@ -38,6 +38,10 @@ func TestShapeDictationDraftByTarget(t *testing.T) {
 	email := shapeDictationDraft(dictationTargetEmailReply, "Customer thread", "Thanks for the update.\n\nI'll send a revision tomorrow.")
 	if !strings.Contains(email, "# Email Reply Draft") || !strings.Contains(email, "Thread: Customer thread") {
 		t.Fatalf("email draft = %q", email)
+	}
+	message := shapeDictationDraft(dictationTargetEmailDraft, "Quarterly update", "Here's the latest status.\n\nI'll send the full details later today.")
+	if !strings.Contains(message, "# Email Draft") || !strings.Contains(message, "Subject: Quarterly update") {
+		t.Fatalf("message draft = %q", message)
 	}
 	review := shapeDictationDraft(dictationTargetReviewComment, "PR #12", "This branch looks good.\n\nPlease tighten the nil check.")
 	if !strings.Contains(review, "# Review Comment Draft") || !strings.Contains(review, "- This branch looks good.") {

--- a/internal/web/static/app-dictation.js
+++ b/internal/web/static/app-dictation.js
@@ -52,9 +52,14 @@ function activeDraftText() {
   return String(getPreviousArtifactText() || dictationState().draftText || '').trim();
 }
 
-function dictationDispatchPrompt(targetLabel, draftText) {
+function dictationDraftLabel(targetLabel) {
   const label = String(targetLabel || 'draft').trim();
-  return `Use this dictated ${label.toLowerCase()} draft as the content to dispatch.\n\n${draftText}`;
+  if (!label) return 'draft';
+  return label.toLowerCase().endsWith('draft') ? label : `${label} draft`;
+}
+
+function dictationDispatchPrompt(targetLabel, draftText) {
+  return `Use this dictated ${dictationDraftLabel(targetLabel).toLowerCase()} as the content to dispatch.\n\n${draftText}`;
 }
 
 function dictationCanvasPayload() {
@@ -84,6 +89,33 @@ async function requestDictation(path, options = {}) {
   }
   const payload = await resp.json();
   return normalizeDictationResponse(payload);
+}
+
+export async function startDictationMode(options = {}) {
+  const prompt = String(options?.prompt || '').trim();
+  if (!prompt) return false;
+  const targetKind = String(options?.targetKind || '').trim();
+  const artifactTitle = Object.prototype.hasOwnProperty.call(options || {}, 'artifactTitle')
+    ? String(options?.artifactTitle || '').trim()
+    : String(getActiveArtifactTitle() || '').trim();
+  const successText = String(options?.successText || '').trim();
+  try {
+    const next = await requestDictation('/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt,
+        target_kind: targetKind,
+        artifact_title: artifactTitle,
+      }),
+    });
+    applyDictationState(next);
+    showStatus(successText || `${next.targetLabel.toLowerCase()} dictation ready`);
+    return true;
+  } catch (err) {
+    showStatus(`dictation failed: ${String(err?.message || err)}`);
+    return false;
+  }
 }
 
 export function ensureDictationUi() {
@@ -119,7 +151,7 @@ export function renderDictationUi() {
   const target = root.querySelector('.dictation-indicator-target');
   if (target) {
     const transcriptState = current.transcript ? 'Listening for more voice input.' : 'Waiting for speech.';
-    target.textContent = `${current.targetLabel} draft. ${transcriptState}`;
+    target.textContent = `${dictationDraftLabel(current.targetLabel)}. ${transcriptState}`;
   }
   const sendButton = root.querySelector('#dictation-send');
   if (sendButton instanceof HTMLButtonElement) {
@@ -134,22 +166,8 @@ export async function maybeHandleDictationCommand(text) {
   if (!['take a letter', 'draft a reply', 'write my review', 'dictate'].includes(normalized)) {
     return false;
   }
-  try {
-    const next = await requestDictation('/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        prompt: trimmed,
-        artifact_title: String(getActiveArtifactTitle() || '').trim(),
-      }),
-    });
-    applyDictationState(next);
-    showStatus(`${next.targetLabel.toLowerCase()} dictation ready`);
-    return true;
-  } catch (err) {
-    showStatus(`dictation failed: ${String(err?.message || err)}`);
-    return true;
-  }
+  await startDictationMode({ prompt: trimmed });
+  return true;
 }
 
 export function isDictationActive() {

--- a/internal/web/static/app-item-sidebar-ui.js
+++ b/internal/web/static/app-item-sidebar-ui.js
@@ -31,8 +31,8 @@ const parentWorkspaceBrowserPath = (...args) => refs.parentWorkspaceBrowserPath(
 const workspaceCompanionEntries = (...args) => refs.workspaceCompanionEntries(...args);
 const openWorkspaceSidebarFile = (...args) => refs.openWorkspaceSidebarFile(...args);
 const openScanImportPicker = (...args) => refs.openScanImportPicker(...args);
-const createNewMailDraft = (...args) => refs.createNewMailDraft(...args);
-const replyToSidebarItem = (...args) => refs.replyToSidebarItem(...args);
+const launchNewMailAuthoring = (...args) => refs.launchNewMailAuthoring(...args);
+const launchReplyAuthoring = (...args) => refs.launchReplyAuthoring(...args);
 
 export async function openItemSidebarView(view = state.itemSidebarView, filters = null) {
   state.fileSidebarMode = 'items';
@@ -515,7 +515,7 @@ export function renderItemSidebarList(list) {
   newMailButton.id = 'new-mail-trigger';
   newMailButton.textContent = 'New Mail';
   newMailButton.addEventListener('click', () => {
-    void createNewMailDraft();
+    void launchNewMailAuthoring();
   });
   actions.appendChild(newMailButton);
   if (activeItem && ['email', 'email_thread'].includes(String(activeItem?.artifact_kind || '').trim().toLowerCase())) {
@@ -525,7 +525,7 @@ export function renderItemSidebarList(list) {
     replyButton.id = 'reply-mail-trigger';
     replyButton.textContent = 'Reply';
     replyButton.addEventListener('click', () => {
-      void replyToSidebarItem(activeItem);
+      void launchReplyAuthoring(activeItem);
     });
     actions.appendChild(replyButton);
   }

--- a/internal/web/static/app-mail-drafts.js
+++ b/internal/web/static/app-mail-drafts.js
@@ -7,6 +7,7 @@ const { refs, state } = context;
 const applyCanvasArtifactEvent = (...args) => refs.applyCanvasArtifactEvent(...args);
 const loadItemSidebarView = (...args) => refs.loadItemSidebarView(...args);
 const showStatus = (...args) => refs.showStatus(...args);
+const startDictationMode = (...args) => refs.startDictationMode(...args);
 
 const MAIL_DRAFT_EDITOR_ID = 'mail-draft-editor';
 const MAIL_DRAFT_STATUS_ID = 'mail-draft-status';
@@ -131,6 +132,38 @@ export async function replyToSidebarItem(item) {
     showStatus(`reply draft failed: ${String(err?.message || err || 'unknown error')}`);
     return false;
   }
+}
+
+function mailAuthoringUsesDictation() {
+  return String(state.interaction?.tool || '').trim().toLowerCase() === 'prompt'
+    && String(state.interaction?.surface || '').trim().toLowerCase() === 'annotate';
+}
+
+function mailReplyArtifactTitle(item) {
+  return String(item?.artifact_title || item?.title || '').trim();
+}
+
+export async function launchNewMailAuthoring() {
+  if (!mailAuthoringUsesDictation()) {
+    return createNewMailDraft();
+  }
+  return startDictationMode({
+    prompt: 'take a letter',
+    targetKind: 'email_draft',
+    successText: 'email draft dictation ready',
+  });
+}
+
+export async function launchReplyAuthoring(item) {
+  if (!mailAuthoringUsesDictation()) {
+    return replyToSidebarItem(item);
+  }
+  return startDictationMode({
+    prompt: 'draft a reply',
+    targetKind: 'email_reply',
+    artifactTitle: mailReplyArtifactTitle(item),
+    successText: 'email reply dictation ready',
+  });
 }
 
 export async function openMailDraftArtifact(artifactID) {

--- a/tests/playwright/dictation-mode.spec.ts
+++ b/tests/playwright/dictation-mode.spec.ts
@@ -22,7 +22,7 @@ test('dictation mode accumulates draft on canvas and dispatches only on explicit
   await input.press('Enter');
 
   await expect(page.locator('#dictation-indicator')).toBeVisible();
-  await expect(page.locator('#dictation-indicator')).toContainText('Email Reply');
+  await expect(page.locator('#dictation-indicator')).toContainText('Email Draft');
 
   let log = await getLog(page);
   expect(log.some((entry) => entry.type === 'api_fetch' && entry.action === 'dictation_start')).toBe(true);
@@ -32,7 +32,7 @@ test('dictation mode accumulates draft on canvas and dispatches only on explicit
     await (window as any)._taburaApp.appendDictationTranscript('Thanks for the update. I can send the revision tomorrow.');
   });
 
-  await expect(page.locator('#canvas-text')).toContainText('Email Reply Draft');
+  await expect(page.locator('#canvas-text')).toContainText('Email Draft');
   await expect(page.locator('#canvas-text')).toContainText('Thanks for the update. I can send the revision tomorrow.');
 
   log = await getLog(page);
@@ -48,7 +48,7 @@ test('dictation mode accumulates draft on canvas and dispatches only on explicit
 
   log = await getLog(page);
   const message = log.find((entry) => entry.type === 'message_sent');
-  expect(String(message?.text || '')).toContain('Use this dictated email reply draft');
+  expect(String(message?.text || '')).toContain('Use this dictated email draft as the content to dispatch.');
   expect(String(message?.text || '')).toContain('Thanks for the update. I can send the revision tomorrow.');
   expect(log.some((entry) => entry.type === 'api_fetch' && entry.action === 'dictation_draft')).toBe(true);
   expect(log.some((entry) => entry.type === 'api_fetch' && entry.action === 'dictation_stop')).toBe(true);

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -211,6 +211,7 @@
       scratch_path: '',
     };
     function dictationLabel(targetKind) {
+      if (targetKind === 'email_draft') return 'Email Draft';
       if (targetKind === 'email_reply') return 'Email Reply';
       if (targetKind === 'review_comment') return 'Review Comment';
       return 'Document Section';
@@ -218,7 +219,8 @@
     function dictationTargetForPrompt(prompt, artifactTitle) {
       const combined = String(`${prompt || ''}\n${artifactTitle || ''}`).toLowerCase();
       if (combined.includes('review') || combined.includes('.diff') || combined.includes('pr ')) return 'review_comment';
-      if (combined.includes('reply') || combined.includes('email') || combined.includes('thread') || combined.includes('letter')) return 'email_reply';
+      if (combined.includes('reply') || combined.includes('thread')) return 'email_reply';
+      if (combined.includes('email') || combined.includes('letter')) return 'email_draft';
       return 'document_section';
     }
     function dictationDraftForState(current) {
@@ -227,6 +229,9 @@
       const paragraphs = transcript
         ? transcript.split(/\n\s*\n/).map((part) => part.trim().replace(/\s+/g, ' ')).filter(Boolean)
         : [];
+      if (current?.target_kind === 'email_draft') {
+        return `# Email Draft\n\n${title ? `Subject: ${title}\n\n` : ''}${paragraphs.join('\n\n') || 'Start speaking to build the message.'}`;
+      }
       if (current?.target_kind === 'email_reply') {
         return `# Email Reply Draft\n\n${title ? `Thread: ${title}\n\n` : ''}${paragraphs.join('\n\n') || 'Start speaking to build the reply.'}`;
       }
@@ -2080,7 +2085,10 @@
       if (u.includes('/api/chat/sessions') && u.includes('/dictation/start') && opts?.method === 'POST') {
         let body = {};
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
-        const targetKind = dictationTargetForPrompt(body.prompt, body.artifact_title);
+        const requestedTargetKind = String(body.target_kind || '').trim().toLowerCase();
+        const targetKind = ['document_section', 'email_draft', 'email_reply', 'review_comment'].includes(requestedTargetKind)
+          ? requestedTargetKind
+          : dictationTargetForPrompt(body.prompt, body.artifact_title);
         dictationState = {
           active: true,
           target_kind: targetKind,

--- a/tests/playwright/mail-drafts.spec.ts
+++ b/tests/playwright/mail-drafts.spec.ts
@@ -44,6 +44,14 @@ async function waitForLogEntry(page: Page, type: string, action?: string) {
   }).toBe(true);
 }
 
+async function setInteractionTool(page: Page, tool: 'pointer' | 'highlight' | 'ink' | 'text_note' | 'prompt') {
+  await page.evaluate((mode) => {
+    (window as any).__setRuntimeState?.({ tool: mode });
+    const app = (window as any)._taburaApp;
+    if (app?.getState) app.getState().interaction.tool = mode;
+  }, tool);
+}
+
 test.describe('mail drafts', () => {
   test('new mail remains available in an empty inbox and supports save, reopen, suggestions, and send', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
@@ -169,5 +177,87 @@ test.describe('mail drafts', () => {
     await expect(page.locator('.mail-draft-account')).toContainText('exchange');
     await expect(page.locator('[name="to"]')).toHaveValue('client@example.com');
     await expect(page.locator('[name="subject"]')).toHaveValue('Re: Client question');
+  });
+
+  test('new mail starts dictation authoring when the prompt tool is active', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [],
+        waiting: [],
+        someday: [],
+        done: [],
+      });
+    });
+    await setInteractionTool(page, 'prompt');
+    await openInbox(page);
+
+    await clearLog(page);
+    await page.locator('#new-mail-trigger').click();
+    await waitForLogEntry(page, 'api_fetch', 'dictation_start');
+    await expect(page.locator('#dictation-indicator')).toContainText('Email Draft');
+
+    await page.evaluate(async () => {
+      await (window as any)._taburaApp.appendDictationTranscript('Hello team. Sending the updated status shortly.');
+    });
+    await expect(page.locator('#canvas-text')).toContainText('Email Draft');
+    await expect(page.locator('#canvas-text')).toContainText('Hello team. Sending the updated status shortly.');
+  });
+
+  test('reply starts dictation authoring when the prompt tool is active', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [{
+          id: 812,
+          title: 'Reply to client',
+          state: 'inbox',
+          sphere: 'private',
+          artifact_id: 612,
+          source: 'exchange',
+          source_ref: 'msg-812',
+          artifact_title: 'Client question',
+          artifact_kind: 'email',
+          actor_name: 'Client',
+          created_at: '2026-03-10 10:00:00',
+          updated_at: '2026-03-10 10:05:00',
+        }],
+        waiting: [],
+        someday: [],
+        done: [],
+      });
+      (window as any).__setItemSidebarArtifacts({
+        612: {
+          id: 612,
+          kind: 'email',
+          title: 'Client question',
+          meta_json: JSON.stringify({
+            subject: 'Client question',
+            sender: 'Client <client@example.com>',
+            thread_id: 'thread-812',
+            body: 'Can you send the revised proposal?',
+          }),
+        },
+      });
+    });
+    await setInteractionTool(page, 'prompt');
+    await openInbox(page);
+    await page.locator('#pr-file-list .pr-file-item').first().click();
+
+    await clearLog(page);
+    await page.locator('#reply-mail-trigger').click();
+    await waitForLogEntry(page, 'api_fetch', 'dictation_start');
+    await expect(page.locator('#dictation-indicator')).toContainText('Email Reply');
+
+    await page.evaluate(async () => {
+      await (window as any)._taburaApp.appendDictationTranscript('I can send the revised proposal this afternoon.');
+    });
+    await expect(page.locator('#canvas-text')).toContainText('Email Reply Draft');
+    await expect(page.locator('#canvas-text')).toContainText('Thread: Client question');
+    await expect(page.locator('#canvas-text')).toContainText('I can send the revised proposal this afternoon.');
   });
 });


### PR DESCRIPTION
## Summary
- route `New Mail` and `Reply` through a mode-aware authoring launcher
- keep typed mail drafts for the existing text flow and start dictation authoring when the prompt tool is active
- add explicit email-draft dictation coverage in the Go unit tests and Playwright harness/specs

## Verification
- Requirement: `new mail button and reply button do nothing`.
  Evidence: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts tests/playwright/dictation-mode.spec.ts`
  Excerpt: `✓ 2 [chromium] › tests/playwright/mail-drafts.spec.ts:56:7 › mail drafts › new mail remains available in an empty inbox and supports save, reopen, suggestions, and send`
  Excerpt: `✓ 3 [chromium] › tests/playwright/mail-drafts.spec.ts:127:7 › mail drafts › reply drafts seed recipient and subject from the selected email item`
- Requirement: `authoring mode where i can speak or type depending on the mode selected`.
  Evidence: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts tests/playwright/dictation-mode.spec.ts`
  Excerpt: `✓ 4 [chromium] › tests/playwright/mail-drafts.spec.ts:182:7 › mail drafts › new mail starts dictation authoring when the prompt tool is active`
  Excerpt: `✓ 5 [chromium] › tests/playwright/mail-drafts.spec.ts:209:7 › mail drafts › reply starts dictation authoring when the prompt tool is active`
  Excerpt: `✓ 1 [chromium] › tests/playwright/dictation-mode.spec.ts:14:5 › dictation mode accumulates draft on canvas and dispatches only on explicit send`
- Requirement: explicit dictation target handling for typed vs spoken mail authoring stays valid in the backend.
  Evidence: `go test ./internal/web -run "TestInferDictationTargetKind|TestShapeDictationDraftByTarget|TestChatSessionDictationLifecycle"`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 0.019s`
