### PR TITLE
fix: Wire approval policy to canvas/artifact flow, collapse plan/yolo (fixes #448)

### DIFF
--- a/docs/approval-execution-policy.md
+++ b/docs/approval-execution-policy.md
@@ -10,6 +10,8 @@ Tabura has one execution-policy model. `plan`, `review`, and `yolo` are not sepa
 | `plan` / `review` | Allowed, but multi-step work should be proposed before execution | Allowed in the normal artifact flow | `approvalPolicy=unlessTrusted`; destructive shell commands still require explicit next-message `confirm` | `approvalPolicy=unlessTrusted` |
 | `yolo` / `autonomous` | Allowed | Allowed in the normal artifact flow | `approvalPolicy=never`; destructive-shell confirmation is bypassed | `approvalPolicy=never` |
 
+The runtime toggle is labeled `Auto` in the top edge controls. That label means `autonomous` execution policy, not a separate interaction mode.
+
 ## Canonical Approval Flow
 
 - Approval requests render as temporary canvas artifacts in the same canvas/artifact flow as other assistant output.
@@ -19,6 +21,7 @@ Tabura has one execution-policy model. `plan`, `review`, and `yolo` are not sepa
 ## Source of Truth
 
 - Session approval mapping: `internal/web/chat_approval.go`
+- Session execution policy mapping: `internal/web/execution_policy.go`
 - Approval policy normalization: `internal/appserver/approval.go`
 - Destructive-command confirmation guard: `internal/web/action_policy.go`
 - Canvas rendering path for approval requests: `internal/web/static/app-chat-transport.js` and `internal/web/static/canvas.js`

--- a/internal/appserver/approval.go
+++ b/internal/appserver/approval.go
@@ -49,6 +49,10 @@ func normalizeApprovalPolicy(raw string) string {
 	}
 }
 
