### PR TITLE
fix: Epic: Interaction architecture pivot - conversation/layer/tool s (fixes #230)

### DIFF
--- a/internal/web/static/app-canvas-transport.js
+++ b/internal/web/static/app-canvas-transport.js
@@ -17,12 +17,13 @@ const showCanvasColumn = (...args) => refs.showCanvasColumn(...args);
 const hideCanvasColumn = (...args) => refs.hideCanvasColumn(...args);
 const isMobileSilent = (...args) => refs.isMobileSilent(...args);
 const exitArtifactEditMode = (...args) => refs.exitArtifactEditMode(...args);
+const isArtifactEditorActive = (...args) => refs.isArtifactEditorActive(...args);
 const resetMailDraftState = (...args) => refs.resetMailDraftState(...args);
 
 export function applyCanvasArtifactEvent(payload) {
   clearWelcomeSurface();
   clearInkDraft();
-  if (state.artifactEditMode) {
+  if (isArtifactEditorActive()) {
     exitArtifactEditMode({ applyChanges: false });
   }
   const kind = String(payload?.kind || '').trim().toLowerCase();

--- a/internal/web/static/app-canvas-ui.js
+++ b/internal/web/static/app-canvas-ui.js
@@ -28,12 +28,13 @@ const canSpeakTTS = (...args) => refs.canSpeakTTS(...args);
 const isDialogueLiveSession = (...args) => refs.isDialogueLiveSession(...args);
 const beginVoiceCapture = (...args) => refs.beginVoiceCapture(...args);
 const applyInteractionDefaultsForPane = (...args) => refs.applyInteractionDefaultsForPane(...args);
+const isArtifactEditorActive = (...args) => refs.isArtifactEditorActive(...args);
 const renderInteractionSurfaceToggle = (...args) => refs.renderInteractionSurfaceToggle(...args);
 
 export function showCanvasColumn(paneId) {
   const col = document.getElementById('canvas-column');
   if (!col) return;
-  if (paneId !== 'canvas-text' && state.artifactEditMode) {
+  if (paneId !== 'canvas-text' && isArtifactEditorActive()) {
     exitArtifactEditMode({ applyChanges: true });
   }
   if (paneId !== 'canvas-text') {
@@ -75,7 +76,7 @@ export function showCanvasColumn(paneId) {
 }
 
 export function hideCanvasColumn() {
-  if (state.artifactEditMode) {
+  if (isArtifactEditorActive()) {
     exitArtifactEditMode({ applyChanges: true });
   }
   exitPrReviewMode();

--- a/internal/web/static/app-context.js
+++ b/internal/web/static/app-context.js
@@ -224,7 +224,6 @@ export const state = {
   itemSidebarMenuOpen: false,
   somedayReviewNudgeEnabled: true,
   prReviewAwaitingArtifact: false,
-  artifactEditMode: false,
   inkDraft: {
     strokes: [],
     activePointerId: null,

--- a/internal/web/static/app-dictation.js
+++ b/internal/web/static/app-dictation.js
@@ -6,6 +6,7 @@ const { refs, state } = context;
 
 const showStatus = (...args) => refs.showStatus(...args);
 const applyCanvasArtifactEvent = (...args) => refs.applyCanvasArtifactEvent(...args);
+const isArtifactEditorActive = (...args) => refs.isArtifactEditorActive(...args);
 const submitMessage = (...args) => refs.submitMessage(...args);
 
 const DICTATION_ACTIONS_ID = 'dictation-actions';
@@ -46,7 +47,7 @@ function applyDictationState(next) {
 
 function activeDraftText() {
   const editor = document.getElementById('artifact-editor');
-  if (state.artifactEditMode && editor instanceof HTMLTextAreaElement) {
+  if (isArtifactEditorActive() && editor instanceof HTMLTextAreaElement) {
     return String(editor.value || '').trim();
   }
   return String(getPreviousArtifactText() || dictationState().draftText || '').trim();

--- a/internal/web/static/app-init.js
+++ b/internal/web/static/app-init.js
@@ -58,6 +58,7 @@ const beginVoiceCapture = (...args) => refs.beginVoiceCapture(...args);
 const openComposerAt = (...args) => refs.openComposerAt(...args);
 const suppressSyntheticClick = (...args) => refs.suppressSyntheticClick(...args);
 const isSuppressedClick = (...args) => refs.isSuppressedClick(...args);
+const isArtifactEditorActive = (...args) => refs.isArtifactEditorActive(...args);
 const isInkTool = (...args) => refs.isInkTool(...args);
 const isEditableTarget = (...args) => refs.isEditableTarget(...args);
 const isUiStopGestureActive = (...args) => refs.isUiStopGestureActive(...args);
@@ -517,7 +518,7 @@ export function bindUi() {
   // Right-click -> artifact editor (text artifacts) or floating text input
   if (clickTarget) {
     clickTarget.addEventListener('contextmenu', (ev) => {
-      if (state.artifactEditMode) {
+      if (isArtifactEditorActive()) {
         ev.preventDefault();
         return;
       }
@@ -670,7 +671,7 @@ export function bindUi() {
     }
     // Escape handling
     if (ev.key === 'Escape' && !ev.metaKey && !ev.ctrlKey && !ev.altKey) {
-      if (state.artifactEditMode) {
+      if (isArtifactEditorActive()) {
         ev.preventDefault();
         exitArtifactEditMode({ applyChanges: true });
         return;
@@ -752,7 +753,7 @@ export function bindUi() {
     if (isCommandCenterVisible()) return;
     if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
     if (isEditableTarget(ev.target)) return;
-    if (state.artifactEditMode) return;
+    if (isArtifactEditorActive()) return;
     if (handleItemSidebarKeyboardShortcut(ev)) return;
     if (handleMailShortcut(ev)) return;
 

--- a/internal/web/static/app-interaction.js
+++ b/internal/web/static/app-interaction.js
@@ -9,6 +9,7 @@ const {
 
 const clearInkDraft = (...args) => refs.clearInkDraft(...args);
 const createSelectionAnnotation = (...args) => refs.createSelectionAnnotation(...args);
+const isArtifactEditorActive = (...args) => refs.isArtifactEditorActive(...args);
 const renderInkControls = (...args) => refs.renderInkControls(...args);
 const updateRuntimePreferences = (...args) => refs.updateRuntimePreferences(...args);
 const syncInteractionBodyState = (...args) => refs.syncInteractionBodyState(...args);
@@ -304,7 +305,7 @@ export function renderToolPalette() {
 }
 
 export function maybeApplySelectionHighlight() {
-  if (state.artifactEditMode) return false;
+  if (isArtifactEditorActive()) return false;
   if (state.interaction.surface !== 'annotate' || state.interaction.tool !== 'highlight') return false;
   const selection = window.getSelection();
   if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return false;

--- a/internal/web/static/app-runtime-ui.js
+++ b/internal/web/static/app-runtime-ui.js
@@ -615,6 +615,12 @@ export function artifactEditorEl() {
   return el instanceof HTMLTextAreaElement ? el : null;
 }
 
+export function isArtifactEditorActive() {
+  const editor = artifactEditorEl();
+  if (!editor) return false;
+  return window.getComputedStyle(editor).display !== 'none';
+}
+
 export function ensureArtifactEditor() {
   const existing = artifactEditorEl();
   if (existing) return existing;
@@ -717,13 +723,12 @@ export function applyArtifactEditorText(text) {
 export function exitArtifactEditMode(options = {}) {
   const applyChanges = options.applyChanges !== false;
   const editor = artifactEditorEl();
-  if (!editor || !state.artifactEditMode) return false;
+  if (!editor || !isArtifactEditorActive()) return false;
   const nextText = editor.value;
   editor.style.display = 'none';
   if (document.activeElement === editor) {
     try { editor.blur(); } catch (_) {}
   }
-  state.artifactEditMode = false;
   document.body.classList.remove('artifact-edit-mode');
   if (applyChanges) {
     applyArtifactEditorText(nextText);
@@ -740,7 +745,6 @@ export function enterArtifactEditMode(clientX, clientY) {
   hideTextInput();
   editor.value = String(getPreviousArtifactText() || '');
   editor.style.display = '';
-  state.artifactEditMode = true;
   document.body.classList.add('artifact-edit-mode');
   editor.focus();
   placeArtifactEditorCaretFromPoint(editor, clientX, clientY);

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -479,12 +479,14 @@ test.describe('floating tool palette', () => {
       const state = (window as any)._taburaApp?.getState?.();
       return {
         conversation: state?.interaction?.conversation,
-        artifactEditMode: document.body.classList.contains('artifact-edit-mode'),
+        hasLegacyArtifactEditFlag: Object.prototype.hasOwnProperty.call(state || {}, 'artifactEditMode'),
+        artifactEditorActive: document.body.classList.contains('artifact-edit-mode'),
       };
     });
     expect(interaction).toEqual({
       conversation: 'idle',
-      artifactEditMode: false,
+      hasLegacyArtifactEditFlag: false,
+      artifactEditorActive: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- remove the legacy `artifactEditMode` flag from frontend app state
- derive editor-active state from the artifact editor itself and reuse that across canvas, dictation, keyboard, and interaction handlers
- extend Playwright coverage to assert the legacy flag is gone while highlight mode still stays out of the editor

## Verification
- Legacy interaction bridge removed
  - `internal/web/static/app-context.js` no longer exposes `artifactEditMode` in app state
  - `tests/playwright/ui-system.spec.ts` now asserts `Object.prototype.hasOwnProperty.call(state, 'artifactEditMode') === false`
- Artifact editor lifecycle still works off the new interaction model
  - `internal/web/static/app-runtime-ui.js` uses `isArtifactEditorActive()` to gate enter/exit behavior instead of a separate state flag
  - `./scripts/playwright.sh tests/playwright/ui-system.spec.ts tests/playwright/artifact-context.spec.ts`
  - output excerpt: `80 passed (56.0s)`
- Annotate flows still avoid accidental editor activation
  - `tests/playwright/ui-system.spec.ts` verifies highlight mode keeps `conversation: 'idle'` and `artifactEditorActive: false`
  - same Playwright run passed, including artifact-context and mobile long-press editor coverage
