### PR TITLE
fix: Final ontology consistency audit: verify all open issues and arc (fixes #494)

### DIFF
--- a/docs/live-runtime-whitepaper.md
+++ b/docs/live-runtime-whitepaper.md
@@ -31,7 +31,7 @@ stacked features:
 - `Dialogue` is the assistant turn-taking path.
 - `Meeting` is the ambient room/call capture path.
 - Hotword remains a subsystem inside that same runtime.
-- Hub remains for ad hoc requests and run monitoring.
+- Ad hoc requests and run monitoring stay workspace-independent. There is no hub entity.
 
 If no artifact is displayed while Meeting is enabled, the idle surface is a
 full-screen minimal face. A black-screen idle mode remains the alternate
@@ -86,8 +86,8 @@ runtime for direct dialogue, meetings, online calls, and ambient workday help.
 - Interaction policy: `#131`
 - Memory/timeline: `#132`
 - Runtime protocol: `#133`
-- Temporary projects: `#134`
-- Hub run monitor: `#135`
+- Ephemeral workspaces: `#134`
+- Run monitor: `#135`
 - Humanoid idle surface / black mode: `#136`
 - Transcript memory/context builder: `#137`
 - Consent/privacy safeguards: `#138`

--- a/docs/object-scoped-intent-ui.md
+++ b/docs/object-scoped-intent-ui.md
@@ -117,9 +117,9 @@ Shared baseline:
 
 Workspace model:
 
-- meetings and long-running jobs should default to temporary workspaces
+- meetings and long-running jobs should default to ephemeral workspaces
 - each workspace keeps one active run in its main thread
-- Hub remains for ad hoc requests and run monitoring only
+- ad hoc requests and run monitoring stay workspace-independent; there is no hub entity
 
 Noise filtering remains important:
 

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -80,11 +80,11 @@ var MCPTools = []Tool{
 	},
 	{
 		Name:        "workspace_list",
-		Description: "List workspaces, optionally filtered by sphere.",
+		Description: "List workspaces, optionally filtered by the legacy work/private top-level context parameter.",
 		Properties: map[string]ToolProperty{
 			"sphere": {
 				Type:        "string",
-				Description: "Optional workspace sphere filter.",
+				Description: "Optional legacy work/private top-level context filter.",
 				Enum:        []string{"work", "private"},
 			},
 		},
@@ -154,7 +154,7 @@ var MCPTools = []Tool{
 	},
 	{
 		Name:        "item_list",
-		Description: "List items, optionally filtered by state, workspace, sphere, or source.",
+		Description: "List items, optionally filtered by state, workspace, legacy work/private top-level context, or source.",
 		Properties: map[string]ToolProperty{
 			"state": {
 				Type:        "string",
@@ -167,7 +167,7 @@ var MCPTools = []Tool{
 			},
 			"sphere": {
 				Type:        "string",
-				Description: "Optional sphere filter.",
+				Description: "Optional legacy work/private top-level context filter.",
 				Enum:        []string{"work", "private"},
 			},
 			"source": {
@@ -219,7 +219,7 @@ var MCPTools = []Tool{
 			},
 			"sphere": {
 				Type:        "string",
-				Description: "Optional sphere override.",
+				Description: "Optional legacy work/private top-level context override.",
 				Enum:        []string{"work", "private"},
 			},
 			"visible_after": {
@@ -311,7 +311,7 @@ var MCPTools = []Tool{
 			},
 			"sphere": {
 				Type:        "string",
-				Description: "Optional sphere override.",
+				Description: "Optional legacy work/private top-level context override.",
 				Enum:        []string{"work", "private"},
 			},
 			"visible_after": {


### PR DESCRIPTION
## Summary
Aligned the active ontology docs and surface descriptions with the five-noun model audited in #494.

## Verification
- Open-issue audit: reviewed epic #453 plus open children #481, #491, #492, #493, and #494 with `gh issue view ... --json title,body`; no issue-body edits were needed because each issue treats hub/project/sphere as legacy removal or migration targets, not surviving product concepts.
- Interaction docs: updated `docs/object-scoped-intent-ui.md` and `docs/live-runtime-whitepaper.md` so they no longer describe Hub as a live entity and use `ephemeral workspaces` wording consistent with `docs/interaction-grammar.md`.
- Surface docs: updated `internal/surface/definitions.go` so the remaining `sphere` request keys are described explicitly as legacy work/private top-level context parameters instead of current ontology terms. Remaining legacy route names stay tracked by #481.
- Verification run: `./scripts/sync-surface.sh --check && go test ./internal/surface`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/surface	0.006s`

