### PR TITLE
fix: email composition / reply UX (fixes #431)

### DIFF
--- a/internal/web/static/app-mail-drafts.js
+++ b/internal/web/static/app-mail-drafts.js
@@ -323,6 +323,31 @@ async function populateRecipientSuggestions(root) {
   } catch (_) {}
 }
 
+function buildMailDraftField(field) {
+  const row = document.createElement('label');
+  row.className = 'mail-draft-field-line';
+
+  const key = document.createElement('span');
+  key.className = 'mail-draft-key';
+  key.textContent = field.label;
+
+  const value = document.createElement('div');
+  value.className = 'mail-draft-field-value';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.name = field.name;
+  input.value = field.value;
+  input.autocomplete = 'off';
+  if (field.list) input.setAttribute('list', field.list);
+  input.addEventListener('input', scheduleMailDraftSave);
+
+  value.appendChild(input);
+  row.appendChild(key);
+  row.appendChild(value);
+  return row;
+}
+
 export function renderMailDraftArtifact(root, event) {
   const draft = event?.draft && typeof event.draft === 'object' ? event.draft : {};
   if (!(root instanceof HTMLElement)) return;
@@ -344,6 +369,7 @@ export function renderMailDraftArtifact(root, event) {
   const header = document.createElement('header');
   header.className = 'mail-draft-header';
   const headerCopy = document.createElement('div');
+  headerCopy.className = 'mail-draft-header-copy';
   const kicker = document.createElement('div');
   kicker.className = 'mail-draft-kicker';
   kicker.textContent = 'Mail Draft';
@@ -355,29 +381,40 @@ export function renderMailDraftArtifact(root, event) {
   account.textContent = `${String(draft?.account_label || '').trim()}${draft?.provider ? ` · ${String(draft.provider).trim()}` : ''}`.trim();
   headerCopy.appendChild(kicker);
   headerCopy.appendChild(heading);
-  headerCopy.appendChild(account);
+  if (account.textContent) {
+    headerCopy.appendChild(account);
+  }
   const headerActions = document.createElement('div');
   headerActions.className = 'mail-draft-header-actions';
+  const status = document.createElement('p');
+  status.id = MAIL_DRAFT_STATUS_ID;
+  status.className = 'mail-draft-status';
+  status.textContent = String(draft?.status || 'draft').trim() || 'draft';
   const send = document.createElement('button');
   send.type = 'button';
   send.className = 'edge-btn';
   send.id = 'mail-draft-send';
   send.textContent = 'Send';
+  headerActions.appendChild(status);
   headerActions.appendChild(send);
   header.appendChild(headerCopy);
   header.appendChild(headerActions);
   shell.appendChild(header);
 
-  const status = document.createElement('p');
-  status.id = MAIL_DRAFT_STATUS_ID;
-  status.className = 'mail-draft-status';
-  status.textContent = String(draft?.status || 'draft').trim() || 'draft';
-  shell.appendChild(status);
-
   const datalist = document.createElement('datalist');
   datalist.id = MAIL_DRAFT_SUGGESTIONS_ID;
   shell.appendChild(datalist);
 
+  const paper = document.createElement('div');
+  paper.className = 'mail-draft-paper';
+
+  const envelope = document.createElement('section');
+  envelope.className = 'mail-draft-envelope';
+  const envelopeLabel = document.createElement('div');
+  envelopeLabel.className = 'mail-draft-section-label';
+  envelopeLabel.textContent = 'Envelope';
+  const envelopeFields = document.createElement('div');
+  envelopeFields.className = 'mail-draft-envelope-fields';
   const fields = [
     { label: 'To', name: 'to', value: Array.isArray(draft?.to) ? draft.to.join(', ') : '', list: MAIL_DRAFT_SUGGESTIONS_ID },
     { label: 'Cc', name: 'cc', value: Array.isArray(draft?.cc) ? draft.cc.join(', ') : '', list: MAIL_DRAFT_SUGGESTIONS_ID },
@@ -385,36 +422,31 @@ export function renderMailDraftArtifact(root, event) {
     { label: 'Subject', name: 'subject', value: String(draft?.subject || '') },
   ];
   fields.forEach((field) => {
-    const row = document.createElement('label');
-    row.className = 'mail-draft-row';
-    const key = document.createElement('span');
-    key.className = 'mail-draft-key';
-    key.textContent = field.label;
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.name = field.name;
-    input.value = field.value;
-    input.autocomplete = 'off';
-    if (field.list) input.setAttribute('list', field.list);
-    input.addEventListener('input', scheduleMailDraftSave);
-    row.appendChild(key);
-    row.appendChild(input);
-    shell.appendChild(row);
+    envelopeFields.appendChild(buildMailDraftField(field));
   });
+  envelope.appendChild(envelopeLabel);
+  envelope.appendChild(envelopeFields);
+  paper.appendChild(envelope);
 
+  const letter = document.createElement('section');
+  letter.className = 'mail-draft-letter';
+  const letterLabel = document.createElement('div');
+  letterLabel.className = 'mail-draft-section-label';
+  letterLabel.textContent = 'Message';
   const bodyRow = document.createElement('label');
   bodyRow.className = 'mail-draft-body-row';
-  const bodyLabel = document.createElement('span');
-  bodyLabel.className = 'mail-draft-key';
-  bodyLabel.textContent = 'Body';
   const body = document.createElement('textarea');
   body.name = 'body';
   body.className = 'mail-draft-body';
   body.value = String(draft?.body || '');
+  body.placeholder = 'Write the message here.';
   body.addEventListener('input', scheduleMailDraftSave);
-  bodyRow.appendChild(bodyLabel);
   bodyRow.appendChild(body);
-  shell.appendChild(bodyRow);
+  letter.appendChild(letterLabel);
+  letter.appendChild(bodyRow);
+  paper.appendChild(letter);
+
+  shell.appendChild(paper);
 
   root.appendChild(shell);
   const sendButton = root.querySelector('#mail-draft-send');

--- a/internal/web/static/mail-drafts.css
+++ b/internal/web/static/mail-drafts.css
@@ -1,5 +1,8 @@
 #canvas-text.mail-draft-canvas {
-  padding: 1rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.04), transparent 12rem),
+    var(--bg);
 }
 
 .canvas-mail-actions {
@@ -13,14 +16,16 @@
 }
 
 .canvas-mail-actions-label {
-  color: var(--fg-muted);
+  color: var(--text-dim);
   font-size: 0.82rem;
   margin-right: 0.2rem;
 }
 
 .mail-draft-editor {
   display: grid;
-  gap: 0.85rem;
+  gap: 1rem;
+  max-width: min(100%, 860px);
+  margin: 0 auto;
 }
 
 .mail-draft-header {
@@ -28,40 +33,148 @@
   justify-content: space-between;
   gap: 1rem;
   align-items: start;
+  padding: 1.15rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(0, 0, 0, 0.03)),
+    var(--bg-surface);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.06);
+}
+
+.mail-draft-header-copy {
+  min-width: 0;
 }
 
 .mail-draft-header h1 {
-  margin: 0.2rem 0 0;
+  margin: 0.3rem 0 0;
+  font-size: clamp(1.3rem, 2vw, 1.55rem);
+  line-height: 1.2;
+}
+
+.mail-draft-header-actions {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: end;
+  min-width: max-content;
 }
 
 .mail-draft-kicker,
