### PR TITLE
fix: Add spatial awareness for print/scan round-trip annotations (fixes #200)

### DIFF
--- a/internal/web/item_print.go
+++ b/internal/web/item_print.go
@@ -62,7 +62,9 @@ var itemPrintTemplate = template.Must(template.New("item-print").Parse(`<!DOCTYP
           <div class="print-muted">{{.Artifact.RefPath}}</div>
           {{end}}
         </div>
-        {{if .Artifact.Content}}
+        {{if .Artifact.ContentHTML}}
+        <div class="print-content print-content-marked">{{.Artifact.ContentHTML}}</div>
+        {{else if .Artifact.Content}}
         <pre class="print-content">{{.Artifact.Content}}</pre>
         {{else}}
         <p class="print-muted">No inline artifact text was available for print preview.</p>
@@ -96,12 +98,13 @@ type printFact struct {
 }
 
 type printArtifactView struct {
-	Kind     string
-	Title    string
-	RefPath  string
-	RefURL   string
-	Content  string
-	Metadata string
+	Kind        string
+	Title       string
+	RefPath     string
+	RefURL      string
+	Content     string
+	ContentHTML template.HTML
+	Metadata    string
 }
 
 type itemPrintView struct {
@@ -194,14 +197,23 @@ func buildPrintArtifactView(artifact store.Artifact) *printArtifactView {
 	metaText, metaPretty := printableArtifactMeta(artifact.MetaJSON)
 	content := printableArtifactContent(artifact, metaText)
 	return &printArtifactView{
-		Kind:     string(artifact.Kind),
-		Title:    firstPrintableValue(optionalStringValue(artifact.Title), optionalStringValue(artifact.RefPath), optionalStringValue(artifact.RefURL), string(artifact.Kind)),
-		RefPath:  optionalStringValue(artifact.RefPath),
-		RefURL:   optionalStringValue(artifact.RefURL),
-		Content:  content,
-		Metadata: metaPretty,
+		Kind:        string(artifact.Kind),
+		Title:       firstPrintableValue(optionalStringValue(artifact.Title), optionalStringValue(artifact.RefPath), optionalStringValue(artifact.RefURL), string(artifact.Kind)),
+		RefPath:     optionalStringValue(artifact.RefPath),
+		RefURL:      optionalStringValue(artifact.RefURL),
+		Content:     content,
+		ContentHTML: printableArtifactContentHTML(artifact, content),
+		Metadata:    metaPretty,
 	}
 }
+
+type printMarkerMode string
+
+const (
+	printMarkerModeNone      printMarkerMode = ""
+	printMarkerModeLine      printMarkerMode = "line"
+	printMarkerModeParagraph printMarkerMode = "paragraph"
+)
 
 func printableArtifactContent(artifact store.Artifact, metaText string) string {
 	if path := strings.TrimSpace(optionalStringValue(artifact.RefPath)); path != "" {
@@ -212,6 +224,76 @@ func printableArtifactContent(artifact store.Artifact, metaText string) string {
 		}
 	}
 	return strings.TrimSpace(metaText)
+}
+
+func printableArtifactContentHTML(artifact store.Artifact, content string) template.HTML {
+	switch printableArtifactMarkerMode(artifact, content) {
+	case printMarkerModeLine:
+		return renderPrintableLineMarkers(content)
+	case printMarkerModeParagraph:
+		return renderPrintableParagraphMarkers(content)
+	default:
+		return ""
+	}
+}
+
+func printableArtifactMarkerMode(artifact store.Artifact, content string) printMarkerMode {
+	if strings.TrimSpace(content) == "" {
+		return printMarkerModeNone
+	}
+	switch artifact.Kind {
+	case store.ArtifactKindEmail, store.ArtifactKindEmailThread, artifactKindEmailDraft:
+		return printMarkerModeParagraph
+	default:
+		return printMarkerModeLine
+	}
+}
+
+func renderPrintableLineMarkers(content string) template.HTML {
+	lines := strings.Split(content, "\n")
+	var b strings.Builder
+	for i, line := range lines {
+		fmt.Fprintf(
+			&b,
+			`<div class="print-marker-row"><span class="print-marker" data-print-marker="line" data-print-value="%d">L%03d</span><span class="print-marker-text">%s</span></div>`,
+			i+1,
+			i+1,
+			template.HTMLEscapeString(line),
+		)
+	}
+	return template.HTML(b.String())
+}
+
+func renderPrintableParagraphMarkers(content string) template.HTML {
+	blocks := splitPrintableParagraphs(content)
+	var b strings.Builder
+	for i, block := range blocks {
+		fmt.Fprintf(
+			&b,
+			`<div class="print-marker-row print-marker-row-paragraph"><span class="print-marker" data-print-marker="paragraph" data-print-value="%d">P%02d</span><span class="print-marker-text">%s</span></div>`,
+			i+1,
+			i+1,
+			template.HTMLEscapeString(block),
+		)
+	}
+	return template.HTML(b.String())
+}
+
+func splitPrintableParagraphs(content string) []string {
+	text := strings.ReplaceAll(content, "\r\n", "\n")
+	parts := strings.Split(text, "\n\n")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		clean := strings.TrimSpace(part)
+		if clean == "" {
+			continue
+		}
+		out = append(out, clean)
+	}
+	if len(out) == 0 && strings.TrimSpace(text) != "" {
+		return []string{strings.TrimSpace(text)}
+	}
+	return out
 }
 
 func printableArtifactMeta(raw *string) (string, string) {

--- a/internal/web/item_print_test.go
+++ b/internal/web/item_print_test.go
@@ -70,6 +70,9 @@ func TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent(t *testing.T) {
 		"Alice",
 		"github",
 		"owner/tabura#193",
+		`data-print-marker="line"`,
+		"L001",
+		"L002",
 		"# Review",
 		"- tighten cover sheet",
 	} {
@@ -79,6 +82,45 @@ func TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent(t *testing.T) {
 	}
 	if strings.Contains(body, "window.print()") {
 		t.Fatalf("html-only print response should not auto-print:\n%s", body)
+	}
+}
+
+func TestItemPrintEmailArtifactUsesParagraphMarkers(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspace, err := app.store.CreateWorkspace("Mail", filepath.Join(t.TempDir(), "workspace"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	metaJSON := `{"text":"First paragraph.\n\nSecond paragraph."}`
+	title := "Re: annotated thread"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindEmail, nil, nil, &title, &metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+	item, err := app.store.CreateItem("Review email", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		ArtifactID:  &artifact.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+
+	rr := doAuthedRequest(t, app.Router(), http.MethodGet, "/api/items/"+itoa(item.ID)+"/print?format=html")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("print html status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, snippet := range []string{
+		`data-print-marker="paragraph"`,
+		"P01",
+		"P02",
+		"First paragraph.",
+		"Second paragraph.",
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("print body missing %q:\n%s", snippet, body)
+		}
 	}
 }
 

--- a/internal/web/scan.go
+++ b/internal/web/scan.go
@@ -63,6 +63,7 @@ type scanMappedAnnotation struct {
 	Content    string          `json:"content"`
 	AnchorText string          `json:"anchor_text,omitempty"`
 	Line       int             `json:"line,omitempty"`
+	Paragraph  int             `json:"paragraph,omitempty"`
 	Page       int             `json:"page,omitempty"`
 	Bounds     *scanNormBounds `json:"bounds,omitempty"`
 	Confidence float64         `json:"confidence,omitempty"`
@@ -539,11 +540,12 @@ func (a *App) extractScanAnnotations(ctx context.Context, req scanExtractRequest
 
 const scanExtractionSystemPrompt = `You extract handwritten annotations from scanned printouts.
 Return strict JSON with shape:
-{"summary":"short summary","annotations":[{"content":"required extracted note text","anchor_text":"printed source text nearest the note if known","line":42,"page":1,"bounds":{"x":0.1,"y":0.2,"width":0.3,"height":0.08},"confidence":0.9}]}
+{"summary":"short summary","annotations":[{"content":"required extracted note text","anchor_text":"printed source text nearest the note if known","line":42,"paragraph":3,"page":1,"bounds":{"x":0.1,"y":0.2,"width":0.3,"height":0.08},"confidence":0.9}]}
 
 Rules:
 - Prefer concise note text in content.
-- Use line for printed code/text documents when you can infer it.
+- Use line for printed code/text/diff documents when you can infer it.
+- Use paragraph for prose/email documents when you can infer it from printed paragraph markers.
 - Use page for PDF/page-based material when you can infer it.
 - bounds must be normalized 0..1 relative to the original artifact page when known.
 - Omit fields you cannot infer.
@@ -570,6 +572,9 @@ func buildScanExtractionUserPrompt(req scanExtractRequest) string {
 		}
 		b.WriteString(text)
 		b.WriteString("\n")
+		b.WriteString("\nPrinted excerpt notes:\n")
+		b.WriteString("- Machine-readable markers may be embedded inline, such as L001 for lines or P01 for paragraphs.\n")
+		b.WriteString("- Prefer those markers when inferring line or paragraph positions.\n")
 	}
 	if meta := strings.TrimSpace(req.SourceMetaPretty); meta != "" {
 		b.WriteString("\nSource metadata:\n")
@@ -593,6 +598,7 @@ func sanitizeScanAnnotations(in []scanMappedAnnotation) []scanMappedAnnotation {
 			Content:    content,
 			AnchorText: strings.TrimSpace(entry.AnchorText),
 			Line:       maxInt(entry.Line, 0),
+			Paragraph:  maxInt(entry.Paragraph, 0),
 			Page:       maxInt(entry.Page, 0),
 			Confidence: clampScanFloat(entry.Confidence),
 		}
@@ -634,6 +640,8 @@ func buildScanUploadSummary(project store.Project, item *store.Item, artifact *s
 		line := fmt.Sprintf("%d. %s", i+1, entry.Content)
 		if entry.Line > 0 {
 			line += fmt.Sprintf(" (line %d)", entry.Line)
+		} else if entry.Paragraph > 0 {
+			line += fmt.Sprintf(" (paragraph %d)", entry.Paragraph)
 		} else if entry.Page > 0 {
 			line += fmt.Sprintf(" (page %d)", entry.Page)
 		}
@@ -662,6 +670,8 @@ func buildScanConfirmSummary(project store.Project, item *store.Item, artifact *
 		line := fmt.Sprintf("%d. %s", i+1, entry.Content)
 		if entry.Line > 0 {
 			line += fmt.Sprintf(" (line %d)", entry.Line)
+		} else if entry.Paragraph > 0 {
+			line += fmt.Sprintf(" (paragraph %d)", entry.Paragraph)
 		} else if entry.Page > 0 {
 			line += fmt.Sprintf(" (page %d)", entry.Page)
 		}

--- a/internal/web/scan_test.go
+++ b/internal/web/scan_test.go
@@ -282,3 +282,43 @@ func TestScanConfirmCreatesAnnotationArtifactAndUpdatesScanMeta(t *testing.T) {
 		t.Fatalf("expected source + scan + review artifacts, got %+v", linked)
 	}
 }
+
+func TestScanSummariesAndPromptPreserveParagraphMarkers(t *testing.T) {
+	project := store.Project{ID: "demo"}
+	item := &store.Item{Title: "Review email"}
+	artifact := &store.Artifact{Title: stringPtr("thread.eml")}
+
+	annotations := []scanMappedAnnotation{
+		{Content: "reply here", AnchorText: "Second paragraph", Paragraph: 2, Confidence: 0.88},
+	}
+
+	uploadSummary := buildScanUploadSummary(project, item, artifact, ".tabura/artifacts/scans/demo.png", scanExtractResult{
+		Summary:     "One margin note detected.",
+		Annotations: annotations,
+	})
+	if !strings.Contains(uploadSummary, "paragraph 2") {
+		t.Fatalf("upload summary missing paragraph marker:\n%s", uploadSummary)
+	}
+
+	confirmSummary := buildScanConfirmSummary(project, item, artifact, annotations)
+	if !strings.Contains(confirmSummary, "paragraph 2") {
+		t.Fatalf("confirm summary missing paragraph marker:\n%s", confirmSummary)
+	}
+
+	prompt := buildScanExtractionUserPrompt(scanExtractRequest{
+		Filename:       "thread-scan.png",
+		MIMEType:       "image/png",
+		Item:           item,
+		SourceArtifact: artifact,
+		SourceText:     "P01 First paragraph.\n\nP02 Second paragraph.",
+	})
+	for _, snippet := range []string{
+		"L001 for lines",
+		"P01 for paragraphs",
+		"Source artifact title: thread.eml",
+	} {
+		if !strings.Contains(prompt, snippet) {
+			t.Fatalf("scan prompt missing %q:\n%s", snippet, prompt)
+		}
+	}
+}

--- a/internal/web/static/app-annotations-scan.js
+++ b/internal/web/static/app-annotations-scan.js
@@ -82,6 +82,37 @@ function approximateTextRectsForLine(line, clamp01) {
   }];
 }
 
+function approximateTextRectsForParagraph(paragraph, clamp01) {
+  const pane = document.getElementById('canvas-text');
+  const paragraphNumber = Number.parseInt(String(paragraph || ''), 10);
+  if (!(pane instanceof HTMLElement) || !pane.classList.contains('is-active') || !Number.isFinite(paragraphNumber) || paragraphNumber <= 0) {
+    return [];
+  }
+  const blockNodes = Array.from(pane.querySelectorAll('p, li, blockquote, article, section')).filter((node) => node instanceof HTMLElement);
+  const block = blockNodes[paragraphNumber - 1];
+  if (block instanceof HTMLElement) {
+    return [normalizedRectFromClientRect(block.getBoundingClientRect(), pane.getBoundingClientRect(), {
+      scrollLeft: pane.scrollLeft,
+      scrollTop: pane.scrollTop,
+      width: Math.max(pane.scrollWidth, pane.clientWidth, 1),
+      height: Math.max(pane.scrollHeight, pane.clientHeight, 1),
+    }, clamp01)];
+  }
+  const paragraphs = String(pane.textContent || '').split(/\n\s*\n+/).map((entry) => entry.trim()).filter(Boolean);
+  if (paragraphs.length === 0) {
+    return [];
+  }
+  const height = Math.max(pane.scrollHeight, pane.clientHeight, 1);
+  const segmentHeight = height / paragraphs.length;
+  const top = Math.max(0, Math.min(height - segmentHeight, (paragraphNumber - 1) * segmentHeight));
+  return [{
+    x: 0.02,
+    y: clamp01(top / height),
+    width: 0.96,
+    height: clamp01(segmentHeight / height),
+  }];
+}
+
 function buildImportedScanAnnotation(entry, index, payload, deps) {
   const {
     clamp01,
@@ -93,6 +124,7 @@ function buildImportedScanAnnotation(entry, index, payload, deps) {
   const currentKind = safeText(state.currentCanvasArtifact?.kind || '');
   const page = Number.parseInt(safeText(entry?.page), 10);
   const line = Number.parseInt(safeText(entry?.line), 10);
+  const paragraph = Number.parseInt(safeText(entry?.paragraph), 10);
   const anchorText = safeText(entry?.anchor_text);
   const text = safeText(entry?.content || entry?.text || 'Scanned note');
   const bounds = normalizeScanBounds(entry?.bounds, clamp01);
@@ -101,6 +133,7 @@ function buildImportedScanAnnotation(entry, index, payload, deps) {
     text,
     anchor_text: anchorText,
     line: Number.isFinite(line) && line > 0 ? line : 0,
+    paragraph: Number.isFinite(paragraph) && paragraph > 0 ? paragraph : 0,
     color: highlightColor,
     notes: [],
     confidence: clamp01(Number(entry?.confidence)),
@@ -122,7 +155,9 @@ function buildImportedScanAnnotation(entry, index, payload, deps) {
   const rects = findTextAnchorRects(anchorText, safeText, collectNormalizedClientRects) || [];
   const mappedRects = rects.length > 0
     ? rects
-    : (Number.isFinite(line) && line > 0 ? approximateTextRectsForLine(line, clamp01) : []);
+    : (Number.isFinite(line) && line > 0
+      ? approximateTextRectsForLine(line, clamp01)
+      : (Number.isFinite(paragraph) && paragraph > 0 ? approximateTextRectsForParagraph(paragraph, clamp01) : []));
   return {
     ...base,
     type: 'highlight',
@@ -258,6 +293,7 @@ export function createScanAnnotationController(deps) {
             content: safeText(entry?.text),
             anchor_text: safeText(entry?.anchor_text),
             line: Number(entry?.line || 0),
+            paragraph: Number(entry?.paragraph || 0),
             page: Number(entry?.page || 0),
             bounds: normalizeScanBounds(Array.isArray(entry?.rects) ? entry.rects[0] : null, clamp01),
             confidence: Number(entry?.confidence || 0),

--- a/internal/web/static/print.css
+++ b/internal/web/static/print.css
@@ -115,6 +115,35 @@ body.print-page {
   font: 0.95rem/1.55 "IBM Plex Mono", "SFMono-Regular", monospace;
 }
 
+.print-content-marked {
+  display: grid;
+  gap: 8px;
+}
+
+.print-marker-row {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.print-marker-row-paragraph {
+  margin-bottom: 8px;
+}
+
+.print-marker {
+  color: #9d9075;
+  font: 700 0.74rem/1.25 "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  user-select: all;
+}
+
+.print-marker-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .print-details {
   margin-top: 16px;
 }

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -775,6 +775,69 @@ test.describe('floating tool palette', () => {
     expect(String(sent?.text || '')).toContain('Selection: "check nil case"');
   });
 
+  test('scan upload preserves paragraph mapping for email artifacts', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [{
+          id: 905,
+          title: 'Review scanned reply notes',
+          state: 'inbox',
+          artifact_id: 702,
+          artifact_kind: 'email',
+          artifact_title: 'Re: follow-up',
+          updated_at: '2026-03-08 10:09:00',
+        }],
+      });
+      (window as any).__setItemSidebarArtifacts({
+        702: {
+          id: 702,
+          kind: 'email',
+          title: 'Re: follow-up',
+          meta_json: JSON.stringify({ text: 'First paragraph.\n\nSecond paragraph.' }),
+        },
+      });
+      (window as any).__setScanUploadResponse({
+        project_id: 'test',
+        item_id: 905,
+        artifact_id: 702,
+        scan_artifact: { id: 992, kind: 'image', title: 'Scanned email annotations' },
+        annotations: [
+          { content: 'reply here', anchor_text: 'Second paragraph.', paragraph: 2, confidence: 0.87 },
+        ],
+      });
+      (window as any).__setScanConfirmResponse({
+        project_id: 'test',
+        item_id: 905,
+        artifact_id: 702,
+        scan_artifact_id: 992,
+        review_artifact: { id: 993, kind: 'annotation', title: 'Reviewed email annotations' },
+      });
+    });
+
+    await page.locator('#edge-left-tap').click();
+    await page.locator('.sidebar-tab', { hasText: 'Inbox' }).click();
+    await page.locator('#pr-file-list .pr-file-item').first().click();
+    await expect(page.locator('#canvas-text')).toContainText('Second paragraph.');
+
+    await page.locator('#scan-upload-trigger').click();
+    await page.setInputFiles('#scan-upload-input', {
+      name: 'annotated-email.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a3xwAAAAASUVORK5CYII=', 'base64'),
+    });
+    await waitForLogEntry(page, 'api_fetch', 'scan_upload');
+    await expect(page.locator('#canvas-text .canvas-user-highlight.is-persistent')).toHaveCount(1);
+
+    await clearLog(page);
+    await page.locator('#annotation-bundle-send').click();
+    await waitForLogEntry(page, 'api_fetch', 'scan_confirm');
+
+    const confirmEntry = (await getLog(page)).find((entry) => entry.type === 'api_fetch' && entry.action === 'scan_confirm');
+    const confirmPayload = (confirmEntry?.payload || {}) as any;
+    const annotations = Array.isArray(confirmPayload.annotations) ? confirmPayload.annotations : [];
+    expect(Number(annotations[0]?.paragraph || 0)).toBe(2);
+  });
+
   test('email thread artifacts opened from the sidebar render thread text on annotate surface', async ({ page }) => {
     await page.evaluate(() => {
       (window as any).__setItemSidebarData({


### PR DESCRIPTION
## Summary
- add print-time machine-readable position markers to item packets: `L###` for line-oriented artifacts and `P##` for paragraph-oriented email artifacts
- extend scan extraction and confirmation payloads to preserve paragraph mappings alongside line/page mappings
- map paragraph-based scan imports back onto the active canvas so reviewed email/prose annotations land on the digital artifact before send

## Verification
- [x] Printed artifacts include position markers for scan mapping
Command: `go test ./internal/web -run 'Test(ItemPrint|Scan)'`
Output: `ok   github.com/krystophny/tabura/internal/web  0.060s`
Evidence: `TestItemPrintHTMLIncludesCoverSheetAndArtifactFileContent` and `TestItemPrintEmailArtifactUsesParagraphMarkers` assert rendered print HTML contains `data-print-marker="line"`, `L001`, `L002`, `data-print-marker="paragraph"`, `P01`, and `P02`.
Implementation: `rg -n "data-print-marker|printMarkerModeParagraph|printMarkerModeLine|ArtifactKindEmail|ArtifactKindEmailThread|artifactKindEmailDraft" internal/web/item_print.go internal/web/static/print.css`
Excerpt: `item_print.go:258` emits `data-print-marker="line" ... L%03d`; `item_print.go:273` emits `data-print-marker="paragraph" ... P%02d`.
- [x] Scan extraction maps annotations to original artifact positions
Command: `go test ./internal/web -run 'Test(ItemPrint|Scan)'`
Output: `ok   github.com/krystophny/tabura/internal/web  0.060s`
Evidence: `TestScanUploadCreatesLinkedArtifactAndSummary`, `TestScanConfirmCreatesAnnotationArtifactAndUpdatesScanMeta`, and `TestScanSummariesAndPromptPreserveParagraphMarkers` cover extracted mappings, stored scan metadata, and paragraph-aware summaries/prompt generation.
Implementation: `rg -n "paragraph|L001 for lines|P01 for paragraphs" internal/web/scan.go`
Excerpt: `scan.go:543-548` adds `paragraph` to the extractor contract; `scan.go:576-577` instructs the extractor to use inline `L001` / `P01` markers.
- [x] Mapping works for code (lines), documents/diffs (line markers), and emails (paragraph markers)
Command: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep 'scan upload imports annotations|scan upload preserves paragraph mapping'`
Output: `2 passed (3.4s)`
Evidence: the first Playwright case covers line-based import/confirm on a markdown artifact; the second covers paragraph-based import/confirm on an email artifact and asserts the `scan_confirm` payload preserves `paragraph: 2`.
Implementation: `rg -n "approximateTextRectsForParagraph|paragraph: Number|scan upload preserves paragraph mapping" internal/web/static/app-annotations-scan.js tests/playwright/ui-system.spec.ts`
Excerpt: `app-annotations-scan.js:85-109` adds paragraph-to-rect mapping; `ui-system.spec.ts:838` asserts the confirmed annotation keeps `paragraph = 2`.
- [x] Mapped annotations shown on the digital artifact for verification
Command: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep 'scan upload imports annotations|scan upload preserves paragraph mapping'`
Output: `2 passed (3.4s)`
Evidence: both Playwright cases assert `#canvas-text .canvas-user-highlight.is-persistent` appears after scan upload, proving imported scan annotations are rendered back onto the live canvas before send.
- [x] Dialogue can immediately act on scanned annotations
Command: `./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep 'scan upload imports annotations'`
Output excerpt: `✓ ... scan upload imports annotations, allows correction, and confirms before send`
Evidence: that test edits the imported annotation, sends the bundle, and asserts the resulting `message_sent` payload contains `Selection: "check nil case"`.
- [x] Markers are unobtrusive in print but machine-readable in scan
Implementation: `rg -n "print-marker" internal/web/static/print.css internal/web/item_print.go`
Excerpt: `print.css` styles `.print-marker` with muted condensed typography while `item_print.go` renders stable `data-print-marker` spans for the extractor-visible marker text.
- [x] Full test coverage for the implemented print/scan marker path
Command: `go test ./internal/web -run 'Test(ItemPrint|Scan)' && ./scripts/playwright.sh tests/playwright/ui-system.spec.ts --grep 'scan upload imports annotations|scan upload preserves paragraph mapping'`
Output excerpts: `ok   github.com/krystophny/tabura/internal/web  0.060s`; `2 passed (3.4s)`
