### PR TITLE
fix: Make AI aware of pen strokes and sketches during dialogue (fixes #199)

### DIFF
--- a/internal/web/chat_canvas_ink.go
+++ b/internal/web/chat_canvas_ink.go
@@ -1,0 +1,562 @@
+package web
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const chatCanvasInkMaxEventsPerSecond = 5
+
+type chatCanvasInkBoundingBox struct {
+	RelativeX      float64 `json:"relative_x"`
+	RelativeY      float64 `json:"relative_y"`
+	RelativeWidth  float64 `json:"relative_width"`
+	RelativeHeight float64 `json:"relative_height"`
+}
+
+type chatCanvasInkLineRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type chatCanvasInkEvent struct {
+	Cursor           *chatCursorContext
+	Gesture          string
+	ArtifactKind     string
+	StrokeCount      int
+	Requested        bool
+	BoundingBox      *chatCanvasInkBoundingBox
+	OverlappingLines *chatCanvasInkLineRange
+	OverlappingText  string
+	SnapshotPath     string
+	OccurredAt       time.Time
+}
+
+type chatCanvasInkTracker struct {
+	mu     sync.Mutex
+	events map[string][]*chatCanvasInkEvent
+	recent map[string][]time.Time
+}
+
+func newChatCanvasInkTracker() *chatCanvasInkTracker {
+	return &chatCanvasInkTracker{
+		events: map[string][]*chatCanvasInkEvent{},
+		recent: map[string][]time.Time{},
+	}
+}
+
+func normalizeChatCanvasInkBoundingBox(raw *chatCanvasInkBoundingBox) *chatCanvasInkBoundingBox {
+	if raw == nil {
+		return nil
+	}
+	box := &chatCanvasInkBoundingBox{
+		RelativeX:      clampCanvasInk01(raw.RelativeX),
+		RelativeY:      clampCanvasInk01(raw.RelativeY),
+		RelativeWidth:  clampCanvasInk01(raw.RelativeWidth),
+		RelativeHeight: clampCanvasInk01(raw.RelativeHeight),
+	}
+	if box.RelativeWidth <= 0 && box.RelativeHeight <= 0 {
+		return nil
+	}
+	return box
+}
+
+func normalizeChatCanvasInkLineRange(raw *chatCanvasInkLineRange) *chatCanvasInkLineRange {
+	if raw == nil {
+		return nil
+	}
+	start := raw.Start
+	end := raw.End
+	if start <= 0 && end <= 0 {
+		return nil
+	}
+	if start <= 0 {
+		start = end
+	}
+	if end <= 0 {
+		end = start
+	}
+	if end < start {
+		start, end = end, start
+	}
+	if start <= 0 {
+		return nil
+	}
+	return &chatCanvasInkLineRange{Start: start, End: end}
+}
+
+func normalizeChatCanvasInkEvent(raw *chatCanvasInkEvent) *chatCanvasInkEvent {
+	if raw == nil {
+		return nil
+	}
+	gesture := strings.ToLower(strings.TrimSpace(raw.Gesture))
+	if gesture == "" {
+		gesture = "freeform"
+	}
+	artifactKind := strings.ToLower(strings.TrimSpace(raw.ArtifactKind))
+	if artifactKind == "" {
+		artifactKind = "text"
+	}
+	occurredAt := raw.OccurredAt.UTC()
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	event := &chatCanvasInkEvent{
+		Cursor:           normalizeChatCursorContext(raw.Cursor),
+		Gesture:          gesture,
+		ArtifactKind:     artifactKind,
+		StrokeCount:      raw.StrokeCount,
+		Requested:        raw.Requested,
+		BoundingBox:      normalizeChatCanvasInkBoundingBox(raw.BoundingBox),
+		OverlappingLines: normalizeChatCanvasInkLineRange(raw.OverlappingLines),
+		OverlappingText:  limitPromptLines(raw.OverlappingText, 8, 420),
+		SnapshotPath:     strings.TrimSpace(raw.SnapshotPath),
+		OccurredAt:       occurredAt,
+	}
+	if event.StrokeCount <= 0 {
+		event.StrokeCount = 1
+	}
+	if event.Cursor == nil && event.BoundingBox == nil && event.OverlappingLines == nil && event.OverlappingText == "" && event.SnapshotPath == "" {
+		return nil
+	}
+	return event
+}
+
+func (t *chatCanvasInkTracker) enqueue(sessionID string, raw *chatCanvasInkEvent) bool {
+	if t == nil {
+		return false
+	}
+	cleanSessionID := strings.TrimSpace(sessionID)
+	if cleanSessionID == "" {
+		return false
+	}
+	event := normalizeChatCanvasInkEvent(raw)
+	if event == nil {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	cutoff := event.OccurredAt.Add(-1 * time.Second)
+	recent := t.recent[cleanSessionID][:0]
+	for _, ts := range t.recent[cleanSessionID] {
+		if ts.After(cutoff) {
+			recent = append(recent, ts)
+		}
+	}
+	if len(recent) >= chatCanvasInkMaxEventsPerSecond {
+		t.recent[cleanSessionID] = recent
+		return false
+	}
+	recent = append(recent, event.OccurredAt)
+	t.recent[cleanSessionID] = recent
+	t.events[cleanSessionID] = append(t.events[cleanSessionID], event)
+	return true
+}
+
+func (t *chatCanvasInkTracker) consume(sessionID string) []*chatCanvasInkEvent {
+	if t == nil {
+		return nil
+	}
+	cleanSessionID := strings.TrimSpace(sessionID)
+	if cleanSessionID == "" {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	events := t.events[cleanSessionID]
+	if len(events) == 0 {
+		return nil
+	}
+	delete(t.events, cleanSessionID)
+	out := make([]*chatCanvasInkEvent, 0, len(events))
+	for _, event := range events {
+		if event != nil {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+func appendCanvasInkPrompt(prompt string, events []*chatCanvasInkEvent) string {
+	contextBlock := formatCanvasInkPromptContext(events)
+	prompt = strings.TrimSpace(prompt)
+	if contextBlock == "" {
+		return prompt
+	}
+	if prompt == "" {
+		return contextBlock
+	}
+	return contextBlock + "\n\n" + prompt
+}
+
+func formatCanvasInkPromptContext(events []*chatCanvasInkEvent) string {
+	filtered := make([]*chatCanvasInkEvent, 0, len(events))
+	requested := false
+	for _, event := range events {
+		normalized := normalizeChatCanvasInkEvent(event)
+		if normalized == nil {
+			continue
+		}
+		filtered = append(filtered, normalized)
+		if normalized.Requested {
+			requested = true
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	lines := []string{"## Canvas Ink Events"}
+	if requested {
+		lines = append(lines, "The latest live ink input arrived during dialogue. Continue from the ink instead of asking the user to repeat or point again.")
+	} else {
+		lines = append(lines, "The user shared live ink during dialogue.")
+	}
+	lines = append(lines, "If a snapshot path is present, inspect that image when handwriting or freeform sketch meaning matters.")
+	for i, event := range filtered {
+		lines = append(lines, fmt.Sprintf("%d. %s", i+1, describeCanvasInkEvent(event)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func describeCanvasInkEvent(event *chatCanvasInkEvent) string {
+	if event == nil {
+		return ""
+	}
+	target := "active artifact"
+	if event.Cursor != nil {
+		if resolved := cursorPromptTarget(event.Cursor); resolved != "" {
+			target = resolved
+		}
+	}
+	label := event.Gesture
+	if label == "" {
+		label = "freeform"
+	}
+	parts := []string{fmt.Sprintf("%s ink over %s", strings.ReplaceAll(label, "_", " "), target)}
+	if event.StrokeCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d stroke(s)", event.StrokeCount))
+	}
+	if event.OverlappingLines != nil {
+		lineText := fmt.Sprintf("overlapping line %d", event.OverlappingLines.Start)
+		if event.OverlappingLines.End > event.OverlappingLines.Start {
+			lineText = fmt.Sprintf("overlapping lines %d-%d", event.OverlappingLines.Start, event.OverlappingLines.End)
+		}
+		parts = append(parts, lineText)
+	}
+	if text := strings.TrimSpace(event.OverlappingText); text != "" {
+		parts = append(parts, "overlapping text "+quotePromptText(text, 220))
+	}
+	if box := event.BoundingBox; box != nil {
+		parts = append(parts, fmt.Sprintf("bounding box %.0f%%, %.0f%% to %.0f%%, %.0f%%",
+			box.RelativeX*100,
+			box.RelativeY*100,
+			(box.RelativeX+box.RelativeWidth)*100,
+			(box.RelativeY+box.RelativeHeight)*100,
+		))
+	}
+	if path := strings.TrimSpace(event.SnapshotPath); path != "" {
+		parts = append(parts, fmt.Sprintf("snapshot path `%s`", path))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (a *App) persistChatCanvasInkSnapshot(sessionID, raw string) string {
+	cleanSessionID := strings.TrimSpace(sessionID)
+	clean := strings.TrimSpace(raw)
+	if cleanSessionID == "" || clean == "" {
+		return ""
+	}
+	data, err := decodeChatCanvasInkSnapshot(clean)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	session, err := a.store.GetChatSession(cleanSessionID)
+	if err != nil {
+		return ""
+	}
+	project, err := a.store.GetProjectByProjectKey(session.ProjectKey)
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(project.RootPath, ".tabura", "artifacts", "tmp", "live-ink")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return ""
+	}
+	name := fmt.Sprintf("%s-%s.png", time.Now().UTC().Format("20060102-150405"), randomToken())
+	absPath := filepath.Join(dir, name)
+	if err := os.WriteFile(absPath, data, 0o644); err != nil {
+		return ""
+	}
+	relPath, err := filepath.Rel(project.RootPath, absPath)
+	if err != nil {
+		return ""
+	}
+	return filepath.ToSlash(relPath)
+}
+
+func decodeChatCanvasInkSnapshot(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	if idx := strings.Index(trimmed, ","); idx >= 0 && strings.HasPrefix(strings.ToLower(trimmed[:idx]), "data:image/png;base64") {
+		trimmed = trimmed[idx+1:]
+	}
+	data, err := base64.StdEncoding.DecodeString(trimmed)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func clampCanvasInk01(value float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0
+	}
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+func recognizeChatCanvasInkGesture(strokes []inkSubmitStroke) string {
+	filtered := normalizeInkStrokesForGesture(strokes)
+	if len(filtered) == 0 {
+		return "freeform"
+	}
+	if isInkCircle(filtered) {
+		return "circle"
+	}
+	if isInkUnderline(filtered) {
+		return "underline"
+	}
+	if isInkCross(filtered) {
+		return "cross"
+	}
+	if isInkQuestionMark(filtered) {
+		return "question_mark"
+	}
+	if isInkArrow(filtered) {
+		return "arrow"
+	}
+	return "freeform"
+}
+
+type inkGesturePoint struct {
+	X float64
+	Y float64
+}
+
+type inkGestureStroke struct {
+	Points []inkGesturePoint
+}
+
+func normalizeInkStrokesForGesture(strokes []inkSubmitStroke) []inkGestureStroke {
+	out := make([]inkGestureStroke, 0, len(strokes))
+	for _, stroke := range strokes {
+		points := make([]inkGesturePoint, 0, len(stroke.Points))
+		for _, point := range stroke.Points {
+			if math.IsNaN(point.X) || math.IsInf(point.X, 0) || math.IsNaN(point.Y) || math.IsInf(point.Y, 0) {
+				continue
+			}
+			points = append(points, inkGesturePoint{X: point.X, Y: point.Y})
+		}
+		if len(points) >= 2 {
+			out = append(out, inkGestureStroke{Points: points})
+		}
+	}
+	return out
+}
+
+func isInkCircle(strokes []inkGestureStroke) bool {
+	if len(strokes) != 1 {
+		return false
+	}
+	stroke := strokes[0]
+	minX, minY, maxX, maxY := inkGestureBounds(stroke.Points)
+	width := maxX - minX
+	height := maxY - minY
+	if width < 12 || height < 12 {
+		return false
+	}
+	ratio := width / height
+	if ratio < 0.55 || ratio > 1.8 {
+		return false
+	}
+	pathLen := inkGestureLength(stroke.Points)
+	if pathLen <= 0 {
+		return false
+	}
+	closure := inkGestureDistance(stroke.Points[0], stroke.Points[len(stroke.Points)-1])
+	return closure <= math.Max(width, height)*0.35 && pathLen >= 1.6*math.Max(width, height)
+}
+
+func isInkUnderline(strokes []inkGestureStroke) bool {
+	if len(strokes) != 1 {
+		return false
+	}
+	stroke := strokes[0]
+	minX, minY, maxX, maxY := inkGestureBounds(stroke.Points)
+	width := maxX - minX
+	height := maxY - minY
+	if width < 16 || height <= 0 || width < height*4 {
+		return false
+	}
+	start := stroke.Points[0]
+	end := stroke.Points[len(stroke.Points)-1]
+	dx := math.Abs(end.X - start.X)
+	dy := math.Abs(end.Y - start.Y)
+	return dx >= dy*2.5 && inkGestureDistance(start, end) >= inkGestureLength(stroke.Points)*0.8
+}
+
+func isInkCross(strokes []inkGestureStroke) bool {
+	if len(strokes) != 2 {
+		return false
+	}
+	a := strokes[0]
+	b := strokes[1]
+	if !inkGestureSegmentIntersects(a.Points[0], a.Points[len(a.Points)-1], b.Points[0], b.Points[len(b.Points)-1]) {
+		return false
+	}
+	return inkGestureDiagonal(a) && inkGestureDiagonal(b)
+}
+
+func isInkQuestionMark(strokes []inkGestureStroke) bool {
+	if len(strokes) != 2 {
+		return false
+	}
+	mainIdx := 0
+	dotIdx := 1
+	if inkGestureLength(strokes[1].Points) > inkGestureLength(strokes[0].Points) {
+		mainIdx = 1
+		dotIdx = 0
+	}
+	main := strokes[mainIdx]
+	dot := strokes[dotIdx]
+	minX, minY, maxX, maxY := inkGestureBounds(main.Points)
+	dotMinX, dotMinY, dotMaxX, dotMaxY := inkGestureBounds(dot.Points)
+	mainWidth := maxX - minX
+	mainHeight := maxY - minY
+	dotWidth := dotMaxX - dotMinX
+	dotHeight := dotMaxY - dotMinY
+	if mainHeight < 14 || mainWidth < 8 {
+		return false
+	}
+	if dotWidth > mainWidth*0.4 || dotHeight > mainHeight*0.35 {
+		return false
+	}
+	dotCenterX := dotMinX + dotWidth/2
+	return dotMinY > maxY && dotCenterX >= minX-mainWidth*0.2 && dotCenterX <= maxX+mainWidth*0.2
+}
+
+func isInkArrow(strokes []inkGestureStroke) bool {
+	if len(strokes) < 2 || len(strokes) > 3 {
+		return false
+	}
+	mainIdx := 0
+	mainLen := 0.0
+	for i, stroke := range strokes {
+		if length := inkGestureLength(stroke.Points); length > mainLen {
+			mainLen = length
+			mainIdx = i
+		}
+	}
+	main := strokes[mainIdx]
+	mainStart := main.Points[0]
+	mainEnd := main.Points[len(main.Points)-1]
+	mainVectorX := mainEnd.X - mainStart.X
+	mainVectorY := mainEnd.Y - mainStart.Y
+	if math.Hypot(mainVectorX, mainVectorY) < 16 {
+		return false
+	}
+	headCount := 0
+	for i, stroke := range strokes {
+		if i == mainIdx {
+			continue
+		}
+		start := stroke.Points[0]
+		end := stroke.Points[len(stroke.Points)-1]
+		if inkGestureDistance(start, mainEnd) > mainLen*0.35 && inkGestureDistance(end, mainEnd) > mainLen*0.35 {
+			continue
+		}
+		sx := end.X - start.X
+		sy := end.Y - start.Y
+		if math.Hypot(sx, sy) < 6 {
+			continue
+		}
+		angle := inkGestureAngleBetween(mainVectorX, mainVectorY, sx, sy)
+		if angle >= 20 && angle <= 80 {
+			headCount++
+		}
+	}
+	return headCount >= 1
+}
+
+func inkGestureDiagonal(stroke inkGestureStroke) bool {
+	start := stroke.Points[0]
+	end := stroke.Points[len(stroke.Points)-1]
+	dx := math.Abs(end.X - start.X)
+	dy := math.Abs(end.Y - start.Y)
+	return dx >= 6 && dy >= 6 && dx <= dy*3 && dy <= dx*3
+}
+
+func inkGestureBounds(points []inkGesturePoint) (float64, float64, float64, float64) {
+	minX := points[0].X
+	minY := points[0].Y
+	maxX := points[0].X
+	maxY := points[0].Y
+	for _, point := range points[1:] {
+		minX = math.Min(minX, point.X)
+		minY = math.Min(minY, point.Y)
+		maxX = math.Max(maxX, point.X)
+		maxY = math.Max(maxY, point.Y)
+	}
+	return minX, minY, maxX, maxY
+}
+
+func inkGestureLength(points []inkGesturePoint) float64 {
+	total := 0.0
+	for i := 1; i < len(points); i++ {
+		total += inkGestureDistance(points[i-1], points[i])
+	}
+	return total
+}
+
+func inkGestureDistance(a, b inkGesturePoint) float64 {
+	return math.Hypot(b.X-a.X, b.Y-a.Y)
+}
+
+func inkGestureAngleBetween(ax, ay, bx, by float64) float64 {
+	aLen := math.Hypot(ax, ay)
+	bLen := math.Hypot(bx, by)
+	if aLen == 0 || bLen == 0 {
+		return 180
+	}
+	cosTheta := ((ax * bx) + (ay * by)) / (aLen * bLen)
+	if cosTheta > 1 {
+		cosTheta = 1
+	} else if cosTheta < -1 {
+		cosTheta = -1
+	}
+	return math.Abs(math.Acos(cosTheta) * 180 / math.Pi)
+}
+
+func inkGestureSegmentIntersects(a1, a2, b1, b2 inkGesturePoint) bool {
+	return inkGestureOrientation(a1, a2, b1)*inkGestureOrientation(a1, a2, b2) <= 0 &&
+		inkGestureOrientation(b1, b2, a1)*inkGestureOrientation(b1, b2, a2) <= 0
+}
+
+func inkGestureOrientation(a, b, c inkGesturePoint) float64 {
+	return (b.X-a.X)*(c.Y-a.Y) - (b.Y-a.Y)*(c.X-a.X)
+}

--- a/internal/web/chat_canvas_ink_test.go
+++ b/internal/web/chat_canvas_ink_test.go
@@ -1,0 +1,171 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testCanvasInkPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a3xwAAAAASUVORK5CYII="
+
+func TestAppendCanvasInkPrompt_PrependsStructuredEvents(t *testing.T) {
+	prompt := appendCanvasInkPrompt("Conversation transcript:\nUSER:\nwhat does this mean?", []*chatCanvasInkEvent{
+		{
+			Cursor: &chatCursorContext{
+				Title:       "notes.md",
+				Line:        4,
+				Surrounding: "3: beta\n4: gamma\n5: delta",
+			},
+			Gesture:          "question_mark",
+			ArtifactKind:     "text",
+			StrokeCount:      2,
+			Requested:        true,
+			OverlappingLines: &chatCanvasInkLineRange{Start: 4, End: 4},
+			OverlappingText:  "3: beta\n4: gamma\n5: delta",
+			SnapshotPath:     ".tabura/artifacts/tmp/live-ink/sample.png",
+		},
+	})
+	if !strings.HasPrefix(prompt, "## Canvas Ink Events") {
+		t.Fatalf("prompt should start with canvas ink context, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Continue from the ink instead of asking the user to repeat or point again.") {
+		t.Fatalf("prompt missing continuation guidance, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "question mark ink over line 4 of \"notes.md\"") {
+		t.Fatalf("prompt missing gesture target, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "snapshot path `.tabura/artifacts/tmp/live-ink/sample.png`") {
+		t.Fatalf("prompt missing snapshot path, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Conversation transcript:\nUSER:\nwhat does this mean?") {
+		t.Fatalf("prompt missing original body, got:\n%s", prompt)
+	}
+}
+
+func TestRecognizeChatCanvasInkGesture(t *testing.T) {
+	tests := []struct {
+		name    string
+		strokes []inkSubmitStroke
+		want    string
+	}{
+		{
+			name: "circle",
+			strokes: []inkSubmitStroke{{
+				Points: []inkSubmitPoint{
+					{X: 10, Y: 20}, {X: 20, Y: 10}, {X: 30, Y: 20}, {X: 20, Y: 30}, {X: 10, Y: 20},
+				},
+			}},
+			want: "circle",
+		},
+		{
+			name: "underline",
+			strokes: []inkSubmitStroke{{
+				Points: []inkSubmitPoint{
+					{X: 10, Y: 20}, {X: 30, Y: 21}, {X: 50, Y: 20},
+				},
+			}},
+			want: "underline",
+		},
+		{
+			name: "cross",
+			strokes: []inkSubmitStroke{
+				{Points: []inkSubmitPoint{{X: 10, Y: 10}, {X: 30, Y: 30}}},
+				{Points: []inkSubmitPoint{{X: 30, Y: 10}, {X: 10, Y: 30}}},
+			},
+			want: "cross",
+		},
+		{
+			name: "arrow",
+			strokes: []inkSubmitStroke{
+				{Points: []inkSubmitPoint{{X: 10, Y: 20}, {X: 40, Y: 20}}},
+				{Points: []inkSubmitPoint{{X: 32, Y: 14}, {X: 40, Y: 20}}},
+				{Points: []inkSubmitPoint{{X: 32, Y: 26}, {X: 40, Y: 20}}},
+			},
+			want: "arrow",
+		},
+		{
+			name: "question mark",
+			strokes: []inkSubmitStroke{
+				{Points: []inkSubmitPoint{{X: 10, Y: 10}, {X: 20, Y: 6}, {X: 28, Y: 12}, {X: 20, Y: 20}, {X: 20, Y: 26}}},
+				{Points: []inkSubmitPoint{{X: 20, Y: 34}, {X: 21, Y: 35}}},
+			},
+			want: "question_mark",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recognizeChatCanvasInkGesture(tc.strokes); got != tc.want {
+				t.Fatalf("recognizeChatCanvasInkGesture() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandleChatWSTextMessage_CanvasInkQueuesRequestedTurnAndPersistsSnapshot(t *testing.T) {
+	app := newAuthedTestApp(t)
+	sessionID := testSessionForCanvasPosition(t, app)
+
+	handleChatWSTextMessage(app, newChatWSConn(nil), sessionID, []byte(`{
+		"type": "canvas_ink",
+		"artifact_kind": "text",
+		"output_mode": "voice",
+		"request_response": true,
+		"snapshot_data_url": "`+testCanvasInkPNGDataURL+`",
+		"total_strokes": 2,
+		"bounding_box": {
+			"relative_x": 0.2,
+			"relative_y": 0.3,
+			"relative_width": 0.25,
+			"relative_height": 0.1
+		},
+		"overlapping_lines": { "start": 3, "end": 4 },
+		"overlapping_text": "2: beta\n3: gamma\n4: delta",
+		"cursor": {
+			"title": "test.txt",
+			"line": 3,
+			"surrounding_text": "2: beta\n3: gamma\n4: delta"
+		},
+		"strokes": [
+			{ "points": [ { "x": 10, "y": 20 }, { "x": 30, "y": 21 }, { "x": 50, "y": 20 } ] }
+		]
+	}`))
+
+	if got := app.turns.queuedCount(sessionID); got != 1 {
+		t.Fatalf("queuedCount = %d, want 1", got)
+	}
+	events := app.chatCanvasInk.consume(sessionID)
+	if len(events) != 1 {
+		t.Fatalf("consume len = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event == nil {
+		t.Fatal("expected event")
+	}
+	if event.Gesture != "underline" {
+		t.Fatalf("gesture = %q, want underline", event.Gesture)
+	}
+	if event.OverlappingLines == nil || event.OverlappingLines.Start != 3 || event.OverlappingLines.End != 4 {
+		t.Fatalf("overlapping lines = %#v", event.OverlappingLines)
+	}
+	if strings.TrimSpace(event.SnapshotPath) == "" {
+		t.Fatal("expected snapshot path")
+	}
+
+	session, err := app.store.GetChatSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetChatSession: %v", err)
+	}
+	project, err := app.store.GetProjectByProjectKey(session.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetProjectByProjectKey: %v", err)
+	}
+	snapshotBytes, err := os.ReadFile(filepath.Join(project.RootPath, filepath.FromSlash(event.SnapshotPath)))
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if len(snapshotBytes) == 0 {
+		t.Fatal("expected snapshot bytes")
+	}
+}

--- a/internal/web/chat_stt.go
+++ b/internal/web/chat_stt.go
@@ -119,16 +119,23 @@ func handleSTTCancel(conn *chatWSConn) {
 
 func handleChatWSTextMessage(a *App, conn *chatWSConn, sessionID string, data []byte) {
 	var msg struct {
-		Type            string             `json:"type"`
-		MimeType        string             `json:"mime_type"`
-		Text            string             `json:"text"`
-		Lang            string             `json:"lang"`
-		RequestID       string             `json:"request_id"`
-		Decision        string             `json:"decision"`
-		OutputMode      string             `json:"output_mode"`
-		Gesture         string             `json:"gesture"`
-		RequestResponse bool               `json:"request_response"`
-		Cursor          *chatCursorContext `json:"cursor"`
+		Type             string                    `json:"type"`
+		MimeType         string                    `json:"mime_type"`
+		Text             string                    `json:"text"`
+		Lang             string                    `json:"lang"`
+		RequestID        string                    `json:"request_id"`
+		Decision         string                    `json:"decision"`
+		OutputMode       string                    `json:"output_mode"`
+		Gesture          string                    `json:"gesture"`
+		RequestResponse  bool                      `json:"request_response"`
+		Cursor           *chatCursorContext        `json:"cursor"`
+		ArtifactKind     string                    `json:"artifact_kind"`
+		SnapshotDataURL  string                    `json:"snapshot_data_url"`
+		TotalStrokes     int                       `json:"total_strokes"`
+		BoundingBox      *chatCanvasInkBoundingBox `json:"bounding_box"`
+		OverlappingLines *chatCanvasInkLineRange   `json:"overlapping_lines"`
+		OverlappingText  string                    `json:"overlapping_text"`
+		Strokes          []inkSubmitStroke         `json:"strokes"`
 	}
 	if err := json.Unmarshal(data, &msg); err != nil {
 		return
@@ -166,7 +173,41 @@ func handleChatWSTextMessage(a *App, conn *chatWSConn, sessionID string, data []
 			return
 		}
 		if msg.RequestResponse {
+			if a.activeChatTurnCount(sessionID) > 0 || a.queuedChatTurnCount(sessionID) > 0 {
+				return
+			}
+			a.enqueueAssistantTurn(sessionID, normalizeTurnOutputMode(msg.OutputMode))
+		}
+	case "canvas_ink":
+		snapshotPath := a.persistChatCanvasInkSnapshot(sessionID, msg.SnapshotDataURL)
+		if !a.chatCanvasInk.enqueue(sessionID, &chatCanvasInkEvent{
+			Cursor:           msg.Cursor,
+			Gesture:          recognizeChatCanvasInkGesture(msg.Strokes),
+			ArtifactKind:     msg.ArtifactKind,
+			StrokeCount:      maxCanvasInkStrokeCount(msg.TotalStrokes, len(msg.Strokes)),
+			Requested:        msg.RequestResponse,
+			BoundingBox:      msg.BoundingBox,
+			OverlappingLines: msg.OverlappingLines,
+			OverlappingText:  msg.OverlappingText,
+			SnapshotPath:     snapshotPath,
+		}) {
+			return
+		}
+		if msg.RequestResponse {
+			if a.activeChatTurnCount(sessionID) > 0 || a.queuedChatTurnCount(sessionID) > 0 {
+				return
+			}
 			a.enqueueAssistantTurn(sessionID, normalizeTurnOutputMode(msg.OutputMode))
 		}
 	}
+}
+
+func maxCanvasInkStrokeCount(total, current int) int {
+	if total > current {
+		return total
+	}
+	if current > 0 {
+		return current
+	}
+	return 1
 }

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -24,6 +24,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
 		return
 	}
+	inkCtx := a.chatCanvasInk.consume(sessionID)
 	positionCtx := a.chatCanvasPositions.consume(sessionID)
 	cursorCtx := turn.cursor
 	userText := queuedUserMessage(messages, turn.messageID)
@@ -54,7 +55,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
-		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, positionCtx, turn.outputMode, profile)
+		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, turn.outputMode, profile)
 		return
 	}
 
@@ -68,6 +69,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
 	}
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
+	prompt = appendCanvasInkPrompt(prompt, inkCtx)
 	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
 	if strings.TrimSpace(prompt) == "" {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
@@ -331,11 +333,12 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 
 // runAssistantTurnLegacy is the single-shot fallback when persistent session
 // fails to connect. Each call creates a new WS + thread.
-func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, positionCtx []*chatCanvasPositionEvent, outputMode string, profile appServerModelProfile) {
+func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string, profile appServerModelProfile) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
 	prompt := buildPromptFromHistoryForSessionWithPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, outputMode, profile.Alias)
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
+	prompt = appendCanvasInkPrompt(prompt, inkCtx)
 	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
 	if strings.TrimSpace(prompt) == "" {
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -108,6 +108,7 @@ type App struct {
 	companionRuntime        *companionRuntimeTracker
 	chatCaptureModes        *chatCaptureModeTracker
 	chatCursorContexts      *chatCursorContextTracker
+	chatCanvasInk           *chatCanvasInkTracker
 	chatCanvasPositions     *chatCanvasPositionTracker
 	dictationSessions       *dictationSessionTracker
 	workspaceWatches        *workspaceWatchTracker
@@ -300,6 +301,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		companionRuntime:        newCompanionRuntimeTracker(),
 		chatCaptureModes:        newChatCaptureModeTracker(),
 		chatCursorContexts:      newChatCursorContextTracker(),
+		chatCanvasInk:           newChatCanvasInkTracker(),
 		chatCanvasPositions:     newChatCanvasPositionTracker(),
 		dictationSessions:       newDictationSessionTracker(),
 		workspaceWatches:        newWorkspaceWatchTracker(),

--- a/internal/web/static/app-env.js
+++ b/internal/web/static/app-env.js
@@ -4,6 +4,7 @@ export {
   renderCanvas,
   clearCanvas,
   resolveCanvasApprovalRequest,
+  getLocationFromPoint,
   getLocationFromSelection,
   clearLineHighlight,
   escapeHtml,

--- a/internal/web/static/app-ink.js
+++ b/internal/web/static/app-ink.js
@@ -1,7 +1,7 @@
 import * as env from './app-env.js';
 import * as context from './app-context.js';
 
-const { marked, apiURL, wsURL, renderCanvas, clearCanvas, getLocationFromSelection, clearLineHighlight, escapeHtml, sanitizeHtml, getActiveArtifactTitle, getActiveTextEventId, getPreviousArtifactText, getUiState, setUiMode, showIndicatorMode, hideIndicator, showTextInput, hideTextInput, showOverlay, hideOverlay, updateOverlay, isOverlayVisible, isTextInputVisible, isRecording, setRecording, getInputAnchor, setInputAnchor, getAnchorFromPoint, buildContextPrefix, getLastInputPosition, setLastInputPosition, configureLiveSession, getLiveSessionSnapshot, handleLiveSessionMessage, isLiveSessionListenActive, LIVE_SESSION_HOTWORD_DEFAULT, LIVE_SESSION_MODE_DIALOGUE, LIVE_SESSION_MODE_MEETING, onLiveSessionTTSPlaybackComplete, cancelLiveSessionListen, startLiveSession, stopLiveSession, initHotword, startHotwordMonitor, stopHotwordMonitor, isHotwordActive, onHotwordDetected, setHotwordThreshold, setHotwordAudioContext, getPreRollAudio, getHotwordMicStream, initVAD, ensureVADLoaded, float32ToWav } = env;
+const { marked, apiURL, wsURL, renderCanvas, clearCanvas, getLocationFromPoint, getLocationFromSelection, clearLineHighlight, escapeHtml, sanitizeHtml, getActiveArtifactTitle, getActiveTextEventId, getPreviousArtifactText, getUiState, setUiMode, showIndicatorMode, hideIndicator, showTextInput, hideTextInput, showOverlay, hideOverlay, updateOverlay, isOverlayVisible, isTextInputVisible, isRecording, setRecording, getInputAnchor, setInputAnchor, getAnchorFromPoint, buildContextPrefix, getLastInputPosition, setLastInputPosition, configureLiveSession, getLiveSessionSnapshot, handleLiveSessionMessage, isLiveSessionListenActive, LIVE_SESSION_HOTWORD_DEFAULT, LIVE_SESSION_MODE_DIALOGUE, LIVE_SESSION_MODE_MEETING, onLiveSessionTTSPlaybackComplete, cancelLiveSessionListen, startLiveSession, stopLiveSession, initHotword, startHotwordMonitor, stopHotwordMonitor, isHotwordActive, onHotwordDetected, setHotwordThreshold, setHotwordAudioContext, getPreRollAudio, getHotwordMicStream, initVAD, ensureVADLoaded, float32ToWav } = env;
 const { refs, state, getState, isVoiceTurn, COMPANION_VIEW_PATH_PREFIX, COMPANION_TRANSCRIPT_VIEW_PATH, COMPANION_SUMMARY_VIEW_PATH, COMPANION_REFERENCES_VIEW_PATH, MEETING_TRANSCRIPT_LABEL, MEETING_SUMMARY_LABEL, MEETING_REFERENCES_LABEL, MEETING_SUMMARY_ITEMS_PANEL_ID, CHAT_CTRL_LONG_PRESS_MS, ARTIFACT_EDIT_LONG_TAP_MS, ITEM_SIDEBAR_VIEWS, ITEM_SIDEBAR_GESTURE_CANCEL_PX, ITEM_SIDEBAR_GESTURE_COMMIT_PX, ITEM_SIDEBAR_GESTURE_LONG_PX, ITEM_SIDEBAR_DEFAULT_LATER_HOUR_UTC, ITEM_SIDEBAR_MENU_ID, DEV_UI_RELOAD_POLL_MS, ASSISTANT_ACTIVITY_POLL_MS, CHAT_WS_STALE_THRESHOLD_MS, ACTIVE_TURN_NO_ID_CLEAR_GRACE_MS, ACTIVE_TURN_ACTIVITY_CLEAR_GRACE_MS, PROJECT_CHAT_MODEL_ALIASES, PROJECT_CHAT_MODEL_REASONING_EFFORTS, TTS_SILENT_STORAGE_KEY, YOLO_MODE_STORAGE_KEY, SOMEDAY_REVIEW_NUDGE_ENABLED_STORAGE_KEY, SOMEDAY_REVIEW_NUDGE_LAST_SHOWN_STORAGE_KEY, SOMEDAY_REVIEW_NUDGE_INTERVAL_MS, ACTIVE_PROJECT_STORAGE_KEY, LAST_VIEW_STORAGE_KEY, RUNTIME_RELOAD_CONTEXT_STORAGE_KEY, SIDEBAR_IMAGE_EXTENSIONS, PANEL_MOTION_WATCH_QUERIES, VOICE_LIFECYCLE, COMPANION_IDLE_SURFACES, COMPANION_RUNTIME_STATES, TOOL_PALETTE_MODES } = context;
 
 const showStatus = (...args) => refs.showStatus(...args);
@@ -109,6 +109,184 @@ function clampPoint(value, max) {
   return Math.max(0, Math.min(Number(max) || 0, value));
 }
 
+function isDialogueInkStreamingActive() {
+  return Boolean(state.liveSessionActive && state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE);
+}
+
+function sendInkChatEvent(payload) {
+  const ws = state.chatWs;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+  ws.send(JSON.stringify(payload));
+  return true;
+}
+
+function strokeBounds(strokes) {
+  const points = Array.isArray(strokes)
+    ? strokes.flatMap((stroke) => (Array.isArray(stroke?.points) ? stroke.points : []))
+    : [];
+  if (points.length === 0) return null;
+  let minX = Number(points[0]?.x) || 0;
+  let minY = Number(points[0]?.y) || 0;
+  let maxX = minX;
+  let maxY = minY;
+  points.forEach((point) => {
+    const x = Number(point?.x) || 0;
+    const y = Number(point?.y) || 0;
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  });
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: Math.max(0, maxX - minX),
+    height: Math.max(0, maxY - minY),
+  };
+}
+
+function mapInkPointToClient(point) {
+  if (!point) return null;
+  if (state.inkDraft.target === 'pdf' && state.inkDraft.pageInner instanceof HTMLElement) {
+    const rect = state.inkDraft.pageInner.getBoundingClientRect();
+    return {
+      x: rect.left + (Number(point.x) || 0),
+      y: rect.top + (Number(point.y) || 0),
+    };
+  }
+  const viewport = document.getElementById('canvas-viewport');
+  if (!(viewport instanceof HTMLElement)) return null;
+  const rect = viewport.getBoundingClientRect();
+  return {
+    x: rect.left + (Number(point.x) || 0) - viewport.scrollLeft,
+    y: rect.top + (Number(point.y) || 0) - viewport.scrollTop,
+  };
+}
+
+function uniqueTextSamples(values) {
+  const seen = new Set();
+  const out = [];
+  values.forEach((value) => {
+    const clean = String(value || '').trim();
+    if (!clean || seen.has(clean)) return;
+    seen.add(clean);
+    out.push(clean);
+  });
+  return out;
+}
+
+function buildInkEventPayload() {
+  if (!isDialogueInkStreamingActive()) return null;
+  const strokes = Array.isArray(state.inkDraft.strokes) ? state.inkDraft.strokes : [];
+  if (strokes.length === 0) return null;
+  const bounds = strokeBounds(strokes);
+  if (!bounds) return null;
+
+  const sampledPoints = strokes.flatMap((stroke) => {
+    const points = Array.isArray(stroke?.points) ? stroke.points : [];
+    if (points.length === 0) return [];
+    const middle = points[Math.floor(points.length / 2)];
+    return [points[0], middle, points[points.length - 1]];
+  });
+  sampledPoints.push({
+    x: bounds.minX + (bounds.width / 2),
+    y: bounds.minY + (bounds.height / 2),
+  });
+
+  const rawLocations = sampledPoints
+    .map((point) => mapInkPointToClient(point))
+    .filter(Boolean)
+    .map((clientPoint) => getLocationFromPoint(clientPoint.x, clientPoint.y))
+    .filter((location) => location && typeof location === 'object');
+
+  const lineNumbers = rawLocations
+    .map((location) => Number(location?.line || 0))
+    .filter((line) => Number.isFinite(line) && line > 0);
+  const surroundingTexts = uniqueTextSamples(rawLocations.map((location) => location?.surroundingText));
+  const cursor = rawLocations.find((location) => location && (location.line || location.page || Number.isFinite(location.relativeX) || location.title)) || null;
+
+  const width = state.inkDraft.target === 'pdf'
+    ? Math.max(1, Number(state.inkDraft.pageWidth) || 1)
+    : Math.max(1, Number(inkLayerEl()?.viewBox.baseVal?.width || inkLayerEl()?.getAttribute('width') || 1));
+  const height = state.inkDraft.target === 'pdf'
+    ? Math.max(1, Number(state.inkDraft.pageHeight) || 1)
+    : Math.max(1, Number(inkLayerEl()?.viewBox.baseVal?.height || inkLayerEl()?.getAttribute('height') || 1));
+
+  const snapshotDataURL = state.inkDraft.target === 'pdf'
+    ? buildPdfInkSnapshotDataURL()
+    : `data:image/png;base64,${buildInkPNGBase64()}`;
+  const overlappingLines = lineNumbers.length > 0
+    ? { start: Math.min(...lineNumbers), end: Math.max(...lineNumbers) }
+    : null;
+
+  return {
+    type: 'canvas_ink',
+    cursor: cursor ? {
+      line: Number(cursor.line || 0) || undefined,
+      page: Number(cursor.page || 0) || undefined,
+      title: String(cursor.title || ''),
+      surrounding_text: String(cursor.surroundingText || ''),
+      relative_x: Number.isFinite(cursor.relativeX) ? cursor.relativeX : undefined,
+      relative_y: Number.isFinite(cursor.relativeY) ? cursor.relativeY : undefined,
+    } : null,
+    artifact_kind: activeArtifactKindForInk(),
+    output_mode: state.ttsSilent ? 'silent' : 'voice',
+    request_response: true,
+    total_strokes: strokes.length,
+    bounding_box: {
+      relative_x: bounds.minX / width,
+      relative_y: bounds.minY / height,
+      relative_width: bounds.width / width,
+      relative_height: bounds.height / height,
+    },
+    overlapping_lines: overlappingLines,
+    overlapping_text: surroundingTexts.join('\n'),
+    snapshot_data_url: snapshotDataURL,
+    strokes: strokes.map((stroke) => ({
+      pointer_type: stroke.pointer_type,
+      width: stroke.width,
+      points: (Array.isArray(stroke?.points) ? stroke.points : []).map((point) => ({
+        x: point.x,
+        y: point.y,
+        pressure: point.pressure,
+      })),
+    })),
+  };
+}
+
+function buildPdfInkSnapshotDataURL() {
+  if (!(state.inkDraft.draftLayer instanceof SVGSVGElement)) return '';
+  const width = Math.max(1, Number(state.inkDraft.pageWidth) || 1);
+  const height = Math.max(1, Number(state.inkDraft.pageHeight) || 1);
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.strokeStyle = '#111827';
+  state.inkDraft.strokes.forEach((stroke) => {
+    const points = Array.isArray(stroke?.points) ? stroke.points : [];
+    if (points.length === 0) return;
+    ctx.beginPath();
+    ctx.lineWidth = Math.max(1.5, Number(stroke?.width) || 2.4);
+    ctx.moveTo(Number(points[0]?.x) || 0, Number(points[0]?.y) || 0);
+    for (let i = 1; i < points.length; i += 1) {
+      ctx.lineTo(Number(points[i]?.x) || 0, Number(points[i]?.y) || 0);
+    }
+    if (points.length === 1) {
+      ctx.lineTo((Number(points[0]?.x) || 0) + 0.01, Number(points[0]?.y) || 0);
+    }
+    ctx.stroke();
+  });
+  return canvas.toDataURL('image/png');
+}
+
 function ensurePdfInkDraftLayer(pageInner, width, height) {
   if (!(pageInner instanceof HTMLElement)) return null;
   let layer = pageInner.querySelector('.canvas-ink-draft-layer');
@@ -209,6 +387,10 @@ export function extendInkStroke(pointerEvent) {
 export function finalizeInkStroke(pointerEvent) {
   if (state.inkDraft.activePointerId !== pointerEvent.pointerId) return false;
   extendInkStroke(pointerEvent);
+  const livePayload = buildInkEventPayload();
+  if (livePayload) {
+    sendInkChatEvent(livePayload);
+  }
   if (state.inkDraft.target === 'pdf') {
     const stroke = state.inkDraft.strokes[state.inkDraft.strokes.length - 1];
     persistPdfInkAnnotation(state.inkDraft.page, state.inkDraft.pageWidth, state.inkDraft.pageHeight, stroke);

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -302,6 +302,43 @@ test.describe('canvas - tabula rasa', () => {
     const img = page.locator('#canvas-img');
     await expect(img).toHaveAttribute('src', /test-ink\.png/);
   });
+
+  test('live dialogue pen stroke emits structured canvas ink context', async ({ page }) => {
+    await clearLog(page);
+    await renderTestArtifact(page, 'alpha\nbeta\ngamma\ndelta\nepsilon');
+    await setInteractionTool(page, 'ink');
+    await page.evaluate(() => {
+      const app = (window as any)._taburaApp;
+      const state = app?.getState?.();
+      if (!state) throw new Error('missing app state');
+      state.liveSessionActive = true;
+      state.liveSessionMode = 'dialogue';
+    });
+
+    await dispatchPenStroke(page, [
+      { x: 220, y: 215, pressure: 0.5 },
+      { x: 255, y: 240, pressure: 0.7 },
+      { x: 290, y: 262, pressure: 0.65 },
+    ]);
+
+    await expect.poll(async () => {
+      const log = await getLog(page);
+      return log.find((entry) => entry.type === 'canvas_ink') || null;
+    }, { timeout: 5_000 }).not.toBeNull();
+
+    const entry = await page.evaluate(() => {
+      const log = (window as any).__harnessLog || [];
+      return log.find((item: any) => item.type === 'canvas_ink') || null;
+    });
+    expect(entry?.request_response).toBe(true);
+    expect(entry?.artifact_kind).toBe('text');
+    expect(entry?.total_strokes).toBe(1);
+    expect(typeof entry?.snapshot_data_url).toBe('string');
+    expect(String(entry?.snapshot_data_url || '')).toMatch(/^data:image\/png;base64,/);
+    expect(Number(entry?.overlapping_lines?.start || 0)).toBeGreaterThan(0);
+    expect(String(entry?.overlapping_text || '').length).toBeGreaterThan(0);
+    expect(Number(entry?.bounding_box?.relative_width || 0)).toBeGreaterThan(0);
+  });
 });
 
 test.describe('canvas - response overlay', () => {

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -2502,6 +2502,20 @@
               output_mode: msg.output_mode,
               cursor: msg.cursor || null,
             });
+          } else if (msg.type === 'canvas_ink') {
+            window.__harnessLog.push({
+              type: 'canvas_ink',
+              request_response: Boolean(msg.request_response),
+              output_mode: msg.output_mode,
+              artifact_kind: msg.artifact_kind,
+              cursor: msg.cursor || null,
+              total_strokes: Number(msg.total_strokes || 0),
+              bounding_box: msg.bounding_box || null,
+              overlapping_lines: msg.overlapping_lines || null,
+              overlapping_text: String(msg.overlapping_text || ''),
+              snapshot_data_url: String(msg.snapshot_data_url || ''),
+              strokes: Array.isArray(msg.strokes) ? msg.strokes : [],
+            });
           }
         } catch (_) {}
       }


### PR DESCRIPTION
## Summary
- stream live `canvas_ink` events on pen-up during dialogue, carrying overlap info, normalized bounds, cumulative stroke count, and an ink snapshot
- persist live ink snapshots under `.tabura/artifacts/tmp/live-ink/` and prepend them to assistant turns through a new `Canvas Ink Events` prompt block
- add backend gesture recognition coverage and a Playwright harness check while preserving the existing ink annotation submit flow

## Verification
- Pen strokes streamed to AI during active dialogue: `./scripts/playwright.sh tests/playwright/canvas.spec.ts --grep "live dialogue pen stroke emits structured canvas ink context"` -> `1 passed (1.8s)`; the harness captured an outbound `canvas_ink` message with `request_response: true`.
- AI receives structured info and a visual snapshot: `go test ./internal/web -run "TestAppendCanvasInkPrompt_PrependsStructuredEvents|TestRecognizeChatCanvasInkGesture|TestHandleChatWSTextMessage_CanvasInkQueuesRequestedTurnAndPersistsSnapshot"` -> `ok   github.com/krystophny/tabura/internal/web 0.024s`; the tests verify overlap lines/text, saved snapshot path under `.tabura/artifacts/tmp/live-ink/...png`, and prompt injection via `## Canvas Ink Events`.
- Basic gesture recognition (`circle`, `underline`, `arrow`, `cross`, `question_mark`): the same `go test` command covers `TestRecognizeChatCanvasInkGesture` and passed with the full gesture table.
- Handwriting/sketch context included for assistant inspection: `TestAppendCanvasInkPrompt_PrependsStructuredEvents` verifies the prompt now tells the assistant to inspect the saved snapshot when handwriting or freeform sketch meaning matters.
- Freeform sketches sent as images for multimodal interpretation: the live-dialogue Playwright case captured `snapshot_data_url` as a PNG data URL on each outbound `canvas_ink` event, and the backend test verifies it is persisted for turn-time inspection.
- Ink during dialogue still doubles as annotations: `./scripts/playwright.sh tests/playwright/canvas.spec.ts --grep "pen stroke shows submit controls and submits ink artifact flow"` -> `1 passed (1.9s)`; the existing ink submit flow still emits `ink_submit` and renders the saved image artifact.
- Works across artifact kinds with position mapping: `internal/web/static/app-ink.js` now samples stroke points through `getLocationFromPoint()`, so text artifacts produce line ranges/text, image artifacts produce normalized coordinates, and PDF artifacts keep page-relative geometry before `persistPdfInkAnnotation(...)`.
- Coverage added for the issue surface: new Go tests `TestAppendCanvasInkPrompt_PrependsStructuredEvents`, `TestRecognizeChatCanvasInkGesture`, `TestHandleChatWSTextMessage_CanvasInkQueuesRequestedTurnAndPersistsSnapshot`, plus the new Playwright case `live dialogue pen stroke emits structured canvas ink context`.
