### PR TITLE
fix: Fix single-tap gesture ambiguity: annotation vs immediate AI... (fixes #447)

### DIFF
--- a/internal/web/static/app-init.js
+++ b/internal/web/static/app-init.js
@@ -166,12 +166,13 @@ export function bindUi() {
       y: Math.floor(window.innerHeight / 2),
     };
   };
-  const beginVoiceCaptureFromPoint = (x, y) => {
-    let anchor = null;
-    if (state.hasArtifact && canvasText) {
-      anchor = getAnchorFromPoint(x, y);
-    }
-    return beginVoiceCapture(x, y, anchor);
+  const captureAnchorAtPoint = (x, y) => {
+    if (!state.hasArtifact) return null;
+    return getAnchorFromPoint(x, y);
+  };
+  const beginVoiceCaptureFromPoint = (x, y, anchor = null) => {
+    const captureAnchor = anchor || captureAnchorAtPoint(x, y);
+    return beginVoiceCapture(x, y, captureAnchor);
   };
   const buildCanvasPositionPayload = (anchor, options = {}) => {
     if (!anchor || typeof anchor !== 'object') return null;
@@ -391,6 +392,7 @@ export function bindUi() {
 
     const handleWorkspaceTap = (target, x, y) => {
       const requestedPositionPrompt = String(state.requestedPositionPrompt || '').trim();
+      let tapAnchor = null;
       if (requestedPositionPrompt) {
         if (state.interaction.tool !== 'prompt') {
           if (prefersTextComposer() && state.hasArtifact && createPdfStickyNoteAt(x, y)) return;
@@ -400,25 +402,22 @@ export function bindUi() {
         const sel = window.getSelection();
         if (sel && !sel.isCollapsed) return;
         rememberMousePosition(x, y);
-        const anchor = state.hasArtifact && canvasText ? getAnchorFromPoint(x, y) : null;
-        pinCursorAnchor(x, y, anchor);
+        tapAnchor = captureAnchorAtPoint(x, y);
+        pinCursorAnchor(x, y, tapAnchor);
         state.requestedPositionPrompt = '';
-        sendCanvasPosition(anchor, { gesture: 'tap', requestResponse: true });
-        showStatus('position shared');
         updateAssistantActivityIndicator();
-        return;
       }
       const liveSessionPointerMode = state.liveSessionActive
-        && (state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE || state.liveSessionMode === LIVE_SESSION_MODE_MEETING);
+        && state.liveSessionMode === LIVE_SESSION_MODE_MEETING;
       if (liveSessionPointerMode) {
         if (prefersTextComposer() && state.hasArtifact && createPdfStickyNoteAt(x, y)) return;
         if (isVoiceInteractionTarget(target, x, y)) return;
         const sel = window.getSelection();
         if (sel && !sel.isCollapsed) return;
         rememberMousePosition(x, y);
-        const anchor = state.hasArtifact && canvasText ? getAnchorFromPoint(x, y) : null;
-        pinCursorAnchor(x, y, anchor);
-        sendCanvasPosition(anchor, { gesture: 'tap' });
+        tapAnchor = tapAnchor || captureAnchorAtPoint(x, y);
+        pinCursorAnchor(x, y, tapAnchor);
+        sendCanvasPosition(tapAnchor, { gesture: 'tap' });
         updateAssistantActivityIndicator();
         return;
       }
@@ -426,10 +425,10 @@ export function bindUi() {
         if (isVoiceInteractionTarget(target, x, y)) return;
         cancelLiveSessionListen();
         if (prefersTextComposer()) {
-          const anchor = state.hasArtifact && canvasText ? getAnchorFromPoint(x, y) : null;
+          const anchor = tapAnchor || captureAnchorAtPoint(x, y);
           openComposerAt(x, y, anchor);
         } else {
-          void beginVoiceCaptureFromPoint(x, y);
+          void beginVoiceCaptureFromPoint(x, y, tapAnchor);
         }
         return;
       }
@@ -447,12 +446,15 @@ export function bindUi() {
         return;
       }
       if (prefersTextComposer()) {
-        const anchor = state.hasArtifact && canvasText ? getAnchorFromPoint(x, y) : null;
+        const anchor = tapAnchor || captureAnchorAtPoint(x, y);
         openComposerAt(x, y, anchor);
         return;
       }
-      if (state.interaction.conversation === 'push_to_talk') {
-        void beginVoiceCaptureFromPoint(x, y);
+      if (
+        state.interaction.conversation === 'push_to_talk'
+        || (state.liveSessionActive && state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE)
+      ) {
+        void beginVoiceCaptureFromPoint(x, y, tapAnchor);
       }
     };
 

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -202,17 +202,6 @@ async function currentDotPosition(page: Page) {
   });
 }
 
-async function submitVoiceStyleMessage(page: Page, text: string) {
-  await page.evaluate(async (messageText) => {
-    const app = (window as any)._taburaApp;
-    if (app?.getState) {
-      app.getState().lastInputOrigin = 'voice';
-    }
-    const mod = await import('../../internal/web/static/app-chat-submit.js');
-    await mod.submitMessage(messageText, { kind: 'voice_transcript' });
-  }, text);
-}
-
 async function triggerVoiceAssistantTTS(page: Page, turnID: string, text = 'Hello there.') {
   await page.evaluate(() => {
     const app = (window as any)._taburaApp;
@@ -230,7 +219,7 @@ test.beforeEach(async ({ page }) => {
   await injectCanvasModuleRef(page);
 });
 
-test('dialogue tap pins a cursor dot and scopes the next voice message without starting capture', async ({ page }) => {
+test('dialogue tap starts local capture with the tapped cursor context', async ({ page }) => {
   await page.evaluate(() => {
     (window as any).__taburaConversationListenMs = 1_200;
   });
@@ -247,31 +236,26 @@ test('dialogue tap pins a cursor dot and scopes the next voice message without s
   const x = 420;
   const y = 360;
   await page.mouse.click(x, y);
-  await page.waitForTimeout(200);
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }).toBe(true);
 
-  const log = await getLog(page);
-  expect(log.some((entry) => entry.type === 'recorder' && entry.action === 'start')).toBe(false);
-  const streamedPosition = log.find((entry) => entry.type === 'canvas_position');
-  expect(streamedPosition?.gesture).toBe('tap');
-  expect(streamedPosition?.request_response).toBe(false);
-  expect((streamedPosition?.cursor as Record<string, unknown> | null)?.title).toBe('test.txt');
+  let log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'canvas_position')).toBe(false);
 
-  await page.evaluate(async ({ x: anchorX, y: anchorY }) => {
-    const ui = await import('../../internal/web/static/ui.js');
-    ui.pinCursorAnchor(anchorX, anchorY, { line: 3, title: 'test.txt' });
-  }, { x, y });
-
-  await submitVoiceStyleMessage(page, 'fix this');
+  await page.mouse.click(x, y);
   await expect.poll(async () => {
     const nextLog = await getLog(page);
     return nextLog.find((entry) => entry.type === 'message_sent') || null;
   }).not.toBeNull();
-  const sentEntry = (await getLog(page)).find((entry) => entry.type === 'message_sent');
 
-  expect(sentEntry?.text).toBe('[Line 3 of "test.txt"] fix this');
+  log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'canvas_position')).toBe(false);
+  const sentEntry = log.find((entry) => entry.type === 'message_sent');
+  expect(String(sentEntry?.text || '')).toContain('hello world');
   expect(sentEntry?.cursor).toMatchObject({
     title: 'test.txt',
-    line: 3,
   });
 });
 
@@ -324,7 +308,7 @@ test('request_position stays local in annotation tools instead of dispatching a 
   expect(await page.evaluate(() => (window as any)._taburaApp.getState().requestedPositionPrompt)).toBe('Tap where the comment should go.');
 });
 
-test('request_position still sends a reply from the prompt tool', async ({ page }) => {
+test('request_position in prompt tool starts a local capture instead of streaming a reply', async ({ page }) => {
   await renderTestArtifact(page);
   await setInteractionTool(page, 'prompt');
   await clearLog(page);
@@ -334,13 +318,26 @@ test('request_position still sends a reply from the prompt tool', async ({ page 
   });
 
   await page.mouse.click(420, 360);
-  await page.waitForTimeout(150);
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }).toBe(true);
 
-  const log = await getLog(page);
-  expect(log.some((entry) => entry.type === 'recorder' && entry.action === 'start')).toBe(false);
-  const streamedPosition = log.find((entry) => entry.type === 'canvas_position');
-  expect(streamedPosition?.gesture).toBe('tap');
-  expect(streamedPosition?.request_response).toBe(true);
-  expect((streamedPosition?.cursor as Record<string, unknown> | null)?.title).toBe('test.txt');
+  let log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'canvas_position')).toBe(false);
   expect(await page.evaluate(() => (window as any)._taburaApp.getState().requestedPositionPrompt)).toBe('');
+
+  await page.mouse.click(420, 360);
+  await expect.poll(async () => {
+    const nextLog = await getLog(page);
+    return nextLog.find((entry) => entry.type === 'message_sent') || null;
+  }).not.toBeNull();
+
+  log = await getLog(page);
+  expect(log.some((entry) => entry.type === 'canvas_position')).toBe(false);
+  const sentEntry = log.find((entry) => entry.type === 'message_sent');
+  expect(String(sentEntry?.text || '')).toContain('hello world');
+  expect(sentEntry?.cursor).toMatchObject({
+    title: 'test.txt',
+  });
 });

--- a/tests/playwright/conversation-mode.spec.ts
+++ b/tests/playwright/conversation-mode.spec.ts
@@ -263,7 +263,7 @@ test('conversation listen timeout hides listening indicator', async ({ page }) =
   }), { timeout: 4_000 }).toBe(false);
 });
 
