### PR TITLE
fix: Add context prefix filtering to store queries (fixes #525)

### DIFF
--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -93,6 +93,9 @@ type ItemListFilter struct {
 	WorkspaceUnassigned bool    `json:"workspace_unassigned,omitempty"`
 	ProjectID           *string `json:"project_id,omitempty"`
 	ContextID           *int64  `json:"context_id,omitempty"`
+	Context             string  `json:"context,omitempty"`
+	resolvedContextIDs  []int64
+	contextResolved     bool
 }
 
 type Context struct {

--- a/internal/store/store_context.go
+++ b/internal/store/store_context.go
@@ -90,6 +90,18 @@ func (s *Store) LinkContextToItem(contextID, itemID int64) error {
 	return err
 }
 
+func (s *Store) LinkContextToArtifact(contextID, artifactID int64) error {
+	if contextID <= 0 || artifactID <= 0 {
+		return errors.New("context_id and artifact_id must be positive integers")
+	}
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO context_artifacts (context_id, artifact_id) VALUES (?, ?)`,
+		contextID,
+		artifactID,
+	)
+	return err
+}
+
 func (s *Store) ListContexts() ([]Context, error) {
 	rows, err := s.db.Query(
 		`SELECT id, name, color, parent_id, created_at

--- a/internal/store/store_context_query.go
+++ b/internal/store/store_context_query.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"sort"
+	"strings"
+)
+
+func normalizeOptionalContextQuery(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func placeholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}
+
+func contextLinkExistsClause(linkTable, entityColumn, entityExpr string, contextIDs []int64) (string, []any) {
+	if len(contextIDs) == 0 {
+		return "0=1", nil
+	}
+	args := make([]any, 0, len(contextIDs))
+	for _, contextID := range contextIDs {
+		args = append(args, contextID)
+	}
+	return `EXISTS (
+SELECT 1
+FROM ` + linkTable + ` link
+WHERE link.` + entityColumn + ` = ` + entityExpr + `
+  AND link.context_id IN (` + placeholders(len(contextIDs)) + `)
+)`, args
+}
+
+func (s *Store) resolveContextQueryIDs(query string) ([]int64, error) {
+	cleanQuery := strings.ToLower(strings.TrimSpace(query))
+	if cleanQuery == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		`WITH RECURSIVE context_paths(id, parent_id, name, path) AS (
+		   SELECT id, parent_id, lower(name), lower(name)
+		   FROM contexts
+		   WHERE parent_id IS NULL
+		   UNION ALL
+		   SELECT c.id, c.parent_id, lower(c.name), cp.path || '/' || lower(c.name)
+		   FROM contexts c
+		   JOIN context_paths cp ON cp.id = c.parent_id
+		 ),
+		 matched_exact(id) AS (
+		   SELECT id
+		   FROM context_paths
+		   WHERE name = ? OR path = ?
+		 ),
+		 matched_prefix(id) AS (
+		   SELECT id
+		   FROM context_paths
+		   WHERE name = ?
+		      OR name LIKE ? || '/%'
+		      OR path = ?
+		      OR path LIKE ? || '/%'
+		 ),
+		 descendants(id) AS (
+		   SELECT id FROM matched_exact
+		   UNION
+		   SELECT c.id
+		   FROM contexts c
+		   JOIN descendants d ON c.parent_id = d.id
+		 )
+		 SELECT DISTINCT id
+		 FROM (
+		   SELECT id FROM matched_prefix
+		   UNION
+		   SELECT id FROM descendants
+		 )
+		 ORDER BY id ASC`,
+		cleanQuery,
+		cleanQuery,
+		cleanQuery,
+		cleanQuery,
+		cleanQuery,
+		cleanQuery,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var contextID int64
+		if err := rows.Scan(&contextID); err != nil {
+			return nil, err
+		}
+		out = append(out, contextID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) workspaceHasAnyContext(workspaceID int64, contextIDs []int64) (bool, error) {
+	if workspaceID <= 0 {
+		return false, nil
+	}
+	clause, args := contextLinkExistsClause("context_workspaces", "workspace_id", "?", contextIDs)
+	var matched int
+	rowArgs := append([]any{workspaceID}, args...)
+	if err := s.db.QueryRow(`SELECT CASE WHEN `+clause+` THEN 1 ELSE 0 END`, rowArgs...).Scan(&matched); err != nil {
+		return false, err
+	}
+	return matched != 0, nil
+}
+
+func (s *Store) entityHasAnyContext(linkTable, entityColumn string, entityID int64, contextIDs []int64) (bool, error) {
+	if entityID <= 0 {
+		return false, nil
+	}
+	clause, args := contextLinkExistsClause(linkTable, entityColumn, "?", contextIDs)
+	var matched int
+	rowArgs := append([]any{entityID}, args...)
+	if err := s.db.QueryRow(`SELECT CASE WHEN `+clause+` THEN 1 ELSE 0 END`, rowArgs...).Scan(&matched); err != nil {
+		return false, err
+	}
+	return matched != 0, nil
+}
+
+func (s *Store) ListWorkspacesByContextPrefix(prefix string) ([]Workspace, error) {
+	cleanPrefix := normalizeOptionalContextQuery(prefix)
+	if cleanPrefix == "" {
+		return nil, errors.New("context is required")
+	}
+	contextIDs, err := s.resolveContextQueryIDs(cleanPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(contextIDs) == 0 {
+		return []Workspace{}, nil
+	}
+	clause, args := contextLinkExistsClause("context_workspaces", "workspace_id", "workspaces.id", contextIDs)
+	rows, err := s.db.Query(
+		`SELECT id, name, dir_path, project_id, `+scopedContextSelect("context_workspaces", "workspace_id", "workspaces.id")+` AS sphere, is_active, mcp_url, canvas_session_id, chat_model, chat_model_reasoning_effort, created_at, updated_at
+		 FROM workspaces
+		 WHERE `+clause,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Workspace
+	for rows.Next() {
+		workspace, err := scanWorkspace(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, workspace)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].IsActive != out[j].IsActive {
+			return out[i].IsActive
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+func (s *Store) ListItemsByContextPrefix(prefix string) ([]Item, error) {
+	cleanPrefix := normalizeOptionalContextQuery(prefix)
+	if cleanPrefix == "" {
+		return nil, errors.New("context is required")
+	}
+	return s.ListItemsFiltered(ItemListFilter{Context: cleanPrefix})
+}
+
+func (s *Store) filterArtifactsByContextIDs(artifacts []Artifact, contextIDs []int64) ([]Artifact, error) {
+	if len(contextIDs) == 0 {
+		return []Artifact{}, nil
+	}
+	out := make([]Artifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		matched, err := s.entityHasAnyContext("context_artifacts", "artifact_id", artifact.ID, contextIDs)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			out = append(out, artifact)
+			continue
+		}
+		homeWorkspaceID, err := s.InferWorkspaceForArtifact(artifact)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		if homeWorkspaceID != nil {
+			matched, err = s.workspaceHasAnyContext(*homeWorkspaceID, contextIDs)
+			if err != nil {
+				return nil, err
+			}
+			if matched {
+				out = append(out, artifact)
+				continue
+			}
+		}
+		workspaces, err := s.ListArtifactLinkWorkspaces(artifact.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		for _, workspace := range workspaces {
+			matched, err = s.workspaceHasAnyContext(workspace.ID, contextIDs)
+			if err != nil {
+				return nil, err
+			}
+			if matched {
+				out = append(out, artifact)
+				break
+			}
+		}
+	}
+	sortArtifactsNewestFirst(out)
+	return out, nil
+}
+
+func (s *Store) ListArtifactsByContextPrefix(prefix string) ([]Artifact, error) {
+	cleanPrefix := normalizeOptionalContextQuery(prefix)
+	if cleanPrefix == "" {
+		return nil, errors.New("context is required")
+	}
+	contextIDs, err := s.resolveContextQueryIDs(cleanPrefix)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, err := s.ListArtifacts()
+	if err != nil {
+		return nil, err
+	}
+	return s.filterArtifactsByContextIDs(artifacts, contextIDs)
+}

--- a/internal/store/store_context_query_test.go
+++ b/internal/store/store_context_query_test.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestContextPrefixQueriesAcrossWorkspacesItemsAndArtifacts(t *testing.T) {
+	s := newTestStore(t)
+
+	work, err := s.CreateContext("Work", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(work) error: %v", err)
+	}
+	w7x, err := s.CreateContext("W7x", &work.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(w7x) error: %v", err)
+	}
+	privateCtx, err := s.CreateContext("Private", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(private) error: %v", err)
+	}
+
+	workspaceDir := filepath.Join(t.TempDir(), "w7x")
+	workspace, err := s.CreateWorkspace("W7x Workspace", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := s.LinkContextToWorkspace(w7x.ID, workspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace() error: %v", err)
+	}
+	privateWorkspace, err := s.CreateWorkspace("Private Workspace", filepath.Join(t.TempDir(), "private"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(private) error: %v", err)
+	}
+	if err := s.LinkContextToWorkspace(privateCtx.ID, privateWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(private) error: %v", err)
+	}
+
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	workspaceItem, err := s.CreateItem("Workspace context item", ItemOptions{
+		State:        ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(workspace) error: %v", err)
+	}
+	privateItem, err := s.CreateItem("Private context item", ItemOptions{
+		State:        ItemStateInbox,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(private) error: %v", err)
+	}
+	if err := s.LinkContextToItem(privateCtx.ID, privateItem.ID); err != nil {
+		t.Fatalf("LinkContextToItem(private) error: %v", err)
+	}
+
+	workspaceArtifactPath := filepath.Join(workspaceDir, "notes.md")
+	workspaceArtifactTitle := "Workspace artifact"
+	workspaceArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, &workspaceArtifactPath, nil, &workspaceArtifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(workspace) error: %v", err)
+	}
+	directArtifactTitle := "Direct context artifact"
+	directArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, nil, nil, &directArtifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(direct) error: %v", err)
+	}
+	if err := s.LinkContextToArtifact(w7x.ID, directArtifact.ID); err != nil {
+		t.Fatalf("LinkContextToArtifact() error: %v", err)
+	}
+	privateArtifactTitle := "Private artifact"
+	privateArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, nil, nil, &privateArtifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(private) error: %v", err)
+	}
+	if err := s.LinkContextToArtifact(privateCtx.ID, privateArtifact.ID); err != nil {
+		t.Fatalf("LinkContextToArtifact(private) error: %v", err)
+	}
+
+	workspaces, err := s.ListWorkspacesByContextPrefix("work/w7x")
+	if err != nil {
+		t.Fatalf("ListWorkspacesByContextPrefix() error: %v", err)
+	}
+	if len(workspaces) != 1 || workspaces[0].ID != workspace.ID {
+		t.Fatalf("ListWorkspacesByContextPrefix() = %+v, want workspace %d", workspaces, workspace.ID)
+	}
+
+	items, err := s.ListItemsByContextPrefix("work")
+	if err != nil {
+		t.Fatalf("ListItemsByContextPrefix(work) error: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != workspaceItem.ID {
+		t.Fatalf("ListItemsByContextPrefix(work) = %+v, want item %d", items, workspaceItem.ID)
+	}
+
+	artifacts, err := s.ListArtifactsByContextPrefix("w7x")
+	if err != nil {
+		t.Fatalf("ListArtifactsByContextPrefix(w7x) error: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("ListArtifactsByContextPrefix(w7x) len = %d, want 2", len(artifacts))
+	}
+	seenArtifacts := map[int64]bool{}
+	for _, artifact := range artifacts {
+		seenArtifacts[artifact.ID] = true
+	}
+	if !seenArtifacts[workspaceArtifact.ID] || !seenArtifacts[directArtifact.ID] || seenArtifacts[privateArtifact.ID] {
+		t.Fatalf("ListArtifactsByContextPrefix(w7x) ids = %#v", seenArtifacts)
+	}
+}
+
+func TestContextPrefixQueriesMatchFlatContextNames(t *testing.T) {
+	s := newTestStore(t)
+
+	march11, err := s.CreateContext("2026/03/11", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(march11) error: %v", err)
+	}
+	march12, err := s.CreateContext("2026/03/12", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(march12) error: %v", err)
+	}
+	april01, err := s.CreateContext("2026/04/01", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(april01) error: %v", err)
+	}
+
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	march11Item, err := s.CreateItem("March 11 item", ItemOptions{State: ItemStateInbox, VisibleAfter: &past})
+	if err != nil {
+		t.Fatalf("CreateItem(march11) error: %v", err)
+	}
+	if err := s.LinkContextToItem(march11.ID, march11Item.ID); err != nil {
+		t.Fatalf("LinkContextToItem(march11) error: %v", err)
+	}
+	march12Item, err := s.CreateItem("March 12 item", ItemOptions{State: ItemStateInbox, VisibleAfter: &past})
+	if err != nil {
+		t.Fatalf("CreateItem(march12) error: %v", err)
+	}
+	if err := s.LinkContextToItem(march12.ID, march12Item.ID); err != nil {
+		t.Fatalf("LinkContextToItem(march12) error: %v", err)
+	}
+	aprilItem, err := s.CreateItem("April 1 item", ItemOptions{State: ItemStateInbox, VisibleAfter: &past})
+	if err != nil {
+		t.Fatalf("CreateItem(april) error: %v", err)
+	}
+	if err := s.LinkContextToItem(april01.ID, aprilItem.ID); err != nil {
+		t.Fatalf("LinkContextToItem(april) error: %v", err)
+	}
+
+	items, err := s.ListItemsByContextPrefix("2026/03")
+	if err != nil {
+		t.Fatalf("ListItemsByContextPrefix(2026/03) error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListItemsByContextPrefix(2026/03) len = %d, want 2", len(items))
+	}
+	seen := map[int64]bool{}
+	for _, item := range items {
+		seen[item.ID] = true
+	}
+	if !seen[march11Item.ID] || !seen[march12Item.ID] || seen[aprilItem.ID] {
+		t.Fatalf("ListItemsByContextPrefix(2026/03) ids = %#v", seen)
+	}
+
+	exact, err := s.ListItemsByContextPrefix("2026/03/11")
+	if err != nil {
+		t.Fatalf("ListItemsByContextPrefix(2026/03/11) error: %v", err)
+	}
+	if len(exact) != 1 || exact[0].ID != march11Item.ID {
+		t.Fatalf("ListItemsByContextPrefix(2026/03/11) = %+v, want item %d", exact, march11Item.ID)
+	}
+}

--- a/internal/store/store_domain_item_query.go
+++ b/internal/store/store_domain_item_query.go
@@ -20,7 +20,7 @@ func (s *Store) ListItemsByStateFiltered(state string, filter ItemListFilter) ([
 	if cleanState == "" {
 		return nil, errors.New("invalid item state")
 	}
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (s *Store) ListInboxItemsForSphere(now time.Time, sphere string) ([]ItemSum
 }
 
 func (s *Store) ListInboxItemsFiltered(now time.Time, filter ItemListFilter) ([]ItemSummary, error) {
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (s *Store) ListWaitingItemsForSphere(sphere string) ([]ItemSummary, error) 
 }
 
 func (s *Store) ListWaitingItemsFiltered(filter ItemListFilter) ([]ItemSummary, error) {
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (s *Store) ListSomedayItemsForSphere(sphere string) ([]ItemSummary, error) 
 }
 
 func (s *Store) ListSomedayItemsFiltered(filter ItemListFilter) ([]ItemSummary, error) {
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (s *Store) ListDoneItemsFiltered(limit int, filter ItemListFilter) ([]ItemS
 	if limit <= 0 {
 		limit = 50
 	}
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (s *Store) CountItemsByStateFiltered(now time.Time, filter ItemListFilter) 
 		ItemStateSomeday: 0,
 		ItemStateDone:    0,
 	}
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (s *Store) ListItems() ([]Item, error) {
 }
 
 func (s *Store) ListItemsFiltered(filter ItemListFilter) ([]Item, error) {
-	normalizedFilter, err := normalizeItemListFilter(filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_item_filters.go
+++ b/internal/store/store_item_filters.go
@@ -31,6 +31,7 @@ func normalizeItemListFilter(filter ItemListFilter) (ItemListFilter, error) {
 			normalized.ProjectID = &projectID
 		}
 	}
+	normalized.Context = normalizeOptionalContextQuery(filter.Context)
 	if filter.ContextID != nil {
 		if *filter.ContextID <= 0 {
 			return ItemListFilter{}, errors.New("context_id must be a positive integer")
@@ -38,6 +39,26 @@ func normalizeItemListFilter(filter ItemListFilter) (ItemListFilter, error) {
 		value := *filter.ContextID
 		normalized.ContextID = &value
 	}
+	if normalized.Context != "" && normalized.ContextID != nil {
+		return ItemListFilter{}, errors.New("context cannot be combined with context_id")
+	}
+	return normalized, nil
+}
+
+func (s *Store) prepareItemListFilter(filter ItemListFilter) (ItemListFilter, error) {
+	normalized, err := normalizeItemListFilter(filter)
+	if err != nil {
+		return ItemListFilter{}, err
+	}
+	if normalized.Context == "" {
+		return normalized, nil
+	}
+	contextIDs, err := s.resolveContextQueryIDs(normalized.Context)
+	if err != nil {
+		return ItemListFilter{}, err
+	}
+	normalized.resolvedContextIDs = contextIDs
+	normalized.contextResolved = true
 	return normalized, nil
 }
 
@@ -72,6 +93,18 @@ func appendItemFilterClauses(parts []string, args []any, filter ItemListFilter, 
 	if filter.ProjectID != nil {
 		parts = append(parts, `COALESCE(`+column("project_id")+`, `+workspaceProjectColumn()+`) = ?`)
 		args = append(args, *filter.ProjectID)
+	}
+	if filter.contextResolved {
+		if len(filter.resolvedContextIDs) == 0 {
+			parts = append(parts, "0=1")
+			return parts, args
+		}
+		contextItemMatch, contextItemArgs := contextLinkExistsClause("context_items", "item_id", outerColumn("id"), filter.resolvedContextIDs)
+		contextWorkspaceMatch, contextWorkspaceArgs := contextLinkExistsClause("context_workspaces", "workspace_id", outerColumn("workspace_id"), filter.resolvedContextIDs)
+		parts = append(parts, `(`+contextItemMatch+` OR `+contextWorkspaceMatch+`)`)
+		args = append(args, contextItemArgs...)
+		args = append(args, contextWorkspaceArgs...)
+		return parts, args
 	}
 	if filter.ContextID != nil {
 		contextItemMatch := `EXISTS (

--- a/internal/web/artifacts.go
+++ b/internal/web/artifacts.go
@@ -21,6 +21,11 @@ func (a *App) handleArtifactList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	kind := store.ArtifactKind(strings.TrimSpace(r.URL.Query().Get("kind")))
+	contextQuery := strings.TrimSpace(r.URL.Query().Get("context"))
+	if strings.EqualFold(contextQuery, "null") {
+		writeAPIError(w, http.StatusBadRequest, "context must not be null")
+		return
+	}
 	workspaceIDText := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
 	linkedOnly := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("linked")), "true")
 	var (
@@ -47,6 +52,24 @@ func (a *App) handleArtifactList(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeDomainStoreError(w, err)
 		return
+	}
+	if contextQuery != "" {
+		contextArtifacts, err := a.store.ListArtifactsByContextPrefix(contextQuery)
+		if err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+		allowed := make(map[int64]struct{}, len(contextArtifacts))
+		for _, artifact := range contextArtifacts {
+			allowed[artifact.ID] = struct{}{}
+		}
+		filtered := make([]store.Artifact, 0, len(artifacts))
+		for _, artifact := range artifacts {
+			if _, ok := allowed[artifact.ID]; ok {
+				filtered = append(filtered, artifact)
+			}
+		}
+		artifacts = filtered
 	}
 	writeAPIData(w, http.StatusOK, map[string]any{
 		"artifacts": artifacts,

--- a/internal/web/context_filters_test.go
+++ b/internal/web/context_filters_test.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestContextQueryFiltersWorkspaceItemAndArtifactAPIs(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	work, err := app.store.CreateContext("Work", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(work) error: %v", err)
+	}
+	w7x, err := app.store.CreateContext("W7x", &work.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(w7x) error: %v", err)
+	}
+	privateCtx, err := app.store.CreateContext("Private", nil)
+	if err != nil {
+		t.Fatalf("CreateContext(private) error: %v", err)
+	}
+
+	workspaceDir := filepath.Join(t.TempDir(), "w7x")
+	workspace, err := app.store.CreateWorkspace("W7x Workspace", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.LinkContextToWorkspace(w7x.ID, workspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace() error: %v", err)
+	}
+	privateWorkspace, err := app.store.CreateWorkspace("Private Workspace", filepath.Join(t.TempDir(), "private"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(private) error: %v", err)
+	}
+	if err := app.store.LinkContextToWorkspace(privateCtx.ID, privateWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(private) error: %v", err)
+	}
+
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	workItem, err := app.store.CreateItem("Work inbox item", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		WorkspaceID:  &workspace.ID,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(work) error: %v", err)
+	}
+	privateItem, err := app.store.CreateItem("Private inbox item", store.ItemOptions{
+		State:        store.ItemStateInbox,
+		VisibleAfter: &past,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(private) error: %v", err)
+	}
+	if err := app.store.LinkContextToItem(privateCtx.ID, privateItem.ID); err != nil {
+		t.Fatalf("LinkContextToItem(private) error: %v", err)
+	}
+
+	workArtifactPath := filepath.Join(workspaceDir, "artifact.md")
+	workArtifactTitle := "Work artifact"
+	workArtifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &workArtifactPath, nil, &workArtifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(work) error: %v", err)
+	}
+	privateArtifactTitle := "Private artifact"
+	privateArtifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, nil, nil, &privateArtifactTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(private) error: %v", err)
+	}
+	if err := app.store.LinkContextToArtifact(privateCtx.ID, privateArtifact.ID); err != nil {
+		t.Fatalf("LinkContextToArtifact(private) error: %v", err)
+	}
+
+	rrWorkspaces := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/workspaces?context=work/w7x", nil)
+	if rrWorkspaces.Code != http.StatusOK {
+		t.Fatalf("workspace context status = %d, want 200: %s", rrWorkspaces.Code, rrWorkspaces.Body.String())
+	}
+	workspaces, ok := decodeJSONDataResponse(t, rrWorkspaces)["workspaces"].([]any)
+	if !ok || len(workspaces) != 1 {
+		t.Fatalf("workspace context payload = %#v", decodeJSONDataResponse(t, rrWorkspaces))
+	}
+	if got := int64(workspaces[0].(map[string]any)["id"].(float64)); got != workspace.ID {
+		t.Fatalf("workspace context id = %d, want %d", got, workspace.ID)
+	}
+
+	rrItems := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?context=work", nil)
+	if rrItems.Code != http.StatusOK {
+		t.Fatalf("item context status = %d, want 200: %s", rrItems.Code, rrItems.Body.String())
+	}
+	items, ok := decodeJSONDataResponse(t, rrItems)["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("item context payload = %#v", decodeJSONDataResponse(t, rrItems))
+	}
+	if got := int64(items[0].(map[string]any)["id"].(float64)); got != workItem.ID {
+		t.Fatalf("item context id = %d, want %d", got, workItem.ID)
+	}
+
+	rrArtifacts := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?context=w7x", nil)
+	if rrArtifacts.Code != http.StatusOK {
+		t.Fatalf("artifact context status = %d, want 200: %s", rrArtifacts.Code, rrArtifacts.Body.String())
+	}
+	artifacts, ok := decodeJSONDataResponse(t, rrArtifacts)["artifacts"].([]any)
+	if !ok || len(artifacts) != 1 {
+		t.Fatalf("artifact context payload = %#v", decodeJSONDataResponse(t, rrArtifacts))
+	}
+	if got := int64(artifacts[0].(map[string]any)["id"].(float64)); got != workArtifact.ID {
+		t.Fatalf("artifact context id = %d, want %d", got, workArtifact.ID)
+	}
+}
+
+func TestItemContextQueryRejectsContextAndContextIDTogether(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/inbox?context=work&context_id=1", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("conflicting context filters status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -119,6 +119,15 @@ func parseItemListFilterQuery(r *http.Request) (store.ItemListFilter, error) {
 		}
 		filter.ContextID = &contextID
 	}
+	if rawContext := strings.TrimSpace(r.URL.Query().Get("context")); rawContext != "" {
+		if strings.EqualFold(rawContext, "null") {
+			return store.ItemListFilter{}, errors.New("context must not be null")
+		}
+		if filter.ContextID != nil {
+			return store.ItemListFilter{}, errors.New("context cannot be combined with context_id")
+		}
+		filter.Context = rawContext
+	}
 	return filter, nil
 }
 

--- a/internal/web/workspaces.go
+++ b/internal/web/workspaces.go
@@ -3,6 +3,8 @@ package web
 import (
 	"net/http"
 	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
 )
 
 type workspaceCreateRequest struct {
@@ -22,10 +24,34 @@ func (a *App) handleWorkspaceList(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
 	}
-	workspaces, err := a.store.ListWorkspacesForSphere(strings.TrimSpace(r.URL.Query().Get("sphere")))
+	sphere := strings.TrimSpace(r.URL.Query().Get("sphere"))
+	contextQuery := strings.TrimSpace(r.URL.Query().Get("context"))
+	if strings.EqualFold(contextQuery, "null") {
+		writeAPIError(w, http.StatusBadRequest, "context must not be null")
+		return
+	}
+	workspaces, err := a.store.ListWorkspacesForSphere(sphere)
 	if err != nil {
 		writeDomainStoreError(w, err)
 		return
+	}
+	if contextQuery != "" {
+		contextWorkspaces, err := a.store.ListWorkspacesByContextPrefix(contextQuery)
+		if err != nil {
+			writeDomainStoreError(w, err)
+			return
+		}
+		allowed := make(map[int64]struct{}, len(contextWorkspaces))
+		for _, workspace := range contextWorkspaces {
+			allowed[workspace.ID] = struct{}{}
+		}
+		filtered := make([]store.Workspace, 0, len(workspaces))
+		for _, workspace := range workspaces {
+			if _, ok := allowed[workspace.ID]; ok {
+				filtered = append(filtered, workspace)
+			}
+		}
+		workspaces = filtered
 	}
 	writeAPIData(w, http.StatusOK, map[string]any{
 		"workspaces": workspaces,


### PR DESCRIPTION
## Summary
- add shared `context=` prefix resolution for hierarchical contexts like `work/w7x` and flat path-style contexts like `2026/03/11`
- reuse that resolution in item filtering and add workspace/artifact context filtering on the list APIs
- add store and web coverage for prefix, exact-match, and conflicting-filter cases

## Verification
- Prefix filtering works for workspaces, items, and artifacts: `go test ./... 2>&1 | tee /tmp/tabula-issue-525-test.log`
  - `ok   github.com/krystophny/tabura/internal/store 1.960s`
  - `ok   github.com/krystophny/tabura/internal/web 10.528s`
  - covered by `TestContextPrefixQueriesAcrossWorkspacesItemsAndArtifacts` and `TestContextQueryFiltersWorkspaceItemAndArtifactAPIs`
- Exact match still works and flat date-style prefixes resolve correctly: `go test ./... 2>&1 | tee /tmp/tabula-issue-525-test.log`
  - `ok   github.com/krystophny/tabura/internal/store 1.960s`
  - covered by `TestContextPrefixQueriesMatchFlatContextNames`
- API endpoints support `context` and reject conflicting item filters: `go test ./... 2>&1 | tee /tmp/tabula-issue-525-test.log`
  - `ok   github.com/krystophny/tabura/internal/web 10.528s`
  - covered by `TestContextQueryFiltersWorkspaceItemAndArtifactAPIs` and `TestItemContextQueryRejectsContextAndContextIDTogether`
- Non-date contexts benefit from the same prefix behavior: `go test ./... 2>&1 | tee /tmp/tabula-issue-525-test.log`
  - `ok   github.com/krystophny/tabura/internal/store 1.960s`
  - covered by the hierarchical `work/w7x` assertions in `TestContextPrefixQueriesAcrossWorkspacesItemsAndArtifacts`