+func NormalizeApprovalPolicy(raw string) string {
+	return normalizeApprovalPolicy(raw)
+}
+
 func parseApprovalRequest(msg map[string]interface{}) (*ApprovalRequest, bool) {
 	method := strings.TrimSpace(stringifyItemValue(msg["method"]))
 	switch method {

--- a/internal/web/chat_approval.go
+++ b/internal/web/chat_approval.go
@@ -18,14 +18,8 @@ type pendingAppServerApproval struct {
 }
 
 func approvalPolicyForSession(mode string, yoloMode bool) string {
-	if yoloMode {
-		return appserver.ApprovalPolicyNever
-	}
-	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "plan", "review":
-		return appserver.ApprovalPolicyUnlessTrusted
-	}
-	return appserver.ApprovalPolicyOnRequest
+	policy := executionPolicyForSession(mode, yoloMode)
+	return appserver.NormalizeApprovalPolicy(policy.ApprovalPolicy)
 }
 
 func mergeApprovalPolicyThreadParams(threadParams map[string]interface{}, mode string, yoloMode bool) map[string]interface{} {

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -190,11 +190,34 @@ func TestBuildPromptFromHistory_IncludesSystemPrompt(t *testing.T) {
 
 func TestBuildPromptFromHistory_PlanMode(t *testing.T) {
 	prompt := buildPromptFromHistory("plan", nil, nil)
-	if !strings.Contains(prompt, "plan mode") {
-		t.Error("prompt should mention plan mode")
+	if !strings.Contains(prompt, "Execution policy is reviewed.") {
+		t.Error("prompt should mention reviewed execution policy")
 	}
 	if !strings.Contains(prompt, "wait for approval") {
-		t.Error("prompt should require approval in plan mode")
+		t.Error("prompt should require approval in reviewed policy")
+	}
+}
+
+func TestBuildPromptFromHistory_ReviewModeUsesReviewedPolicy(t *testing.T) {
+	prompt := buildPromptFromHistory("review", nil, nil)
+	if !strings.Contains(prompt, "Execution policy is reviewed.") {
+		t.Error("review prompt should mention reviewed execution policy")
+	}
+	if !strings.Contains(prompt, "wait for approval") {
+		t.Error("review prompt should require approval")
+	}
+}
+
+func TestBuildPromptFromHistoryForSession_AutonomousPolicy(t *testing.T) {
+	prompt := buildPromptFromHistoryForSessionWithPolicy("chat", true, "session-42", []store.ChatMessage{{
+		Role:         "user",
+		ContentPlain: "apply the fix",
+	}}, nil, turnOutputModeVoice, "")
+	if !strings.Contains(prompt, "Execution policy is autonomous.") {
+		t.Fatal("autonomous prompt should mention autonomous execution policy")
+	}
+	if strings.Contains(prompt, "wait for approval") {
+		t.Fatal("autonomous prompt should not wait for approval")
 	}
 }
 

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -153,7 +153,6 @@ func TestParseSystemAction(t *testing.T) {
 		{name: "switch model", raw: `{"action":"switch_model","alias":"gpt","effort":"high"}`, wantAction: "switch_model"},
 		{name: "toggle silent", raw: `{"action":"toggle_silent"}`, wantAction: "toggle_silent"},
 		{name: "toggle live dialogue", raw: `{"action":"toggle_live_dialogue"}`, wantAction: "toggle_live_dialogue"},
-		{name: "toggle conversation alias", raw: `{"action":"toggle_conversation"}`, wantAction: "toggle_live_dialogue"},
 		{name: "cancel work", raw: `{"action":"cancel_work"}`, wantAction: "cancel_work"},
 		{name: "show status", raw: `{"action":"show_status"}`, wantAction: "show_status"},
 		{name: "shell", raw: `{"action":"shell","command":"ls -1"}`, wantAction: "shell"},

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -240,8 +240,6 @@ func systemActionStringParam(params map[string]interface{}, key string) string {
 
 func normalizeSystemActionName(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "toggle_conversation":
-		return "toggle_live_dialogue"
 	case "switch_project", "switch_workspace", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "workspace_watch_start", "workspace_watch_stop", "workspace_watch_status", "batch_work", "batch_configure", "review_policy", "batch_limit", "batch_status", "assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "link_workspace_artifact", "list_linked_artifacts", "switch_model", "toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "shell", "open_file_canvas", "show_calendar", "show_briefing", "make_item", "delegate_item", "snooze_item", "split_items", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "create_github_issue", "create_github_issue_split", "print_item", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "sync_project", "sync_sources", "map_todoist_project", "sync_todoist", "create_todoist_task", "sync_evernote", "sync_bear", "promote_bear_checklist", "sync_zotero", "cursor_open_item", "cursor_triage_item", "cursor_open_path", "triage_item_by_title":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:

--- a/internal/web/chat_prompt.go
+++ b/internal/web/chat_prompt.go
@@ -114,10 +114,18 @@ func buildPromptFromHistoryForModeWithCompanion(mode string, messages []store.Ch
 }
 
 func buildPromptFromHistoryForSession(mode, sessionID string, messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
-	return buildPromptFromHistoryForSessionWithCompanion(mode, sessionID, messages, canvas, nil, outputMode, modelAlias)
+	return buildPromptFromHistoryForSessionWithPolicy(mode, false, sessionID, messages, canvas, outputMode, modelAlias)
 }
 
 func buildPromptFromHistoryForSessionWithCompanion(mode, sessionID string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
+	return buildPromptFromHistoryForSessionWithCompanionPolicy(mode, false, sessionID, messages, canvas, companion, outputMode, modelAlias)
+}
+
+func buildPromptFromHistoryForSessionWithPolicy(mode string, autonomous bool, sessionID string, messages []store.ChatMessage, canvas *canvasContext, outputMode string, modelAlias string) string {
+	return buildPromptFromHistoryForSessionWithCompanionPolicy(mode, autonomous, sessionID, messages, canvas, nil, outputMode, modelAlias)
+}
+
+func buildPromptFromHistoryForSessionWithCompanionPolicy(mode string, autonomous bool, sessionID string, messages []store.ChatMessage, canvas *canvasContext, companion *companionPromptContext, outputMode string, modelAlias string) string {
 	isVoiceMode := isVoiceOutputMode(outputMode)
 	const maxHistory = 80
 	if len(messages) > maxHistory {
@@ -138,16 +146,11 @@ func buildPromptFromHistoryForSessionWithCompanion(mode, sessionID string, messa
 	}
 
 	_ = modelAlias
+	appendExecutionPolicyPrompt(&b, mode, autonomous)
 
 	if isVoiceMode && canvas != nil && canvas.HasArtifact {
 		b.WriteString("## Current Artifact\n")
 		fmt.Fprintf(&b, "- Active artifact tab: %q (kind: %s)\n\n", canvas.ArtifactTitle, canvas.ArtifactKind)
-	}
-
-	if strings.EqualFold(strings.TrimSpace(mode), "plan") {
-		b.WriteString("You are in plan mode. Propose actions step by step and wait for approval before executing risky or tool-driven work.\n")
-		b.WriteString("Explain what you intend to do and why, then continue once the approval decision is available.\n")
-		b.WriteString("For research tasks, propose each retrieval step clearly and present findings as artifacts or concise chat updates.\n\n")
 	}
 	appendResearchArtifactPrompt(&b, outputMode, userText, researchArtifactRoot(sessionID))
 
@@ -174,6 +177,21 @@ func buildPromptFromHistoryForSessionWithCompanion(mode, sessionID string, messa
 		b.WriteString("Reply as ASSISTANT.")
 	}
 	return b.String()
+}
+
+func appendExecutionPolicyPrompt(b *strings.Builder, mode string, autonomous bool) {
+	if b == nil {
+		return
+	}
+	switch executionPolicyForSession(mode, autonomous).Name {
+	case executionPolicyReviewed:
+		b.WriteString("Execution policy is reviewed. Propose actions step by step and wait for approval before executing risky or tool-driven work.\n")
+		b.WriteString("Explain what you intend to do and why, then continue once the approval decision is available.\n")
+		b.WriteString("For research tasks, propose each retrieval step clearly and present findings as artifacts or concise chat updates.\n\n")
+	case executionPolicyAutonomous:
+		b.WriteString("Execution policy is autonomous. Do not stall for approval unless the platform explicitly blocks the action.\n")
+		b.WriteString("Keep using the normal canvas/artifact flow for proposed changes, findings, and status updates.\n\n")
+	}
 }
 
 // buildTurnPrompt constructs a prompt for a resumed thread: only the latest

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -64,7 +64,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	if resumed {
 		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
 	} else {
-		prompt = buildPromptFromHistoryForSessionWithCompanion(session.Mode, sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
+		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
 		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
 	}
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
@@ -334,7 +334,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, positionCtx []*chatCanvasPositionEvent, outputMode string, profile appServerModelProfile) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
-	prompt := buildPromptFromHistoryForSession(session.Mode, sessionID, messages, canvasCtx, outputMode, profile.Alias)
+	prompt := buildPromptFromHistoryForSessionWithPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, outputMode, profile.Alias)
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
 	if strings.TrimSpace(prompt) == "" {

--- a/internal/web/execution_policy.go
+++ b/internal/web/execution_policy.go
@@ -1,0 +1,35 @@
+package web
+
+import "strings"
+
+const (
+	executionPolicyDefault    = "default"
+	executionPolicyReviewed   = "reviewed"
+	executionPolicyAutonomous = "autonomous"
+)
+
+type executionPolicy struct {
+	Name           string
+	ApprovalPolicy string
+}
+
+func executionPolicyForSession(mode string, autonomous bool) executionPolicy {
+	if autonomous {
+		return executionPolicy{
+			Name:           executionPolicyAutonomous,
+			ApprovalPolicy: "never",
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "plan", "review":
+		return executionPolicy{
+			Name:           executionPolicyReviewed,
+			ApprovalPolicy: "unlessTrusted",
+		}
+	default:
+		return executionPolicy{
+			Name:           executionPolicyDefault,
+			ApprovalPolicy: "on-request",
+		}
+	}
+}

--- a/internal/web/runtime_prefs.go
+++ b/internal/web/runtime_prefs.go
@@ -197,8 +197,9 @@ func (a *App) handleRuntimeYoloModeUpdate(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, map[string]interface{}{
-		"ok":      true,
-		"enabled": req.Enabled,
+		"ok":               true,
+		"enabled":          req.Enabled,
+		"execution_policy": executionPolicyForSession("chat", req.Enabled).Name,
 	})
 }
 

--- a/internal/web/runtime_prefs_test.go
+++ b/internal/web/runtime_prefs_test.go
@@ -30,6 +30,9 @@ func TestRuntimeIncludesSafetyPreferences(t *testing.T) {
 	if got := boolFromAny(payload["safety_yolo_mode"]); got {
 		t.Fatalf("safety_yolo_mode = %v, want false", got)
 	}
+	if got := strFromAny(payload["execution_policy"]); got != executionPolicyDefault {
+		t.Fatalf("execution_policy = %q, want %q", got, executionPolicyDefault)
+	}
 	if got := boolFromAny(payload["disclaimer_ack_required"]); !got {
 		t.Fatalf("disclaimer_ack_required = %v, want true", got)
 	}
@@ -56,6 +59,13 @@ func TestRuntimeYoloModeUpdatePersists(t *testing.T) {
 	if setRR.Code != http.StatusOK {
 		t.Fatalf("set yolo status=%d body=%s", setRR.Code, setRR.Body.String())
 	}
+	var setPayload map[string]any
+	if err := json.Unmarshal(setRR.Body.Bytes(), &setPayload); err != nil {
+		t.Fatalf("decode yolo response: %v", err)
+	}
+	if got := strFromAny(setPayload["execution_policy"]); got != executionPolicyAutonomous {
+		t.Fatalf("execution_policy = %q, want %q", got, executionPolicyAutonomous)
+	}
 	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("runtime status=%d body=%s", rr.Code, rr.Body.String())
@@ -66,6 +76,9 @@ func TestRuntimeYoloModeUpdatePersists(t *testing.T) {
 	}
 	if got := boolFromAny(payload["safety_yolo_mode"]); !got {
 		t.Fatalf("safety_yolo_mode = %v, want true", got)
+	}
+	if got := strFromAny(payload["execution_policy"]); got != executionPolicyAutonomous {
+		t.Fatalf("execution_policy = %q, want %q", got, executionPolicyAutonomous)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -527,6 +527,7 @@ func (a *App) handleRuntime(w http.ResponseWriter, r *http.Request) {
 		"startup_behavior":            a.runtimeStartupBehavior(),
 		"active_sphere":               a.runtimeActiveSphere(),
 		"safety_yolo_mode":            a.yoloModeEnabled(),
+		"execution_policy":            executionPolicyForSession("chat", a.yoloModeEnabled()).Name,
 		"disclaimer_version":          disclaimerVersionCurrent,
 		"disclaimer_ack_required":     a.disclaimerAckRequired(),
 		"disclaimer_ack_version":      a.disclaimerAckVersion(),

--- a/internal/web/static/app-chat-transport.js
+++ b/internal/web/static/app-chat-transport.js
@@ -379,7 +379,19 @@ export function handleChatEvent(payload) {
   }
 
   if (type === 'mode_changed') {
-    setChatMode(payload.mode || 'chat');
+    const nextMode = String(payload.mode || 'chat').trim().toLowerCase();
+    setChatMode(nextMode);
+    const activeProjectID = String(state.activeProjectId || '').trim();
+    if (activeProjectID) {
+      const existing = state.projects.find((item) => item.id === activeProjectID);
+      if (existing) {
+        upsertProject({
+          ...existing,
+          chat_mode: nextMode,
+        });
+      }
+    }
+    renderEdgeTopModelButtons();
     const message = String(payload.message || '').trim();
     if (message) appendPlainMessage('system', message);
     return;
@@ -476,7 +488,7 @@ export function handleChatEvent(payload) {
       openPrintView(String(action?.url || '').trim());
     } else if (actionType === 'batch_status') {
       applyBatchStatus(action);
-    } else if (actionType === 'toggle_live_dialogue' || actionType === 'toggle_conversation') {
+    } else if (actionType === 'toggle_live_dialogue') {
       const next = state.liveSessionActive ? '' : LIVE_SESSION_MODE_DIALOGUE;
       const action = next
         ? activateLiveSession(next)

--- a/internal/web/static/app-projects.js
+++ b/internal/web/static/app-projects.js
@@ -84,6 +84,13 @@ function visibleProjectsForSphere(sphere = state.activeSphere) {
   return state.projects.filter((project) => projectMatchesSphere(project, sphere));
 }
 
+function currentExecutionPolicy(project = activeProject()) {
+  if (state.yoloMode) return 'autonomous';
+  const mode = String(project?.chat_mode || 'chat').trim().toLowerCase();
+  if (mode === 'plan' || mode === 'review') return 'reviewed';
+  return 'default';
+}
+
 async function ensureVisibleActiveProject() {
   const current = activeProject();
   if (!current || projectMatchesSphere(current, state.activeSphere)) {
@@ -486,7 +493,9 @@ export function renderEdgeTopModelButtons() {
   const yoloButton = document.createElement('button');
   yoloButton.type = 'button';
   yoloButton.className = 'edge-project-btn edge-model-btn edge-yolo-btn';
-  yoloButton.textContent = 'yolo';
+  yoloButton.textContent = 'Auto';
+  yoloButton.title = `Execution policy: ${currentExecutionPolicy(project)}`;
+  yoloButton.setAttribute('aria-label', 'Autonomous execution policy');
   yoloButton.setAttribute('aria-pressed', state.yoloMode ? 'true' : 'false');
   if (state.yoloMode) {
     yoloButton.classList.add('is-active');

--- a/internal/web/static/app-tts.js
+++ b/internal/web/static/app-tts.js
@@ -341,10 +341,10 @@ export function toggleYoloMode() {
   const next = !Boolean(state.yoloMode);
   setYoloMode(next)
     .then(() => {
-      showStatus(next ? 'yolo mode on' : 'yolo mode off');
+      showStatus(next ? 'autonomous policy on' : 'autonomous policy off');
     })
     .catch((err) => {
-      showStatus(`yolo update failed: ${String(err?.message || err || 'unknown error')}`);
+      showStatus(`autonomous policy update failed: ${String(err?.message || err || 'unknown error')}`);
       renderEdgeTopModelButtons();
     });
 }

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -960,6 +960,18 @@ test.describe('mode_changed event', () => {
     const text = await chatHistory.textContent();
     expect(text).toContain('Entering plan mode.');
   });
+
+  test('execution policy control stays explicit when mode changes', async ({ page }) => {
+    const autoButton = page.locator('#edge-top-models .edge-yolo-btn');
+    await expect(autoButton).toHaveText('Auto');
+    await expect(autoButton).toHaveAttribute('title', /Execution policy: default/);
+
+    await injectChatEvent(page, { type: 'mode_changed', mode: 'review' });
+    await page.waitForTimeout(100);
+
+    await expect(autoButton).toHaveAttribute('title', /Execution policy: reviewed/);
+    await expect(page.locator('#edge-top-models')).not.toContainText('yolo');
+  });
 });
 
 test.describe('approval_request event', () => {


### PR DESCRIPTION
## Summary
- centralize session execution-policy mapping and use it for approval policy, runtime metadata, and prompt guidance
- relabel the top-edge toggle to `Auto`, remove the legacy `toggle_conversation` alias, and keep approval requests in the normal canvas/artifact flow
- document the checked-in policy table and source-of-truth links in `docs/approval-execution-policy.md`

## Verification
- Policy table defined and checked into docs: `docs/approval-execution-policy.md` now contains the policy table, the `Auto` label note, and source-of-truth links.
- Approval requests render in the canonical canvas/artifact flow: `npx playwright test tests/playwright/ui-system.spec.ts --grep "execution policy control stays explicit when mode changes|renders approval card and sends approval response"`; excerpt: `approval_request event › renders approval card and sends approval response` and `2 passed (2.0s)`. The test asserts `#canvas-text` becomes active and `#canvas-text .canvas-approval-actions` is visible.
- No fuzzy mode leakage between plan/yolo/approval concepts: `go test ./internal/web ./internal/appserver`; excerpt: `ok   github.com/krystophny/tabura/internal/web` and `ok   github.com/krystophny/tabura/internal/appserver`. Coverage includes `TestBuildPromptFromHistory_ReviewModeUsesReviewedPolicy`, `TestBuildPromptFromHistoryForSession_AutonomousPolicy`, and `TestRuntimeYoloModeUpdatePersists`.
- Execution policy stays explicit in the primary UI: `npx playwright test tests/playwright/ui-system.spec.ts --grep "execution policy control stays explicit when mode changes|renders approval card and sends approval response"`; excerpt: `mode_changed event › execution policy control stays explicit when mode changes`. The test verifies the control label is `Auto`, the title changes from `Execution policy: default` to `Execution policy: reviewed`, and visible `yolo` copy is removed.
