### PR TITLE
fix: Make more battery friendly (fixes #456)

### DIFF
--- a/internal/web/static/app-projects.js
+++ b/internal/web/static/app-projects.js
@@ -833,7 +833,22 @@ export async function refreshProjectRunStates() {
 
 export function startAssistantActivityWatcher() {
   if (state.assistantActivityTimer !== null) return;
-  const tick = () => {
+  const clearAssistantActivityTimer = () => {
+    if (state.assistantActivityTimer !== null) {
+      window.clearTimeout(state.assistantActivityTimer);
+      state.assistantActivityTimer = null;
+    }
+  };
+  const scheduleAssistantActivityTick = (delayMs = ASSISTANT_ACTIVITY_POLL_MS) => {
+    clearAssistantActivityTimer();
+    if (document.hidden) return;
+    const delay = Number.isFinite(delayMs) ? Math.max(0, Math.floor(delayMs)) : ASSISTANT_ACTIVITY_POLL_MS;
+    state.assistantActivityTimer = window.setTimeout(() => {
+      state.assistantActivityTimer = null;
+      void tick();
+    }, delay);
+  };
+  const tick = async () => {
     if (document.hidden) return;
     if (hasLocalStopCapableWork() && state.chatWs && state.chatWsLastMessageAt > 0) {
       const elapsed = Date.now() - state.chatWsLastMessageAt;
@@ -841,16 +856,20 @@ export function startAssistantActivityWatcher() {
         state.chatWsLastMessageAt = 0;
         closeChatWs();
         openChatWs();
+        scheduleAssistantActivityTick(ASSISTANT_ACTIVITY_POLL_MS);
         return;
       }
     }
-    void refreshAssistantActivity();
-    void refreshProjectRunStates();
+    try {
+      await refreshAssistantActivity();
+      await refreshProjectRunStates();
+    } finally {
+      scheduleAssistantActivityTick(ASSISTANT_ACTIVITY_POLL_MS);
+    }
   };
-  state.assistantActivityTimer = window.setInterval(tick, ASSISTANT_ACTIVITY_POLL_MS);
-  tick();
+  scheduleAssistantActivityTick(0);
   window.addEventListener('focus', () => {
-    tick();
+    scheduleAssistantActivityTick(0);
     if (document.hidden || state.chatVoiceCapture) return;
     requestMicRefresh();
     releaseMicStream({ force: true });
@@ -858,6 +877,7 @@ export function startAssistantActivityWatcher() {
   });
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
+      clearAssistantActivityTimer();
       requestMicRefresh();
       stopHotwordMonitor();
       state.hotwordActive = false;
@@ -873,16 +893,18 @@ export function startAssistantActivityWatcher() {
       }
       return;
     }
-    tick();
+    scheduleAssistantActivityTick(0);
     requestHotwordSync();
   });
   window.addEventListener('pageshow', () => {
+    scheduleAssistantActivityTick(0);
     if (state.chatVoiceCapture) return;
     requestMicRefresh();
     releaseMicStream({ force: true });
     requestHotwordSync();
   });
   window.addEventListener('pagehide', () => {
+    clearAssistantActivityTimer();
     requestMicRefresh();
     stopHotwordMonitor();
     state.hotwordActive = false;

--- a/internal/web/static/app-runtime-ui.js
+++ b/internal/web/static/app-runtime-ui.js
@@ -605,16 +605,41 @@ export async function pollRuntimeForRuntimeReload() {
   }
 }
 
+function clearRuntimeReloadWatcherTimer() {
+  if (runtimeReloadTimer !== null) {
+    window.clearTimeout(runtimeReloadTimer);
+    runtimeReloadTimer = null;
+  }
+}
+
+function scheduleRuntimeReloadWatcher(delayMs = DEV_UI_RELOAD_POLL_MS) {
+  clearRuntimeReloadWatcherTimer();
+  if (runtimeReloadRequested || document.hidden) return;
+  const delay = Number.isFinite(delayMs) ? Math.max(0, Math.floor(delayMs)) : DEV_UI_RELOAD_POLL_MS;
+  runtimeReloadTimer = window.setTimeout(async () => {
+    runtimeReloadTimer = null;
+    if (document.hidden) return;
+    await pollRuntimeForRuntimeReload();
+    scheduleRuntimeReloadWatcher(DEV_UI_RELOAD_POLL_MS);
+  }, delay);
+}
+
+export function isRuntimeReloadWatcherScheduled() {
+  return runtimeReloadTimer !== null;
+}
+
 export function startRuntimeReloadWatcher() {
   if (runtimeReloadTimer !== null) return;
-  const tick = () => {
-    void pollRuntimeForRuntimeReload();
-  };
-  runtimeReloadTimer = window.setInterval(tick, DEV_UI_RELOAD_POLL_MS);
-  tick();
-  window.addEventListener('focus', tick);
+  scheduleRuntimeReloadWatcher(0);
+  window.addEventListener('focus', () => {
+    scheduleRuntimeReloadWatcher(0);
+  });
   document.addEventListener('visibilitychange', () => {
-    if (!document.hidden) tick();
+    if (document.hidden) {
+      clearRuntimeReloadWatcherTimer();
+      return;
+    }
+    scheduleRuntimeReloadWatcher(0);
   });
 }
 

--- a/tests/playwright/battery-friendly.spec.ts
+++ b/tests/playwright/battery-friendly.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type HarnessLogEntry = { type: string; action?: string; [key: string]: unknown };
+
+async function getLog(page: Page): Promise<HarnessLogEntry[]> {
+  return page.evaluate(() => (window as any).__harnessLog.slice());
+}
+
+async function clearLog(page: Page) {
+  await page.evaluate(() => { (window as any).__harnessLog.splice(0); });
+}
+
+async function waitWsReady(page: Page) {
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    return s.chatWs && s.chatWs.readyState === (window as any).WebSocket.OPEN;
+  }, null, { timeout: 5_000 });
+}
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await waitWsReady(page);
+  await page.waitForTimeout(250);
+}
+
+async function setDocumentHidden(page: Page, hidden: boolean) {
+  await page.evaluate((nextHidden) => {
+    const value = Boolean(nextHidden);
+    const visibility = value ? 'hidden' : 'visible';
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => value,
+    });
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibility,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }, hidden);
+}
+
+async function isRuntimeWatcherScheduled(page: Page): Promise<boolean> {
+  return page.evaluate(async () => {
+    const mod = await import('../../internal/web/static/app-runtime-ui.js');
+    return mod.isRuntimeReloadWatcherScheduled();
+  });
+}
+
+async function isAssistantWatcherScheduled(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const app = (window as any)._taburaApp;
+    return Boolean(app?.getState?.().assistantActivityTimer);
+  });
+}
+
+test('background tabs stop polling until visible again', async ({ page }) => {
+  await waitReady(page);
+
+  await expect.poll(() => isRuntimeWatcherScheduled(page)).toBe(true);
+  await expect.poll(() => isAssistantWatcherScheduled(page)).toBe(true);
+
+  await clearLog(page);
+  await setDocumentHidden(page, true);
+
+  await expect.poll(() => isRuntimeWatcherScheduled(page)).toBe(false);
+  await expect.poll(() => isAssistantWatcherScheduled(page)).toBe(false);
+
+  await page.waitForTimeout(1_800);
+  const hiddenLog = await getLog(page);
+  expect(hiddenLog.filter((entry) => entry.type === 'api_fetch' && entry.action === 'runtime_meta')).toHaveLength(0);
+  expect(hiddenLog.filter((entry) => entry.type === 'api_fetch' && entry.action === 'projects_activity')).toHaveLength(0);
+
+  await clearLog(page);
+  await setDocumentHidden(page, false);
+
+  await expect.poll(() => isRuntimeWatcherScheduled(page)).toBe(true);
+  await expect.poll(() => isAssistantWatcherScheduled(page)).toBe(true);
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return {
+      runtime: log.some((entry) => entry.type === 'api_fetch' && entry.action === 'runtime_meta'),
+      activity: log.some((entry) => entry.type === 'api_fetch' && entry.action === 'projects_activity'),
+    };
+  }).toEqual({ runtime: true, activity: true });
+});

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1515,6 +1515,12 @@
         }), { status: 200 });
       }
       if (u.includes('/api/projects/activity')) {
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'projects_activity',
+          method: opts?.method || 'GET',
+          url: u,
+        });
         const projects = harnessProjects.map((project) => ({
           project_id: project.id,
           project_key: project.project_key,
@@ -2386,6 +2392,12 @@
         return new Response(JSON.stringify({ active: 0, queued: 0 }), { status: 200 });
       }
       if (u.includes('/api/runtime')) {
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'runtime_meta',
+          method: opts?.method || 'GET',
+          url: u,
+        });
         return new Response(JSON.stringify({ ...runtimeState }), { status: 200 });
       }
       if (u.includes('/api/canvas/')) {


### PR DESCRIPTION
## Summary
Stop background polling churn in hidden tabs.

- replace the runtime reload interval with a visibility-aware timeout scheduler
- replace assistant activity polling with a visibility-aware timeout scheduler
- add a Playwright regression that proves hidden tabs stop polling and visible tabs resume immediately

## Verification
- Requirement: frontend browser work should stop wasting battery in the background.
  Evidence: `tests/playwright/battery-friendly.spec.ts` hides the harness tab, asserts both watchers unschedule, and asserts zero `/api/runtime` and `/api/projects/activity` fetches for 1.8s.
- Requirement: no compromise on UX.
  Evidence: the same spec restores visibility, asserts both watchers reschedule immediately, and observes both fetches resume.
- Command: `npx playwright test tests/playwright/battery-friendly.spec.ts 2>&1 | tee /tmp/tabura-issue-456-test.log`
  Output excerpt:
  `✓  1 [chromium] › tests/playwright/battery-friendly.spec.ts:58:5 › background tabs stop polling until visible again (2.2s)`
  `1 passed (3.2s)`