### PR TITLE
fix: Audit auxiliary surfaces: keep only justified exceptions to main (fixes #450)

### DIFF
--- a/docs/auxiliary-surfaces.md
+++ b/docs/auxiliary-surfaces.md
@@ -1,0 +1,24 @@
+# Auxiliary Surfaces
+
+The main Tabura environment is `/`. Auxiliary surfaces are allowed only when they are narrower than the main workspace, materially faster for one job, and write back into the same Workspace / Artifact / Item / Actor model.
+
+## Allowed exceptions
+
+### `/capture`
+
+- Purpose: fast mobile or transient capture when opening the full workspace would add friction.
+- Boundary: it is capture-only. It does not expose chat state, project switching, or a second workflow shell.
+- Canonical write-back: it creates an `idea_note` artifact through `POST /api/artifacts` and then creates an inbox item through `POST /api/items`.
+- Canonical semantics: capture is still "make an artifact, create an item", not a separate product universe.
+
+### `GET /api/items/{item_id}/print`
+
+- Purpose: render a read-only print packet for an existing item and its linked artifact.
+- Boundary: it does not create or mutate alternate state and does not introduce a separate editor.
+- Canonical read-back: the page is derived from the current item, workspace, actor, and artifact records.
+- Canonical semantics: printing is a presentation of the existing ontology, not a second item system.
+
+## Non-exceptions
+
+- `/canvas` is not a second surface. It redirects into the main workspace shell.
+- No additional standalone page, panel, or sheet should introduce a parallel ontology or custom action grammar.

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -20,10 +20,11 @@ Read in this order:
 2. `gesture-truth-table.md`
 3. `approval-execution-policy.md`
 4. `interfaces.md`
-5. `architecture.md`
-6. `live-runtime-whitepaper.md`
-7. `meeting-notes-privacy.md`
-8. `codex-app-server-pivot.md`
+5. `auxiliary-surfaces.md`
+6. `architecture.md`
+7. `live-runtime-whitepaper.md`
+8. `meeting-notes-privacy.md`
+9. `codex-app-server-pivot.md`
 
 Integrated protocol reference:
 

--- a/internal/web/server_security_test.go
+++ b/internal/web/server_security_test.go
@@ -110,6 +110,8 @@ func TestServeCaptureUsesStandaloneAssets(t *testing.T) {
 		`src="./static/capture.js`,
 		`id="capture-record"`,
 		`id="capture-note"`,
+		`same inbox and artifact flow`,
+		`href="./"`,
 	} {
 		if !strings.Contains(body, fragment) {
 			t.Fatalf("GET /capture body missing %q", fragment)
@@ -192,6 +194,24 @@ func TestPrivacyCapturePageDoesNotPersistVoiceAudio(t *testing.T) {
 	for _, forbidden := range []string{"indexeddb", "queued locally", "saved locally"} {
 		if strings.Contains(source, forbidden) {
 			t.Fatalf("capture.js contains forbidden persisted-audio marker %q", forbidden)
+		}
+	}
+}
+
+func TestCapturePageUsesCanonicalItemAndArtifactAPIs(t *testing.T) {
+	data, err := staticFiles.ReadFile("static/capture.js")
+	if err != nil {
+		t.Fatalf("ReadFile(static/capture.js): %v", err)
+	}
+	source := string(data)
+	for _, required := range []string{"./api/artifacts", "./api/items"} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("capture.js missing canonical API %q", required)
+		}
+	}
+	for _, forbidden := range []string{"./api/chat", "./api/projects", "./api/capture"} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("capture.js contains parallel surface API %q", forbidden)
 		}
 	}
 }

--- a/internal/web/static/capture.css
+++ b/internal/web/static/capture.css
@@ -85,6 +85,14 @@ body::before {
   color: var(--capture-muted);
 }
 
