### PR TITLE
fix: Collapse live runtime: only Dialogue and Meeting survive (fixes #446)

### DIFF
--- a/docs/live-runtime-whitepaper.md
+++ b/docs/live-runtime-whitepaper.md
@@ -1,47 +1,47 @@
-# Companion Mode Whitepaper
+# Live Runtime Whitepaper
 
 > **Legal notice:** Tabura is provided "as is" and "as available" without warranties, and to the maximum extent permitted by applicable law the authors/contributors accept no liability for damages, data loss, or misuse. You are solely responsible for backups, verification, and safe operation. See [`DISCLAIMER.md`](/DISCLAIMER.md).
 
 ## Summary
 
-Tabura's active direction is a single assistant surface: **Companion Mode**.
+Tabura exposes one live runtime with exactly two user-facing types:
+**Dialogue** and **Meeting**.
 
-Companion Mode replaces the split between conversation mode, participant mode,
-and meeting-specific assistant planning. It is intended for:
-
-- live in-person meetings
-- one-on-one conversations
-- solo workday assistant presence
-- online calls as one additional context source
+- **Dialogue** is direct back-and-forth with Tabura, including the post-TTS
+  follow-up listen window.
+- **Meeting** is ambient capture for in-room or online meetings, including
+  transcript, summary, references, and follow-up item generation.
 
 ## Core Principles
 
-- **Botless**: no assistant attendee joins Zoom/Meet/Teams
-- **Local-first**: Tabura owns capture, buffering, state, and UI locally
-- **Whisper-backed**: default STT path remains the `voxtype` Whisper sidecar
-- **Always-transcribing for context**: transcript context is continuous while the mode is active
-- **Manual control**: users explicitly enter and leave Companion Mode
-- **Project-scoped**: context and work belong to projects, not to a global floating agent
+- **One live runtime**: hotword, capture, and state transitions belong to one
+  shared live-session owner.
+- **Two visible modes only**: the UI exposes `Dialogue` and `Meeting`, not
+  overlapping assistant sub-products.
+- **Botless**: no assistant attendee joins Zoom/Meet/Teams.
+- **Local-first**: Tabura owns capture, buffering, state, and UI locally.
+- **Whisper-backed**: default STT path remains the `voxtype` Whisper sidecar.
+- **Manual control**: users explicitly enter and leave live mode.
 
 ## Product Shape
 
-Companion Mode should feel like one humanoid assistant, not multiple separate
-features:
+The live runtime should feel like one coherent system rather than several
+stacked features:
 
-- meetings are project sessions
-- long-running tasks are project runs
-- Hub remains for ad hoc requests and run monitoring
-- each project keeps one active run in its main thread
-- meetings and long-running jobs default to temporary projects
+- `Dialogue` is the assistant turn-taking path.
+- `Meeting` is the ambient room/call capture path.
+- Hotword remains a subsystem inside that same runtime.
+- Hub remains for ad hoc requests and run monitoring.
 
-If no document is displayed, the idle surface is a full-screen minimal humanoid
-face. A black-screen idle mode is the alternate surface.
+If no artifact is displayed while Meeting is enabled, the idle surface is a
+full-screen minimal face. A black-screen idle mode remains the alternate
+surface.
 
 ## Persistence Model
 
 - audio remains RAM-only
 - text artifacts are persisted
-- meetings and long tasks can be persisted or discarded explicitly
+- meeting outputs can be persisted or discarded explicitly
 - persisted artifacts include transcript text, summaries, references, and run outputs
 
 ## Architectural Consequences
@@ -49,6 +49,7 @@ face. A black-screen idle mode is the alternate surface.
 - no private repo is required
 - no extension/plugin product architecture is required
 - new product behavior belongs in the public `krystophny/tabura` repo
+- live voice behavior is governed by one shared live-session runtime
 - product modularity should come from normal `internal/` package boundaries
 
 ## Research Basis
@@ -62,9 +63,8 @@ The planned direction is informed by current commercial and open systems:
 - Tolan: voice-first assistant presence with a clear persona and simple visual state
 
 Tabura should borrow the best parts of those systems without copying their
-cloud-recorder assumptions. The target is one public, project-scoped,
-Whisper-backed companion surface for live meetings, online calls, and ambient
-workday help.
+cloud-recorder assumptions. The target is one public, Whisper-backed live
+runtime for direct dialogue, meetings, online calls, and ambient workday help.
 
 ## Research References
 

--- a/docs/meeting-notes-privacy.md
+++ b/docs/meeting-notes-privacy.md
@@ -16,7 +16,7 @@ This document formalizes the audio privacy guarantees for Tabura's speech-to-tex
 
 ## Meeting Consent Boundary
 
-- Meeting capture is explicit opt-in. Capture must not start until `companion_enabled=true` on the current project config API.
+- Meeting capture is explicit opt-in. Capture must not start until meeting live mode is enabled. The current config API expresses that as `companion_enabled=true`.
 - Disabling Meeting live mode is an exit action: any active participant capture session must stop immediately.
 - Meeting capture defaults to microphone-only input. Alternate capture sources are not accepted through the config surface.
 

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -21,7 +21,7 @@ Read in this order:
 3. `approval-execution-policy.md`
 4. `interfaces.md`
 5. `architecture.md`
-6. `companion-mode-whitepaper.md`
+6. `live-runtime-whitepaper.md`
 7. `meeting-notes-privacy.md`
 8. `codex-app-server-pivot.md`
 

--- a/internal/web/projects_companion_test.go
+++ b/internal/web/projects_companion_test.go
@@ -209,14 +209,14 @@ func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 		SessionID:   sess.ID,
 		StartTS:     100,
 		EndTS:       101,
-		Text:        "Tabura, open the companion transcript.",
+		Text:        "Tabura, open the meeting transcript.",
 		CommittedAt: 102,
 		Status:      "final",
 	})
 	if err != nil {
 		t.Fatalf("AddParticipantSegment: %v", err)
 	}
