### PR TITLE
fix: Epic: Unified annotation, dictation, and physical I/O (fixes #172)

### DIFF
--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -577,6 +577,38 @@ test.describe('floating tool palette', () => {
     await expect(page.locator('#canvas-pdf .canvas-annotation-badge')).toHaveText('1');
   });
 
+  test('tablet touch keeps PDF notes local until explicit bundle send', async ({ page }) => {
+    await page.setViewportSize({ width: 834, height: 1112 });
+    await injectCanvasModuleRef(page);
+    await renderPdfArtifactMock(page);
+    await setInteractionTool(page, 'text_note');
+    await clearLog(page);
+
+    const pageBox = await page.locator('#canvas-pdf .canvas-pdf-page-inner').boundingBox();
+    if (!pageBox) throw new Error('pdf page unavailable for tablet touch note test');
+    await dispatchTouchTap(page, pageBox.x + 180, pageBox.y + 240);
+
+    await expect(page.locator('#canvas-pdf .canvas-sticky-note')).toHaveCount(1);
+    await expect(page.locator('#annotation-bubble')).toBeVisible();
+
+    await page.locator('#annotation-note-input').fill('Follow up on this section');
+    await page.locator('#annotation-note-save').click();
+    await expect(page.locator('#canvas-pdf .canvas-annotation-badge')).toHaveText('1');
+
+    let sentMessages = (await getLog(page)).filter((entry) => entry.type === 'message_sent');
+    expect(sentMessages).toHaveLength(0);
+
+    await page.locator('#annotation-bundle-send').click();
+    await waitForLogEntry(page, 'message_sent');
+
+    sentMessages = (await getLog(page)).filter((entry) => entry.type === 'message_sent');
+    expect(sentMessages).toHaveLength(1);
+    expect(String(sentMessages[0]?.text || '')).toContain('Use these annotations as instructions for the current artifact.');
+    expect(String(sentMessages[0]?.text || '')).toContain('PDF sticky note on page 1');
+    expect(String(sentMessages[0]?.text || '')).toContain('text: Follow up on this section');
+    await expect(page.locator('#canvas-pdf .canvas-annotation-badge')).toHaveCount(0);
+  });
+
   test('ink tool persists page-anchored PDF strokes across rerender', async ({ page }) => {
     await injectCanvasModuleRef(page);
     await renderPdfArtifactMock(page);


### PR DESCRIPTION
## Summary
- add Playwright coverage for the tablet/touch PDF annotation flow so stylus-style notes stay local until an explicit bundle send

## Verification
- Frontend harness build: `npm run build:frontend` -> `built 42 frontend modules`
- Annotation accumulation stays local until explicit send: `./scripts/playwright.sh tests/playwright/dictation-mode.spec.ts tests/playwright/ui-system.spec.ts tests/playwright/canvas.spec.ts --grep 'dictation mode accumulates draft on canvas and dispatches only on explicit send|highlight annotations stay local until bundle send|scan upload imports annotations, allows correction, and confirms before send|loads the print view into the hidden print iframe|tablet touch keeps PDF notes local until explicit bundle send' 2>&1 | tee /tmp/test.log` -> `✓ tests/playwright/ui-system.spec.ts:632:7 › floating tool palette › highlight annotations stay local until bundle send`
- Dictation composition mode stays draft-only until send: same command -> `✓ tests/playwright/dictation-mode.spec.ts:14:5 › dictation mode accumulates draft on canvas and dispatches only on explicit send`
- Scan upload / correction / confirm flow: same command -> `✓ tests/playwright/ui-system.spec.ts:742:7 › floating tool palette › scan upload imports annotations, allows correction, and confirms before send`
- Print flow coverage: same command -> `✓ tests/playwright/ui-system.spec.ts:1564:7 › system_action print item › loads the print view into the hidden print iframe`
- Tablet interaction parity: same command -> `✓ tests/playwright/ui-system.spec.ts:580:7 › floating tool palette › tablet touch keeps PDF notes local until explicit bundle send`
- Targeted epic coverage pass: same command -> `5 passed (4.7s)`
