### PR TITLE
fix: epic: external provider integration layer (fixes #248)

### DIFF
--- a/internal/web/source_poller_test.go
+++ b/internal/web/source_poller_test.go
@@ -3,9 +3,11 @@ package web
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/krystophny/tabura/internal/store"
 	tabsync "github.com/krystophny/tabura/internal/sync"
 )
 
@@ -30,6 +32,22 @@ func (s *stubSourceSyncRunner) RunOnce(context.Context) (tabsync.RunResult, erro
 func (s *stubSourceSyncRunner) RunNow(context.Context) (tabsync.RunResult, error) {
 	s.runNowCount++
 	return s.runNowResult, s.runNowErr
+}
+
+type scriptedSyncProvider struct {
+	name   string
+	syncFn func(context.Context, store.ExternalAccount, tabsync.Sink) error
+}
+
+func (p *scriptedSyncProvider) Name() string {
+	return p.name
+}
+
+func (p *scriptedSyncProvider) Sync(ctx context.Context, account store.ExternalAccount, sink tabsync.Sink) error {
+	if p == nil || p.syncFn == nil {
+		return nil
+	}
+	return p.syncFn(ctx, account, sink)
 }
 
 func TestSourcePollerLoopRunsRunnerUntilCanceled(t *testing.T) {
@@ -104,6 +122,182 @@ func TestSyncNowCommandForcesImmediateRun(t *testing.T) {
 	runner, _ := app.sourceSync.(*stubSourceSyncRunner)
 	if runner.runNowCount != 1 {
 		t.Fatalf("runNowCount = %d, want 1", runner.runNowCount)
+	}
+}
+
+func TestSyncSourcesNowPopulatesUnifiedInboxAcrossProviders(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspace, err := app.store.CreateWorkspace("Ops", filepath.Join(t.TempDir(), "ops"), store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	project, err := app.store.CreateProject("Ops Program", "ops-program", filepath.Join(t.TempDir(), "program"), "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	todoAccount, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "Todoist Work", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(todoist) error: %v", err)
+	}
+	imapAccount, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderIMAP, "IMAP Work", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount(imap) error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderTodoist, "project", "alpha", &workspace.ID, &project.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping(todoist) error: %v", err)
+	}
+	if _, err := app.store.SetContainerMapping(store.ExternalProviderIMAP, "folder", "INBOX/Work", &workspace.ID, &project.ID, nil); err != nil {
+		t.Fatalf("SetContainerMapping(imap) error: %v", err)
+	}
+
+	sink := tabsync.NewStoreSink(app.store)
+	engine := tabsync.NewEngine(app.store, app.store, sink, tabsync.Options{})
+	engine.Register(&scriptedSyncProvider{
+		name: store.ExternalProviderTodoist,
+		syncFn: func(ctx context.Context, account store.ExternalAccount, sink tabsync.Sink) error {
+			_, err := sink.UpsertItem(ctx, store.Item{
+				Title:     "Prepare incident report",
+				Source:    stringPtr(store.ExternalProviderTodoist),
+				SourceRef: stringPtr("task:todo-1"),
+			}, store.ExternalBinding{
+				AccountID:    account.ID,
+				Provider:     account.Provider,
+				ObjectType:   "task",
+				RemoteID:     "todo-1",
+				ContainerRef: stringPtr("alpha"),
+			})
+			return err
+		},
+	})
+	engine.Register(&scriptedSyncProvider{
+		name: store.ExternalProviderIMAP,
+		syncFn: func(ctx context.Context, account store.ExternalAccount, sink tabsync.Sink) error {
+			title := "Architecture review request"
+			artifact, err := sink.UpsertArtifact(ctx, store.Artifact{
+				Kind:  store.ArtifactKindEmail,
+				Title: &title,
+			}, store.ExternalBinding{
+				AccountID:    account.ID,
+				Provider:     account.Provider,
+				ObjectType:   "message",
+				RemoteID:     "msg-1",
+				ContainerRef: stringPtr("INBOX/Work"),
+			})
+			if err != nil {
+				return err
+			}
+			_, err = sink.UpsertItem(ctx, store.Item{
+				Title:      "Reply to architecture review",
+				ArtifactID: &artifact.ID,
+				Source:     stringPtr(store.ExternalProviderIMAP),
+				SourceRef:  stringPtr("message:msg-1"),
+			}, store.ExternalBinding{
+				AccountID:    account.ID,
+				Provider:     account.Provider,
+				ObjectType:   "message_item",
+				RemoteID:     "msg-1:item",
+				ContainerRef: stringPtr("INBOX/Work"),
+			})
+			return err
+		},
+	})
+	app.sourceSync = engine
+
+	result, err := app.syncSourcesNow(context.Background())
+	if err != nil {
+		t.Fatalf("syncSourcesNow() error: %v", err)
+	}
+	if len(result.Accounts) != 2 {
+		t.Fatalf("len(result.Accounts) = %d, want 2", len(result.Accounts))
+	}
+	for _, account := range result.Accounts {
+		if account.Err != nil {
+			t.Fatalf("account sync error = %v", account.Err)
+		}
+		if account.Skipped {
+			t.Fatalf("account %d skipped unexpectedly: %#v", account.AccountID, account)
+		}
+	}
+
+	todoItem, err := app.store.GetItemBySource(store.ExternalProviderTodoist, "task:todo-1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(todoist) error: %v", err)
+	}
+	if todoItem.WorkspaceID == nil || *todoItem.WorkspaceID != workspace.ID {
+		t.Fatalf("todo workspace = %v, want %d", todoItem.WorkspaceID, workspace.ID)
+	}
+	if todoItem.ProjectID == nil || *todoItem.ProjectID != project.ID {
+		t.Fatalf("todo project = %v, want %q", todoItem.ProjectID, project.ID)
+	}
+	if todoItem.Sphere != store.SphereWork {
+		t.Fatalf("todo sphere = %q, want %q", todoItem.Sphere, store.SphereWork)
+	}
+	if _, err := app.store.GetBindingByRemote(todoAccount.ID, store.ExternalProviderTodoist, "task", "todo-1"); err != nil {
+		t.Fatalf("GetBindingByRemote(todoist) error: %v", err)
+	}
+
+	imapItem, err := app.store.GetItemBySource(store.ExternalProviderIMAP, "message:msg-1")
+	if err != nil {
+		t.Fatalf("GetItemBySource(imap) error: %v", err)
+	}
+	if imapItem.ArtifactID == nil {
+		t.Fatal("imap item missing linked artifact")
+	}
+	if imapItem.WorkspaceID == nil || *imapItem.WorkspaceID != workspace.ID {
+		t.Fatalf("imap workspace = %v, want %d", imapItem.WorkspaceID, workspace.ID)
+	}
+	if imapItem.ProjectID == nil || *imapItem.ProjectID != project.ID {
+		t.Fatalf("imap project = %v, want %q", imapItem.ProjectID, project.ID)
+	}
+	if _, err := app.store.GetBindingByRemote(imapAccount.ID, store.ExternalProviderIMAP, "message", "msg-1"); err != nil {
+		t.Fatalf("GetBindingByRemote(imap artifact) error: %v", err)
+	}
+	if _, err := app.store.GetBindingByRemote(imapAccount.ID, store.ExternalProviderIMAP, "message_item", "msg-1:item"); err != nil {
+		t.Fatalf("GetBindingByRemote(imap item) error: %v", err)
+	}
+	links, err := app.store.ListArtifactWorkspaceLinks(workspace.ID)
+	if err != nil {
+		t.Fatalf("ListArtifactWorkspaceLinks() error: %v", err)
+	}
+	if len(links) != 1 || links[0].ArtifactID != *imapItem.ArtifactID {
+		t.Fatalf("workspace artifact links = %#v, want artifact %d", links, *imapItem.ArtifactID)
+	}
+
+	rrInbox := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?sphere=work", nil)
+	if rrInbox.Code != http.StatusOK {
+		t.Fatalf("GET /api/items/inbox status = %d, want 200: %s", rrInbox.Code, rrInbox.Body.String())
+	}
+	inboxPayload := decodeJSONDataResponse(t, rrInbox)
+	inboxItems, ok := inboxPayload["items"].([]any)
+	if !ok || len(inboxItems) != 2 {
+		t.Fatalf("inbox payload = %#v, want 2 items", inboxPayload)
+	}
+
+	rrTodo := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?sphere=work&source=todoist", nil)
+	if rrTodo.Code != http.StatusOK {
+		t.Fatalf("GET /api/items/inbox?source=todoist status = %d, want 200: %s", rrTodo.Code, rrTodo.Body.String())
+	}
+	todoPayload := decodeJSONDataResponse(t, rrTodo)
+	todoItems, ok := todoPayload["items"].([]any)
+	if !ok || len(todoItems) != 1 {
+		t.Fatalf("todoist inbox payload = %#v, want 1 item", todoPayload)
+	}
+	if got := strFromAny(todoItems[0].(map[string]any)["title"]); got != "Prepare incident report" {
+		t.Fatalf("todoist inbox title = %q, want %q", got, "Prepare incident report")
+	}
+
+	rrIMAP := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?sphere=work&source=imap", nil)
+	if rrIMAP.Code != http.StatusOK {
+		t.Fatalf("GET /api/items/inbox?source=imap status = %d, want 200: %s", rrIMAP.Code, rrIMAP.Body.String())
+	}
+	imapPayload := decodeJSONDataResponse(t, rrIMAP)
+	imapItems, ok := imapPayload["items"].([]any)
+	if !ok || len(imapItems) != 1 {
+		t.Fatalf("imap inbox payload = %#v, want 1 item", imapPayload)
+	}
+	if got := strFromAny(imapItems[0].(map[string]any)["title"]); got != "Reply to architecture review" {
+		t.Fatalf("imap inbox title = %q, want %q", got, "Reply to architecture review")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an engine-backed integration test that syncs Todoist and IMAP accounts through the shared external-provider pipeline
- verify container mappings, external bindings, workspace artifact links, and unified inbox source filters in one end-to-end path

## Verification
- External providers feed the same Item/Artifact/Workspace/Project graph: `go test ./internal/web ./internal/sync 2>&1 | tee /tmp/tabura-issue-248-test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web	7.412s`, `ok   github.com/krystophny/tabura/internal/sync	(cached)`
  Evidence: `TestSyncSourcesNowPopulatesUnifiedInboxAcrossProviders` creates work-scoped Todoist and IMAP accounts, maps their containers into one workspace/project, and syncs both through `tabsync.NewEngine` in `internal/web/source_poller_test.go`.
- Provider-agnostic sync engine is exercised with provider-specific adapters: the new test registers scripted Todoist and IMAP providers against the shared engine and runs `app.syncSourcesNow(...)`.
- Binding tracking and workspace/project inference are verified after sync: the test asserts `GetBindingByRemote(...)` for both providers and `ListArtifactWorkspaceLinks(...)` for the IMAP artifact.
- One inbox per sphere with provider filtering is verified through HTTP: the test checks `/api/items/inbox?sphere=work`, `/api/items/inbox?sphere=work&source=todoist`, and `/api/items/inbox?sphere=work&source=imap` for the expected items.