-	if err := app.store.AddParticipantEvent(sess.ID, seg.ID, "segment_committed", `{"text":"Tabura, open the companion transcript."}`); err != nil {
+	if err := app.store.AddParticipantEvent(sess.ID, seg.ID, "segment_committed", `{"text":"Tabura, open the meeting transcript."}`); err != nil {
 		t.Fatalf("AddParticipantEvent segment_committed: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 	if state.DirectedSpeechGate.LastEventType != "segment_committed" {
 		t.Fatalf("directed_speech_gate.last_event_type = %q, want segment_committed", state.DirectedSpeechGate.LastEventType)
 	}
-	if state.DirectedSpeechGate.EvaluatedText != "Tabura, open the companion transcript." {
+	if state.DirectedSpeechGate.EvaluatedText != "Tabura, open the meeting transcript." {
 		t.Fatalf("directed_speech_gate.evaluated_text = %q", state.DirectedSpeechGate.EvaluatedText)
 	}
 	if state.InteractionPolicy.Decision != companionInteractionDecisionRespond {

--- a/internal/web/static/app-projects.js
+++ b/internal/web/static/app-projects.js
@@ -186,7 +186,7 @@ export async function refreshCompanionState(projectID = state.activeProjectId) {
   const resp = await fetch(apiURL(`projects/${encodeURIComponent(project.id)}/companion/state`), { cache: 'no-store' });
   if (!resp.ok) {
     resetCompanionState();
-    throw new Error(`companion state failed: HTTP ${resp.status}`);
+    throw new Error(`meeting state failed: HTTP ${resp.status}`);
   }
   const payload = await resp.json();
   applyCompanionState(payload);

--- a/tests/playwright/chat-voice-send.spec.ts
+++ b/tests/playwright/chat-voice-send.spec.ts
@@ -236,7 +236,7 @@ async function switchToTestProject(page: Page) {
   })).toBe('ready');
 }
 
-async function setConversationMode(page: Page, enabled: boolean) {
+async function setDialogueMode(page: Page, enabled: boolean) {
   if (enabled) {
     await switchToTestProject(page);
     await waitForEdgeButtons(page);
@@ -838,9 +838,9 @@ test('stt empty reason is surfaced as visible voice capture error', async ({ pag
   expect(log.some((entry) => entry.type === 'message_sent')).toBe(false);
 });
 
-test('conversation PTT empty transcript surfaces error instead of silent drop', async ({ page }) => {
+test('dialogue PTT empty transcript surfaces error instead of silent drop', async ({ page }) => {
   await clearLog(page);
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
   await setHarnessSTTTranscribeResponse(page, { text: '', reason: 'no_speech_detected' }, 200);
 
   await page.keyboard.down('Control');

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1574,7 +1574,7 @@
       if (u.includes('/api/projects/') && u.includes('/transcript')) {
         const format = new URL(u, window.location.href).searchParams.get('format') || 'json';
         if (format === 'md') {
-          return new Response('# Meeting Transcript\n\n- **Speaker** (10:00:00): Harness companion transcript\n', {
+          return new Response('# Meeting Transcript\n\n- **Speaker** (10:00:00): Harness meeting transcript\n', {
             status: 200,
             headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
           });
@@ -1585,13 +1585,13 @@
           project_key: '/tmp/test',
           sessions: [{ id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' }],
           session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
-          segments: [{ id: 1, session_id: 'psess-harness-001', start_ts: 100, end_ts: 100, speaker: 'Speaker', text: 'Harness companion transcript', model: 'whisper-1', latency_ms: 10, committed_at: 100, status: 'final' }],
+          segments: [{ id: 1, session_id: 'psess-harness-001', start_ts: 100, end_ts: 100, speaker: 'Speaker', text: 'Harness meeting transcript', model: 'whisper-1', latency_ms: 10, committed_at: 100, status: 'final' }],
         }), { status: 200 });
       }
       if (u.includes('/api/projects/') && u.includes('/summary')) {
         const format = new URL(u, window.location.href).searchParams.get('format') || 'json';
         if (format === 'md') {
-          return new Response('# Meeting Summary\n\nHarness companion summary\n', {
+          return new Response('# Meeting Summary\n\nHarness meeting summary\n', {
             status: 200,
             headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
           });
@@ -1602,7 +1602,7 @@
           project_key: '/tmp/test',
           sessions: [{ id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' }],
           session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
-          summary_text: 'Harness companion summary',
+          summary_text: 'Harness meeting summary',
           updated_at: 101,
         }), { status: 200 });
       }
@@ -1636,7 +1636,7 @@
             id: 701,
             kind: 'markdown',
             title: 'Meeting Summary',
-            meta_json: JSON.stringify({ summary: 'Harness companion summary' }),
+            meta_json: JSON.stringify({ summary: 'Harness meeting summary' }),
           },
         };
         window.__harnessLog.push({
@@ -1663,7 +1663,7 @@
           project_key: '/tmp/test',
           sessions: [{ id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' }],
           session: { id: 'psess-harness-001', project_key: '/tmp/test', started_at: 100, ended_at: 0, config_json: '{}' },
-          summary_text: 'Harness companion summary',
+          summary_text: 'Harness meeting summary',
           proposed_items: proposals,
         }), { status: 200 });
       }

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -54,7 +54,7 @@ async function triggerVoiceAssistantTTS(page: Page, turnID: string, text = 'Hell
   await injectChatEvent(page, { type: 'assistant_output', role: 'assistant', turn_id: turnID, message: text });
 }
 
-async function setConversationListenWindowMs(page: Page, ms: number) {
+async function setDialogueListenWindowMs(page: Page, ms: number) {
   await page.evaluate((value) => {
     (window as any).__taburaConversationListenMs = value;
   }, ms);
@@ -85,7 +85,7 @@ async function switchToTestProject(page: Page) {
   })).toBe('ready');
 }
 
-async function setConversationMode(page: Page, enabled: boolean) {
+async function setDialogueMode(page: Page, enabled: boolean) {
   if (enabled) {
     await switchToTestProject(page);
     await waitForEdgeButtons(page);
@@ -128,8 +128,8 @@ async function waitForHotwordStart(page: Page) {
 
 test('hotword detection starts recording directly', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await clearLog(page);
 
@@ -160,7 +160,7 @@ test('hotword runtime pins explicit ONNX wasm asset URLs', async ({ page }) => {
 
 test('hotword plus speech starts recording', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 2_500);
+  await setDialogueListenWindowMs(page, 2_500);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames([
       ...Array.from({ length: 8 }, () => -80),
@@ -168,7 +168,7 @@ test('hotword plus speech starts recording', async ({ page }) => {
       ...Array.from({ length: 8 }, () => -80),
     ]);
   });
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await clearLog(page);
 
@@ -182,7 +182,7 @@ test('hotword plus speech starts recording', async ({ page }) => {
 
 test('hotword capture tolerates initial pause before user speech', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 2_500);
+  await setDialogueListenWindowMs(page, 2_500);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames([
       ...Array.from({ length: 36 }, () => -80), // ~1.44s initial pause
@@ -190,7 +190,7 @@ test('hotword capture tolerates initial pause before user speech', async ({ page
       ...Array.from({ length: 40 }, () => -80),
     ]);
   });
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await clearLog(page);
 
@@ -206,10 +206,10 @@ test('hotword capture tolerates initial pause before user speech', async ({ page
   expect(log.some((entry) => entry.type === 'recorder' && entry.action === 'stop')).toBe(false);
 });
 
-test('hotword empty transcript re-opens conversation listen window', async ({ page }) => {
+test('hotword empty transcript re-opens dialogue listen window', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 2_500);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 2_500);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await page.evaluate(() => {
     (window as any).__setSTTTranscribeResponse({ text: '', reason: 'no_speech_detected' }, 200);
@@ -240,7 +240,7 @@ test('hotword empty transcript re-opens conversation listen window', async ({ pa
 
 test('hotword is paused during recording', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 3_000);
+  await setDialogueListenWindowMs(page, 3_000);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames([
       ...Array.from({ length: 8 }, () => -80),
@@ -248,7 +248,7 @@ test('hotword is paused during recording', async ({ page }) => {
       ...Array.from({ length: 20 }, () => -12),
     ]);
   });
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await clearLog(page);
 
@@ -266,8 +266,8 @@ test('hotword is paused during recording', async ({ page }) => {
 
 test('hotword is paused while TTS playback is active', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 2_500);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 2_500);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await page.evaluate(() => {
     (window as any).__setTTSPlaybackDelayMs(500);
@@ -288,8 +288,8 @@ test('hotword is paused while TTS playback is active', async ({ page }) => {
 
 test('Dialogue off keeps hotword disabled', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, false);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, false);
   await clearLog(page);
 
   await triggerHotword(page);
@@ -306,8 +306,8 @@ test('Dialogue off keeps hotword disabled', async ({ page }) => {
 
 test('hotword init failure degrades gracefully with no crash', async ({ page }) => {
   await waitReady(page, '?hotword=fail');
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, true);
   await clearLog(page);
 
   await triggerHotword(page);
@@ -326,7 +326,7 @@ test('hotword init failure degrades gracefully with no crash', async ({ page }) 
 
 test('Dialogue with hotword active shows pause indicator', async ({ page }) => {
   await waitReady(page);
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
 
   await expect.poll(async () => page.evaluate(() => {
@@ -360,8 +360,8 @@ test('meeting mode hotword still starts direct recording', async ({ page }) => {
 
 test('follow-up timeout returns to pause indicator', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 500);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 500);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames(Array.from({ length: 120 }, () => -80));
@@ -383,8 +383,8 @@ test('follow-up timeout returns to pause indicator', async ({ page }) => {
 
 test('hotword re-arms after follow-up timeout and starts a second turn', async ({ page }) => {
   await waitReady(page);
-  await setConversationListenWindowMs(page, 500);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 500);
+  await setDialogueMode(page, true);
   await waitForHotwordStart(page);
   await clearLog(page);
 

--- a/tests/playwright/live-dialogue.spec.ts
+++ b/tests/playwright/live-dialogue.spec.ts
@@ -42,7 +42,7 @@ async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   }, payload);
 }
 
-async function setConversationListenWindowMs(page: Page, ms: number) {
+async function setDialogueListenWindowMs(page: Page, ms: number) {
   await page.evaluate((value) => {
     (window as any).__taburaConversationListenMs = value;
   }, ms);
@@ -73,7 +73,7 @@ async function switchToTestProject(page: Page) {
   })).toBe('ready');
 }
 
-async function setConversationMode(page: Page, enabled: boolean) {
+async function setDialogueMode(page: Page, enabled: boolean) {
   if (enabled) {
     await switchToTestProject(page);
     await waitForEdgeButtons(page);
@@ -143,13 +143,15 @@ test('Live panel swaps Dialogue/Meeting choices for active status and Stop', asy
   await expect(page.locator('#edge-top-models .edge-live-dialogue-btn')).toBeVisible();
   await expect(page.locator('#edge-top-models .edge-live-meeting-btn')).toBeVisible();
 
-  await setConversationMode(page, true);
+  await setDialogueMode(page, true);
 
   await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Dialogue');
   await expect(page.locator('#edge-top-models .edge-live-stop-btn')).toBeVisible();
   await expect(page.locator('#edge-top-models .edge-live-dialogue-btn')).toHaveCount(0);
+  await expect(page.locator('#edge-top-models')).not.toContainText('Companion');
+  await expect(page.locator('#edge-top-models')).not.toContainText('Conversation');
 
-  await setConversationMode(page, false);
+  await setDialogueMode(page, false);
   await expect(page.locator('#edge-top-models .edge-live-dialogue-btn')).toBeVisible();
   await expect(page.locator('#edge-top-models .edge-live-meeting-btn')).toBeVisible();
 });
@@ -180,8 +182,8 @@ test('Meeting entry shows active status and returns to choices on Stop', async (
 });
 
 test('Dialogue shows listening indicator after TTS playback completes', async ({ page }) => {
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, true);
   await clearLog(page);
 
   await triggerVoiceAssistantTTS(page, 'conv-listening-1');
@@ -198,8 +200,8 @@ test('Dialogue shows listening indicator after TTS playback completes', async ({
 });
 
 test('Dialogue off does not open listening indicator after TTS', async ({ page }) => {
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, false);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, false);
   await clearLog(page);
 
   await triggerVoiceAssistantTTS(page, 'conv-disabled-1');
@@ -217,9 +219,9 @@ test('Dialogue off does not open listening indicator after TTS', async ({ page }
   expect(isListening).toBe(false);
 });
 
-test('speech onset during conversation listen starts recording', async ({ page }) => {
-  await setConversationListenWindowMs(page, 3_000);
-  await setConversationMode(page, true);
+test('speech onset during dialogue listen starts recording', async ({ page }) => {
+  await setDialogueListenWindowMs(page, 3_000);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames([
       ...Array.from({ length: 8 }, () => -80),
@@ -242,9 +244,9 @@ test('speech onset during conversation listen starts recording', async ({ page }
   })).toBe(true);
 });
 
-test('conversation listen timeout hides listening indicator', async ({ page }) => {
-  await setConversationListenWindowMs(page, 500);
-  await setConversationMode(page, true);
+test('dialogue listen timeout hides listening indicator', async ({ page }) => {
+  await setDialogueListenWindowMs(page, 500);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames(Array.from({ length: 120 }, () => -80));
   });
@@ -263,9 +265,9 @@ test('conversation listen timeout hides listening indicator', async ({ page }) =
   }), { timeout: 4_000 }).toBe(false);
 });
 
-test('tap during conversation listen cancels listen and starts recording', async ({ page }) => {
-  await setConversationListenWindowMs(page, 3_000);
-  await setConversationMode(page, true);
+test('tap during dialogue listen cancels listen and starts recording', async ({ page }) => {
+  await setDialogueListenWindowMs(page, 3_000);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames(Array.from({ length: 200 }, () => -80));
   });
@@ -292,8 +294,8 @@ test('tap during conversation listen cancels listen and starts recording', async
 });
 
 test('PTT during dialogue listen cancels listen and starts push-to-talk', async ({ page }) => {
-  await setConversationListenWindowMs(page, 3_000);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 3_000);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames(Array.from({ length: 200 }, () => -80));
   });
@@ -320,8 +322,8 @@ test('PTT during dialogue listen cancels listen and starts push-to-talk', async 
 });
 
 test('silent mode with dialogue enabled does not open follow-up listen', async ({ page }) => {
-  await setConversationListenWindowMs(page, 1_200);
-  await setConversationMode(page, true);
+  await setDialogueListenWindowMs(page, 1_200);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     const app = (window as any)._taburaApp;
     const state = app?.getState?.();
@@ -346,9 +348,9 @@ test('silent mode with dialogue enabled does not open follow-up listen', async (
   expect(isListening).toBe(false);
 });
 
-test('conversation listen timeout returns to pause indicator when hotword is active', async ({ page }) => {
-  await setConversationListenWindowMs(page, 500);
-  await setConversationMode(page, true);
+test('dialogue listen timeout returns to pause indicator when hotword is active', async ({ page }) => {
+  await setDialogueListenWindowMs(page, 500);
+  await setDialogueMode(page, true);
   await page.evaluate(() => {
     (window as any).__setVadDbFrames(Array.from({ length: 120 }, () => -80));
   });

--- a/tests/playwright/live-meeting.spec.ts
+++ b/tests/playwright/live-meeting.spec.ts
@@ -28,7 +28,7 @@ async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
   }, payload);
 }
 
-async function setHarnessCompanionState(
+async function setHarnessMeetingState(
   page: Page,
   {
     enabled = true,
@@ -115,7 +115,7 @@ async function setHarnessCompanionState(
   }, { enabled, idleSurface, runtimeState, reason });
 }
 
-async function waitForCompanionSurface(page: Page, state: string, surface: string) {
+async function waitForMeetingSurface(page: Page, state: string, surface: string) {
   await expect.poll(async () => page.evaluate(() => {
     const node = document.getElementById('companion-idle-surface');
     if (!(node instanceof HTMLElement)) return null;
@@ -172,7 +172,7 @@ async function switchSidebarToFiles(page: Page) {
   await expect(page.locator('.sidebar-tab.is-active')).toContainText('Files');
 }
 
-test('workspace sidebar exposes companion transcript, summary, and references viewer entries', async ({ page }) => {
+test('workspace sidebar exposes meeting transcript, summary, and references viewer entries', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await waitReady(page);
 
@@ -184,10 +184,10 @@ test('workspace sidebar exposes companion transcript, summary, and references vi
   await expect(page.locator('#pr-file-list')).toContainText('Meeting References');
 
   await page.getByRole('button', { name: 'Meeting Transcript' }).click();
-  await expect(page.locator('#canvas-text')).toContainText('Harness companion transcript');
+  await expect(page.locator('#canvas-text')).toContainText('Harness meeting transcript');
 
   await page.getByRole('button', { name: 'Meeting Summary' }).click();
-  await expect(page.locator('#canvas-text')).toContainText('Harness companion summary');
+  await expect(page.locator('#canvas-text')).toContainText('Harness meeting summary');
 
   await page.getByRole('button', { name: 'Meeting References' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Acme');
@@ -245,40 +245,40 @@ test('meeting summary proposes selectable inbox items and creates the chosen one
     && Number(entry.payload.selected[0]) === 0)).toBe(true);
 });
 
-test('companion idle surface tracks runtime state and hides behind open artifacts', async ({ page }) => {
+test('meeting idle surface tracks runtime state and hides behind open artifacts', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await waitReady(page);
   await switchToProject(page, 'test');
-  await setHarnessCompanionState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
+  await setHarnessMeetingState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
   await clearCanvas(page);
   await page.evaluate(() => {
     (window as any)._taburaApp?.syncCompanionIdleSurface?.();
   });
 
-  await waitForCompanionSurface(page, 'idle', 'robot');
+  await waitForMeetingSurface(page, 'idle', 'robot');
 
   for (const nextState of ['listening', 'thinking', 'talking', 'error'] as const) {
-    await setHarnessCompanionState(page, {
+    await setHarnessMeetingState(page, {
       enabled: true,
       idleSurface: 'robot',
       runtimeState: nextState,
       reason: nextState,
     });
-    await waitForCompanionSurface(page, nextState, 'robot');
+    await waitForMeetingSurface(page, nextState, 'robot');
   }
 
   await page.locator('#edge-left-tap').click();
   await switchSidebarToFiles(page);
   await page.getByRole('button', { name: 'Meeting Transcript' }).click();
-  await expect(page.locator('#canvas-text')).toContainText('Harness companion transcript');
+  await expect(page.locator('#canvas-text')).toContainText('Harness meeting transcript');
   await expect(page.locator('#companion-idle-surface')).toBeHidden();
 });
 
-test('black mode toggle updates the companion idle surface preference', async ({ page }) => {
+test('black mode toggle updates the meeting idle surface preference', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await waitReady(page);
   await switchToProject(page, 'test');
-  await setHarnessCompanionState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
+  await setHarnessMeetingState(page, { enabled: true, idleSurface: 'robot', runtimeState: 'idle' });
   await clearCanvas(page);
   await page.evaluate(() => {
     (window as any)._taburaApp?.syncCompanionIdleSurface?.();
@@ -294,6 +294,6 @@ test('black mode toggle updates the companion idle surface preference', async ({
     button.click();
   });
 
-  await waitForCompanionSurface(page, 'idle', 'black');
+  await waitForMeetingSurface(page, 'idle', 'black');
   await expect(blackButton).toHaveAttribute('aria-pressed', 'true');
 });


### PR DESCRIPTION
## Summary

- Rename the primary live-runtime doc and the legacy-named Playwright specs to Dialogue/Meeting terminology.
- Update meeting-facing docs, harness fixtures, and the remaining visible runtime/test copy to use meeting/dialogue wording instead of companion/conversation wording.
- Keep the existing live runtime behavior intact while adding an explicit UI assertion that the live panel only surfaces Dialogue/Meeting.

## Verification

- Requirement: Only two user-facing live session types exist and legacy-named Playwright specs are gone.
  Command: `./scripts/playwright.sh tests/playwright/live-dialogue.spec.ts tests/playwright/live-meeting.spec.ts tests/playwright/hotword.spec.ts tests/playwright/chat-voice-send.spec.ts 2>&1 | tee /tmp/test.log`
  Evidence: `/tmp/test.log` contains `tests/playwright/live-dialogue.spec.ts:140:5 › Live panel swaps Dialogue/Meeting choices for active status and Stop` and `62 passed (47.9s)`.

- Requirement: No Companion Mode / conversation mode wording remains in primary UX paths for the live runtime.
  Evidence: `[tests/playwright/live-dialogue.spec.ts](/home/ert/code/assi/tabula/tests/playwright/live-dialogue.spec.ts)`, `[tests/playwright/live-meeting.spec.ts](/home/ert/code/assi/tabula/tests/playwright/live-meeting.spec.ts)`, and `[tests/playwright/harness.html](/home/ert/code/assi/tabula/tests/playwright/harness.html)` now use Dialogue/Meeting and meeting transcript/summary wording only.

- Requirement: Meeting transcript/summary surfaces still work in the canonical live/runtime flow.
  Evidence: `/tmp/test.log` contains `tests/playwright/live-meeting.spec.ts:175:5 › workspace sidebar exposes meeting transcript, summary, and references viewer entries`.

- Requirement: Directed speech metadata still works with the renamed meeting-facing copy.
  Command: `go test ./internal/web -run "TestProjectCompanionStateExposesDirectedSpeechGateMetadata" 2>&1 | tee /tmp/test.log`
  Evidence: `/tmp/test.log` contains `ok   github.com/krystophny/tabura/internal/web`.

- Requirement: Hotword and dialogue PTT behavior remain governed by the same live-session runtime.
  Evidence: `/tmp/test.log` contains `tests/playwright/chat-voice-send.spec.ts:841:5 › dialogue PTT empty transcript surfaces error instead of silent drop` plus the passing hotword/live-dialogue suite in the same run.
