### PR TITLE
fix: Final test and docs sweep: unified semantics (fixes #452)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ The browser UI is a full-viewport canvas with no visible chrome:
 - **Tabula rasa**: blank white screen when no artifact is loaded.
 - **Artifact mode**: document (text, image, PDF) fills the viewport.
 - No toolbar, no prompt bar, no chat column. All interaction is invisible.
-- **Edge panels** (hidden): top edge = project switcher, right edge = chat log / diagnostics. Revealed by hovering near screen edge (desktop) or swiping inward (mobile).
+- **Edge panels** (hidden): top edge = workspace switcher, right edge = chat log / diagnostics. Revealed by hovering near screen edge (desktop) or swiping inward (mobile).
 
 ## Primary Data Flows
 

--- a/docs/auxiliary-surfaces.md
+++ b/docs/auxiliary-surfaces.md
@@ -7,7 +7,7 @@ The main Tabura environment is `/`. Auxiliary surfaces are allowed only when the
 ### `/capture`
 
 - Purpose: fast mobile or transient capture when opening the full workspace would add friction.
-- Boundary: it is capture-only. It does not expose chat state, project switching, or a second workflow shell.
+- Boundary: it is capture-only. It does not expose chat state, workspace switching, or a second workflow shell.
 - Canonical write-back: it creates an `idea_note` artifact through `POST /api/artifacts` and then creates an inbox item through `POST /api/items`.
 - Canonical semantics: capture is still "make an artifact, create an item", not a separate product universe.
 

--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -61,7 +61,7 @@ Auxiliary surfaces are allowed only when all of the following are true:
 - The surface exists to make one job materially faster.
 - The surface writes back into the same Workspace / Artifact / Item / Actor / Label ontology.
 - The surface does not create its own action grammar.
-- The surface does not create a parallel runtime shell, inbox, review system, or project universe.
+- The surface does not create a parallel runtime shell, inbox, review system, or workspace universe.
 
 If a surface cannot satisfy all of those constraints, it does not belong in the product.
 

--- a/docs/object-scoped-intent-ui.md
+++ b/docs/object-scoped-intent-ui.md
@@ -115,10 +115,10 @@ Shared baseline:
 - black mode is the alternate idle surface
 - if a canvas document is visible, the document takes precedence over the idle surface
 
-Project model:
+Workspace model:
 
-- meetings and long-running jobs should default to temporary projects
-- each project keeps one active run in its main thread
+- meetings and long-running jobs should default to temporary workspaces
+- each workspace keeps one active run in its main thread
 - Hub remains for ad hoc requests and run monitoring only
 
 Noise filtering remains important:

--- a/internal/web/static/app-annotations-scan.js
+++ b/internal/web/static/app-annotations-scan.js
@@ -203,7 +203,7 @@ export function createScanAnnotationController(deps) {
       return false;
     }
     if (!safeText(state.activeProjectId)) {
-      showStatus('scan import requires an active project');
+      showStatus('scan import requires an active workspace');
       return false;
     }
     if (scanUploadInFlight) {

--- a/internal/web/static/app-chat-transport.js
+++ b/internal/web/static/app-chat-transport.js
@@ -821,7 +821,7 @@ export async function switchProject(projectID) {
   if (nextProjectID === state.activeProjectId && state.chatSessionId) return;
 
   state.projectSwitchInFlight = true;
-  showStatus('switching project...');
+  showStatus('switching workspace...');
   await deactivateLiveSession({ silent: true, disableMeetingConfig: true });
   cancelChatVoiceCapture();
   closeChatWs();
@@ -865,9 +865,9 @@ export async function switchProject(projectID) {
     openChatWs();
     showStatus(`ready`);
   } catch (err) {
-    const message = String(err?.message || err || 'project switch failed');
-    appendPlainMessage('system', `Project switch failed: ${message}`);
-    showStatus(`project switch failed: ${message}`);
+    const message = String(err?.message || err || 'workspace switch failed');
+    appendPlainMessage('system', `Workspace switch failed: ${message}`);
+    showStatus(`workspace switch failed: ${message}`);
   } finally {
     state.projectSwitchInFlight = false;
     renderEdgeTopModelButtons();

--- a/internal/web/static/app-chat-ui.js
+++ b/internal/web/static/app-chat-ui.js
@@ -503,7 +503,7 @@ export function renderWelcomeSurface(payload) {
   const sections = Array.isArray(payload?.sections) ? payload.sections : [];
   const title = String(payload?.title || 'Welcome').trim() || 'Welcome';
   const subtitle = isHubActive()
-    ? 'Choose a project or change a global runtime preference.'
+    ? 'Choose a workspace or change a global runtime preference.'
     : 'Pick up a recent file, open docs, or switch modes before asking.';
   const normalizedSections = sections.map((section, index) => ({
     ...section,

--- a/internal/web/static/app-item-sidebar-utils.js
+++ b/internal/web/static/app-item-sidebar-utils.js
@@ -434,10 +434,10 @@ export async function performItemSidebarProjectUpdate(item, projectID = '', proj
     }
     state.itemSidebarActiveItemID = itemID;
     await loadItemSidebarView(state.itemSidebarView);
-    showStatus(projectID ? `project set to ${String(projectName || '').trim() || 'selected project'}` : 'project cleared');
+    showStatus(projectID ? `label set to ${String(projectName || '').trim() || 'selected label'}` : 'label cleared');
     return true;
   } catch (err) {
-    showStatus(`project picker failed: ${String(err?.message || err || 'unknown error')}`);
+    showStatus(`label picker failed: ${String(err?.message || err || 'unknown error')}`);
     return false;
   }
 }
@@ -570,14 +570,14 @@ export async function showItemSidebarProjectMenu(item, x, y) {
   try {
     const projects = await fetchItemSidebarProjects();
     if (projects.length === 0) {
-      showStatus('no projects available');
+      showStatus('no labels available');
       return false;
     }
     const currentProjectID = String(item?.project_id || '').trim();
     const entries = [];
     if (currentProjectID) {
       entries.push({
-        label: 'Clear project',
+        label: 'Clear label',
         action: 'clear_project',
         onClick: () => performItemSidebarProjectUpdate(item, '', ''),
       });
@@ -592,7 +592,7 @@ export async function showItemSidebarProjectMenu(item, x, y) {
     showItemSidebarMenu(entries, x, y);
     return true;
   } catch (err) {
-    showStatus(`project picker failed: ${String(err?.message || err || 'unknown error')}`);
+    showStatus(`label picker failed: ${String(err?.message || err || 'unknown error')}`);
     return false;
   }
 }
@@ -654,7 +654,7 @@ export function showItemSidebarActionMenu(item, x, y) {
         onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
       },
       {
-        label: 'Project...',
+        label: 'Label...',
         action: 'project',
         onClick: () => showItemSidebarProjectMenu(item, x, y),
       },
@@ -680,7 +680,7 @@ export function showItemSidebarActionMenu(item, x, y) {
         onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
       },
       {
-        label: 'Project...',
+        label: 'Label...',
         action: 'project',
         onClick: () => showItemSidebarProjectMenu(item, x, y),
       },
@@ -706,7 +706,7 @@ export function showItemSidebarActionMenu(item, x, y) {
         onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
       },
       {
-        label: 'Project...',
+        label: 'Label...',
         action: 'project',
         onClick: () => showItemSidebarProjectMenu(item, x, y),
       },
@@ -735,7 +735,7 @@ export function showItemSidebarActionMenu(item, x, y) {
         onClick: () => showItemSidebarWorkspaceMenu(item, x, y),
       },
       {
-        label: 'Project...',
+        label: 'Label...',
         action: 'project',
         onClick: () => showItemSidebarProjectMenu(item, x, y),
       },

--- a/internal/web/static/app-projects.js
+++ b/internal/web/static/app-projects.js
@@ -336,11 +336,11 @@ export function renderEdgeTopProjects() {
       button.classList.add('is-queued');
     }
     button.dataset.runState = runState.status;
-    button.textContent = String(project.name || project.id || 'Project');
+    button.textContent = String(project.name || project.id || 'Workspace');
     const summary = projectRunStateSummary(project);
     const rootPath = String(project.root_path || '').trim();
     button.title = rootPath ? `${summary} | ${rootPath}` : summary;
-    button.setAttribute('aria-label', `${String(project.name || project.id || 'Project')}: ${summary}`);
+    button.setAttribute('aria-label', `${String(project.name || project.id || 'Workspace')}: ${summary}`);
     button.addEventListener('click', () => {
       if (isHubProject(project)) {
         void switchToHub();

--- a/internal/web/static/app-startup.js
+++ b/internal/web/static/app-startup.js
@@ -110,7 +110,7 @@ async function init() {
 
   await fetchProjects();
   const initialProjectID = resolveInitialProjectID();
-  if (!initialProjectID) throw new Error('no projects available');
+  if (!initialProjectID) throw new Error('no workspaces available');
   await switchProject(initialProjectID);
   if (isMobileSilent()) {
     const edgeRight = document.getElementById('edge-right');

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -92,10 +92,10 @@
       <div id="edge-top" class="edge-panel edge-top">
         <div class="edge-panel-inner">
           <div class="edge-panel-head">
-            <span class="edge-panel-title">Projects</span>
+            <span class="edge-panel-title">Workspaces</span>
             <button id="btn-edge-rasa" type="button" class="edge-btn">Tabula Rasa</button>
           </div>
-          <div id="edge-top-models" aria-label="Project chat model"></div>
+          <div id="edge-top-models" aria-label="Workspace runtime controls"></div>
           <div id="edge-top-projects"></div>
         </div>
       </div>
@@ -111,7 +111,7 @@
 
       <!-- Hidden elements for data/state (not visible) -->
       <div id="toolbar" style="display:none">
-        <div id="project-tab-strip" role="tablist" aria-label="Projects"></div>
+        <div id="project-tab-strip" role="tablist" aria-label="Workspaces"></div>
         <span id="chat-mode-pill" class="badge">chat</span>
       </div>
       <section id="project-overview" class="project-overview is-hidden" style="display:none">

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -89,7 +89,11 @@ async function setInteractionTool(page: Page, tool: 'pointer' | 'highlight' | 'i
   await page.evaluate((mode) => {
     (window as any).__setRuntimeState?.({ tool: mode });
     const app = (window as any)._taburaApp;
-    if (app?.getState) app.getState().interaction.tool = mode;
+    if (app?.getState) {
+      const interaction = app.getState().interaction;
+      interaction.tool = mode;
+      interaction.conversation = mode === 'pointer' || mode === 'prompt' ? 'push_to_talk' : 'idle';
+    }
   }, tool);
 }
 
@@ -232,6 +236,19 @@ test.describe('canvas - tabula rasa', () => {
     await expect(indicator).toBeVisible();
     await expect(page.locator('.stop-square')).toBeVisible();
     await expect(page.locator('.record-dot')).toBeHidden();
+  });
+
+  test('ink mode tap does not reuse prompt tap-to-voice behavior', async ({ page }) => {
+    await clearLog(page);
+    await setInteractionTool(page, 'ink');
+
+    await page.mouse.click(400, 400);
+    await page.waitForTimeout(300);
+
+    const log = await getLog(page);
+    expect(log.some((entry) => entry.type === 'recorder' && entry.action === 'start')).toBe(false);
+    await expect(page.locator('#indicator')).toBeHidden();
+    await expect(page.locator('#ink-controls')).toBeHidden();
   });
 
   test('right-click opens text input at position', async ({ page }) => {

--- a/tests/playwright/chat-harness.html
+++ b/tests/playwright/chat-harness.html
@@ -41,10 +41,10 @@
       <div id="edge-top" class="edge-panel edge-top">
         <div class="edge-panel-inner">
           <div class="edge-panel-head">
-            <span class="edge-panel-title">Projects</span>
+            <span class="edge-panel-title">Workspaces</span>
             <button id="btn-edge-rasa" type="button" class="edge-btn">Tabula Rasa</button>
           </div>
-          <div id="edge-top-models" aria-label="Project chat model"></div>
+          <div id="edge-top-models" aria-label="Workspace runtime controls"></div>
           <div id="edge-top-projects"></div>
         </div>
       </div>
@@ -63,7 +63,7 @@
       </div>
 
       <div id="toolbar" style="display:none">
-        <div id="project-tab-strip" role="tablist" aria-label="Projects"></div>
+        <div id="project-tab-strip" role="tablist" aria-label="Workspaces"></div>
         <span id="status-text">ready</span>
         <span id="chat-mode-pill" class="badge">chat</span>
       </div>

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -73,10 +73,10 @@
       <div id="edge-top" class="edge-panel edge-top">
         <div class="edge-panel-inner">
           <div class="edge-panel-head">
-            <span class="edge-panel-title">Projects</span>
+            <span class="edge-panel-title">Workspaces</span>
             <button id="btn-edge-rasa" type="button" class="edge-btn">Tabula Rasa</button>
           </div>
-          <div id="edge-top-models" aria-label="Project chat model"></div>
+          <div id="edge-top-models" aria-label="Workspace runtime controls"></div>
           <div id="edge-top-projects"></div>
         </div>
       </div>
@@ -95,7 +95,7 @@
       </div>
 
       <div id="toolbar" style="display:none">
-        <div id="project-tab-strip" role="tablist" aria-label="Projects"></div>
+        <div id="project-tab-strip" role="tablist" aria-label="Workspaces"></div>
         <span id="status-text">ready</span>
         <span id="chat-mode-pill" class="badge">chat</span>
       </div>

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -521,7 +521,7 @@ test.describe('inbox triage interactions', () => {
     expect(triageCalls.map((entry: any) => entry?.payload?.action)).toEqual(['done', 'delete', 'delegate', 'later']);
   });
 
-  test('desktop context menu workspace and project pickers reassign the active item', async ({ page }) => {
+  test('desktop context menu workspace and label pickers reassign the active item', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await waitReady(page);
     await page.evaluate(() => {
@@ -552,8 +552,8 @@ test.describe('inbox triage interactions', () => {
     }).toBe(true);
 
     await row.click({ button: 'right' });
-    await expect(page.locator('#item-sidebar-menu')).toContainText('Project...');
-    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Project...' }).click();
+    await expect(page.locator('#item-sidebar-menu')).toContainText('Label...');
+    await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Label...' }).click();
     await expect(page.locator('#item-sidebar-menu')).toContainText('Test');
     await page.locator('#item-sidebar-menu .item-sidebar-menu-item', { hasText: 'Test' }).click();
     await expect.poll(async () => {

--- a/tests/playwright/live-dialogue.spec.ts
+++ b/tests/playwright/live-dialogue.spec.ts
@@ -139,6 +139,8 @@ test.beforeEach(async ({ page }) => {
 
 test('Live panel swaps Dialogue/Meeting choices for active status and Stop', async ({ page }) => {
   await waitForEdgeButtons(page);
+  await expect(page.locator('#edge-top .edge-panel-title')).toHaveText('Workspaces');
+  await expect(page.locator('#edge-top-models')).toHaveAttribute('aria-label', 'Workspace runtime controls');
   await expect(page.locator('#edge-top-models .edge-live-label')).toHaveText('Live');
   await expect(page.locator('#edge-top-models .edge-live-dialogue-btn')).toBeVisible();
   await expect(page.locator('#edge-top-models .edge-live-meeting-btn')).toBeVisible();

--- a/tests/playwright/live-meeting.spec.ts
+++ b/tests/playwright/live-meeting.spec.ts
@@ -1,5 +1,15 @@
 import { expect, test, type Page } from '@playwright/test';
 
+async function clearLog(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__harnessLog.splice(0);
+  });
+}
+
+async function getLog(page: Page) {
+  return page.evaluate(() => (window as any).__harnessLog.slice());
+}
+
 async function waitReady(page: Page) {
   await page.goto('/tests/playwright/harness.html');
   await page.waitForFunction(() => {
@@ -272,6 +282,30 @@ test('meeting idle surface tracks runtime state and hides behind open artifacts'
   await page.getByRole('button', { name: 'Meeting Transcript' }).click();
   await expect(page.locator('#canvas-text')).toContainText('Harness meeting transcript');
   await expect(page.locator('#companion-idle-surface')).toBeHidden();
+});
+
+test('meeting tap stays cursor-only and does not start local capture', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await waitReady(page);
+  await switchToProject(page, 'test');
+  const meetingButton = page.locator('#edge-top-models .edge-live-meeting-btn');
+  await expect(meetingButton).toBeEnabled();
+  await page.evaluate(() => {
+    const button = document.querySelector('#edge-top-models .edge-live-meeting-btn');
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('meeting button not found');
+    }
+    button.click();
+  });
+  await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Meeting');
+  await clearLog(page);
+
+  await page.mouse.click(420, 320);
+  await page.waitForTimeout(300);
+
+  const log = await getLog(page);
+  expect(log.some((entry: any) => entry?.type === 'recorder' && entry?.action === 'start')).toBe(false);
+  await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Meeting');
 });
 
 test('black mode toggle updates the meeting idle surface preference', async ({ page }) => {


### PR DESCRIPTION
## Summary
- align the primary UI copy with the final Workspace / Label / Dialogue / Meeting terminology
- tighten Playwright coverage around tap routing, live-mode visibility, capture write-back, and approval canvas flow
- update the interaction docs to match the same product model

## Verification
- No conflicting tap behavior across annotation vs prompt flows:
  - `npx playwright test tests/playwright/canvas.spec.ts --grep "ink mode tap does not reuse prompt tap-to-voice behavior"`
  - `/tmp/test-rerun.log`: `ink mode tap does not reuse prompt tap-to-voice behavior` passed
  - `npx playwright test tests/playwright/live-meeting.spec.ts --grep "meeting tap stays cursor-only and does not start local capture"`
  - `/tmp/test-rerun-2.log`: `1 passed (1.5s)`
- Live runtime only exposes Dialogue and Meeting:
  - `npx playwright test tests/playwright/live-dialogue.spec.ts --grep "Live panel swaps Dialogue/Meeting choices for active status and Stop"`
  - `/tmp/test-live-dialogue.log`: `1 passed (1.6s)`
- Old naming no longer appears in primary UX/state:
  - `rg -n "Workspaces|Workspace runtime controls|Choose a workspace|Label\\.\\.\\.|label set to|scan import requires an active workspace" internal/web/static/index.html internal/web/static/app-chat-ui.js internal/web/static/app-item-sidebar-utils.js internal/web/static/app-annotations-scan.js tests/playwright/harness.html tests/playwright/chat-harness.html`
  - Key matches: `internal/web/static/index.html:95`, `internal/web/static/app-chat-ui.js:506`, `internal/web/static/app-item-sidebar-utils.js:657`, `tests/playwright/harness.html:76`
- Approval requests render in the canonical canvas/artifact flow:
  - `npx playwright test tests/playwright/ui-system.spec.ts --grep "renders approval card and sends approval response"`
  - `/tmp/test-verification.log`: approval test passed
- Auxiliary surfaces write back into the same ontology:
  - `npx playwright test tests/playwright/capture.spec.ts --grep "saves a typed note and stays outside the canvas shell|transcribes a voice memo and saves an artifact-backed inbox item"`
  - `/tmp/test-verification.log`: both capture tests passed
- Docs, tests, and UI copy reflect the same model:
  - `rg -n "workspace switching|workspace universe|workspace switcher|Workspace model|temporary workspaces" docs/auxiliary-surfaces.md docs/interaction-grammar.md docs/architecture.md docs/object-scoped-intent-ui.md`
  - Key matches: `docs/auxiliary-surfaces.md:10`, `docs/interaction-grammar.md:64`, `docs/architecture.md:63`, `docs/object-scoped-intent-ui.md:118`
