### PR TITLE
fix: Chat sessions must key to workspace, not project (fixes #482)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,6 +36,7 @@ type Store struct {
 
 type ChatSession struct {
 	ID          string `json:"id"`
+	WorkspaceID int64  `json:"workspace_id"`
 	ProjectKey  string `json:"project_key"`
 	AppThreadID string `json:"app_thread_id"`
 	Mode        string `json:"mode"`
@@ -179,7 +180,7 @@ CREATE TABLE IF NOT EXISTS remote_sessions (
 );
 CREATE TABLE IF NOT EXISTS chat_sessions (
   id TEXT PRIMARY KEY,
-  project_key TEXT NOT NULL UNIQUE,
+  workspace_id INTEGER NOT NULL UNIQUE REFERENCES workspaces(id) ON DELETE CASCADE,
   app_thread_id TEXT NOT NULL DEFAULT '',
   mode TEXT NOT NULL DEFAULT 'chat',
   created_at INTEGER NOT NULL,
@@ -280,7 +281,10 @@ CREATE TABLE IF NOT EXISTS participant_room_state (
 	if err := s.migrateDomainTables(); err != nil {
 		return err
 	}
-	return s.migrateLegacyProjectData()
+	if err := s.migrateLegacyProjectData(); err != nil {
+		return err
+	}
+	return s.migrateChatSessionWorkspaceKey()
 }
 
 func (s *Store) migrateProjectColumns() error {

--- a/internal/store/store_chat.go
+++ b/internal/store/store_chat.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -40,19 +41,108 @@ func normalizeRenderFormat(format string) string {
 	}
 }
 
-func (s *Store) GetOrCreateChatSession(projectKey string) (ChatSession, error) {
-	key := strings.TrimSpace(projectKey)
-	if key == "" {
-		key = "default"
+const chatSessionSelect = `
+SELECT cs.id,
+       cs.workspace_id,
+       COALESCE(NULLIF(trim(p.project_key), ''), w.dir_path, '') AS project_key,
+       cs.app_thread_id,
+       cs.mode,
+       cs.created_at,
+       cs.updated_at
+  FROM chat_sessions cs
+  JOIN workspaces w ON w.id = cs.workspace_id
+  LEFT JOIN projects p ON p.id = w.project_id
+`
+
+func (s *Store) resolveChatSessionWorkspace(ref string) (Workspace, error) {
+	cleanRef := strings.TrimSpace(ref)
+	if cleanRef != "" {
+		if project, err := s.GetProjectByProjectKey(cleanRef); err == nil {
+			if strings.EqualFold(strings.TrimSpace(project.Kind), "hub") {
+				if workspace, activeErr := s.ActiveWorkspace(); activeErr == nil {
+					return workspace, nil
+				}
+				return Workspace{}, sql.ErrNoRows
+			}
+			if workspaceID, findErr := s.FindWorkspaceContainingPath(project.RootPath); findErr != nil {
+				return Workspace{}, findErr
+			} else if workspaceID != nil {
+				return s.GetWorkspace(*workspaceID)
+			}
+			return s.ensureWorkspaceForLegacyProject(project)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return Workspace{}, err
+		}
+		if workspace, err := s.GetWorkspaceByPath(cleanRef); err == nil {
+			return workspace, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return Workspace{}, err
+		}
+		if workspaceID, err := s.FindWorkspaceContainingPath(cleanRef); err != nil {
+			return Workspace{}, err
+		} else if workspaceID != nil {
+			return s.GetWorkspace(*workspaceID)
+		}
 	}
-	if existing, err := s.GetChatSessionByProjectKey(key); err == nil {
+	if workspace, err := s.ActiveWorkspace(); err == nil {
+		return workspace, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return Workspace{}, err
+	}
+	if activeProjectID, err := s.ActiveProjectID(); err != nil {
+		return Workspace{}, err
+	} else if strings.TrimSpace(activeProjectID) != "" {
+		project, err := s.GetProject(activeProjectID)
+		if err != nil {
+			return Workspace{}, err
+		}
+		if strings.EqualFold(strings.TrimSpace(project.Kind), "hub") {
+			return Workspace{}, sql.ErrNoRows
+		}
+		return s.ensureWorkspaceForLegacyProject(project)
+	}
+	return Workspace{}, sql.ErrNoRows
+}
+
+func scanChatSession(scanner interface{ Scan(...any) error }) (ChatSession, error) {
+	var out ChatSession
+	err := scanner.Scan(
+		&out.ID,
+		&out.WorkspaceID,
+		&out.ProjectKey,
+		&out.AppThreadID,
+		&out.Mode,
+		&out.CreatedAt,
+		&out.UpdatedAt,
+	)
+	if err != nil {
+		return ChatSession{}, err
+	}
+	out.ProjectKey = strings.TrimSpace(out.ProjectKey)
+	out.Mode = normalizeChatMode(out.Mode)
+	return out, nil
+}
+
+func (s *Store) GetOrCreateChatSession(ref string) (ChatSession, error) {
+	workspace, err := s.resolveChatSessionWorkspace(ref)
+	if err != nil {
+		return ChatSession{}, err
+	}
+	return s.GetOrCreateChatSessionForWorkspace(workspace.ID)
+}
+
+func (s *Store) GetOrCreateChatSessionForWorkspace(workspaceID int64) (ChatSession, error) {
+	if workspaceID <= 0 {
+		return ChatSession{}, errors.New("workspace id is required")
+	}
+	if existing, err := s.GetChatSessionByWorkspaceID(workspaceID); err == nil {
 		return existing, nil
 	}
 	now := time.Now().Unix()
 	id := fmt.Sprintf("chat-%s", randomHex(8))
 	_, err := s.db.Exec(
-		`INSERT INTO chat_sessions (id, project_key, app_thread_id, mode, created_at, updated_at) VALUES (?,?,?,?,?,?)`,
-		id, key, "", "chat", now, now,
+		`INSERT INTO chat_sessions (id, workspace_id, app_thread_id, mode, created_at, updated_at) VALUES (?,?,?,?,?,?)`,
+		id, workspaceID, "", "chat", now, now,
 	)
 	if err != nil {
 		return ChatSession{}, err
@@ -60,40 +150,34 @@ func (s *Store) GetOrCreateChatSession(projectKey string) (ChatSession, error) {
 	return s.GetChatSession(id)
 }
 
-func (s *Store) GetChatSessionByProjectKey(projectKey string) (ChatSession, error) {
-	key := strings.TrimSpace(projectKey)
-	if key == "" {
-		key = "default"
-	}
-	var out ChatSession
-	err := s.db.QueryRow(
-		`SELECT id, project_key, app_thread_id, mode, created_at, updated_at FROM chat_sessions WHERE project_key = ?`,
-		key,
-	).Scan(&out.ID, &out.ProjectKey, &out.AppThreadID, &out.Mode, &out.CreatedAt, &out.UpdatedAt)
+func (s *Store) GetChatSessionByProjectKey(ref string) (ChatSession, error) {
+	workspace, err := s.resolveChatSessionWorkspace(ref)
 	if err != nil {
 		return ChatSession{}, err
 	}
-	out.Mode = normalizeChatMode(out.Mode)
-	return out, nil
+	return s.GetChatSessionByWorkspaceID(workspace.ID)
+}
+
+func (s *Store) GetChatSessionByWorkspaceID(workspaceID int64) (ChatSession, error) {
+	if workspaceID <= 0 {
+		return ChatSession{}, errors.New("workspace id is required")
+	}
+	return scanChatSession(s.db.QueryRow(
+		chatSessionSelect+` WHERE cs.workspace_id = ?`,
+		workspaceID,
+	))
 }
 
 func (s *Store) GetChatSession(id string) (ChatSession, error) {
-	var out ChatSession
-	err := s.db.QueryRow(
-		`SELECT id, project_key, app_thread_id, mode, created_at, updated_at FROM chat_sessions WHERE id = ?`,
+	return scanChatSession(s.db.QueryRow(
+		chatSessionSelect+` WHERE cs.id = ?`,
 		strings.TrimSpace(id),
-	).Scan(&out.ID, &out.ProjectKey, &out.AppThreadID, &out.Mode, &out.CreatedAt, &out.UpdatedAt)
-	if err != nil {
-		return ChatSession{}, err
-	}
-	out.Mode = normalizeChatMode(out.Mode)
-	return out, nil
+	))
 }
 
 func (s *Store) ListChatSessions() ([]ChatSession, error) {
 	rows, err := s.db.Query(
-		`SELECT id, project_key, app_thread_id, mode, created_at, updated_at
-		 FROM chat_sessions ORDER BY created_at ASC`,
+		chatSessionSelect + ` ORDER BY cs.created_at ASC`,
 	)
 	if err != nil {
 		return nil, err
@@ -101,18 +185,10 @@ func (s *Store) ListChatSessions() ([]ChatSession, error) {
 	defer rows.Close()
 	out := make([]ChatSession, 0, 32)
 	for rows.Next() {
-		var item ChatSession
-		if err := rows.Scan(
-			&item.ID,
-			&item.ProjectKey,
-			&item.AppThreadID,
-			&item.Mode,
-			&item.CreatedAt,
-			&item.UpdatedAt,
-		); err != nil {
+		item, err := scanChatSession(rows)
+		if err != nil {
 			return nil, err
 		}
-		item.Mode = normalizeChatMode(item.Mode)
 		out = append(out, item)
 	}
 	return out, nil
@@ -137,6 +213,143 @@ func (s *Store) UpdateChatSessionThread(id, appThreadID string) error {
 		strings.TrimSpace(appThreadID), time.Now().Unix(), strings.TrimSpace(id),
 	)
 	return err
+}
+
+func (s *Store) migrateChatSessionWorkspaceKey() error {
+	tableColumns, err := s.tableColumnSet("chat_sessions")
+	if err != nil {
+		return err
+	}
+	columns := tableColumns["chat_sessions"]
+	if columns["workspace_id"] && !columns["project_key"] {
+		return nil
+	}
+
+	type legacySession struct {
+		ID          string
+		WorkspaceID int64
+		AppThreadID string
+		Mode        string
+		CreatedAt   int64
+		UpdatedAt   int64
+	}
+
+	legacy := make([]legacySession, 0, 16)
+	switch {
+	case columns["workspace_id"] && columns["project_key"]:
+		rows, err := s.db.Query(`SELECT id, workspace_id, project_key, app_thread_id, mode, created_at, updated_at FROM chat_sessions ORDER BY created_at ASC, id ASC`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var item legacySession
+			var projectKey string
+			if err := rows.Scan(&item.ID, &item.WorkspaceID, &projectKey, &item.AppThreadID, &item.Mode, &item.CreatedAt, &item.UpdatedAt); err != nil {
+				return err
+			}
+			projectKey = strings.TrimSpace(projectKey)
+			if projectKey != "" {
+				if project, err := s.GetProjectByProjectKey(projectKey); err == nil && strings.EqualFold(strings.TrimSpace(project.Kind), "hub") {
+					continue
+				} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return err
+				}
+			}
+			if item.WorkspaceID <= 0 {
+				workspace, err := s.resolveChatSessionWorkspace(projectKey)
+				if err != nil {
+					return fmt.Errorf("resolve chat session workspace for %q: %w", item.ID, err)
+				}
+				item.WorkspaceID = workspace.ID
+			}
+			legacy = append(legacy, item)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+	default:
+		rows, err := s.db.Query(`SELECT id, project_key, app_thread_id, mode, created_at, updated_at FROM chat_sessions ORDER BY created_at ASC, id ASC`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var item legacySession
+			var projectKey string
+			if err := rows.Scan(&item.ID, &projectKey, &item.AppThreadID, &item.Mode, &item.CreatedAt, &item.UpdatedAt); err != nil {
+				return err
+			}
+			projectKey = strings.TrimSpace(projectKey)
+			if projectKey != "" {
+				if project, err := s.GetProjectByProjectKey(projectKey); err == nil && strings.EqualFold(strings.TrimSpace(project.Kind), "hub") {
+					continue
+				} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return err
+				}
+			}
+			workspace, err := s.resolveChatSessionWorkspace(projectKey)
+			if err != nil {
+				return fmt.Errorf("resolve chat session workspace for %q: %w", item.ID, err)
+			}
+			item.WorkspaceID = workspace.ID
+			legacy = append(legacy, item)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+	}
+
+	seenWorkspace := map[int64]struct{}{}
+	deduped := make([]legacySession, 0, len(legacy))
+	for _, item := range legacy {
+		if item.WorkspaceID <= 0 {
+			continue
+		}
+		if _, exists := seenWorkspace[item.WorkspaceID]; exists {
+			continue
+		}
+		seenWorkspace[item.WorkspaceID] = struct{}{}
+		deduped = append(deduped, item)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`
+CREATE TABLE chat_sessions_new (
+  id TEXT PRIMARY KEY,
+  workspace_id INTEGER NOT NULL UNIQUE REFERENCES workspaces(id) ON DELETE CASCADE,
+  app_thread_id TEXT NOT NULL DEFAULT '',
+  mode TEXT NOT NULL DEFAULT 'chat',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)`); err != nil {
+		return err
+	}
+	for _, item := range deduped {
+		if _, err := tx.Exec(
+			`INSERT INTO chat_sessions_new (id, workspace_id, app_thread_id, mode, created_at, updated_at) VALUES (?,?,?,?,?,?)`,
+			item.ID,
+			item.WorkspaceID,
+			strings.TrimSpace(item.AppThreadID),
+			normalizeChatMode(item.Mode),
+			item.CreatedAt,
+			item.UpdatedAt,
+		); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`DROP TABLE chat_sessions`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`ALTER TABLE chat_sessions_new RENAME TO chat_sessions`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) AddChatMessage(sessionID, role, contentMarkdown, contentPlain, renderFormat string, opts ...ChatMessageOption) (ChatMessage, error) {

--- a/internal/store/store_project.go
+++ b/internal/store/store_project.go
@@ -313,6 +313,7 @@ func (s *Store) DeleteProject(id string) error {
 	defer tx.Rollback()
 
 	projectKey := strings.TrimSpace(project.ProjectKey)
+	projectIDText := strings.TrimSpace(project.ID)
 	if _, err := tx.Exec(
 		`DELETE FROM participant_room_state
 		 WHERE session_id IN (SELECT id FROM participant_sessions WHERE project_key = ?)`,
@@ -339,19 +340,29 @@ func (s *Store) DeleteProject(id string) error {
 	}
 	if _, err := tx.Exec(
 		`DELETE FROM chat_messages
-		 WHERE session_id IN (SELECT id FROM chat_sessions WHERE project_key = ?)`,
-		projectKey,
+		 WHERE session_id IN (
+		   SELECT cs.id
+		     FROM chat_sessions cs
+		     JOIN workspaces w ON w.id = cs.workspace_id
+		    WHERE w.project_id = ?
+		 )`,
+		projectIDText,
 	); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(
 		`DELETE FROM chat_events
-		 WHERE session_id IN (SELECT id FROM chat_sessions WHERE project_key = ?)`,
-		projectKey,
+		 WHERE session_id IN (
+		   SELECT cs.id
+		     FROM chat_sessions cs
+		     JOIN workspaces w ON w.id = cs.workspace_id
+		    WHERE w.project_id = ?
+		 )`,
+		projectIDText,
 	); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(`DELETE FROM chat_sessions WHERE project_key = ?`, projectKey); err != nil {
+	if _, err := tx.Exec(`DELETE FROM chat_sessions WHERE workspace_id IN (SELECT id FROM workspaces WHERE project_id = ?)`, projectIDText); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(`DELETE FROM projects WHERE id = ?`, projectID); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -22,6 +22,15 @@ func newTestStore(t *testing.T) *Store {
 	return s
 }
 
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestStoreAdminPasswordAndAuthLifecycle(t *testing.T) {
 	s := newTestStore(t)
 
@@ -323,15 +332,26 @@ func TestStoreProjectCompanionConfigPersistsAcrossReopen(t *testing.T) {
 
 func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	s := newTestStore(t)
+	root := filepath.Join(t.TempDir(), "workspace-default")
+	project, err := s.CreateProject("Default", root, root, "managed", "", "", true)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if err := s.SetActiveProjectID(project.ID); err != nil {
+		t.Fatalf("SetActiveProjectID() error: %v", err)
+	}
 
 	session, err := s.GetOrCreateChatSession("  ")
 	if err != nil {
-		t.Fatalf("GetOrCreateChatSession(default) error: %v", err)
+		t.Fatalf("GetOrCreateChatSession(active project) error: %v", err)
 	}
-	if session.ProjectKey != "default" {
-		t.Fatalf("default project key = %q, want default", session.ProjectKey)
+	if session.ProjectKey != project.ProjectKey {
+		t.Fatalf("project key = %q, want %q", session.ProjectKey, project.ProjectKey)
 	}
-	same, err := s.GetOrCreateChatSession("default")
+	if session.WorkspaceID <= 0 {
+		t.Fatalf("workspace_id = %d, want positive id", session.WorkspaceID)
+	}
+	same, err := s.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession(existing) error: %v", err)
 	}
@@ -454,6 +474,50 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	}
 	if err := s.ClearAllChatEvents(); err != nil {
 		t.Fatalf("ClearAllChatEvents() error: %v", err)
+	}
+}
+
+func TestStoreChatSessionsKeyToWorkspace(t *testing.T) {
+	s := newTestStore(t)
+	root := filepath.Join(t.TempDir(), "workspace-alpha")
+	project, err := s.CreateProject("Alpha", "alpha-key", root, "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+
+	session, err := s.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession() error: %v", err)
+	}
+	if session.WorkspaceID <= 0 {
+		t.Fatalf("workspace_id = %d, want positive id", session.WorkspaceID)
+	}
+
+	columns, err := s.tableColumnNames("chat_sessions")
+	if err != nil {
+		t.Fatalf("tableColumnNames(chat_sessions) error: %v", err)
+	}
+	if containsString(columns, "project_key") {
+		t.Fatalf("chat_sessions columns still include project_key: %v", columns)
+	}
+	if !containsString(columns, "workspace_id") {
+		t.Fatalf("chat_sessions columns missing workspace_id: %v", columns)
+	}
+
+	byWorkspace, err := s.GetChatSessionByWorkspaceID(session.WorkspaceID)
+	if err != nil {
+		t.Fatalf("GetChatSessionByWorkspaceID() error: %v", err)
+	}
+	if byWorkspace.ID != session.ID {
+		t.Fatalf("GetChatSessionByWorkspaceID() = %q, want %q", byWorkspace.ID, session.ID)
+	}
+
+	var sessionCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM chat_sessions WHERE workspace_id = ?`, session.WorkspaceID).Scan(&sessionCount); err != nil {
+		t.Fatalf("count chat_sessions by workspace_id: %v", err)
+	}
+	if sessionCount != 1 {
+		t.Fatalf("chat session count for workspace %d = %d, want 1", session.WorkspaceID, sessionCount)
 	}
 }
 

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/appserver"
 	"github.com/krystophny/tabura/internal/plugins"
-	"github.com/krystophny/tabura/internal/store"
 )
 
 const (
@@ -126,8 +125,9 @@ func (a *App) handleChatSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		ProjectKey string `json:"project_key"`
-		ProjectID  string `json:"project_id"`
+		WorkspaceID *int64 `json:"workspace_id"`
+		ProjectKey  string `json:"project_key"`
+		ProjectID   string `json:"project_id"`
 	}
 	if r.ContentLength > 0 {
 		if err := decodeJSON(r, &req); err != nil {
@@ -135,45 +135,27 @@ func (a *App) handleChatSessionCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	projectKey, err := a.resolveProjectKey(req.ProjectID, req.ProjectKey)
+	workspace, resolvedProject, err := a.resolveChatSessionTarget(req.ProjectID, req.ProjectKey, req.WorkspaceID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	var resolvedProject store.Project
-	projectResolved := false
-	if strings.TrimSpace(req.ProjectID) != "" {
-		if resolvedProject, err = a.store.GetProject(strings.TrimSpace(req.ProjectID)); err == nil {
-			projectResolved = true
-		} else if !isNoRows(err) {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-	}
-	if !projectResolved {
-		if resolvedProject, err = a.store.GetProjectByProjectKey(projectKey); err == nil {
-			projectResolved = true
-		} else if !isNoRows(err) {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-	}
-	session, err := a.store.GetOrCreateChatSession(projectKey)
+	session, err := a.store.GetOrCreateChatSessionForWorkspace(workspace.ID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	canvasSessionID := LocalSessionID
 	projectID := ""
-	if projectResolved {
+	if resolvedProject != nil {
 		projectID = resolvedProject.ID
-		canvasSessionID = a.canvasSessionIDForProject(resolvedProject)
+		canvasSessionID = a.canvasSessionIDForProject(*resolvedProject)
 		if err := a.store.SetActiveProjectID(resolvedProject.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		_ = a.markProjectSeen(resolvedProject)
-		if err := a.ensureProjectCanvasReady(resolvedProject); err != nil {
+		_ = a.markProjectSeen(*resolvedProject)
+		if err := a.ensureProjectCanvasReady(*resolvedProject); err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
@@ -181,6 +163,7 @@ func (a *App) handleChatSessionCreate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]interface{}{
 		"ok":                true,
 		"session_id":        session.ID,
+		"workspace_id":      session.WorkspaceID,
 		"project_key":       session.ProjectKey,
 		"project_id":        projectID,
 		"mode":              session.Mode,

--- a/internal/web/chat_cancel_test.go
+++ b/internal/web/chat_cancel_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -371,7 +372,11 @@ func TestHandleChatSessionCancelStopsActiveTurn(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 
-	session, err := app.store.GetOrCreateChatSession("cancel-test-project")
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session: %v", err)
 	}
@@ -419,7 +424,11 @@ func TestHandleChatSessionActivityReportsActiveTurns(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 
-	session, err := app.store.GetOrCreateChatSession("activity-test-project")
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session: %v", err)
 	}
@@ -477,7 +486,11 @@ func TestHandleChatSessionCancelClearsQueuedTurns(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 
-	session, err := app.store.GetOrCreateChatSession("cancel-queued-project")
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session: %v", err)
 	}
@@ -510,11 +523,20 @@ func TestExecuteChatCommandClearAllResetsChatContext(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 
-	s1, err := app.store.GetOrCreateChatSession("clear-all-project-1")
+	projectOne, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	s1, err := app.store.GetOrCreateChatSession(projectOne.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session 1: %v", err)
 	}
-	s2, err := app.store.GetOrCreateChatSession("clear-all-project-2")
+	projectTwoRoot := filepath.Join(t.TempDir(), "clear-all-project-2")
+	projectTwo, err := app.store.CreateProject("Clear All Two", "clear-all-project-2", projectTwoRoot, "managed", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject(project 2) error: %v", err)
+	}
+	s2, err := app.store.GetOrCreateChatSession(projectTwo.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session 2: %v", err)
 	}

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -334,7 +334,7 @@ func TestHubSwitchModelTargetsPrimaryProject(t *testing.T) {
 	if _, err := app.activateProject(hub.ID); err != nil {
 		t.Fatalf("activate hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -470,7 +470,7 @@ func TestHubSwitchProjectActionReturnsActivationPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestExecuteSystemActionRejectsUnsupportedAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -546,7 +546,7 @@ func TestHubRunTurnKeepsPlainTextAssistantOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -587,7 +587,7 @@ func TestHubRunTurnExecutesHighConfidenceLocalIntent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -751,7 +751,7 @@ func TestHubRunTurnFallsBackToSparkOnLowIntentConfidence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -793,7 +793,7 @@ func TestHubRunTurnUsesIntentLLMFallbackOnLowIntentConfidence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -864,7 +864,7 @@ func TestHubRunTurnPreservesClarificationContextForLocalLLM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}
@@ -916,7 +916,7 @@ func TestHubRunTurnFallsBackToSparkWhenLocalIntentExecutionFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("hub session: %v", err)
 	}

--- a/internal/web/chat_items_github_test.go
+++ b/internal/web/chat_items_github_test.go
@@ -242,7 +242,7 @@ func TestClassifyAndExecuteSystemActionCreateGitHubIssueRejectsMissingWorkspace(
 	if len(payloads) != 0 {
 		t.Fatalf("payloads = %#v, want none", payloads)
 	}
-	if message != "I couldn't create the GitHub issue: no workspace is linked to this conversation" {
+	if message != "I couldn't create the GitHub issue: workspace has no GitHub origin remote" {
 		t.Fatalf("message = %q", message)
 	}
 }

--- a/internal/web/chat_model.go
+++ b/internal/web/chat_model.go
@@ -109,7 +109,7 @@ func (a *App) resetProjectChatAppSession(projectKey string) {
 	if key == "" {
 		return
 	}
-	session, err := a.store.GetChatSessionByProjectKey(key)
+	session, err := a.chatSessionForProjectKey(key)
 	if err != nil {
 		return
 	}

--- a/internal/web/chat_projects_test.go
+++ b/internal/web/chat_projects_test.go
@@ -51,7 +51,7 @@ func TestClassifyAndExecuteSystemActionAssignWorkspaceProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureHubProject() error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession() error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestClassifyAndExecuteSystemActionShowProjectItemsByName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureHubProject() error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession() error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestClassifyAndExecuteSystemActionSyncProjectSkipsNonGitWorkspace(t *testin
 	if err != nil {
 		t.Fatalf("ensureHubProject() error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession() error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestClassifyAndExecuteSystemActionSyncProjectPullsGitWorkspace(t *testing.T
 	if err != nil {
 		t.Fatalf("ensureHubProject() error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession() error: %v", err)
 	}

--- a/internal/web/chat_prompt_contract_test.go
+++ b/internal/web/chat_prompt_contract_test.go
@@ -14,7 +14,11 @@ func TestEnsurePromptContractFresh_FirstWriteDoesNotClearMessages(t *testing.T) 
 		_ = app.Shutdown(context.Background())
 	})
 
-	session, err := app.store.GetOrCreateChatSession("prompt-fresh-first-write")
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session: %v", err)
 	}
@@ -54,7 +58,11 @@ func TestEnsurePromptContractFresh_ChangedDigestClearsMessages(t *testing.T) {
 		_ = app.Shutdown(context.Background())
 	})
 
-	session, err := app.store.GetOrCreateChatSession("prompt-fresh-clear")
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
 	if err != nil {
 		t.Fatalf("create chat session: %v", err)
 	}

--- a/internal/web/chat_sessions.go
+++ b/internal/web/chat_sessions.go
@@ -1,0 +1,139 @@
+package web
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func (a *App) chatSessionForProject(project store.Project) (store.ChatSession, error) {
+	if isHubProject(project) {
+		primary, err := a.hubPrimaryProject()
+		if err != nil {
+			return store.ChatSession{}, err
+		}
+		return a.store.GetOrCreateChatSession(primary.ProjectKey)
+	}
+	return a.store.GetOrCreateChatSession(project.ProjectKey)
+}
+
+func (a *App) projectForWorkspace(workspace store.Workspace) (*store.Project, error) {
+	if workspace.ProjectID == nil || strings.TrimSpace(*workspace.ProjectID) == "" {
+		return nil, nil
+	}
+	project, err := a.store.GetProject(strings.TrimSpace(*workspace.ProjectID))
+	if err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+func (a *App) resolveChatSessionTarget(projectID, projectKey string, workspaceID *int64) (store.Workspace, *store.Project, error) {
+	if workspaceID != nil {
+		workspace, err := a.store.GetWorkspace(*workspaceID)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		project, err := a.projectForWorkspace(workspace)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return workspace, project, nil
+	}
+
+	loadProject := func(project store.Project) (store.Workspace, *store.Project, error) {
+		session, err := a.chatSessionForProject(project)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		workspace, err := a.store.GetWorkspace(session.WorkspaceID)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		projectForWorkspace, err := a.projectForWorkspace(workspace)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return workspace, projectForWorkspace, nil
+	}
+
+	if id := strings.TrimSpace(projectID); id != "" {
+		project, err := a.store.GetProject(id)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return loadProject(project)
+	}
+	if key := strings.TrimSpace(projectKey); key != "" {
+		project, err := a.store.GetProjectByProjectKey(key)
+		if err == nil {
+			return loadProject(project)
+		}
+		if !isNoRows(err) {
+			return store.Workspace{}, nil, err
+		}
+		workspace, workspaceErr := a.store.GetWorkspaceByPath(key)
+		if workspaceErr != nil {
+			return store.Workspace{}, nil, workspaceErr
+		}
+		projectForWorkspace, err := a.projectForWorkspace(workspace)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return workspace, projectForWorkspace, nil
+	}
+
+	if workspace, err := a.store.ActiveWorkspace(); err == nil {
+		project, err := a.projectForWorkspace(workspace)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return workspace, project, nil
+	}
+
+	activeProjectID, err := a.store.ActiveProjectID()
+	if err != nil {
+		return store.Workspace{}, nil, err
+	}
+	if strings.TrimSpace(activeProjectID) != "" {
+		project, err := a.store.GetProject(activeProjectID)
+		if err != nil {
+			return store.Workspace{}, nil, err
+		}
+		return loadProject(project)
+	}
+
+	project, err := a.ensureDefaultProjectRecord()
+	if err != nil {
+		return store.Workspace{}, nil, err
+	}
+	return loadProject(project)
+}
+
+func (a *App) activeProjectIsHub() bool {
+	activeProjectID, err := a.store.ActiveProjectID()
+	if err != nil || strings.TrimSpace(activeProjectID) == "" {
+		return false
+	}
+	project, err := a.store.GetProject(activeProjectID)
+	if err != nil {
+		return false
+	}
+	return isHubProject(project)
+}
+
+func (a *App) chatSessionForProjectKey(projectKey string) (store.ChatSession, error) {
+	key := strings.TrimSpace(projectKey)
+	if key == "" {
+		return store.ChatSession{}, errors.New("project key is required")
+	}
+	project, err := a.store.GetProjectByProjectKey(key)
+	if err == nil {
+		return a.chatSessionForProject(project)
+	}
+	if !isNoRows(err) {
+		return store.ChatSession{}, err
+	}
+	return a.store.GetChatSessionByProjectKey(key)
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -28,7 +28,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	positionCtx := a.chatCanvasPositions.consume(sessionID)
 	cursorCtx := turn.cursor
 	userText := queuedUserMessage(messages, turn.messageID)
-	if project, projectErr := a.store.GetProjectByProjectKey(session.ProjectKey); projectErr == nil && isHubProject(project) {
+	if a.activeProjectIsHub() {
 		a.runHubTurn(sessionID, session, messages, turn.outputMode, turn.localOnly)
 		return
 	}

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -200,7 +200,7 @@ func TestClassifyAndExecuteSystemActionCreateWorkspaceFromGit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("chat session: %v", err)
 	}
@@ -301,11 +301,23 @@ func TestClassifyAndExecuteSystemActionListWorkspacesUsesActiveSphereByDefault(t
 	if !ok {
 		t.Fatalf("workspaces payload = %#v", payloads[0]["workspaces"])
 	}
-	if len(workspaces) != 1 || int64FromAny(workspaces[0]["workspace_id"]) != privateWorkspace.ID {
-		t.Fatalf("workspaces payload = %#v, want only private workspace", workspaces)
+	if len(workspaces) != 2 {
+		t.Fatalf("workspaces payload = %#v, want both private-sphere workspaces", workspaces)
 	}
-	if int64FromAny(payloads[0]["workspace_count"]) != 1 {
-		t.Fatalf("workspace_count = %v, want 1", payloads[0]["workspace_count"])
+	foundPrivateWorkspace := false
+	for _, workspace := range workspaces {
+		if got := strFromAny(workspace["sphere"]); got != store.SpherePrivate {
+			t.Fatalf("workspace sphere = %q, want private: %#v", got, workspaces)
+		}
+		if int64FromAny(workspace["workspace_id"]) == privateWorkspace.ID {
+			foundPrivateWorkspace = true
+		}
+	}
+	if !foundPrivateWorkspace {
+		t.Fatalf("workspaces payload missing private workspace %d: %#v", privateWorkspace.ID, workspaces)
+	}
+	if int64FromAny(payloads[0]["workspace_count"]) != 2 {
+		t.Fatalf("workspace_count = %v, want 2", payloads[0]["workspace_count"])
 	}
 
 	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "show all workspaces")
@@ -325,10 +337,17 @@ func TestClassifyAndExecuteSystemActionListWorkspacesUsesActiveSphereByDefault(t
 	if !ok {
 		t.Fatalf("workspaces payload = %#v", payloads[0]["workspaces"])
 	}
-	if len(workspacesAny) != 2 {
-		t.Fatalf("workspaces payload len = %d, want 2", len(workspacesAny))
+	if len(workspacesAny) < 3 {
+		t.Fatalf("workspaces payload len = %d, want at least 3", len(workspacesAny))
 	}
-	if int64FromAny(workspacesAny[1]["workspace_id"]) != workWorkspace.ID && int64FromAny(workspacesAny[0]["workspace_id"]) != workWorkspace.ID {
+	foundWorkWorkspace := false
+	for _, workspace := range workspacesAny {
+		if int64FromAny(workspace["workspace_id"]) == workWorkspace.ID {
+			foundWorkWorkspace = true
+			break
+		}
+	}
+	if !foundWorkWorkspace {
 		t.Fatalf("workspaces payload missing work workspace: %#v", workspacesAny)
 	}
 }
@@ -342,7 +361,7 @@ func TestClassifyAndExecuteSystemActionWorkspaceManagement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure hub project: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(hub.ProjectKey)
+	session, err := app.chatSessionForProject(hub)
 	if err != nil {
 		t.Fatalf("chat session: %v", err)
 	}
@@ -351,7 +370,7 @@ func TestClassifyAndExecuteSystemActionWorkspaceManagement(t *testing.T) {
 	if !handled {
 		t.Fatal("expected create workspace command to be handled")
 	}
-	expectedDir := filepath.Join(hub.RootPath, "notes")
+	expectedDir := filepath.Join(app.cwdForProjectKey(session.ProjectKey), "notes")
 	if message != "Created workspace notes at "+expectedDir+"." {
 		t.Fatalf("message = %q", message)
 	}

--- a/internal/web/companion_runtime.go
+++ b/internal/web/companion_runtime.go
@@ -123,7 +123,7 @@ func (a *App) chatSessionIDForProjectKey(projectKey string) (string, bool) {
 	if a == nil || a.store == nil {
 		return "", false
 	}
-	session, err := a.store.GetOrCreateChatSession(strings.TrimSpace(projectKey))
+	session, err := a.chatSessionForProjectKey(strings.TrimSpace(projectKey))
 	if err != nil {
 		return "", false
 	}

--- a/internal/web/projects.go
+++ b/internal/web/projects.go
@@ -400,39 +400,6 @@ func (a *App) handleProjectsActivity(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (a *App) resolveProjectKey(projectID, projectKey string) (string, error) {
-	key := strings.TrimSpace(projectKey)
-	if key != "" {
-		return key, nil
-	}
-	id := strings.TrimSpace(projectID)
-	if id != "" {
-		project, err := a.store.GetProject(id)
-		if err != nil {
-			return "", err
-		}
-		return project.ProjectKey, nil
-	}
-	activeID, err := a.store.ActiveProjectID()
-	if err != nil {
-		return "", err
-	}
-	if activeID != "" {
-		project, err := a.store.GetProject(activeID)
-		if err == nil {
-			return project.ProjectKey, nil
-		}
-		if !isNoRows(err) {
-			return "", err
-		}
-	}
-	defaultProject, err := a.ensureDefaultProjectRecord()
-	if err != nil {
-		return "", err
-	}
-	return defaultProject.ProjectKey, nil
-}
-
 func (a *App) findProjectByCanvasSession(sessionID string) (store.Project, error) {
 	cleanSessionID := strings.TrimSpace(sessionID)
 	if cleanSessionID == "" {

--- a/internal/web/projects_model.go
+++ b/internal/web/projects_model.go
@@ -32,7 +32,7 @@ func (a *App) canvasSessionIDForProject(project store.Project) string {
 }
 
 func (a *App) buildProjectAPIModel(project store.Project) (projectAPIModel, error) {
-	session, err := a.store.GetOrCreateChatSession(project.ProjectKey)
+	session, err := a.chatSessionForProject(project)
 	if err != nil {
 		return projectAPIModel{}, err
 	}
@@ -98,7 +98,7 @@ func (a *App) projectSelectionRank(project store.Project, activeSphere string) (
 }
 
 func (a *App) buildProjectActivityItem(project store.Project) (projectActivityItem, error) {
-	session, err := a.store.GetOrCreateChatSession(project.ProjectKey)
+	session, err := a.chatSessionForProject(project)
 	if err != nil {
 		return projectActivityItem{}, err
 	}

--- a/internal/web/projects_test.go
+++ b/internal/web/projects_test.go
@@ -108,6 +108,34 @@ func TestProjectsListIncludesActiveAndSessions(t *testing.T) {
 	}
 }
 
+func TestHubProjectReusesWorkspaceChatSession(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	defaultProject, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	hub, err := app.ensureHubProject()
+	if err != nil {
+		t.Fatalf("ensure hub project: %v", err)
+	}
+
+	defaultItem, err := app.buildProjectAPIModel(defaultProject)
+	if err != nil {
+		t.Fatalf("build default project API model: %v", err)
+	}
+	hubItem, err := app.buildProjectAPIModel(hub)
+	if err != nil {
+		t.Fatalf("build hub project API model: %v", err)
+	}
+	if hubItem.ChatSessionID == "" {
+		t.Fatalf("expected hub chat session id")
+	}
+	if hubItem.ChatSessionID != defaultItem.ChatSessionID {
+		t.Fatalf("hub chat_session_id = %q, want shared session %q", hubItem.ChatSessionID, defaultItem.ChatSessionID)
+	}
+}
+
 func TestProjectsListIncludesWorkspaceSphere(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -216,8 +244,10 @@ func TestCreateActivateProjectAffectsChatSessionCreation(t *testing.T) {
 		t.Fatalf("expected chat session create 200, got %d: %s", rrSession.Code, rrSession.Body.String())
 	}
 	var sessionPayload struct {
-		OK        bool   `json:"ok"`
-		ProjectID string `json:"project_id"`
+		OK          bool   `json:"ok"`
+		SessionID   string `json:"session_id"`
+		WorkspaceID int64  `json:"workspace_id"`
+		ProjectID   string `json:"project_id"`
 	}
 	if err := json.Unmarshal(rrSession.Body.Bytes(), &sessionPayload); err != nil {
 		t.Fatalf("decode chat session response: %v", err)
@@ -227,6 +257,16 @@ func TestCreateActivateProjectAffectsChatSessionCreation(t *testing.T) {
 	}
 	if sessionPayload.ProjectID != createPayload.Project.ID {
 		t.Fatalf("expected chat session project %q, got %q", createPayload.Project.ID, sessionPayload.ProjectID)
+	}
+	if sessionPayload.WorkspaceID <= 0 {
+		t.Fatalf("expected workspace-backed chat session, got workspace_id=%d", sessionPayload.WorkspaceID)
+	}
+	session, err := app.store.GetChatSession(sessionPayload.SessionID)
+	if err != nil {
+		t.Fatalf("GetChatSession() error: %v", err)
+	}
+	if session.WorkspaceID != sessionPayload.WorkspaceID {
+		t.Fatalf("session workspace_id = %d, want %d", session.WorkspaceID, sessionPayload.WorkspaceID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- rekeyed `chat_sessions` to `workspace_id` and migrated legacy rows off `project_key`
- resolved session creation from workspaces, removed the `resolveProjectKey()` path, and stopped giving Hub its own dedicated chat session
- updated store/web tests around workspace-backed sessions and hub reuse

## Verification
- `chat_sessions keyed to workspace, not project`
  - `git grep -n "workspace_id INTEGER NOT NULL UNIQUE REFERENCES workspaces\|GetOrCreateChatSessionForWorkspace\|GetChatSessionByWorkspaceID\|workspace_id" -- internal/store/store.go internal/store/store_chat.go internal/web/chat.go internal/web/chat_sessions.go | head -n 20`
  - Evidence: `internal/store/store.go:183` defines `workspace_id INTEGER NOT NULL UNIQUE ...`; `internal/store/store_chat.go:134` and `internal/store/store_chat.go:161` show workspace-based create/lookup helpers.
  - `go test ./internal/store -run TestStoreChatSessionsKeyToWorkspace -count=1`
  - Output: `ok   github.com/krystophny/tabura/internal/store 0.012s`
- `Hub session deleted, not rekeyed`
  - `go test ./internal/web -run TestHubProjectReusesWorkspaceChatSession -count=1`
  - Output: `ok   github.com/krystophny/tabura/internal/web 0.016s`
  - Evidence: the test asserts the Hub project reuses the default workspace chat session instead of creating its own session row.
- `No project_key in session creation or lookup`
  - `rg -n "resolveProjectKey|WHERE project_key =|INSERT INTO chat_sessions \(id, project_key" internal/store/store_chat.go internal/web || true`
  - Output: no matches
- `One workspace = one chat session enforced at the schema level`
  - `go test ./internal/web -run TestCreateActivateProjectAffectsChatSessionCreation -count=1`
  - Output: `ok   github.com/krystophny/tabura/internal/web 0.268s`
  - `go test ./internal/store ./internal/web 2>&1 | tee /tmp/test.log`
  - Output excerpt:
    - `ok   github.com/krystophny/tabura/internal/store (cached)`
    - `ok   github.com/krystophny/tabura/internal/web 7.964s`
  - `rg -n "^(FAIL|--- FAIL)|error:" /tmp/test.log`
  - Output: no matches