+.capture-boundary {
+  margin: 12px 0 0;
+  max-width: 34ch;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--capture-ink);
+}
+
 .capture-alert {
   margin: 18px 0 0;
   padding: 12px 14px;
@@ -124,6 +132,7 @@ body::before {
 .capture-retry:focus-visible,
 .capture-fallback:focus-visible,
 .capture-reset:focus-visible,
+.capture-return a:focus-visible,
 #capture-note:focus-visible {
   outline: 3px solid rgba(29, 122, 82, 0.24);
   outline-offset: 2px;
@@ -252,6 +261,21 @@ body::before {
 
 .capture-status[data-tone="error"] {
   color: var(--capture-accent-strong);
+}
+
+.capture-return {
+  margin: 18px 0 0;
+  font-size: 0.88rem;
+}
+
+.capture-return a {
+  color: var(--capture-accent-strong);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.capture-return a:hover {
+  text-decoration: underline;
 }
 
 body[data-capture-state="recording"] .capture-record {

--- a/internal/web/static/capture.html
+++ b/internal/web/static/capture.html
@@ -13,7 +13,8 @@
     <section class="capture-card" aria-labelledby="capture-title">
       <p class="capture-kicker">Quick Capture</p>
       <h1 id="capture-title">Catch the thought before it drifts.</h1>
-      <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+      <p class="capture-copy">Capture a note fast, save it as an inbox item with a note artifact, and leave the full workspace out of the way.</p>
+      <p class="capture-boundary">Quick Capture is a narrow exception to the main workspace. It always writes back into the same inbox and artifact flow.</p>
       <p id="capture-alert" class="capture-alert" hidden></p>
 
       <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
@@ -41,6 +42,7 @@
       </div>
 
       <p id="capture-status" class="capture-status" role="status" aria-live="polite"></p>
+      <p class="capture-return"><a href="./">Open full workspace</a></p>
     </section>
   </main>
 

--- a/tests/playwright/capture-harness.html
+++ b/tests/playwright/capture-harness.html
@@ -11,7 +11,8 @@
     <section class="capture-card" aria-labelledby="capture-title">
       <p class="capture-kicker">Quick Capture</p>
       <h1 id="capture-title">Catch the thought before it drifts.</h1>
-      <p class="capture-copy">Capture a note fast, save it into the inbox, and leave the full canvas out of the way.</p>
+      <p class="capture-copy">Capture a note fast, save it as an inbox item with a note artifact, and leave the full workspace out of the way.</p>
+      <p class="capture-boundary">Quick Capture is a narrow exception to the main workspace. It always writes back into the same inbox and artifact flow.</p>
       <p id="capture-alert" class="capture-alert" hidden></p>
 
       <button id="capture-record" class="capture-record" type="button" aria-pressed="false">
@@ -39,6 +40,7 @@
       </div>
 
       <p id="capture-status" class="capture-status" role="status" aria-live="polite"></p>
+      <p class="capture-return"><a href="./">Open full workspace</a></p>
     </section>
   </main>
 

--- a/tests/playwright/capture.spec.ts
+++ b/tests/playwright/capture.spec.ts
@@ -8,6 +8,8 @@ test.describe('capture page', () => {
     await expect(page.locator('#capture-page')).toBeVisible();
     await expect(page.locator('#workspace')).toHaveCount(0);
     await expect(page.locator('#edge-left-tap')).toHaveCount(0);
+    await expect(page.locator('.capture-boundary')).toContainText('same inbox and artifact flow');
+    await expect(page.locator('.capture-return')).toContainText('Open full workspace');
     await expect(page.locator('#capture-save')).toBeDisabled();
 
     await page.locator('#capture-note').fill('Follow up with the review queue tomorrow morning. Capture the blockers too.');


### PR DESCRIPTION
## Summary
- make `/capture` explicitly describe its narrow boundary and point back to the main workspace
- document the only allowed auxiliary surfaces and how they map back into the core ontology
- add tests that lock the capture surface to canonical item/artifact APIs and keep print item-backed

## Verification
- All auxiliary surfaces audited
  - Evidence: [docs/auxiliary-surfaces.md](/home/ert/code/assi/tabula/docs/auxiliary-surfaces.md) documents the surviving exceptions (`/capture`, `GET /api/items/{item_id}/print`) and the non-exception redirect (`/canvas`).
- Surviving surfaces documented with justification
  - Evidence: [docs/auxiliary-surfaces.md](/home/ert/code/assi/tabula/docs/auxiliary-surfaces.md) explains each surviving surface's purpose, boundary, and canonical write-back/read-back semantics.
- No auxiliary surface introduces a parallel ontology
  - Command: `go test ./internal/web -run 'TestServeCaptureUsesStandaloneAssets|TestCapturePageUsesCanonicalItemAndArtifactAPIs|TestPrivacyCapturePageDoesNotPersistVoiceAudio|TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent|TestItemPrintDefaultIncludesAutoPrintAndArtifactMetadataFallback' 2>&1 | tee /tmp/issue450-go.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web  0.046s`
  - Covered checks: [server_security_test.go](/home/ert/code/assi/tabula/internal/web/server_security_test.go#L96) verifies `/capture` stays outside the full shell, [server_security_test.go](/home/ert/code/assi/tabula/internal/web/server_security_test.go#L201) verifies it uses `./api/artifacts` and `./api/items` instead of a parallel surface API, and the print tests in [item_print_test.go](/home/ert/code/assi/tabula/internal/web/item_print_test.go#L21) and [item_print_test.go](/home/ert/code/assi/tabula/internal/web/item_print_test.go#L77) verify the print route is derived from the existing item/workspace/artifact records.
- All write back into the same domain model
  - Command: `./scripts/playwright.sh tests/playwright/capture.spec.ts 2>&1 | tee /tmp/issue450-playwright.log`
  - Output excerpt: `8 passed (2.4s)`
  - Covered checks: [capture.spec.ts](/home/ert/code/assi/tabula/tests/playwright/capture.spec.ts#L4) verifies the capture surface stays outside the canvas shell while [capture.spec.ts](/home/ert/code/assi/tabula/tests/playwright/capture.spec.ts#L38) verifies voice capture produces an artifact-backed inbox item.
- Artifact verification
  - Evidence: [capture.html](/home/ert/code/assi/tabula/internal/web/static/capture.html#L16) now states that Quick Capture writes back into the inbox and artifact flow, and [capture.html](/home/ert/code/assi/tabula/internal/web/static/capture.html#L45) gives a direct return path to the main workspace.
