### PR TITLE
fix: Define gesture truth table for all input tools and surface state (fixes #444)

### DIFF
--- a/docs/gesture-truth-table.md
+++ b/docs/gesture-truth-table.md
@@ -1,0 +1,39 @@
+# Gesture Truth Table
+
+This document is the explicit gesture matrix for Tabura's shipped runtime.
+
+The table below describes visible runtime states, not hidden implementation flags:
+
+- `Blank surface` means no artifact is visible and no live session is active.
+- `Artifact visible` means an artifact is on canvas and no live session is active.
+- `Annotation mode` means the annotation surface is active and the selected tool is part of the visible state (`pointer`, `highlight`, `ink`, `text_note`, or `prompt`).
+- `Dialogue live` and `Meeting live` override ordinary prompt/annotation routing.
+
+Canonical rule: no gesture may have two incompatible meanings in the same visible state.
+
+Canonical tap-to-voice rule: when a tap resolves to voice, it always means `start local capture bound to the current context`. On artifact surfaces, that context includes the tapped cursor anchor. A follow-up tap or `Enter` while recording stops and sends that same local capture; it does not create a second start meaning.
+
+Current authority for the shipped behavior:
+
+- `internal/web/static/app-init.js`
+- `internal/web/static/live-session.js`
+- `tests/playwright/canvas.spec.ts`
+- `tests/playwright/canvas-cursor-context.spec.ts`
+- `tests/playwright/ui-system.spec.ts`
+- `tests/playwright/artifact-context.spec.ts`
+
+| Input | Blank surface | Artifact visible | Annotation mode | Dialogue live | Meeting live |
+| --- | --- | --- | --- | --- | --- |
+| Tap | Starts local capture from the tapped point in the default `pointer` / `prompt` path. A second tap stops and sends. | Starts local capture bound to the tapped artifact anchor in the default `pointer` / `prompt` path. A second tap stops and sends. | No generic tap-to-voice. The selected annotation tool owns the tap: `text_note` places a sticky note / annotation bubble, `ink` waits for pen contact, `highlight` preserves selection-driven annotation, and `prompt` uses the same local capture rule as the default path. | If Dialogue is in the post-TTS listen window, tap cancels that listen window and immediately starts local capture bound to the tapped context. Otherwise tap follows the same local-capture rule as the default path. | Never starts a new local capture. Tap pins or moves the cursor context and sends a `canvas_position` update only. |
+| Tap+voice | Means the same thing everywhere it exists: start local capture tied to the current tap context, then speak into that local capture. | Means the same thing everywhere it exists: start local capture tied to the tapped artifact location, then speak into that local capture. | Exists only for the visible `prompt` tool. Other annotation tools keep tap local to annotation placement/editing and do not reinterpret it as voice. | Means cancel listen if needed, then start local capture tied to the tapped context. | Not available. Meeting taps stay cursor-only even if the user speaks after tapping. |
+| Right-click | Opens the floating composer at the clicked point. | Opens the floating composer at the clicked point unless the target is an editable text artifact, in which case it enters artifact edit mode. | Editable text artifacts enter artifact edit mode first; otherwise the floating composer opens. | Cancels the Dialogue listen window, then opens the floating composer or artifact editor using the same precedence as the non-live path. | Opens the floating composer or artifact editor using the same precedence as the non-live path. The meeting session itself keeps running. |
+| Typing | Printable keys open the chat-pane composer if the right panel is pinned; otherwise they open the floating composer only when the editor / `text_note` path is active. | Same as blank surface, but submitted text carries the active artifact context when one exists. | Printable keys route into the composer only for the visible text-composition path. Annotation tools otherwise keep keyboard input for shortcuts or focused editors. | Typing cancels the Dialogue listen window before routing into the relevant composer. | Typing routes into the same composer paths as the non-live UI; it does not start or stop meeting capture. |
+| Ink/stylus | No annotation stroke is created because there is nothing to annotate. | Pen input is inert unless the annotation surface is active with the `ink` tool selected. | Pen contact with the `ink` tool draws on `#ink-layer`; `Enter` submits the draft and `Escape` clears it. Finger or mouse taps do not substitute for pen strokes. | Live state does not change pen semantics. Dialogue still requires an explicit tap-to-voice path for audio capture. | Live state does not change pen semantics. Meeting still treats taps as cursor updates, not voice capture. |
+| Enter | If local capture is recording, stop and send. If a composer is focused, send and clear it. | Same as blank surface, with artifact context preserved on submission. | Submits the focused composer; when `ink` has a dirty draft, submits the ink draft instead of sending chat text. | If local capture is recording, stop and send. If a composer is focused, send and clear it. Dialogue listen itself is not started by `Enter`. | Sends focused composer text or other explicit submit actions, but does not control meeting capture. |
+| Escape | Dismisses overlay/input first. If nothing transient is open, it falls through to stop/cancel behavior. | Dismisses overlay/input first, then closes panels, then clears the artifact back to tabula rasa if nothing else is open. | Exits artifact edit mode, clears dirty ink drafts, dismisses overlays/inputs, then falls through to the same panel/artifact clearing order. | Cancels recording if one is active; otherwise dismisses UI layers using the normal precedence. It does not invent a second tap meaning. | Dismisses UI layers using the normal precedence; if no transient UI is open and an artifact is visible, the artifact clears, but Escape is not the meeting start gesture. |
+
+Precedence notes:
+
+1. Live session state wins over ordinary prompt/annotation routing.
+2. Inside `Annotation mode`, the selected tool is part of the visible state and therefore part of the gesture contract.
+3. `Tap-to-voice` is not a second product model. It is only the local-capture branch of the main interaction grammar.

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -17,12 +17,13 @@ Current runtime baseline:
 Read in this order:
 
 1. `object-scoped-intent-ui.md`
-2. `approval-execution-policy.md`
-3. `interfaces.md`
-4. `architecture.md`
-5. `companion-mode-whitepaper.md`
-6. `meeting-notes-privacy.md`
-7. `codex-app-server-pivot.md`
+2. `gesture-truth-table.md`
+3. `approval-execution-policy.md`
+4. `interfaces.md`
+5. `architecture.md`
+6. `companion-mode-whitepaper.md`
+7. `meeting-notes-privacy.md`
+8. `codex-app-server-pivot.md`
 
 Integrated protocol reference:
 

--- a/internal/surface/spec_docs_test.go
+++ b/internal/surface/spec_docs_test.go
@@ -1,0 +1,50 @@
+package surface
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func repoRootFromCaller(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func TestGestureTruthTableDocIsIndexedAndStructured(t *testing.T) {
+	root := repoRootFromCaller(t)
+
+	truthTablePath := filepath.Join(root, "docs", "gesture-truth-table.md")
+	truthTable, err := os.ReadFile(truthTablePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", truthTablePath, err)
+	}
+	content := string(truthTable)
+
+	requiredSnippets := []string{
+		"| Input | Blank surface | Artifact visible | Annotation mode | Dialogue live | Meeting live |",
+		"Canonical tap-to-voice rule",
+		"`start local capture bound to the current context`",
+		"Live session state wins over ordinary prompt/annotation routing.",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("%s missing snippet %q", truthTablePath, snippet)
+		}
+	}
+
+	specIndexPath := filepath.Join(root, "docs", "spec-index.md")
+	specIndex, err := os.ReadFile(specIndexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", specIndexPath, err)
+	}
+	if !strings.Contains(string(specIndex), "`gesture-truth-table.md`") {
+		t.Fatalf("%s does not reference gesture-truth-table.md", specIndexPath)
+	}
+}


### PR DESCRIPTION
## Summary
- add `docs/gesture-truth-table.md` as the explicit interaction matrix for blank surface, artifact visible, annotation mode, Dialogue live, and Meeting live
- index the new spec from `docs/spec-index.md`
- add `internal/surface/spec_docs_test.go` so the truth table and index link stay enforced in CI

## Verification
- Truth table is defined and checked into docs: `docs/gesture-truth-table.md` now contains the full matrix headed by `| Input | Blank surface | Artifact visible | Annotation mode | Dialogue live | Meeting live |`.
- No gesture has ambiguous semantics across states: `docs/gesture-truth-table.md` explicitly states `no gesture may have two incompatible meanings in the same visible state` and adds precedence rules for live-session override plus annotation-tool ownership.
- Tap-to-voice has exactly one meaning: `docs/gesture-truth-table.md` defines the canonical rule as `start local capture bound to the current context`, applies it to blank/artifact/dialogue states, and explicitly excludes Meeting taps from starting capture.
- The new truth table is discoverable from canonical docs: `docs/spec-index.md` now lists `gesture-truth-table.md` in the read order.
- Guard coverage for the doc and index link: `go test ./internal/surface -run TestGestureTruthTableDocIsIndexedAndStructured` -> `ok   github.com/krystophny/tabura/internal/surface\t0.001s`
- Runtime behavior still matches the documented matrix: `./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts tests/playwright/canvas.spec.ts tests/playwright/ui-system.spec.ts tests/playwright/artifact-context.spec.ts --grep "dialogue tap starts local capture with the tapped cursor context|meeting taps move the pinned cursor without starting a new recording|keyboard typing activates text input, Enter sends, text cleared|right-click opens text input at position|Escape clears artifact when nothing else is open|touch tap on canvas starts recording on mobile|right-click on artifact opens artifact editor"` -> `7 passed (4.3s)`
