### PR TITLE
fix: Bug report: bug reports should appear instantly in inbox and mov (fixes #412)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -245,8 +245,19 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 	if err != nil {
 		return ghIssueListItem{}, 0, err
 	}
-	source := "bug_report"
-	sourceRef := fmt.Sprintf("issue:%d", issue.Number)
+	ownerRepo := ""
+	if workspaceID != nil {
+		ownerRepo, _ = a.store.GitHubRepoForWorkspace(*workspaceID)
+	}
+	if ownerRepo == "" {
+		ownerRepo = bugReportOwnerRepoFromIssueURL(issue.URL)
+	}
+	source := "github"
+	sourceRef := githubIssueSourceRef(ownerRepo, issue.Number)
+	if ownerRepo == "" {
+		source = "bug_report"
+		sourceRef = legacyBugReportIssueSourceRef(issue.Number)
+	}
 	item, err := a.store.CreateItem(strings.TrimSpace(issue.Title), store.ItemOptions{
 		WorkspaceID: workspaceID,
 		Source:      &source,
@@ -254,10 +265,6 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 	})
 	if err != nil {
 		return ghIssueListItem{}, 0, err
-	}
-	ownerRepo := bugReportOwnerRepoFromIssueURL(issue.URL)
-	if ownerRepo == "" && workspaceID != nil {
-		ownerRepo, _ = a.store.GitHubRepoForWorkspace(*workspaceID)
 	}
 	if ownerRepo != "" {
 		if err := a.syncGitHubIssueArtifact(item, ownerRepo, issue); err != nil {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -159,7 +159,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	if got := strFromAny(canvasState["artifact_title"]); got != "README.md" {
 		t.Fatalf("canvas_state.artifact_title = %q, want %q", got, "README.md")
 	}
-	item, err := app.store.GetItemBySource("bug_report", "issue:77")
+	item, err := app.store.GetItemBySource("github", "owner/tabula#77")
 	if err != nil {
 		t.Fatalf("GetItemBySource() error: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	if workspace.Sphere != store.SphereWork {
 		t.Fatalf("workspace.Sphere = %q, want %q", workspace.Sphere, store.SphereWork)
 	}
-	item, err := app.store.GetItemBySource("bug_report", "issue:91")
+	item, err := app.store.GetItemBySource("github", "owner/tabula#91")
 	if err != nil {
 		t.Fatalf("GetItemBySource() error: %v", err)
 	}

--- a/internal/web/items_github.go
+++ b/internal/web/items_github.go
@@ -53,6 +53,10 @@ func optionalTrimmedString(raw string) *string {
 	return &clean
 }
 
+func legacyBugReportIssueSourceRef(number int) string {
+	return fmt.Sprintf("issue:%d", number)
+}
+
 func githubIssueSourceRef(ownerRepo string, number int) string {
 	return fmt.Sprintf("%s#%d", strings.TrimSpace(ownerRepo), number)
 }
@@ -160,6 +164,20 @@ func (a *App) syncGitHubIssueArtifact(item store.Item, ownerRepo string, issue g
 	return err
 }
 
+func migrateLegacyBugReportIssue(a *App, workspaceID int64, ownerRepo string, issue ghIssueListItem) error {
+	legacy, err := a.store.GetItemBySource("bug_report", legacyBugReportIssueSourceRef(issue.Number))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if legacy.WorkspaceID == nil || *legacy.WorkspaceID != workspaceID {
+		return nil
+	}
+	return a.store.UpdateItemSource(legacy.ID, "github", githubIssueSourceRef(ownerRepo, issue.Number))
+}
+
 func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error) {
 	workspace, err := a.store.GetWorkspace(workspaceID)
 	if err != nil {
@@ -190,6 +208,9 @@ func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error
 		}
 		if strings.TrimSpace(issue.Title) == "" {
 			return itemGitHubSyncResponse{}, fmt.Errorf("github issue #%d title is required", issue.Number)
+		}
+		if err := migrateLegacyBugReportIssue(a, workspace.ID, repo, issue); err != nil {
+			return itemGitHubSyncResponse{}, err
 		}
 
 		item, err := a.store.UpsertItemFromSource("github", githubIssueSourceRef(repo, issue.Number), issue.Title, &workspace.ID)

--- a/internal/web/items_github_test.go
+++ b/internal/web/items_github_test.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os/exec"
 	"path/filepath"
@@ -171,6 +173,60 @@ func TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote(t *testing.T) {
 	})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("sync without remote status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGitHubIssueSyncMigratesLegacyBugReportItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	repoDir := filepath.Join(t.TempDir(), "workspace")
+	initGitHubWorkspaceRepo(t, repoDir, "https://github.com/owner/tabula.git")
+	workspace, err := app.store.CreateWorkspace("Repo", repoDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	source := "bug_report"
+	sourceRef := legacyBugReportIssueSourceRef(77)
+	item, err := app.store.CreateItem("Old bug report title", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Source:      &source,
+		SourceRef:   &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(legacy bug report) error: %v", err)
+	}
+
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		if cwd != repoDir {
+			t.Fatalf("gh cwd = %q, want %q", cwd, repoDir)
+		}
+		return `[
+			{"number":77,"title":"Bug report: Inbox sync migration","url":"https://github.com/owner/tabula/issues/77","state":"CLOSED","labels":[{"name":"bug"}],"assignees":[]}
+		]`, nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/sync/github", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("sync status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	migrated, err := app.store.GetItemBySource("github", "owner/tabula#77")
+	if err != nil {
+		t.Fatalf("GetItemBySource(migrated) error: %v", err)
+	}
+	if migrated.ID != item.ID {
+		t.Fatalf("migrated item ID = %d, want %d", migrated.ID, item.ID)
+	}
+	if migrated.State != store.ItemStateDone {
+		t.Fatalf("migrated item state = %q, want %q", migrated.State, store.ItemStateDone)
+	}
+	if migrated.Title != "Bug report: Inbox sync migration" {
+		t.Fatalf("migrated item title = %q, want synced title", migrated.Title)
+	}
+	if _, err := app.store.GetItemBySource("bug_report", "issue:77"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("legacy bug report source lookup error = %v, want sql.ErrNoRows", err)
 	}
 }
 

--- a/internal/web/static/app-bug-report.js
+++ b/internal/web/static/app-bug-report.js
@@ -11,6 +11,8 @@ const sttStart = (...args) => refs.sttStart(...args);
 const sttSendBlob = (...args) => refs.sttSendBlob(...args);
 const sttStop = (...args) => refs.sttStop(...args);
 const sttCancel = (...args) => refs.sttCancel(...args);
+const loadItemSidebarView = (...args) => refs.loadItemSidebarView(...args);
+const refreshItemSidebarCounts = (...args) => refs.refreshItemSidebarCounts(...args);
 
 const BUG_REPORT_SHORTCUT_KEY = 'b';
 const BUG_REPORT_TOUCH_HOLD_MS = 700;
@@ -700,6 +702,11 @@ async function saveBugReport() {
     });
     showCanvasColumn('canvas-text');
     const issueNumber = Number(payload?.issue_number || 0);
+    try {
+      await refreshBugReportInboxState();
+    } catch (refreshErr) {
+      console.warn('bug report inbox refresh failed', refreshErr);
+    }
     showStatus(issueNumber > 0 ? `bug report filed: #${issueNumber}` : `bug bundle saved: ${safeText(payload?.bundle_path) || 'ok'}`);
   } catch (err) {
     showStatus(`bug bundle failed: ${safeText(err?.message || err) || 'unknown error'}`);
@@ -708,6 +715,14 @@ async function saveBugReport() {
       save.disabled = false;
     }
   }
+}
+
+async function refreshBugReportInboxState() {
+  if (!String(state.activeProjectId || '').trim()) return false;
+  if (state.prReviewDrawerOpen && state.fileSidebarMode === 'items' && String(state.itemSidebarView || '').trim().toLowerCase() === 'inbox') {
+    return loadItemSidebarView('inbox');
+  }
+  return refreshItemSidebarCounts();
 }
 
 function onBugReportPointerDown(event) {

--- a/tests/playwright/bug-report.spec.ts
+++ b/tests/playwright/bug-report.spec.ts
@@ -58,6 +58,20 @@ test.describe('bug report flow', () => {
     await expect(page.locator('#canvas-text')).toContainText('#77');
   });
 
+  test('filed bug reports appear in inbox immediately', async ({ page }) => {
+    await waitReady(page);
+
+    await page.locator('#edge-left-tap').click();
+    await expect(page.locator('#pr-file-list')).toContainText('Review parser cleanup');
+
+    await page.locator('#bug-report-button').click();
+    await page.locator('#bug-report-note').fill('Harness inbox refresh');
+    await page.locator('#bug-report-save').click();
+
+    await expect(page.locator('#pr-file-list')).toContainText('Bug report: Harness repro');
+    await expect(page.locator('#edge-left-tap')).toHaveAttribute('data-inbox-count', '3');
+  });
+
   test('keyboard shortcut opens the bug report sheet', async ({ page }) => {
     await waitReady(page);
 

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1254,6 +1254,20 @@
           url: u,
           trigger: body.trigger || '',
         });
+        prependInboxItem({
+          id: 103,
+          title: 'Bug report: Harness repro',
+          state: 'inbox',
+          sphere: 'private',
+          artifact_id: 0,
+          source: 'github',
+          source_ref: 'owner/tabula#77',
+          artifact_title: 'Bug report: Harness repro',
+          artifact_kind: 'github_issue',
+          actor_name: '',
+          created_at: '2026-03-08 15:04:05',
+          updated_at: '2026-03-08 15:04:05',
+        });
         return new Response(JSON.stringify({
           ok: true,
           bundle_path: '.tabura/artifacts/bugs/20260308-150405-abcd1234/bundle.json',


### PR DESCRIPTION
## Summary
- create bug-report items with the normal GitHub issue source identity so they stay in the inbox flow
- migrate legacy bug_report items during GitHub issue sync so closed issues move the existing inbox item to DONE instead of creating duplicates
- refresh inbox state after filing a bug report so the inbox list/count updates immediately in the UI

## Verification
- Requirement: bug reports appear instantly in inbox.
  Evidence: ./scripts/playwright.sh tests/playwright/bug-report.spec.ts
  Output excerpt: ✓  2 [chromium] › tests/playwright/bug-report.spec.ts:61:7 › bug report flow › filed bug reports appear in inbox immediately
- Requirement: new bug reports are tracked as GitHub-backed inbox items.
  Evidence: go test ./internal/web -run "TestHandleBugReportCreate|TestGitHubIssueSync"
  Output excerpt: ok   github.com/krystophny/tabura/internal/web 0.128s
  Coverage: TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts, TestHandleBugReportCreateUsesLocalProjectFallback
- Requirement: resolved GitHub bug reports move to DONE.
  Evidence: go test ./internal/web -run "TestHandleBugReportCreate|TestGitHubIssueSync"
  Output excerpt: ok   github.com/krystophny/tabura/internal/web 0.128s
  Coverage: TestGitHubIssueSyncMigratesLegacyBugReportItems
- Requirement: focused bug-report regression checks still pass.
  Evidence: ./scripts/playwright.sh tests/playwright/bug-report.spec.ts
  Output excerpt: 5 passed (3.1s)
