### PR TITLE
fix: Bug report: "Turning pages" doesnt work in canvas for inbox to f (fixes #421)

### DIFF
--- a/internal/web/static/app-item-sidebar-ui.js
+++ b/internal/web/static/app-item-sidebar-ui.js
@@ -54,6 +54,43 @@ export function activeItemSidebarShortcutTarget() {
   return items.find((item) => Number(item?.id || 0) === activeID) || items[0];
 }
 
+function activeCanvasSidebarItemIndex() {
+  if (!state.hasArtifact || state.prReviewMode || state.fileSidebarMode !== 'items') {
+    return -1;
+  }
+  const items = Array.isArray(state.itemSidebarItems) ? state.itemSidebarItems : [];
+  if (items.length <= 1) return -1;
+  const activeID = Number(state.itemSidebarActiveItemID || 0);
+  if (activeID <= 0) return -1;
+  const activeIndex = items.findIndex((item) => Number(item?.id || 0) === activeID);
+  if (activeIndex < 0) return -1;
+  const activeItem = items[activeIndex];
+  const currentTitle = String(state.currentCanvasArtifact?.title || '').trim();
+  if (!currentTitle) return -1;
+  const expectedTitles = [
+    String(activeItem?.artifact_title || '').trim(),
+    String(activeItem?.title || '').trim(),
+  ].filter(Boolean);
+  return expectedTitles.includes(currentTitle) ? activeIndex : -1;
+}
+
+export function stepItemSidebarItem(delta) {
+  const shift = Number(delta);
+  if (!Number.isFinite(shift) || shift === 0) return false;
+  const items = Array.isArray(state.itemSidebarItems) ? state.itemSidebarItems : [];
+  if (items.length <= 1) return false;
+  const currentIndex = activeCanvasSidebarItemIndex();
+  if (currentIndex < 0) return false;
+  const nextIndex = ((currentIndex + Math.trunc(shift)) % items.length + items.length) % items.length;
+  if (nextIndex === currentIndex) return false;
+  const nextItem = items[nextIndex];
+  if (!nextItem) return false;
+  state.itemSidebarActiveItemID = Number(nextItem?.id || 0);
+  renderPrReviewFileList();
+  void openSidebarItem(nextItem);
+  return true;
+}
+
 export async function loadItemSidebarView(view = state.itemSidebarView, filters = null) {
   const normalizedView = normalizeItemSidebarView(view);
   const normalizedFilters = normalizeItemSidebarFilters(filters === null ? state.itemSidebarFilters : filters);

--- a/internal/web/static/app-pr-review.js
+++ b/internal/web/static/app-pr-review.js
@@ -14,6 +14,7 @@ const renderSidebarTabs = (...args) => refs.renderSidebarTabs(...args);
 const renderSidebarRow = (...args) => refs.renderSidebarRow(...args);
 const renderWorkspaceFileList = (...args) => refs.renderWorkspaceFileList(...args);
 const clearWelcomeSurface = (...args) => refs.clearWelcomeSurface(...args);
+const stepItemSidebarItem = (...args) => refs.stepItemSidebarItem(...args);
 
 export function isMobileViewport() {
   return window.matchMedia('(max-width: 767px)').matches;
@@ -711,6 +712,9 @@ export function stepPrReviewFile(delta) {
 export function stepCanvasFile(delta) {
   if (state.prReviewMode) {
     return stepPrReviewFile(delta);
+  }
+  if (stepItemSidebarItem(delta)) {
+    return true;
   }
   return stepWorkspaceFile(delta);
 }

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -183,6 +183,50 @@ async function queueSidebarResponseDelay(
   }, { nextView: view, nextDelayMs: delayMs });
 }
 
+async function swipeCanvas(page: Page, dx: number, dy = 0) {
+  await page.locator('#canvas-viewport').evaluate((el, payload) => {
+    const target = el as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    const startX = rect.left + rect.width / 2;
+    const startY = rect.top + rect.height / 2;
+    const endX = startX + Number(payload.dx || 0);
+    const endY = startY + Number(payload.dy || 0);
+    const makeTouch = (clientX: number, clientY: number) => new Touch({
+      identifier: 1,
+      target,
+      clientX,
+      clientY,
+      pageX: clientX,
+      pageY: clientY,
+      screenX: clientX,
+      screenY: clientY,
+    });
+    const startTouch = makeTouch(startX, startY);
+    const endTouch = makeTouch(endX, endY);
+    target.dispatchEvent(new TouchEvent('touchstart', {
+      bubbles: true,
+      cancelable: true,
+      touches: [startTouch],
+      changedTouches: [startTouch],
+      targetTouches: [startTouch],
+    }));
+    target.dispatchEvent(new TouchEvent('touchmove', {
+      bubbles: true,
+      cancelable: true,
+      touches: [endTouch],
+      changedTouches: [endTouch],
+      targetTouches: [endTouch],
+    }));
+    target.dispatchEvent(new TouchEvent('touchend', {
+      bubbles: true,
+      cancelable: true,
+      touches: [],
+      changedTouches: [endTouch],
+      targetTouches: [],
+    }));
+  }, { dx, dy });
+}
+
 async function touchPhase(page: Page, selector: string, phase: 'start' | 'move' | 'end', dx = 0, dy = 0) {
   await page.locator(selector).evaluate((el, payload) => {
     const target = el as HTMLElement;
@@ -411,6 +455,24 @@ test.describe('inbox triage interactions', () => {
     await expect(page.locator('#canvas-text')).toContainText('create these idea items');
     await expect(page.locator('#canvas-text')).toContainText('Draft the rollout checklist');
     await expect(page.locator('#canvas-text')).toContainText('Add regression coverage');
+  });
+
+  test('mobile canvas swipe flips between inbox items', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+
+    await page.locator('#pr-file-list .pr-file-item[data-item-id="101"]').click();
+    await expect(page.locator('#canvas-text')).toContainText('Break parser cleanup into a small refactor');
+    await expect(page.locator('#pr-file-list .pr-file-item.is-active[data-item-id="101"]')).toHaveCount(1);
+
+    await swipeCanvas(page, -160, 0);
+    await expect(page.locator('#canvas-text')).toContainText('Need a response before tomorrow morning');
+    await expect(page.locator('#pr-file-list .pr-file-item.is-active[data-item-id="102"]')).toHaveCount(1);
+
+    await swipeCanvas(page, 160, 0);
+    await expect(page.locator('#canvas-text')).toContainText('Break parser cleanup into a small refactor');
+    await expect(page.locator('#pr-file-list .pr-file-item.is-active[data-item-id="101"]')).toHaveCount(1);
   });
 
   test('touch gestures expose feedback and commit done, delete, delegate, and later', async ({ page }) => {


### PR DESCRIPTION
## Summary
- route canvas page-turn navigation through item-sidebar items when the active canvas artifact came from the sidebar
- keep existing PR-review and workspace file stepping unchanged
- add a Playwright regression for mobile inbox swipes across canvas items

## Verification
- Inbox canvas page turns now flip between inbox items: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts` -> `/tmp/test.log:360` shows `mobile canvas swipe flips between inbox items` passed; that test asserts the canvas switches from `Parser cleanup plan` content to `Re: triage follow-up` content and back.
- Existing inbox flows still hold after the change: `./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts` -> `/tmp/test.log:668` shows `13 passed (10.1s)` for the full inbox triage spec.