-test('tap during conversation listen pins a cursor instead of starting recording', async ({ page }) => {
+test('tap during conversation listen cancels listen and starts recording', async ({ page }) => {
   await setConversationListenWindowMs(page, 3_000);
   await setConversationMode(page, true);
   await page.evaluate(() => {
@@ -279,19 +279,16 @@ test('tap during conversation listen pins a cursor instead of starting recording
   })).toBe(true);
 
   await page.mouse.click(420, 360);
-  await page.waitForTimeout(150);
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }).toBe(true);
 
-  const startedRecording = await page.evaluate(() => {
-    return Array.isArray((window as any).__harnessLog)
-      && (window as any).__harnessLog.some((entry: any) => entry.type === 'recorder' && entry.action === 'start');
-  });
-  expect(startedRecording).toBe(false);
-
-  const cursorPinned = await page.evaluate(() => {
+  const indicatorRecording = await page.evaluate(() => {
     const indicator = document.getElementById('indicator');
-    return Boolean(indicator?.classList.contains('is-cursor'));
+    return Boolean(indicator?.classList.contains('is-recording'));
   });
-  expect(cursorPinned).toBe(true);
+  expect(indicatorRecording).toBe(true);
 });
 
 test('PTT during dialogue listen cancels listen and starts push-to-talk', async ({ page }) => {


### PR DESCRIPTION
## Summary
- route prompt-tool and dialogue taps through local voice capture instead of immediate `canvas_position` dispatch
- keep meeting-mode tap cursor pinning intact while binding tap-started capture to the current artifact anchor
- update Playwright coverage so prompt and annotation tap flows assert the same local-first contract

## Verification
- Tap-to-voice has one stable semantic contract.
  - Command: `./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts tests/playwright/conversation-mode.spec.ts`
  - Evidence: `/tmp/test.log` includes `dialogue tap starts local capture with the tapped cursor context`
  - Evidence: `/tmp/test.log` includes `tap during conversation listen cancels listen and starts recording`
- Old single-tap immediate prompt dispatch no longer conflicts with annotation accumulation.
  - Command: `./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts tests/playwright/conversation-mode.spec.ts`
  - Evidence: `/tmp/test.log` includes `request_position stays local in annotation tools instead of dispatching a reply`
  - Evidence: `/tmp/test.log` includes `request_position in prompt tool starts a local capture instead of streaming a reply`
- Tests assert no conflicting tap behavior across annotation vs prompt flows.
  - Command: `./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts tests/playwright/conversation-mode.spec.ts`
  - Evidence: `/tmp/test.log` ends with `14 passed (11.4s)`
