### PR TITLE
fix: Unify silent and non-silent panel behavior: full-width panels wi (fixes #436)

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -86,7 +86,7 @@
       <button id="surface-toggle" type="button" class="surface-toggle" aria-label="Switch interaction surface" style="display:none"></button>
 
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
-      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
+      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Toggle chat panel"></button>
       <button id="edge-top-tap" type="button" class="edge-top-tap" aria-label="Toggle top panel"></button>
 
       <div id="edge-top" class="edge-panel edge-top">

--- a/internal/web/static/mobile.css
+++ b/internal/web/static/mobile.css
@@ -76,7 +76,7 @@
   }
 
   .edge-right {
-    width: 85vw;
+    width: 100vw;
   }
 
   .edge-top {

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -832,7 +832,7 @@ test.describe('canvas - edge panels', () => {
     await expect(cpInput).toBeVisible();
   });
 
-  test('touch tap on right edge opens chat panel without recording', async ({ page }) => {
+  test('touch tap on right edge toggles a full-width chat panel without recording', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await clearLog(page);
 
@@ -841,24 +841,26 @@ test.describe('canvas - edge panels', () => {
     expect(initialClasses).not.toContain('edge-pinned');
 
     // Dispatch synthetic touch events at right edge (x=372, well inside 30px zone)
-    await page.evaluate(() => {
-      const x = window.innerWidth - 3;
-      const y = Math.floor(window.innerHeight / 2);
-      const target = document.elementFromPoint(x, y) || document.body;
-      const touchInit = { clientX: x, clientY: y, pageX: x, pageY: y, identifier: 0, target };
-      const touch = new Touch(touchInit);
-      target.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], changedTouches: [touch], bubbles: true }));
-      target.dispatchEvent(new TouchEvent('touchend', { touches: [], changedTouches: [touch], bubbles: true, cancelable: true }));
-    });
+    await dispatchTouchTap(page, 372, 333);
     await page.waitForTimeout(300);
 
     // Panel should be pinned
     await expect(edgeRight).toHaveClass(/edge-pinned/);
+    const width = await edgeRight.evaluate(el => getComputedStyle(el).width);
+    expect(parseInt(width, 10)).toBeGreaterThanOrEqual(370);
 
     // No recording should have started
     const log = await getLog(page);
     const sttStart = log.find(e => e.type === 'stt' && e.action === 'start');
     expect(sttStart).toBeFalsy();
+
+    // Same edge tap should hide the panel again.
+    await dispatchTouchTap(page, 372, 333);
+    await page.waitForTimeout(200);
+
+    const classes = await edgeRight.getAttribute('class');
+    expect(classes).not.toContain('edge-pinned');
+    expect(classes).not.toContain('edge-active');
   });
 
   test('touch tap inside pinned chat panel does not cancel default focus flow', async ({ page }) => {

--- a/tests/playwright/chat-harness.html
+++ b/tests/playwright/chat-harness.html
@@ -36,7 +36,7 @@
 
       <div id="tool-palette" class="tool-palette" aria-label="Interaction tools"></div>
 
-      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
+      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Toggle chat panel"></button>
 
       <div id="edge-top" class="edge-panel edge-top">
         <div class="edge-panel-inner">

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -67,7 +67,7 @@
       <button id="surface-toggle" type="button" class="surface-toggle" aria-label="Switch interaction surface" style="display:none"></button>
 
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
-      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Open chat panel"></button>
+      <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Toggle chat panel"></button>
       <button id="edge-top-tap" type="button" class="edge-top-tap" aria-label="Toggle top panel"></button>
 
       <div id="edge-top" class="edge-panel edge-top">

--- a/tests/playwright/silent-mode.spec.ts
+++ b/tests/playwright/silent-mode.spec.ts
@@ -75,6 +75,27 @@ async function injectCanvasEvent(page: Page, payload: Record<string, unknown>) {
   }, payload);
 }
 
