### PR TITLE
fix: Write canonical interaction grammar document (fixes #443)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ Short version:
 - prefer radical cleanup over preserving weak legacy shapes
 - optimize for UX, code quality, and maintainability
 
+Canonical product interaction reference:
+- `docs/interaction-grammar.md`
+
 ## Fast Path Rule
 
 For direct runtime requests, run the obvious command first, then verify.

--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -1,0 +1,77 @@
+# Interaction Grammar
+
+This document is the canonical product reference for Tabura's interaction model.
+
+If code, UI copy, storage, tests, or follow-on design notes disagree with this document, the implementation is wrong and should be changed. The document is not a compatibility promise for legacy shapes.
+
+## Authoritative Ontology
+
+Tabura has exactly five primary product nouns:
+
+- Workspace
+- Artifact
+- Item
+- Actor
+- Label
+
+Project is not a product concept. Session and message are transport or storage details, not user-facing ontology.
+
+## Authoritative Live Model
+
+Tabura exposes exactly two live runtime modes:
+
+- Dialogue
+- Meeting
+
+Anything else is either a temporary implementation detail or a bug in naming, UX, or state modeling.
+
+## Canonical Action Semantics
+
+All shipped actions must reduce to this grammar:
+
+- Open / Show
+- Annotate / Capture
+- Compose
+- Bundle / Review
+- Dispatch / Execute
+- Track as Item
+- Delegate to Actor
+
+These actions may appear in different UI contexts, but they must not change meaning across surfaces.
+
+## Allowed Tool Modalities
+
+Tabura may accept input through these modalities:
+
+- tap-to-voice
+- right-click and type
+- keyboard direct input
+- ink or stylus
+- live Dialogue
+- live Meeting
+- narrow intake surfaces
+
+These are input paths into the same system, not alternate product models.
+
+## Rules for Auxiliary Surfaces
+
+Auxiliary surfaces are allowed only when all of the following are true:
+
+- The surface is narrower than the main workspace.
+- The surface exists to make one job materially faster.
+- The surface writes back into the same Workspace / Artifact / Item / Actor / Label ontology.
+- The surface does not create its own action grammar.
+- The surface does not create a parallel runtime shell, inbox, review system, or project universe.
+
+If a surface cannot satisfy all of those constraints, it does not belong in the product.
+
+## Rules for New Artifact Kinds
+
+New artifact kinds are allowed only when all of the following are true:
+
+- The artifact still participates in the same ontology.
+- The artifact can be opened, annotated, composed around, reviewed, dispatched, tracked, or delegated without inventing a separate grammar.
+- Any artifact-specific affordance remains a narrow specialization of the canonical actions above.
+- The artifact does not require its own naming scheme for live modes, state, or workflow concepts.
+
+Artifact kinds may add presentation or extraction details. They must not define a second product.

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -16,15 +16,16 @@ Current runtime baseline:
 
 Read in this order:
 
-1. `object-scoped-intent-ui.md`
-2. `gesture-truth-table.md`
-3. `approval-execution-policy.md`
-4. `interfaces.md`
-5. `auxiliary-surfaces.md`
-6. `architecture.md`
-7. `live-runtime-whitepaper.md`
-8. `meeting-notes-privacy.md`
-9. `codex-app-server-pivot.md`
+1. `interaction-grammar.md`
+2. `object-scoped-intent-ui.md`
+3. `gesture-truth-table.md`
+4. `approval-execution-policy.md`
+5. `interfaces.md`
+6. `auxiliary-surfaces.md`
+7. `architecture.md`
+8. `live-runtime-whitepaper.md`
+9. `meeting-notes-privacy.md`
+10. `codex-app-server-pivot.md`
 
 Integrated protocol reference:
 

--- a/internal/surface/spec_docs_test.go
+++ b/internal/surface/spec_docs_test.go
@@ -48,3 +48,54 @@ func TestGestureTruthTableDocIsIndexedAndStructured(t *testing.T) {
 		t.Fatalf("%s does not reference gesture-truth-table.md", specIndexPath)
 	}
 }
+
+func TestInteractionGrammarDocIsIndexedAndLinked(t *testing.T) {
+	root := repoRootFromCaller(t)
+
+	grammarPath := filepath.Join(root, "docs", "interaction-grammar.md")
+	grammarDoc, err := os.ReadFile(grammarPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", grammarPath, err)
+	}
+	content := string(grammarDoc)
+
+	requiredSnippets := []string{
+		"## Authoritative Ontology",
+		"## Authoritative Live Model",
+		"## Canonical Action Semantics",
+		"## Allowed Tool Modalities",
+		"## Rules for Auxiliary Surfaces",
+		"## Rules for New Artifact Kinds",
+		"Project is not a product concept.",
+		"- Dialogue",
+		"- Meeting",
+		"- Workspace",
+		"- Artifact",
+		"- Item",
+		"- Actor",
+		"- Label",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("%s missing snippet %q", grammarPath, snippet)
+		}
+	}
+
+	specIndexPath := filepath.Join(root, "docs", "spec-index.md")
+	specIndex, err := os.ReadFile(specIndexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", specIndexPath, err)
+	}
+	if !strings.Contains(string(specIndex), "`interaction-grammar.md`") {
+		t.Fatalf("%s does not reference interaction-grammar.md", specIndexPath)
+	}
+
+	claudePath := filepath.Join(root, "CLAUDE.md")
+	claudeDoc, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", claudePath, err)
+	}
+	if !strings.Contains(string(claudeDoc), "`docs/interaction-grammar.md`") {
+		t.Fatalf("%s does not reference docs/interaction-grammar.md", claudePath)
+	}
+}


### PR DESCRIPTION
## Summary
- add `docs/interaction-grammar.md` as the canonical interaction model reference
- index it first in `docs/spec-index.md` and link it from `CLAUDE.md`
- enforce the document structure and references in `internal/surface/spec_docs_test.go`

## Verification
- Requirement: Document exists and covers all six sections above.
  Evidence: `docs/interaction-grammar.md` now includes `Authoritative Ontology`, `Authoritative Live Model`, `Canonical Action Semantics`, `Allowed Tool Modalities`, `Rules for Auxiliary Surfaces`, and `Rules for New Artifact Kinds`; `TestInteractionGrammarDocIsIndexedAndLinked` asserts all six headings are present.
- Requirement: Ontology section explicitly states the five nouns and excludes Project.
  Evidence: `docs/interaction-grammar.md` lists `Workspace`, `Artifact`, `Item`, `Actor`, and `Label`, and states `Project is not a product concept.`; `TestInteractionGrammarDocIsIndexedAndLinked` asserts those snippets.
- Requirement: Future issues and PRs can reference it as the canonical source.
  Evidence: `docs/spec-index.md` now lists `interaction-grammar.md` first under `Product and Behavior Specs`.
- Requirement: `CLAUDE.md` links to it.
  Evidence: `CLAUDE.md` now includes `docs/interaction-grammar.md` under `Canonical product interaction reference`.
- Command: `go test ./internal/surface 2>&1 | tee /tmp/test.log`
  Output: `ok   github.com/krystophny/tabura/internal/surface	0.006s`
