### PR TITLE
fix: Bug report submit fails from non-git workspace (fixes #434)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,7 +20,10 @@ import (
 	"github.com/krystophny/tabura/internal/store"
 )
 
-const taburaVersion = "0.1.8"
+const (
+	taburaVersion            = "0.1.8"
+	taburaBugReportOwnerRepo = "krystophny/tabura"
+)
 
 type bugReportRequest struct {
 	Trigger          string          `json:"trigger"`
@@ -233,8 +235,7 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 	if err != nil {
 		return ghIssueListItem{}, 0, err
 	}
-	ownerRepo := a.resolveBugReportGitHubRepo(workspace, workspaceID)
-	if err := a.ensureGitHubLabels(workspace.DirPath, ownerRepo, map[string]struct {
+	if err := a.ensureGitHubLabels("", taburaBugReportOwnerRepo, map[string]struct {
 		Color       string
 		Description string
 	}{
@@ -244,8 +245,8 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 		return ghIssueListItem{}, 0, err
 	}
 	issue, err := a.createGitHubIssueInWorkspaceWithRepo(
-		workspace.DirPath,
-		ownerRepo,
+		"",
+		taburaBugReportOwnerRepo,
 		bugReportIssueTitle(bundle),
 		bugReportIssueBody(bundle, toBugReportRelativePath(workspace.DirPath, bundlePath)),
 		[]string{"bug", "p0"},
@@ -254,49 +255,18 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 	if err != nil {
 		return ghIssueListItem{}, 0, err
 	}
-	if ownerRepo == "" {
-		ownerRepo = bugReportOwnerRepoFromIssueURL(issue.URL)
-	}
-	source := "github"
-	sourceRef := githubIssueSourceRef(ownerRepo, issue.Number)
-	if ownerRepo == "" {
-		source = "bug_report"
-		sourceRef = legacyBugReportIssueSourceRef(issue.Number)
-	}
 	item, err := a.store.CreateItem(strings.TrimSpace(issue.Title), store.ItemOptions{
 		WorkspaceID: workspaceID,
-		Source:      &source,
-		SourceRef:   &sourceRef,
+		Source:      optionalTrimmedString("github"),
+		SourceRef:   optionalTrimmedString(githubIssueSourceRef(taburaBugReportOwnerRepo, issue.Number)),
 	})
 	if err != nil {
 		return ghIssueListItem{}, 0, err
 	}
-	if ownerRepo != "" {
-		if err := a.syncGitHubIssueArtifact(item, ownerRepo, issue); err != nil {
-			return ghIssueListItem{}, 0, err
-		}
+	if err := a.syncGitHubIssueArtifact(item, taburaBugReportOwnerRepo, issue); err != nil {
+		return ghIssueListItem{}, 0, err
 	}
 	return issue, item.ID, nil
-}
-
-func (a *App) resolveBugReportGitHubRepo(workspace bugReportWorkspace, workspaceID *int64) string {
-	if workspaceID != nil && *workspaceID > 0 {
-		if ownerRepo, err := a.store.GitHubRepoForWorkspace(*workspaceID); err == nil {
-			ownerRepo = strings.TrimSpace(ownerRepo)
-			if ownerRepo != "" {
-				return ownerRepo
-			}
-		}
-	}
-	if ownerRepo := bugReportGitRemoteOwnerRepo(workspace.DirPath); ownerRepo != "" {
-		return ownerRepo
-	}
-	if root := strings.TrimSpace(a.localProjectDir); root != "" {
-		if ownerRepo := bugReportGitRemoteOwnerRepo(root); ownerRepo != "" {
-			return ownerRepo
-		}
-	}
-	return ""
 }
 
 func (a *App) ensureBugReportWorkspaceID(workspace bugReportWorkspace) (*int64, error) {
@@ -415,27 +385,6 @@ func bugReportCanvasArtifactTitle(raw json.RawMessage) string {
 		}
 	}
 	return ""
-}
-
-func bugReportOwnerRepoFromIssueURL(raw string) string {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || !strings.EqualFold(parsed.Host, "github.com") {
-		return ""
-	}
-	return normalizeBugReportGitHubOwnerRepo(parsed.Path)
-}
-
-func bugReportGitRemoteOwnerRepo(dirPath string) string {
-	clean := strings.TrimSpace(dirPath)
-	if clean == "" {
-		return ""
-	}
-	cmd := exec.Command("git", "-C", clean, "remote", "get-url", "origin")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return normalizeBugReportGitHubOwnerRepo(string(output))
 }
 
 func normalizeBugReportGitHubOwnerRepo(raw string) string {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -31,8 +31,8 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	var ghCalls [][]string
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
 		ghCalls = append(ghCalls, append([]string{cwd}, args...))
-		if cwd != workspaceDir {
-			t.Fatalf("gh cwd = %q, want %q", cwd, workspaceDir)
+		if cwd != "" {
+			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"}]`, nil
@@ -41,10 +41,10 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 			return "", nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
-			return "https://github.com/owner/tabula/issues/77\n", nil
+			return "https://github.com/krystophny/tabura/issues/77\n", nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
-			return `{"number":77,"title":"Bug report: The indicator froze after the tap","url":"https://github.com/owner/tabula/issues/77","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+			return `{"number":77,"title":"Bug report: The indicator froze after the tap","url":"https://github.com/krystophny/tabura/issues/77","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
 		}
 		t.Fatalf("unexpected gh invocation: %v", args)
 		return "", nil
@@ -96,7 +96,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	if got := intFromAny(payload["issue_number"], 0); got != 77 {
 		t.Fatalf("issue_number = %d, want 77", got)
 	}
-	if got := strFromAny(payload["issue_url"]); got != "https://github.com/owner/tabula/issues/77" {
+	if got := strFromAny(payload["issue_url"]); got != "https://github.com/krystophny/tabura/issues/77" {
 		t.Fatalf("issue_url = %q", got)
 	}
 	if got := strFromAny(payload["issue_title"]); got != "Bug report: The indicator froze after the tap" {
@@ -144,7 +144,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	if got := strFromAny(bundle["annotated_image"]); got != annotatedPath {
 		t.Fatalf("bundle annotated_image = %q, want %q", got, annotatedPath)
 	}
-	if got := strFromAny(bundle["github_issue_url"]); got != "https://github.com/owner/tabula/issues/77" {
+	if got := strFromAny(bundle["github_issue_url"]); got != "https://github.com/krystophny/tabura/issues/77" {
 		t.Fatalf("bundle github_issue_url = %q", got)
 	}
 	if got := intFromAny(bundle["github_issue_number"], 0); got != 77 {
@@ -160,7 +160,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	if got := strFromAny(canvasState["artifact_title"]); got != "README.md" {
 		t.Fatalf("canvas_state.artifact_title = %q, want %q", got, "README.md")
 	}
-	item, err := app.store.GetItemBySource("github", "owner/tabula#77")
+	item, err := app.store.GetItemBySource("github", "krystophny/tabura#77")
 	if err != nil {
 		t.Fatalf("GetItemBySource() error: %v", err)
 	}
@@ -188,6 +188,7 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		t.Fatal("missing gh issue create call")
 	}
 	for _, needle := range []string{
+		"--repo krystophny/tabura",
 		"--label bug",
 		"--label p0",
 		"--title Bug report: The indicator froze after the tap",
@@ -217,17 +218,17 @@ func TestHandleBugReportCreateFallsBackToWorkspaceSphere(t *testing.T) {
 		t.Fatalf("SetActiveWorkspace() error: %v", err)
 	}
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
-		if cwd != workspaceDir {
-			t.Fatalf("gh cwd = %q, want %q", cwd, workspaceDir)
+		if cwd != "" {
+			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"},{"name":"p0"}]`, nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
-			return "https://github.com/owner/tabula/issues/88\n", nil
+			return "https://github.com/krystophny/tabura/issues/88\n", nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
-			return `{"number":88,"title":"Bug report: Sphere fallback","url":"https://github.com/owner/tabula/issues/88","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+			return `{"number":88,"title":"Bug report: Sphere fallback","url":"https://github.com/krystophny/tabura/issues/88","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
 		}
 		t.Fatalf("unexpected gh invocation: %v", args)
 		return "", nil
@@ -284,17 +285,17 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
-		if cwd != localProjectDir {
-			t.Fatalf("gh cwd = %q, want %q", cwd, localProjectDir)
+		if cwd != "" {
+			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"},{"name":"p0"}]`, nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
-			return "https://github.com/owner/tabula/issues/91\n", nil
+			return "https://github.com/krystophny/tabura/issues/91\n", nil
 		}
 		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
-			return `{"number":91,"title":"Bug report: Local project fallback","url":"https://github.com/owner/tabula/issues/91","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+			return `{"number":91,"title":"Bug report: Local project fallback","url":"https://github.com/krystophny/tabura/issues/91","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
 		}
 		t.Fatalf("unexpected gh invocation: %v", args)
 		return "", nil
@@ -315,12 +316,70 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	if workspace.Sphere != store.SphereWork {
 		t.Fatalf("workspace.Sphere = %q, want %q", workspace.Sphere, store.SphereWork)
 	}
-	item, err := app.store.GetItemBySource("github", "owner/tabula#91")
+	item, err := app.store.GetItemBySource("github", "krystophny/tabura#91")
 	if err != nil {
 		t.Fatalf("GetItemBySource() error: %v", err)
 	}
 	if item.WorkspaceID == nil || *item.WorkspaceID != workspace.ID {
 		t.Fatalf("item.WorkspaceID = %v, want %d", item.WorkspaceID, workspace.ID)
+	}
+}
+
+func TestHandleBugReportCreateUsesCanonicalRepoFromNonGitWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	workspaceDir := t.TempDir()
+	workspace, err := app.store.CreateWorkspace("Hub", workspaceDir, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	var calls [][]string
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		calls = append(calls, append([]string{cwd}, args...))
+		if cwd != "" {
+			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
+		}
+		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
+			return `[{"name":"bug"},{"name":"p0"}]`, nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/krystophny/tabura/issues/104\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":104,"title":"Bug report: Submission should work outside git repos","url":"https://github.com/krystophny/tabura/issues/104","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
+		"note":                "Submission should work outside git repos.",
+		"screenshot_data_url": testPNGDataURL,
+	})
+	if rr.Code != 200 {
+		t.Fatalf("POST /api/bugs/report status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	if got := intFromAny(payload["issue_number"], 0); got != 104 {
+		t.Fatalf("issue_number = %d, want 104", got)
+	}
+	if got := strFromAny(payload["issue_url"]); got != "https://github.com/krystophny/tabura/issues/104" {
+		t.Fatalf("issue_url = %q", got)
+	}
+	if _, err := app.store.GetItemBySource("github", "krystophny/tabura#104"); err != nil {
+		t.Fatalf("GetItemBySource() error: %v", err)
+	}
+	createCall := ""
+	for _, call := range calls {
+		if len(call) > 2 && call[1] == "issue" && call[2] == "create" {
+			createCall = strings.Join(call[1:], " ")
+			break
+		}
+	}
+	if !strings.Contains(createCall, "--repo krystophny/tabura") {
+		t.Fatalf("create call = %q, want canonical repo flag", createCall)
 	}
 }
 
@@ -336,7 +395,7 @@ func TestHandleBugReportCreateSucceedsWhenIssueCreationFails(t *testing.T) {
 	}
 	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
 		if len(args) >= 2 && args[0] == "label" && args[1] == "list" {
-			return "", errors.New("gh label list failed: fatal: not a git repository (or any of the parent directories): .git")
+			return "", errors.New("gh label list failed: permission denied")
 		}
 		t.Fatalf("unexpected gh invocation: %v", args)
 		return "", nil
@@ -361,8 +420,8 @@ func TestHandleBugReportCreateSucceedsWhenIssueCreationFails(t *testing.T) {
 		t.Fatalf("issue_number = %d, want 0 on github failure", got)
 	}
 	issueErr := strFromAny(payload["issue_error"])
-	if !strings.Contains(strings.ToLower(issueErr), "not a git repository") {
-		t.Fatalf("issue_error = %q, want git repository error", issueErr)
+	if !strings.Contains(strings.ToLower(issueErr), "permission denied") {
+		t.Fatalf("issue_error = %q, want github failure", issueErr)
 	}
 	bundleBytes, err := os.ReadFile(filepath.Join(workspaceDir, filepath.FromSlash(bundlePath)))
 	if err != nil {


### PR DESCRIPTION
## Summary
- route bug-report GitHub label and issue creation through the canonical `krystophny/tabura` repo instead of the active workspace repo
- stop passing workspace git context into `gh` for bug-report submission while keeping bug bundles under the active workspace artifacts
- add regression coverage for successful submission from a non-git workspace and keep the generic GitHub-failure fallback covered

## Verification
- Requirement: submitting a bug from a non-git workspace succeeds instead of failing with a git-repo error.
  Evidence: `go test ./internal/web -run "TestHandleBugReportCreate" 2>&1 | tee /tmp/test.log` -> `ok   github.com/krystophny/tabura/internal/web	0.229s`
  Test: `TestHandleBugReportCreateUsesCanonicalRepoFromNonGitWorkspace` asserts `POST /api/bugs/report` returns `200`, stores item source `github krystophny/tabura#104`, and the `gh issue create` invocation contains `--repo krystophny/tabura`.
- Requirement: bug reporting always targets the Tabura repository context.
  Evidence: `TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts` now expects the created issue URL and stored source ref in `krystophny/tabura`, and inspects the captured `gh issue create` call for `--repo krystophny/tabura`.
- Requirement: the bug bundle still lands under workspace artifacts.
  Evidence: `TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts` verifies `bundle_path` under `.tabura/artifacts/bugs/.../bundle.json` plus the screenshot and annotated artifact paths.
- Requirement: GitHub-side failures still do not break local bug bundle capture.
  Evidence: `TestHandleBugReportCreateSucceedsWhenIssueCreationFails` still returns `200` and persists `github_issue_error` in the written bundle when `gh` returns `permission denied`.
