### PR TITLE
fix: submission of bugs still failing (fixes #477)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -227,6 +227,11 @@ func (a *App) resolveBugReportWorkspace() (bugReportWorkspace, error) {
 		}
 		return bugReportWorkspace{Name: name, DirPath: root}, nil
 	}
+	if workspace, ok, err := a.resolveTaburaBugReportWorkspace(); err != nil {
+		return bugReportWorkspace{}, err
+	} else if ok {
+		return workspace, nil
+	}
 	return bugReportWorkspace{}, errors.New("bug report requires an active workspace or local project")
 }
 
@@ -235,7 +240,8 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 	if err != nil {
 		return ghIssueListItem{}, 0, err
 	}
-	if err := a.ensureGitHubLabels("", taburaBugReportOwnerRepo, map[string]struct {
+	githubCWD := resolveBugReportGitHubCommandDir(workspace.DirPath)
+	if err := a.ensureGitHubLabels(githubCWD, taburaBugReportOwnerRepo, map[string]struct {
 		Color       string
 		Description string
 	}{
@@ -245,7 +251,7 @@ func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundl
 		return ghIssueListItem{}, 0, err
 	}
 	issue, err := a.createGitHubIssueInWorkspaceWithRepo(
-		"",
+		githubCWD,
 		taburaBugReportOwnerRepo,
 		bugReportIssueTitle(bundle),
 		bugReportIssueBody(bundle, toBugReportRelativePath(workspace.DirPath, bundlePath)),
@@ -309,6 +315,34 @@ func normalizeBugReportSphere(raw string) string {
 	}
 }
 
+func (a *App) resolveTaburaBugReportWorkspace() (bugReportWorkspace, bool, error) {
+	workspaceID, err := a.store.FindWorkspaceByGitRemote(taburaBugReportOwnerRepo)
+	if err != nil {
+		return bugReportWorkspace{}, false, err
+	}
+	if workspaceID != nil && *workspaceID > 0 {
+		workspace, err := a.store.GetWorkspace(*workspaceID)
+		if err != nil {
+			return bugReportWorkspace{}, false, err
+		}
+		return bugReportWorkspace{
+			Name:    workspace.Name,
+			DirPath: workspace.DirPath,
+			ID:      workspaceID,
+			Sphere:  workspace.Sphere,
+		}, true, nil
+	}
+	repoRoot := resolveCanonicalGitHubRepoRoot(taburaBugReportOwnerRepo)
+	if repoRoot == "" {
+		return bugReportWorkspace{}, false, nil
+	}
+	return bugReportWorkspace{
+		Name:    "Tabura",
+		DirPath: repoRoot,
+		Sphere:  store.SphereWork,
+	}, true, nil
+}
+
 func (a *App) ensureGitHubLabels(cwd, ownerRepo string, wanted map[string]struct {
 	Color       string
 	Description string
@@ -357,6 +391,43 @@ func withGitHubRepoArg(args []string, ownerRepo string) []string {
 	out = append(out, args...)
 	out = append(out, "--repo", clean)
 	return out
+}
+
+func resolveBugReportGitHubCommandDir(workspaceDir string) string {
+	if repoRoot := resolveCanonicalGitHubRepoRoot(taburaBugReportOwnerRepo); repoRoot != "" {
+		return repoRoot
+	}
+	return resolveGitRepoRoot(workspaceDir)
+}
+
+func resolveCanonicalGitHubRepoRoot(ownerRepo string) string {
+	target := normalizeBugReportGitHubOwnerRepo(ownerRepo)
+	if target == "" {
+		return ""
+	}
+	for _, candidate := range githubCommandDirCandidates("") {
+		repoRoot := resolveGitRepoRoot(candidate)
+		if repoRoot == "" {
+			continue
+		}
+		if resolveBugReportGitRemoteOwnerRepo(repoRoot) == target {
+			return repoRoot
+		}
+	}
+	return ""
+}
+
+func resolveBugReportGitRemoteOwnerRepo(dir string) string {
+	clean := strings.TrimSpace(dir)
+	if clean == "" {
+		return ""
+	}
+	cmd := exec.Command("git", "-C", clean, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return normalizeBugReportGitHubOwnerRepo(string(out))
 }
 
 func bugReportIssueTitle(bundle bugReportBundle) string {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -29,10 +29,11 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 		t.Fatalf("SetActiveWorkspace() error: %v", err)
 	}
 	var ghCalls [][]string
+	wantCWD := resolveBugReportGitHubCommandDir(workspaceDir)
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
 		ghCalls = append(ghCalls, append([]string{cwd}, args...))
-		if cwd != "" {
-			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
+		if cwd != wantCWD {
+			t.Fatalf("gh cwd = %q, want %q", cwd, wantCWD)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"}]`, nil
@@ -217,9 +218,10 @@ func TestHandleBugReportCreateFallsBackToWorkspaceSphere(t *testing.T) {
 	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
 		t.Fatalf("SetActiveWorkspace() error: %v", err)
 	}
+	wantCWD := resolveBugReportGitHubCommandDir(workspaceDir)
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
-		if cwd != "" {
-			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
+		if cwd != wantCWD {
+			t.Fatalf("gh cwd = %q, want %q", cwd, wantCWD)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"},{"name":"p0"}]`, nil
@@ -257,6 +259,7 @@ func TestHandleBugReportCreateFallsBackToWorkspaceSphere(t *testing.T) {
 }
 
 func TestHandleBugReportCreateRequiresWorkspaceContext(t *testing.T) {
+	t.Chdir(t.TempDir())
 	app := newAuthedTestApp(t)
 	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
 		"screenshot_data_url": testPNGDataURL,
@@ -284,9 +287,10 @@ func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	t.Cleanup(func() {
 		_ = app.Shutdown(context.Background())
 	})
+	wantCWD := resolveBugReportGitHubCommandDir(localProjectDir)
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
-		if cwd != "" {
-			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
+		if cwd != wantCWD {
+			t.Fatalf("gh cwd = %q, want %q", cwd, wantCWD)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"},{"name":"p0"}]`, nil
@@ -336,10 +340,11 @@ func TestHandleBugReportCreateUsesCanonicalRepoFromNonGitWorkspace(t *testing.T)
 		t.Fatalf("SetActiveWorkspace() error: %v", err)
 	}
 	var calls [][]string
+	wantCWD := resolveBugReportGitHubCommandDir(workspaceDir)
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
 		calls = append(calls, append([]string{cwd}, args...))
-		if cwd != "" {
-			t.Fatalf("gh cwd = %q, want empty bug-report gh context", cwd)
+		if cwd != wantCWD {
+			t.Fatalf("gh cwd = %q, want %q", cwd, wantCWD)
 		}
 		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
 			return `[{"name":"bug"},{"name":"p0"}]`, nil
@@ -380,6 +385,65 @@ func TestHandleBugReportCreateUsesCanonicalRepoFromNonGitWorkspace(t *testing.T)
 	}
 	if !strings.Contains(createCall, "--repo krystophny/tabura") {
 		t.Fatalf("create call = %q, want canonical repo flag", createCall)
+	}
+}
+
+func TestHandleBugReportCreateFallsBackToTaburaRepoWithoutWorkspace(t *testing.T) {
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	addGitRemote(t, repoDir, "https://github.com/krystophny/tabura.git")
+	t.Chdir(repoDir)
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if err := app.store.AddAuthSession(testAuthToken); err != nil {
+		t.Fatalf("AddAuthSession() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	wantCWD := resolveBugReportGitHubCommandDir("")
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		if cwd != wantCWD {
+			t.Fatalf("gh cwd = %q, want %q", cwd, wantCWD)
+		}
+		if len(args) >= 3 && args[0] == "label" && args[1] == "list" {
+			return `[{"name":"bug"},{"name":"p0"}]`, nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return "https://github.com/krystophny/tabura/issues/118\n", nil
+		}
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "view" {
+			return `{"number":118,"title":"Bug report: Repo fallback","url":"https://github.com/krystophny/tabura/issues/118","state":"OPEN","labels":[{"name":"bug"},{"name":"p0"}],"assignees":[]}`, nil
+		}
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
+		"note":                "Repo fallback.",
+		"screenshot_data_url": testPNGDataURL,
+	})
+	if rr.Code != 200 {
+		t.Fatalf("POST /api/bugs/report status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	bundlePath := strFromAny(payload["bundle_path"])
+	if !strings.HasPrefix(bundlePath, ".tabura/artifacts/bugs/") {
+		t.Fatalf("bundle_path = %q, want .tabura/artifacts/bugs/... path", bundlePath)
+	}
+	workspace, err := app.store.GetWorkspaceByPath(repoDir)
+	if err != nil {
+		t.Fatalf("GetWorkspaceByPath() error: %v", err)
+	}
+	if workspace.Sphere != store.SphereWork {
+		t.Fatalf("workspace.Sphere = %q, want %q", workspace.Sphere, store.SphereWork)
+	}
+	if _, err := app.store.GetItemBySource("github", "krystophny/tabura#118"); err != nil {
+		t.Fatalf("GetItemBySource() error: %v", err)
 	}
 }
 

--- a/internal/web/chat_pr.go
+++ b/internal/web/chat_pr.go
@@ -50,43 +50,58 @@ func runGitHubCLI(ctx context.Context, cwd string, args ...string) (string, erro
 	return string(out), nil
 }
 
-func resolveGitHubCommandDir(cwd string) string {
-	clean := strings.TrimSpace(cwd)
-	candidates := []string{}
-	if clean != "" {
-		candidates = append(candidates, clean)
+func githubCommandDirCandidates(cwd string) []string {
+	seen := map[string]struct{}{}
+	candidates := make([]string, 0, 16)
+	appendChain := func(raw string) {
+		clean := strings.TrimSpace(raw)
+		if clean == "" {
+			return
+		}
 		dir := filepath.Clean(clean)
 		for {
+			if _, ok := seen[dir]; !ok {
+				seen[dir] = struct{}{}
+				candidates = append(candidates, dir)
+			}
 			parent := filepath.Dir(dir)
 			if parent == dir {
 				break
 			}
-			candidates = append(candidates, parent)
 			dir = parent
 		}
 	}
+	appendChain(cwd)
 	if wd, err := os.Getwd(); err == nil {
-		candidates = append(candidates, wd, filepath.Clean(filepath.Dir(wd)))
+		appendChain(wd)
 	}
 	if exe, err := os.Executable(); err == nil {
-		exeDir := filepath.Dir(exe)
-		candidates = append(candidates, exeDir, filepath.Clean(filepath.Dir(exeDir)))
+		appendChain(filepath.Dir(exe))
 	}
-	for _, candidate := range candidates {
-		if looksLikeGitRepo(candidate) {
-			return candidate
+	return candidates
+}
+
+func resolveGitRepoRoot(dir string) string {
+	clean := strings.TrimSpace(dir)
+	if clean == "" {
+		return ""
+	}
+	command := exec.Command("git", "-C", clean, "rev-parse", "--show-toplevel")
+	out, err := command.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func resolveGitHubCommandDir(cwd string) string {
+	clean := strings.TrimSpace(cwd)
+	for _, candidate := range githubCommandDirCandidates(clean) {
+		if root := resolveGitRepoRoot(candidate); root != "" {
+			return root
 		}
 	}
 	return clean
-}
-
-func looksLikeGitRepo(dir string) bool {
-	command := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree")
-	out, err := command.Output()
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) == "true"
 }
 
 func countUnifiedDiffFiles(diff string) int {


### PR DESCRIPTION
## Summary
Fix bug-report submission so it can resolve a Tabura repo context directly instead of requiring an active workspace/local project, and so `gh` runs with an explicit repo-backed cwd when available.

## Verification
- Requirement: bug submission must still work when no active workspace/local project is selected, as long as Tabura is running inside its repo. Evidence: `go test ./internal/web -run 'TestHandleBugReportCreate'` -> `ok   github.com/krystophny/tabura/internal/web 0.157s`; includes `TestHandleBugReportCreateFallsBackToTaburaRepoWithoutWorkspace`.
- Requirement: bug submission must target Tabura via `gh`, not an ambient non-repo context. Evidence: the same test run includes `TestHandleBugReportCreateUsesCanonicalRepoFromNonGitWorkspace` and `TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts`, which assert the resolved `gh` cwd and `--repo krystophny/tabura`.
