### PR TITLE
fix: Bug report: swipe is clunky for inbox and in conflict with swipr (fixes #414)

### DIFF
--- a/internal/web/static/app-edge-panels.js
+++ b/internal/web/static/app-edge-panels.js
@@ -358,12 +358,9 @@ export function initEdgePanels() {
     const preserveCanvasHorizontalSwipe = Boolean(state.hasArtifact && startsInCanvasViewport);
     const topOpen = Boolean(edgeTop && (edgeTop.classList.contains('edge-active') || edgeTop.classList.contains('edge-pinned')));
     const rightOpen = Boolean(edgeRight && (edgeRight.classList.contains('edge-active') || edgeRight.classList.contains('edge-pinned')));
-    const leftOpen = Boolean(state.prReviewDrawerOpen);
-    if (leftOpen && target && target.closest('#pr-file-pane')) {
-      edgeTouchStart = { x: t.clientX, y: t.clientY, edge: 'left-open' };
-    } else if (rightOpen && target && target.closest('#edge-right')) {
+    if (rightOpen && target && target.closest('#edge-right')) {
       edgeTouchStart = { x: t.clientX, y: t.clientY, edge: 'right-open' };
-    } else if (topOpen && target && target.closest('#edge-top')) {
+    } else if (topOpen && t.clientY < topEdgeTapSize && target && target.closest('#edge-top')) {
       edgeTouchStart = { x: t.clientX, y: t.clientY, edge: 'top-open' };
     } else if (!preserveCanvasHorizontalSwipe && isLeftEdgeTapCoordinate(t.clientX)) {
       edgeTouchStart = { x: t.clientX, y: t.clientY, edge: 'left' };
@@ -391,14 +388,8 @@ export function initEdgePanels() {
     } else if (edgeTouchStart.edge === 'top' && dy > 30 && absDy > absDx * 1.1 && edgeTop) {
       edgeTop.classList.add('edge-active');
       edgeTouchHandled = true;
-    } else if (edgeTouchStart.edge === 'left-open' && dx < -30 && absDx > absDy * 1.1 && state.prReviewDrawerOpen) {
-      setPrReviewDrawerOpen(false);
-      edgeTouchHandled = true;
     } else if (edgeTouchStart.edge === 'right-open' && dx > 30 && absDx > absDy * 1.1 && edgeRight) {
       edgeRight.classList.remove('edge-active', 'edge-pinned');
-      edgeTouchHandled = true;
-    } else if (edgeTouchStart.edge === 'top-open' && dy < -30 && absDy > absDx * 1.1 && edgeTop) {
-      edgeTop.classList.remove('edge-active', 'edge-pinned');
       edgeTouchHandled = true;
     }
   }, { passive: true });
@@ -431,6 +422,12 @@ export function initEdgePanels() {
           case 'top':
             if (edgeTop) {
               edgeTop.classList.add('edge-pinned');
+              handledTapAction = true;
+            }
+            break;
+          case 'top-open':
+            if (edgeTop) {
+              edgeTop.classList.remove('edge-active', 'edge-pinned');
               handledTapAction = true;
             }
             break;

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -918,14 +918,14 @@ test.describe('canvas - edge panels', () => {
     expect(classes).not.toContain('edge-active');
   });
 
-  test('touch swipe up hides pinned top panel', async ({ page }) => {
+  test('touch tap on the top strip hides the pinned top panel', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     const edgeTop = page.locator('#edge-top');
     await dispatchTouchTap(page, 187, 3);
     await page.waitForTimeout(200);
     await expect(edgeTop).toHaveClass(/edge-pinned/);
 
-    await dispatchTouchSwipe(page, 187, 140, 187, 24);
+    await dispatchTouchTap(page, 187, 3);
     await page.waitForTimeout(150);
 
     const classes = await edgeTop.getAttribute('class');
@@ -941,14 +941,21 @@ test.describe('canvas - edge panels', () => {
     await expect(edgeTop).toHaveClass(/edge-pinned/);
   });
 
-  test('touch swipe left hides file sidebar drawer', async ({ page }) => {
+  test('touch tap on the sidebar edge strip hides the file sidebar drawer', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     const pane = page.locator('#pr-file-pane');
+    const edgeLeftTap = page.locator('#edge-left-tap');
     await dispatchTouchTap(page, 3, 333);
     await page.waitForTimeout(200);
     await expect(pane).toHaveClass(/is-open/);
 
-    await dispatchTouchSwipe(page, 220, 333, 80, 333);
+    const closeZone = await edgeLeftTap.boundingBox();
+    expect(closeZone).not.toBeNull();
+    await dispatchTouchTap(
+      page,
+      Number(closeZone?.x || 0) + Number(closeZone?.width || 0) / 2,
+      Number(closeZone?.y || 0) + Number(closeZone?.height || 0) / 2,
+    );
     await page.waitForTimeout(150);
 
     const paneClasses = await pane.getAttribute('class');

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -440,6 +440,7 @@ test.describe('inbox triage interactions', () => {
     await touchPhase(page, row, 'move', -100, 0);
     await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'delegate');
     await touchPhase(page, row, 'end', -100, 0);
+    await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
     await expect(page.locator('#item-sidebar-menu')).toBeVisible();
     await expect(page.locator('#item-sidebar-menu')).toContainText('Alice');
     await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Codex' }).click();
@@ -450,6 +451,7 @@ test.describe('inbox triage interactions', () => {
     await touchPhase(page, row, 'move', -185, 0);
     await expect(page.locator(row)).toHaveAttribute('data-triage-action', 'later');
     await touchPhase(page, row, 'end', -185, 0);
+    await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
     await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
 
     const log = await page.evaluate(() => (window as any).__harnessLog || []);


### PR DESCRIPTION
## Summary
- remove the mobile swipe-close path that competed with inbox row triage gestures
- close the top panel with a tap in its edge strip instead of a swipe gesture
- lock the new mobile contract with focused Playwright coverage

## Verification
- Inbox swipe triage no longer closes the sidebar: `./scripts/playwright.sh tests/playwright/canvas.spec.ts tests/playwright/inbox-triage.spec.ts 2>&1 | tee /tmp/test.log` -> `✓ 12 [chromium] › tests/playwright/inbox-triage.spec.ts:416:7 › inbox triage interactions › touch gestures expose feedback and commit done, delete, delegate, and later (762ms)`; this spec now asserts `#pr-file-pane` stays open after left-swipe delegate and later actions.
- Sidebar closes from the dedicated tap strip instead of a swipe: same command -> `✓ 44 [chromium] › tests/playwright/canvas.spec.ts:944:7 › canvas - edge panels › touch tap on the sidebar edge strip hides the file sidebar drawer (731ms)`.
- Top bar closes from the top tap strip: same command -> `✓ 42 [chromium] › tests/playwright/canvas.spec.ts:921:7 › canvas - edge panels › touch tap on the top strip hides the pinned top panel (710ms)`.
- Focused regression suite passed after the change: same command -> `44 passed (31.8s)`.
