### PR TITLE
fix: email drafting UX and logics (fixes #478)

### DIFF
--- a/internal/web/static/app-init.ts
+++ b/internal/web/static/app-init.ts
@@ -145,7 +145,7 @@ export function bindUi() {
   const isVoiceInteractionTarget = (target, x, y) => (
     isInEdgeZone(x, y)
     || (target instanceof Element
-      && target.closest('button,a,input,textarea,select,[contenteditable="true"],.overlay,.floating-input,.edge-panel,#canvas-pdf .canvas-pdf-page,#canvas-pdf .textLayer,#canvas-pdf .annotationLayer'))
+      && target.closest('button,a,input,textarea,select,[contenteditable="true"],.overlay,.floating-input,.edge-panel,.canvas-embedded-ui,#canvas-pdf .canvas-pdf-page,#canvas-pdf .textLayer,#canvas-pdf .annotationLayer'))
   );
   const rememberMousePosition = (x, y) => {
     if (!Number.isFinite(x) || !Number.isFinite(y)) return;
@@ -257,7 +257,7 @@ export function bindUi() {
     const isTapOnInteractiveUi = (ev) => {
       const t = ev.target;
       if (!(t instanceof Element)) return false;
-      return Boolean(t.closest('button, a, input, textarea, select, #edge-left-tap, #edge-right-tap, #edge-top-tap, #edge-top, #edge-right, #pr-file-pane, #pr-file-drawer-backdrop'));
+      return Boolean(t.closest('button, a, input, textarea, select, .canvas-embedded-ui, #edge-left-tap, #edge-right-tap, #edge-top-tap, #edge-top, #edge-right, #pr-file-pane, #pr-file-drawer-backdrop'));
     };
     const handleIndicatorTap = (ev, x, y, isTouch = false) => {
       if (!isIndicatorArmed()) return;
@@ -547,6 +547,7 @@ export function bindUi() {
         return;
       }
       if (ev.target instanceof Element && ev.target.closest('.edge-panel')) return;
+      if (isEditableTarget(ev.target)) return;
       if (canEnterArtifactEditModeFromTarget(ev.target)) {
         ev.preventDefault();
         enterArtifactEditMode(ev.clientX, ev.clientY);

--- a/internal/web/static/app-mail-drafts.ts
+++ b/internal/web/static/app-mail-drafts.ts
@@ -364,7 +364,7 @@ export function renderMailDraftArtifact(root, event) {
 
   const shell = document.createElement('section');
   shell.id = MAIL_DRAFT_EDITOR_ID;
-  shell.className = 'mail-draft-editor';
+  shell.className = 'mail-draft-editor canvas-embedded-ui';
 
   const header = document.createElement('header');
   header.className = 'mail-draft-header';

--- a/internal/web/static/app-runtime-ui.ts
+++ b/internal/web/static/app-runtime-ui.ts
@@ -645,7 +645,7 @@ export function startRuntimeReloadWatcher() {
 
 export function isEditableTarget(target) {
   if (!(target instanceof Element)) return false;
-  return Boolean(target.closest('input,textarea,select,[contenteditable="true"]'));
+  return Boolean(target.closest('input,textarea,select,[contenteditable="true"],.canvas-embedded-ui'));
 }
 
 export function artifactEditorEl() {
@@ -688,6 +688,7 @@ export function canEnterArtifactEditModeFromTarget(target) {
   if (state.prReviewMode) return false;
   if (!(target instanceof Element)) return false;
   if (!target.closest('#canvas-text')) return false;
+  if (target.closest('.canvas-embedded-ui')) return false;
   if (target.closest('a,button,input,textarea,select,[contenteditable="true"]')) return false;
   if (isRecording() || shouldStopInUiClick()) return false;
   return true;

--- a/internal/web/static/mail-drafts.css
+++ b/internal/web/static/mail-drafts.css
@@ -24,7 +24,7 @@
 .mail-draft-editor {
   display: grid;
   gap: 1rem;
-  max-width: min(100%, 860px);
+  max-width: min(100%, 1180px);
   margin: 0 auto;
 }
 
@@ -271,6 +271,22 @@
   border-top: 2px solid var(--border);
   margin-top: 1rem;
   padding-top: 1rem;
+}
+
+@media (min-width: 980px) {
+  .mail-draft-paper {
+    grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  .mail-draft-envelope {
+    border-bottom: none;
+    border-right: 1px solid rgba(0, 0, 0, 0.14);
+  }
+
+  .mail-draft-letter {
+    min-width: 0;
+  }
 }
 
 @media (max-width: 760px) {

--- a/tests/playwright/mail-drafts.spec.ts
+++ b/tests/playwright/mail-drafts.spec.ts
@@ -90,8 +90,15 @@ test.describe('mail drafts', () => {
         columns: style.gridTemplateColumns,
       };
     });
+    const paperLayout = await page.locator('.mail-draft-paper').evaluate((node) => {
+      const style = window.getComputedStyle(node as HTMLElement);
+      return {
+        columns: style.gridTemplateColumns,
+      };
+    });
     expect(composerLayout.display).toBe('grid');
     expect(composerLayout.columns).not.toBe('none');
+    expect(paperLayout.columns.split(' ').length).toBeGreaterThan(1);
     await expect.poll(async () => page.locator('#mail-draft-recipient-suggestions option').count()).toBe(2);
     await expect(page.locator('#mail-draft-recipient-suggestions option').nth(0)).toHaveAttribute('value', 'ada@example.com');
     await expect(page.locator('#mail-draft-recipient-suggestions option').nth(1)).toHaveAttribute('value', 'bob@example.com');
@@ -134,6 +141,33 @@ test.describe('mail drafts', () => {
 
     await page.locator('.sidebar-tab', { hasText: 'Done' }).click();
     await expect(page.locator('#pr-file-list')).toContainText('Quarterly update');
+  });
+
+  test('mail drafts keep focus inside the form instead of reopening the floating composer', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [],
+        waiting: [],
+        someday: [],
+        done: [],
+      });
+    });
+
+    await openInbox(page);
+    await page.locator('#new-mail-trigger').click();
+    await waitForLogEntry(page, 'api_fetch', 'mail_draft_create');
+
+    await setInteractionTool(page, 'text_note');
+    await page.locator('.mail-draft-envelope .mail-draft-field-line').first().click();
+    await expect(page.locator('#floating-input')).toBeHidden();
+    await expect(page.locator('[name="to"]')).toBeFocused();
+
+    await page.locator('.mail-draft-body-row').click();
+    await expect(page.locator('#floating-input')).toBeHidden();
+    await expect(page.locator('[name="body"]')).toBeFocused();
   });
 
   test('reply drafts seed recipient and subject from the selected email item', async ({ page }) => {


### PR DESCRIPTION
## Summary
- keep mail draft canvas interactions inside the draft form instead of reopening the floating composer
- give desktop mail drafts a real two-column layout while preserving the mobile stack
- add Playwright coverage for both behaviors

## Verification
- Requirement: draft email forms stay directly editable without annotation-mode text boxes reopening.
  - Command: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts`
  - Evidence: `/tmp/issue-478-playwright.log` contains `✓   2 [chromium] › tests/playwright/mail-drafts.spec.ts:146:7 › mail drafts › mail drafts keep focus inside the form instead of reopening the floating composer`.
  - Test detail: the spec clicks `.mail-draft-field-line` and `.mail-draft-body-row`, then asserts `#floating-input` stays hidden and focus lands on the intended mail field.
- Requirement: desktop draft email UI no longer renders as the mobile layout.
  - Command: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts`
  - Evidence: `/tmp/issue-478-playwright.log` contains `✓   1 [chromium] › tests/playwright/mail-drafts.spec.ts:56:7 › mail drafts › new mail remains available in an empty inbox and supports save, reopen, suggestions, and send`.
  - Test detail: that spec runs at `1280x800` and reads the computed `gridTemplateColumns` for `.mail-draft-paper`, requiring more than one desktop column.
- Regression coverage: `./scripts/playwright.sh tests/playwright/mail-drafts.spec.ts`
  - Evidence: `/tmp/issue-478-playwright.log` ends with `14 passed (18.5s)`.