+async function tapRightEdgeToggle(page: Page, identifier: number) {
+  await page.evaluate((touchIdentifier) => {
+    const tap = document.getElementById('edge-right-tap');
+    if (!(tap instanceof HTMLElement)) return;
+    const rect = tap.getBoundingClientRect();
+    const x = Math.floor(rect.left + rect.width / 2);
+    const y = Math.floor(rect.top + rect.height / 2);
+    const target = document.elementFromPoint(x, y) || tap;
+    const touch = new Touch({
+      clientX: x,
+      clientY: y,
+      pageX: x,
+      pageY: y,
+      identifier: touchIdentifier,
+      target,
+    });
+    target.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], changedTouches: [touch], bubbles: true }));
+    target.dispatchEvent(new TouchEvent('touchend', { touches: [], changedTouches: [touch], bubbles: true, cancelable: true }));
+  }, identifier);
+}
+
 test.describe('silent mode mobile', () => {
   test.use({ viewport: { width: 375, height: 667 } });
 
@@ -89,6 +110,25 @@ test.describe('silent mode mobile', () => {
   test('body has silent-mode class', async ({ page }) => {
     const hasSilent = await page.evaluate(() => document.body.classList.contains('silent-mode'));
     expect(hasSilent).toBe(true);
+  });
+
+  test('right edge tap toggles the silent chat panel while keeping it full width', async ({ page }) => {
+    const edgeRight = page.locator('#edge-right');
+    await expect(edgeRight).toHaveClass(/edge-pinned/);
+
+    const width = await edgeRight.evaluate(el => getComputedStyle(el).width);
+    expect(parseInt(width, 10)).toBeGreaterThanOrEqual(370);
+
+    await tapRightEdgeToggle(page, 0);
+    await page.waitForTimeout(200);
+    await expect(edgeRight).not.toHaveClass(/edge-pinned/);
+
+    await tapRightEdgeToggle(page, 1);
+    await page.waitForTimeout(200);
+
+    await expect(edgeRight).toHaveClass(/edge-pinned/);
+    const reopenedWidth = await edgeRight.evaluate(el => getComputedStyle(el).width);
+    expect(parseInt(reopenedWidth, 10)).toBeGreaterThanOrEqual(370);
   });
 
   test('chat pane stays focused for autoCanvas temp response artifacts', async ({ page }) => {


### PR DESCRIPTION
## Summary
- make the mobile chat edge panel full width in both silent and non-silent flows
- keep the right-edge control semantically aligned as a toggle in the app and harness markup
- add Playwright coverage for tap-to-show and tap-to-hide behavior in both mobile modes

## Verification
- Requirement: Panels in both modes use full width.
  Evidence: [mobile.css](/home/ert/code/assi/tabula/internal/web/static/mobile.css#L78) sets `.edge-right { width: 100vw; }` for mobile, so non-silent now matches silent.
  Evidence: `./scripts/playwright.sh tests/playwright/canvas.spec.ts tests/playwright/silent-mode.spec.ts 2>&1 | tee /tmp/issue-436-playwright.log`
  Output: `/tmp/issue-436-playwright.log:210` shows `silent mode mobile › right edge tap toggles the silent chat panel while keeping it full width`; `/tmp/issue-436-playwright.log:2137` shows `canvas - edge panels › touch tap on right edge toggles a full-width chat panel without recording`.
- Requirement: Same show/hide behavior in both modes.
  Evidence: [silent-mode.spec.ts](/home/ert/code/assi/tabula/tests/playwright/silent-mode.spec.ts#L115) closes and reopens the silent mobile panel with the same right-edge tap.
  Evidence: [canvas.spec.ts](/home/ert/code/assi/tabula/tests/playwright/canvas.spec.ts#L835) opens and closes the non-silent mobile panel with the same right-edge tap.
- Requirement: Tap area controls visibility consistently (tap to show, tap to hide).
  Evidence: [index.html](/home/ert/code/assi/tabula/internal/web/static/index.html#L89), [harness.html](/home/ert/code/assi/tabula/tests/playwright/harness.html#L70), and [chat-harness.html](/home/ert/code/assi/tabula/tests/playwright/chat-harness.html#L39) now label `#edge-right-tap` as `Toggle chat panel`, matching the enforced behavior.
  Evidence: the single Playwright run finished with `/tmp/issue-436-playwright.log:2399` -> `46 passed (32.4s)`.
