### PR TITLE
fix: Artifact-kind discipline: prevent mini-UI paradigm sprawl (fixes #451)

### DIFF
--- a/docs/artifact-kind-taxonomy.md
+++ b/docs/artifact-kind-taxonomy.md
@@ -1,0 +1,44 @@
+# Artifact Kind Taxonomy
+
+This is the canonical artifact-kind contract for the shipped runtime.
+
+Rules:
+
+- Every artifact kind renders through the canonical canvas surfaces only: `text_artifact`, `pdf_artifact`, or `image_artifact`.
+- Artifact kinds may change copy, metadata, and available actions, but they may not invent a separate gesture model or a parallel mini-app.
+- Items stay the open-loop tracker. Artifacts stay the thing on canvas. Special kinds only narrow which canonical actions are emphasized.
+
+## Canonical actions
+
+- `open_show`
+- `annotate_capture`
+- `compose`
+- `bundle_review`
+- `dispatch_execute`
+- `track_item`
+- `delegate_actor`
+
+## Current kinds
+
+| Kind | Family | Canvas surface | Canonical emphasis |
+| --- | --- | --- | --- |
+| `document`, `markdown`, `pdf`, `image`, `reference` | reference | text / pdf / image | open, annotate, review, track |
+| `transcript` | transcript | text | open, annotate, review, track |
+| `plan_note`, `idea_note`, `external_note` | planning note / captured note | text | open, annotate, compose, review, track |
+| `annotation` | review bundle | text | open, annotate, review, dispatch, track |
+| `github_issue`, `github_pr` | proposal / review artifact | text | open, annotate, review, dispatch, track, delegate |
+| `external_task` | action card | text | open, compose, dispatch, track, delegate |
+| `email`, `email_thread` | message | text | open, annotate, compose, dispatch, track |
+
+## Boundary
+
+- Mail artifacts may expose mail actions, but they still live on the same text canvas and do not get a separate interaction grammar.
+- Review artifacts may expose review or dispatch controls, but they still route through the same canvas, prompt, and item semantics.
+- Planning notes and transcripts remain text artifacts; they do not get bespoke panes or alternate gesture meanings.
+
+Authority in code:
+
+- `internal/web/static/artifact-taxonomy.js`
+- `internal/web/static/app-item-sidebar-artifacts.js`
+- `internal/web/static/canvas-actions.js`
+- `tests/playwright/artifact-kind-taxonomy.spec.ts`

--- a/internal/web/static/app-item-sidebar-artifacts.js
+++ b/internal/web/static/app-item-sidebar-artifacts.js
@@ -1,5 +1,10 @@
 import * as env from './app-env.js';
 import * as context from './app-context.js';
+import {
+  artifactCanvasEventKind,
+  artifactSupportsMailActions,
+  artifactUsesThreadHTML,
+} from './artifact-taxonomy.js';
 
 const { apiURL } = env;
 const { refs, SIDEBAR_IMAGE_EXTENSIONS } = context;
@@ -261,7 +266,7 @@ export function buildEmailThreadHTML(title, artifactMeta) {
 
 function buildSidebarCanvasMeta(item, artifactKind) {
   const normalizedKind = String(artifactKind || item?.artifact_kind || '').trim().toLowerCase();
-  if (normalizedKind !== 'email' && normalizedKind !== 'email_thread') {
+  if (!artifactSupportsMailActions(normalizedKind)) {
     return undefined;
   }
   return {
@@ -323,7 +328,7 @@ export async function openSidebarArtifactItem(item) {
       text: buildSidebarItemFallbackText(item),
       meta: fallbackMeta,
     };
-    if (fallbackArtifactKind === 'email_thread') {
+    if (artifactUsesThreadHTML(fallbackArtifactKind)) {
       noArtifactEvent.threadMeta = parseSidebarArtifactMeta(item?.artifact_meta_json || '');
     }
     applyCanvasArtifactEvent(noArtifactEvent);
@@ -338,17 +343,18 @@ export async function openSidebarArtifactItem(item) {
   const artifact = payload?.artifact || {};
   const refPath = String(artifact?.ref_path || '').trim();
   const artifactKind = String(artifact?.kind || item?.artifact_kind || '').trim().toLowerCase();
+  const canvasKind = artifactCanvasEventKind(artifactKind, refPath);
   if (refPath && !refPath.startsWith('/')) {
-    if (artifactKind === 'pdf' || artifactKind === 'pdf_artifact' || refPath.toLowerCase().endsWith('.pdf')) {
+    if (canvasKind === 'pdf_artifact') {
       applyCanvasArtifactEvent({
-        kind: 'pdf_artifact',
+        kind: canvasKind,
         event_id: `sidebar-item-${artifactID}-${Date.now()}`,
         title: String(artifact?.title || item?.artifact_title || item?.title || refPath),
         path: refPath,
       });
       return true;
     }
-    if (SIDEBAR_IMAGE_EXTENSIONS.has(`.${String(refPath.split('.').pop() || '').toLowerCase()}`)) {
+    if (canvasKind === 'image_artifact' || SIDEBAR_IMAGE_EXTENSIONS.has(`.${String(refPath.split('.').pop() || '').toLowerCase()}`)) {
       applyCanvasArtifactEvent({
         kind: 'image_artifact',
         event_id: `sidebar-item-${artifactID}-${Date.now()}`,
@@ -365,7 +371,7 @@ export async function openSidebarArtifactItem(item) {
     text: buildSidebarItemFallbackText(item, artifact),
     meta: buildSidebarCanvasMeta(item, artifactKind),
   };
-  if (artifactKind === 'email_thread') {
+  if (artifactUsesThreadHTML(artifactKind)) {
     textEvent.threadMeta = parseSidebarArtifactMeta(artifact?.meta_json || '');
   }
   applyCanvasArtifactEvent(textEvent);

--- a/internal/web/static/artifact-taxonomy.js
+++ b/internal/web/static/artifact-taxonomy.js
@@ -1,0 +1,184 @@
+const IMAGE_EXTENSIONS = new Set([
+  '.apng',
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.tif',
+  '.tiff',
+  '.webp',
+]);
+
+export const CANONICAL_ACTION_SEMANTICS = Object.freeze([
+  'open_show',
+  'annotate_capture',
+  'compose',
+  'bundle_review',
+  'dispatch_execute',
+  'track_item',
+  'delegate_actor',
+]);
+
+const DEFAULT_CANVAS_SURFACE = 'text_artifact';
+const DEFAULT_SPEC = Object.freeze({
+  family: 'artifact',
+  canvas_surface: DEFAULT_CANVAS_SURFACE,
+  interaction_model: 'canonical_canvas',
+  actions: Object.freeze([
+    'open_show',
+    'annotate_capture',
+    'compose',
+    'bundle_review',
+    'track_item',
+  ]),
+  mail_actions: false,
+});
+
+export const ARTIFACT_KIND_TAXONOMY = Object.freeze({
+  annotation: Object.freeze({
+    family: 'review_bundle',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'dispatch_execute', 'track_item']),
+    mail_actions: false,
+  }),
+  document: Object.freeze({
+    family: 'reference',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  email: Object.freeze({
+    family: 'message',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'dispatch_execute', 'track_item']),
+    mail_actions: true,
+  }),
+  email_thread: Object.freeze({
+    family: 'message',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'bundle_review', 'dispatch_execute', 'track_item']),
+    mail_actions: true,
+  }),
+  external_note: Object.freeze({
+    family: 'captured_note',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'track_item']),
+    mail_actions: false,
+  }),
+  external_task: Object.freeze({
+    family: 'action_card',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'compose', 'dispatch_execute', 'track_item', 'delegate_actor']),
+    mail_actions: false,
+  }),
+  github_issue: Object.freeze({
+    family: 'proposal',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'bundle_review', 'dispatch_execute', 'track_item']),
+    mail_actions: false,
+  }),
+  github_pr: Object.freeze({
+    family: 'proposal',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'dispatch_execute', 'track_item', 'delegate_actor']),
+    mail_actions: false,
+  }),
+  idea_note: Object.freeze({
+    family: 'planning_note',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  image: Object.freeze({
+    family: 'reference',
+    canvas_surface: 'image_artifact',
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  markdown: Object.freeze({
+    family: 'reference',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  pdf: Object.freeze({
+    family: 'reference',
+    canvas_surface: 'pdf_artifact',
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  plan_note: Object.freeze({
+    family: 'planning_note',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'compose', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  reference: Object.freeze({
+    family: 'reference',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+  transcript: Object.freeze({
+    family: 'transcript',
+    canvas_surface: DEFAULT_CANVAS_SURFACE,
+    interaction_model: 'canonical_canvas',
+    actions: Object.freeze(['open_show', 'annotate_capture', 'bundle_review', 'track_item']),
+    mail_actions: false,
+  }),
+});
+
+export function normalizeArtifactKind(kind) {
+  return String(kind || '').trim().toLowerCase();
+}
+
+export function artifactKindSpec(kind) {
+  const normalized = normalizeArtifactKind(kind);
+  const spec = ARTIFACT_KIND_TAXONOMY[normalized];
+  if (spec) return spec;
+  return DEFAULT_SPEC;
+}
+
+function imageExtensionFromPath(refPath) {
+  const normalized = String(refPath || '').trim().toLowerCase();
+  if (!normalized) return '';
+  const dot = normalized.lastIndexOf('.');
+  if (dot < 0) return '';
+  return normalized.slice(dot);
+}
+
+export function artifactCanvasEventKind(kind, refPath = '') {
+  const normalized = normalizeArtifactKind(kind);
+  if (normalized === 'email_draft') return DEFAULT_CANVAS_SURFACE;
+  if (normalized === 'pdf') return 'pdf_artifact';
+  if (normalized === 'image') return 'image_artifact';
+  if (String(refPath || '').trim().toLowerCase().endsWith('.pdf')) return 'pdf_artifact';
+  if (IMAGE_EXTENSIONS.has(imageExtensionFromPath(refPath))) return 'image_artifact';
+  return artifactKindSpec(normalized).canvas_surface || DEFAULT_CANVAS_SURFACE;
+}
+
+export function artifactSupportsMailActions(kind) {
+  return artifactKindSpec(kind).mail_actions === true;
+}
+
+export function artifactUsesThreadHTML(kind) {
+  return normalizeArtifactKind(kind) === 'email_thread';
+}

--- a/internal/web/static/canvas-actions.js
+++ b/internal/web/static/canvas-actions.js
@@ -1,4 +1,5 @@
 import { refs, state } from './app-context.js';
+import { artifactSupportsMailActions } from './artifact-taxonomy.js';
 import {
   launchForwardAuthoring,
   launchNewMailAuthoring,
@@ -13,7 +14,7 @@ function activeCanvasMailItem(event) {
   const items = Array.isArray(state.itemSidebarItems) ? state.itemSidebarItems : [];
   const item = items.find((entry) => Number(entry?.id || 0) === itemID) || null;
   const artifactKind = String(item?.artifact_kind || meta?.artifact_kind || '').trim().toLowerCase();
-  if (artifactKind !== 'email' && artifactKind !== 'email_thread') return null;
+  if (!artifactSupportsMailActions(artifactKind)) return null;
   return item;
 }
 

--- a/tests/playwright/artifact-kind-taxonomy.spec.ts
+++ b/tests/playwright/artifact-kind-taxonomy.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    const wsOpen = (window as any).WebSocket.OPEN;
+    return s.chatWs?.readyState === wsOpen && s.canvasWs?.readyState === wsOpen;
+  }, null, { timeout: 8_000 });
+}
+
+async function openSidebarTab(page: Page, label: 'Inbox' | 'Waiting' | 'Someday' | 'Done') {
+  const pane = page.locator('#pr-file-pane');
+  const isOpen = await pane.evaluate((node) => node.classList.contains('is-open'));
+  if (!isOpen) {
+    await page.locator('#edge-left-tap').click();
+  }
+  await expect(pane).toHaveClass(/is-open/);
+  await page.locator('.sidebar-tab', { hasText: label }).click();
+  await expect(page.locator('.sidebar-tab.is-active')).toContainText(label);
+}
+
+test('artifact taxonomy keeps every stored kind on canonical canvas surfaces', async ({ page }) => {
+  await waitReady(page);
+
+  const taxonomy = await page.evaluate(async () => {
+    const mod = await import('../../internal/web/static/artifact-taxonomy.js');
+    return {
+      actions: mod.CANONICAL_ACTION_SEMANTICS,
+      specs: mod.ARTIFACT_KIND_TAXONOMY,
+    };
+  });
+
+  expect(Object.keys(taxonomy.specs).sort()).toEqual([
+    'annotation',
+    'document',
+    'email',
+    'email_thread',
+    'external_note',
+    'external_task',
+    'github_issue',
+    'github_pr',
+    'idea_note',
+    'image',
+    'markdown',
+    'pdf',
+    'plan_note',
+    'reference',
+    'transcript',
+  ]);
+
+  for (const spec of Object.values(taxonomy.specs as Record<string, any>)) {
+    expect(spec.interaction_model).toBe('canonical_canvas');
+    expect(['text_artifact', 'pdf_artifact', 'image_artifact']).toContain(spec.canvas_surface);
+    for (const action of spec.actions as string[]) {
+      expect(taxonomy.actions).toContain(action);
+    }
+  }
+});
+
+test('plan notes and GitHub issues stay on text canvas without mail-only actions', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+
+  await openSidebarTab(page, 'Someday');
+  await page.locator('#pr-file-list .pr-file-item[data-item-id="301"]').click();
+  await expect(page.locator('#canvas-text')).toContainText('Gesture backlog');
+  await expect(page.locator('#canvas-new-mail-trigger')).toHaveCount(0);
+  await expect(page.locator('#canvas-reply-mail-trigger')).toHaveCount(0);
+
+  await openSidebarTab(page, 'Done');
+  await page.locator('#pr-file-list .pr-file-item[data-item-id="401"]').click();
+  await expect(page.locator('#canvas-text')).toContainText('Capture checklist');
+  await expect(page.locator('#canvas-new-mail-trigger')).toHaveCount(0);
+  await expect(page.locator('#canvas-reply-mail-trigger')).toHaveCount(0);
+});
+
+test('mail threads keep canonical text canvas rendering and mail actions', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+
+  await page.evaluate(() => {
+    (window as any).__setItemSidebarData({
+      inbox: [{
+        id: 105,
+        title: 'Urgent follow-up',
+        state: 'inbox',
+        sphere: 'private',
+        artifact_id: 505,
+        source: 'exchange',
+        source_ref: 'thread-505',
+        artifact_title: 'Urgent follow-up',
+        artifact_kind: 'email_thread',
+        actor_name: 'Ada',
+        created_at: '2026-03-08 10:04:00',
+        updated_at: '2026-03-08 10:05:00',
+      }],
+      waiting: [],
+      someday: [],
+      done: [],
+    });
+  });
+
+  await openSidebarTab(page, 'Inbox');
+  await page.locator('#pr-file-list .pr-file-item[data-item-id="105"]').click();
+  await expect(page.locator('#canvas-text')).toContainText('Urgent follow-up');
+  await expect(page.locator('#canvas-text')).toContainText('Need a response before tomorrow morning.');
+  await expect(page.locator('#reply-mail-trigger')).toBeVisible();
+
+  await page.locator('#edge-left-tap').click();
+  await expect(page.locator('#pr-file-pane')).not.toHaveClass(/is-open/);
+  await expect(page.locator('#canvas-new-mail-trigger')).toBeVisible();
+  await expect(page.locator('#canvas-reply-mail-trigger')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add a shared artifact taxonomy contract so stored kinds map to canonical canvas surfaces and action semantics in one place
- route sidebar artifact opening and canvas mail actions through that contract instead of ad hoc kind checks
- document the taxonomy and add targeted Playwright coverage for non-mail and mail artifact flows

## Verification
- Requirement: Artifact-kind taxonomy documented
  Evidence: [docs/artifact-kind-taxonomy.md](/home/ert/code/assi/tabula/docs/artifact-kind-taxonomy.md#L1) defines the canonical actions, current kind table, and boundary rules; [artifact-taxonomy.js](/home/ert/code/assi/tabula/internal/web/static/artifact-taxonomy.js#L16) is the runtime contract.
- Requirement: Each kind maps to canonical action semantics, not custom UI paradigms
  Evidence: [artifact-taxonomy.js](/home/ert/code/assi/tabula/internal/web/static/artifact-taxonomy.js#L41) assigns every stored kind a `canvas_surface`, `interaction_model`, and canonical `actions` set; [artifact-kind-taxonomy.spec.ts](/home/ert/code/assi/tabula/tests/playwright/artifact-kind-taxonomy.spec.ts#L25) asserts every stored kind stays within the canonical surface/action set.
- Requirement: No artifact kind invents its own mini-interaction model
  Evidence: `./scripts/playwright.sh tests/playwright/artifact-kind-taxonomy.spec.ts 2>&1 | tee /tmp/test.log`
  Output excerpt:
  - `artifact taxonomy keeps every stored kind on canonical canvas surfaces`
  - `plan notes and GitHub issues stay on text canvas without mail-only actions`
  - `mail threads keep canonical text canvas rendering and mail actions`
  - `3 passed (2.6s)`