-.mail-draft-account,
-.mail-draft-status,
-.mail-draft-key {
-  color: var(--fg-muted);
+.mail-draft-account {
+  color: var(--text-dim);
   font-size: 0.9rem;
 }
 
-.mail-draft-row,
-.mail-draft-body-row {
+.mail-draft-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+}
+
+.mail-draft-status {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.mail-draft-paper {
   display: grid;
-  gap: 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  overflow: hidden;
+  background: var(--bg-surface);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.07);
+}
+
+.mail-draft-envelope,
+.mail-draft-letter {
+  padding: 1rem 1.2rem 1.2rem;
+}
+
+.mail-draft-envelope {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.14);
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.035), rgba(255, 255, 255, 0)),
+    var(--bg-surface);
+}
+
+.mail-draft-section-label {
+  color: var(--text-dim);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  margin-bottom: 0.8rem;
+}
+
+.mail-draft-envelope-fields {
+  display: grid;
+}
+
+.mail-draft-field-line {
+  display: grid;
+  grid-template-columns: minmax(4.5rem, 5rem) minmax(0, 1fr);
+  gap: 0.8rem;
+  align-items: center;
+  padding: 0.45rem 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.mail-draft-field-line:first-child {
+  border-top: none;
+}
+
+.mail-draft-field-value {
+  min-width: 0;
 }
 
 .mail-draft-editor input,
 .mail-draft-editor textarea {
   width: 100%;
-  border: 1px solid var(--border-color);
-  background: var(--bg-elevated);
-  color: var(--fg);
-  border-radius: 10px;
-  padding: 0.7rem 0.8rem;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  border-radius: 0;
+  padding: 0.2rem 0;
   font: inherit;
 }
 
+.mail-draft-field-line:focus-within,
+.mail-draft-body-row:focus-within {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.mail-draft-key {
+  color: var(--text-dim);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.mail-draft-letter {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(0, 0, 0, 0.02)),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 2.05rem,
+      rgba(0, 0, 0, 0.05) 2.05rem,
+      rgba(0, 0, 0, 0.05) 2.11rem
+    );
+}
+
+.mail-draft-body-row {
+  display: grid;
+  min-height: 22rem;
+  padding: 0.2rem 0 0.4rem;
+}
+
 .mail-draft-body {
-  min-height: 18rem;
+  min-height: 20rem;
   resize: vertical;
+  line-height: 1.7;
 }
 
 .thread-subject h1 {
@@ -158,4 +271,29 @@
   border-top: 2px solid var(--border);
   margin-top: 1rem;
   padding-top: 1rem;
+}
+
+@media (max-width: 760px) {
+  .mail-draft-header {
+    flex-direction: column;
+  }
+
+  .mail-draft-header-actions {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .mail-draft-field-line {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+
+  .mail-draft-envelope,
+  .mail-draft-letter {
+    padding-inline: 0.95rem;
+  }
+
+  .mail-draft-body-row {
+    min-height: 18rem;
+  }
 }

--- a/tests/playwright/mail-drafts.spec.ts
+++ b/tests/playwright/mail-drafts.spec.ts
@@ -80,6 +80,18 @@ test.describe('mail drafts', () => {
 
     await expect(page.locator('#canvas-text')).toHaveClass(/mail-draft-canvas/);
     await expect(page.locator('.mail-draft-title')).toContainText('Draft email');
+    await expect(page.locator('.mail-draft-envelope .mail-draft-section-label')).toHaveText('Envelope');
+    await expect(page.locator('.mail-draft-letter .mail-draft-section-label')).toHaveText('Message');
+    await expect(page.locator('.mail-draft-envelope .mail-draft-field-line')).toHaveCount(4);
+    const composerLayout = await page.locator('.mail-draft-envelope .mail-draft-field-line').first().evaluate((node) => {
+      const style = window.getComputedStyle(node as HTMLElement);
+      return {
+        display: style.display,
+        columns: style.gridTemplateColumns,
+      };
+    });
+    expect(composerLayout.display).toBe('grid');
+    expect(composerLayout.columns).not.toBe('none');
     await expect.poll(async () => page.locator('#mail-draft-recipient-suggestions option').count()).toBe(2);
     await expect(page.locator('#mail-draft-recipient-suggestions option').nth(0)).toHaveAttribute('value', 'ada@example.com');
     await expect(page.locator('#mail-draft-recipient-suggestions option').nth(1)).toHaveAttribute('value', 'bob@example.com');


### PR DESCRIPTION
## Summary
- refresh the mail draft canvas into a paper-like composer with a distinct envelope header and message body
- keep send/status controls in the draft header while preserving existing create, reply, reply-all, and forward flows
- add a focused Playwright assertion for the new composer structure without expanding the test surface beyond the mail draft spec

## Verification
- Requirement: proper spacing and a clear visual split between addressing fields and the message body.
  Evidence: `tests/playwright/mail-drafts.spec.ts` now asserts separate `Envelope` and `Message` sections plus a grid layout for the address rows before exercising save/reopen/send.
- Requirement: composition and reply flows still work after the UX refresh.
  Evidence: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts 2>&1 | tee /tmp/tabura-issue-431-playwright.log`
  Output excerpt: `13 passed (12.4s)`
