### PR TITLE
fix: Add addressedness detection to unified local brain (fixes #519)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -28,6 +28,11 @@ type SystemAction struct {
 	Params map[string]interface{} `json:"-"`
 }
 
+type intentPlanClassification struct {
+	Actions   []*SystemAction
+	Addressed *bool
+}
+
 const systemActionLastShellPathPlaceholder = "$last_shell_path"
 
 func extractEmbeddedJSON(raw string) string {
@@ -178,35 +183,40 @@ func parseSystemActionJSON(raw string) (*SystemAction, error) {
 	return actions[0], nil
 }
 
-func parseSystemActionsJSON(raw string) ([]*SystemAction, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil, nil
+func decodeSystemActionCandidate(candidate string) (interface{}, bool) {
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(candidate), &decoded); err == nil {
+		return decoded, true
 	}
-	decodeJSON := func(candidate string) (interface{}, bool) {
-		var decoded interface{}
-		if err := json.Unmarshal([]byte(candidate), &decoded); err == nil {
+	repaired := repairMalformedCommandQuotes(candidate)
+	if repaired != candidate {
+		if err := json.Unmarshal([]byte(repaired), &decoded); err == nil {
 			return decoded, true
 		}
-		repaired := repairMalformedCommandQuotes(candidate)
-		if repaired != candidate {
-			if err := json.Unmarshal([]byte(repaired), &decoded); err == nil {
-				return decoded, true
-			}
-		}
+	}
+	return nil, false
+}
+
+func decodeSystemActionJSON(raw string) (interface{}, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
 		return nil, false
 	}
-	decoded, ok := decodeJSON(trimmed)
+	decoded, ok := decodeSystemActionCandidate(trimmed)
 	if !ok {
 		embedded := extractEmbeddedJSON(trimmed)
 		if embedded == "" {
-			return nil, nil
+			return nil, false
 		}
-		decoded, ok = decodeJSON(embedded)
+		decoded, ok = decodeSystemActionCandidate(embedded)
 		if !ok {
-			return nil, nil
+			return nil, false
 		}
 	}
+	return decoded, true
+}
+
+func collectSystemActionsFromDecoded(decoded interface{}) []*SystemAction {
 	collect := func(values []interface{}) []*SystemAction {
 		actions := make([]*SystemAction, 0, len(values))
 		for _, value := range values {
@@ -221,26 +231,30 @@ func parseSystemActionsJSON(raw string) ([]*SystemAction, error) {
 	case map[string]interface{}:
 		if rawActions, ok := typed["actions"]; ok {
 			items, _ := rawActions.([]interface{})
-			actions := collect(items)
-			if len(actions) == 0 {
-				return nil, nil
-			}
-			return actions, nil
+			return collect(items)
 		}
 		action := parseSystemActionObject(typed)
 		if action == nil {
-			return nil, nil
+			return nil
 		}
-		return []*SystemAction{action}, nil
+		return []*SystemAction{action}
 	case []interface{}:
-		actions := collect(typed)
-		if len(actions) == 0 {
-			return nil, nil
-		}
-		return actions, nil
+		return collect(typed)
 	default:
+		return nil
+	}
+}
+
+func parseSystemActionsJSON(raw string) ([]*SystemAction, error) {
+	decoded, ok := decodeSystemActionJSON(raw)
+	if !ok {
 		return nil, nil
 	}
+	actions := collectSystemActionsFromDecoded(decoded)
+	if len(actions) == 0 {
+		return nil, nil
+	}
+	return actions, nil
 }
 
 func systemActionStringParam(params map[string]interface{}, key string) string {
@@ -511,6 +525,8 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 		return "", nil, false
 	}
 	intentText := trimmedText
+	livePolicy := a.LivePolicy()
+	assumeAddressed := livePolicy.Config().AssumeAddressed
 	tryExecutePlan := func(actions []*SystemAction) (string, []map[string]interface{}, bool) {
 		enforced := enforceRoutingPolicy(trimmedText, actions)
 		if len(enforced) == 0 {
@@ -541,21 +557,40 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 	if a != nil && a.calendarNow != nil {
 		now = a.calendarNow().UTC()
 	}
-	if match := tryDeterministicFastPath(trimmedText, deterministicFastPathContext{
-		Now:         now,
-		CaptureMode: captureMode,
-		Cursor:      cursor,
-	}); match != nil {
-		if message, payloads, handled := a.executeDeterministicFastPath(ctx, sessionID, session, trimmedText, match); handled {
+	tryDeterministicPlan := func() (string, []map[string]interface{}, bool) {
+		match := tryDeterministicFastPath(trimmedText, deterministicFastPathContext{
+			Now:         now,
+			CaptureMode: captureMode,
+			Cursor:      cursor,
+		})
+		if match == nil {
+			return "", nil, false
+		}
+		return a.executeDeterministicFastPath(ctx, sessionID, session, trimmedText, match)
+	}
+	if assumeAddressed {
+		if message, payloads, handled := tryDeterministicPlan(); handled {
 			return message, payloads, true
 		}
 	}
 	intentText = a.contextualizeClarificationReplyForSession(sessionID, trimmedText)
 	if strings.TrimSpace(a.intentLLMURL) != "" {
-		llmActions, llmErr := a.classifyIntentPlanWithLLM(ctx, intentText)
+		classification, llmErr := a.classifyIntentPlanWithLLMResult(ctx, intentText)
 		if llmErr == nil {
-			if message, payloads, ok := tryExecutePlan(llmActions); ok {
+			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed); known && !addressed {
+				return "", []map[string]interface{}{{
+					"type":              "meeting_capture",
+					"addressed":         false,
+					"suppress_response": true,
+				}}, true
+			}
+			if message, payloads, ok := tryExecutePlan(classification.Actions); ok {
 				return message, payloads, true
+			}
+			if !assumeAddressed {
+				if message, payloads, handled := tryDeterministicPlan(); handled {
+					return message, payloads, true
+				}
 			}
 		}
 		if requestRequiresOpenCanvasAction(intentText) {
@@ -567,6 +602,11 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 			return "I couldn't open that file on canvas. Please provide an exact relative path (for example: docs/CLAUDE.md).", nil, true
 		}
 	}
+	if !assumeAddressed && isCompanionDirectAddress(intentText) {
+		if message, payloads, handled := tryDeterministicPlan(); handled {
+			return message, payloads, true
+		}
+	}
 
 	if cursor != nil && cursor.hasPointedItem() && looksLikeStandaloneSystemRequest(trimmedText) {
 		if message, payloads, ok := a.suggestCanonicalActionsForCursorItem(cursor); ok {
@@ -574,6 +614,19 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 		}
 	}
 	return "", nil, false
+}
+
+func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool) (bool, bool) {
+	if normalizeLivePolicy(policy.String()) != LivePolicyMeeting {
+		return true, true
+	}
+	if isCompanionDirectAddress(text) {
+		return true, true
+	}
+	if addressed == nil {
+		return false, false
+	}
+	return *addressed, true
 }
 
 func (a *App) suggestCanonicalActionsForCursorItem(cursor *chatCursorContext) (string, []map[string]interface{}, bool) {

--- a/internal/web/chat_intent_addressed_test.go
+++ b/internal/web/chat_intent_addressed_test.go
@@ -1,0 +1,165 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseIntentPlanClassificationReadsAddressedField(t *testing.T) {
+	classification, err := parseIntentPlanClassification(`{"addressed":false,"action":"toggle_silent"}`)
+	if err != nil {
+		t.Fatalf("parseIntentPlanClassification returned error: %v", err)
+	}
+	if classification.Addressed == nil {
+		t.Fatal("expected addressed classification")
+	}
+	if *classification.Addressed {
+		t.Fatal("addressed = true, want false")
+	}
+	if len(classification.Actions) != 1 {
+		t.Fatalf("actions length = %d, want 1", len(classification.Actions))
+	}
+	if classification.Actions[0].Action != "toggle_silent" {
+		t.Fatalf("action = %q, want toggle_silent", classification.Actions[0].Action)
+	}
+}
+
+func TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness(t *testing.T) {
+	var systemPrompt string
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode llm request: %v", err)
+		}
+		messages, _ := payload["messages"].([]interface{})
+		if len(messages) == 0 {
+			t.Fatal("missing llm messages")
+		}
+		first, _ := messages[0].(map[string]interface{})
+		systemPrompt = strings.TrimSpace(strFromAny(first["content"]))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": `{"addressed":true,"kind":"dialogue"}`,
+					},
+				},
+			},
+		})
+	}))
+	defer llm.Close()
+
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = llm.URL
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	classification, err := app.classifyIntentPlanWithLLMResult(context.Background(), "what changed?")
+	if err != nil {
+		t.Fatalf("classifyIntentPlanWithLLMResult returned error: %v", err)
+	}
+	if classification.Addressed == nil || !*classification.Addressed {
+		t.Fatalf("addressed = %#v, want true", classification.Addressed)
+	}
+	if !strings.Contains(systemPrompt, `include an "addressed" boolean`) {
+		t.Fatalf("system prompt = %q, want addressedness instruction", systemPrompt)
+	}
+}
+
+func TestRunAssistantTurnSuppressesUnaddressedMeetingTurn(t *testing.T) {
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"addressed":false,"action":"toggle_silent"}`)
+	defer llm.Close()
+
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = llm.URL
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForProject(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "please summarize the budget discussion", "please summarize the budget discussion", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if app.silentModeEnabled() {
+		t.Fatal("silent mode toggled for unaddressed meeting turn")
+	}
+	if got := latestAssistantMessage(t, app, session.ID); got != "" {
+		t.Fatalf("assistant message = %q, want empty", got)
+	}
+}
+
+func TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification(t *testing.T) {
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"addressed":false,"action":"toggle_silent"}`)
+	defer llm.Close()
+
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = llm.URL
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForProject(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "Tabura, be quiet", "Tabura, be quiet", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "Tabura, be quiet", nil, "")
+	if !handled {
+		t.Fatal("expected explicit direct address to be handled")
+	}
+	if message != "Toggled silent mode." {
+		t.Fatalf("message = %q, want %q", message, "Toggled silent mode.")
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "toggle_silent" {
+		t.Fatalf("payloads = %#v, want toggle_silent payload", payloads)
+	}
+}
+
+func TestRunAssistantTurnDialogueIgnoresAddressedFlag(t *testing.T) {
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"addressed":false,"action":"toggle_silent"}`)
+	defer llm.Close()
+
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = llm.URL
+	setLivePolicyForTest(t, app, LivePolicyDialogue)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForProject(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "be quiet", nil, "")
+	if !handled {
+		t.Fatal("expected dialogue mode to ignore addressed flag")
+	}
+	if message != "Toggled silent mode." {
+		t.Fatalf("message = %q, want %q", message, "Toggled silent mode.")
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "toggle_silent" {
+		t.Fatalf("payloads = %#v, want toggle_silent payload", payloads)
+	}
+}

--- a/internal/web/chat_intent_layers.go
+++ b/internal/web/chat_intent_layers.go
@@ -106,7 +106,11 @@ func normalizeIntentResponseKind(raw string) string {
 }
 
 func buildIntentLLMSystemPrompt() string {
-	return strings.TrimSpace(`You are Tabura's local router. Output JSON only.
+	return buildIntentLLMSystemPromptForPolicy(LivePolicyDialogue)
+}
+
+func buildIntentLLMSystemPromptForPolicy(policy LivePolicy) string {
+	prompt := `You are Tabura's local router. Output JSON only.
 System commands: ` + strings.Join(intentPromptSystemCommands, ", ") + `.
 Canonical artifact actions: ` + strings.Join(artifactTaxonomy.CanonicalActionOrder, ", ") + `.
 Return exactly one of:
@@ -125,7 +129,15 @@ For track_item include visible_after or count when relevant.
 For annotate_capture or compose on idea notes include target="idea_note".
 For bundle_review on someday work include target="someday" and operation.
 For dispatch_execute issue filing include target="github_issue" and mode="split" when local items are also required.
-Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`)
+Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
+	if normalizeLivePolicy(policy.String()) == LivePolicyMeeting {
+		prompt += `
+Meeting mode: include an "addressed" boolean on every JSON response indicating whether the utterance is directed at Tabura.
+If the user explicitly mentions "Tabura" or "assistant", set "addressed":true.
+For meeting discussion not directed at Tabura, use {"addressed":false,"kind":"dialogue"}.
+For addressed commands/plans, keep the same response shape and add "addressed":true at the top level.`
+	}
+	return strings.TrimSpace(prompt)
 }
 
 func translateCanonicalActionForExecution(action *SystemAction) *SystemAction {

--- a/internal/web/chat_intent_llm.go
+++ b/internal/web/chat_intent_llm.go
@@ -78,17 +78,60 @@ func (a *App) localIntentLLMModel() string {
 	return clean
 }
 
-func (a *App) classifyIntentPlanWithLLM(ctx context.Context, text string) ([]*SystemAction, error) {
+func addressedBoolPtr(value bool) *bool {
+	v := value
+	return &v
+}
+
+func parseOptionalBool(value interface{}) (bool, bool) {
+	switch typed := value.(type) {
+	case bool:
+		return typed, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		default:
+			return false, false
+		}
+	default:
+		return false, false
+	}
+}
+
+func parseIntentPlanClassification(raw string) (intentPlanClassification, error) {
+	decoded, ok := decodeSystemActionJSON(raw)
+	if !ok {
+		return intentPlanClassification{}, nil
+	}
+	result := intentPlanClassification{
+		Actions: collectSystemActionsFromDecoded(decoded),
+	}
+	if obj, ok := decoded.(map[string]interface{}); ok {
+		if addressed, ok := parseOptionalBool(obj["addressed"]); ok {
+			result.Addressed = addressedBoolPtr(addressed)
+		}
+	}
+	return result, nil
+}
+
+func (a *App) classifyIntentPlanWithLLMResult(ctx context.Context, text string) (intentPlanClassification, error) {
 	baseURL := strings.TrimRight(strings.TrimSpace(a.intentLLMURL), "/")
 	if baseURL == "" {
-		return nil, nil
+		return intentPlanClassification{}, nil
 	}
 	trimmedText := strings.TrimSpace(text)
 	if trimmedText == "" {
-		return nil, nil
+		return intentPlanClassification{}, nil
 	}
 	requiresOpenCanvas := requestRequiresOpenCanvasAction(trimmedText)
-	requestPlan := func(systemPrompt string, userPrompt string) ([]*SystemAction, error) {
+	policy := LivePolicyDialogue
+	if a != nil {
+		policy = a.LivePolicy()
+	}
+	requestPlan := func(systemPrompt string, userPrompt string) (intentPlanClassification, error) {
 		requestBody, _ := json.Marshal(map[string]interface{}{
 			"model":       a.localIntentLLMModel(),
 			"temperature": 0,
@@ -113,60 +156,55 @@ func (a *App) classifyIntentPlanWithLLM(ctx context.Context, text string) ([]*Sy
 			bytes.NewReader(requestBody),
 		)
 		if err != nil {
-			return nil, err
+			return intentPlanClassification{}, err
 		}
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return nil, err
+			return intentPlanClassification{}, err
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, intentLLMResponseLimit))
-			return nil, fmt.Errorf("intent llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			return intentPlanClassification{}, fmt.Errorf("intent llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 		var payload localIntentLLMChatCompletionResponse
 		if err := json.NewDecoder(io.LimitReader(resp.Body, intentLLMResponseLimit)).Decode(&payload); err != nil {
-			return nil, err
+			return intentPlanClassification{}, err
 		}
 		if len(payload.Choices) == 0 {
-			return nil, nil
+			return intentPlanClassification{}, nil
 		}
 		content := strings.TrimSpace(payload.Choices[0].Message.Content)
 		if content == "" {
-			return nil, nil
+			return intentPlanClassification{}, nil
 		}
-		actions, parseErr := parseSystemActionsJSON(stripCodeFence(content))
+		classification, parseErr := parseIntentPlanClassification(stripCodeFence(content))
 		if parseErr != nil {
-			return nil, parseErr
+			return intentPlanClassification{}, parseErr
 		}
-		if len(actions) == 0 {
-			return nil, nil
-		}
-		normalized := make([]*SystemAction, 0, len(actions))
-		for _, action := range actions {
+		normalized := make([]*SystemAction, 0, len(classification.Actions))
+		for _, action := range classification.Actions {
 			if normalizedAction := normalizeSystemActionForExecution(action, trimmedText); normalizedAction != nil {
 				normalized = append(normalized, normalizedAction)
 			}
 		}
-		if len(normalized) == 0 {
-			return nil, nil
-		}
-		return normalized, nil
+		classification.Actions = normalized
+		return classification, nil
 	}
 
-	initialSystemPrompt := intentLLMSystemPrompt
+	initialSystemPrompt := buildIntentLLMSystemPromptForPolicy(policy)
 	if requiresOpenCanvas {
 		initialSystemPrompt += "\n\nConstraint: for explicit open/show/display file requests you MUST return an actions array whose final step is open_file_canvas. If path is uncertain, include a shell search step first and then use path=\"$last_shell_path\"."
 	}
-	actions, err := requestPlan(initialSystemPrompt, trimmedText)
+	classification, err := requestPlan(initialSystemPrompt, trimmedText)
 	if err != nil {
-		return nil, err
+		return intentPlanClassification{}, err
 	}
-	if requiresOpenCanvas && !planContainsAction(actions, "open_file_canvas") {
+	if requiresOpenCanvas && !planContainsAction(classification.Actions, "open_file_canvas") {
 		previousPlanJSON := "null"
-		if len(actions) > 0 {
-			if encoded, marshalErr := json.Marshal(actions); marshalErr == nil {
+		if len(classification.Actions) > 0 {
+			if encoded, marshalErr := json.Marshal(classification.Actions); marshalErr == nil {
 				previousPlanJSON = string(encoded)
 			}
 		}
@@ -175,22 +213,30 @@ func (a *App) classifyIntentPlanWithLLM(ctx context.Context, text string) ([]*Sy
 		if len(hints) > 0 {
 			hintText = strings.Join(hints, ", ")
 		}
-		retrySystemPrompt := intentLLMSystemPrompt + "\n\nConstraint: for explicit open/show/display file requests you MUST return an actions array whose final step is open_file_canvas. If path is uncertain, include a shell search step first and then use path=\"$last_shell_path\"."
+		retrySystemPrompt := buildIntentLLMSystemPromptForPolicy(policy) + "\n\nConstraint: for explicit open/show/display file requests you MUST return an actions array whose final step is open_file_canvas. If path is uncertain, include a shell search step first and then use path=\"$last_shell_path\"."
 		retryUserPrompt := "User request:\n" + trimmedText + "\n\nExtracted filename hints:\n" + hintText + "\n\nPrevious invalid plan (missing open_file_canvas or empty):\n" + previousPlanJSON
-		if repaired, repairErr := requestPlan(retrySystemPrompt, retryUserPrompt); repairErr == nil && len(repaired) > 0 {
-			actions = repaired
+		if repaired, repairErr := requestPlan(retrySystemPrompt, retryUserPrompt); repairErr == nil && len(repaired.Actions) > 0 {
+			classification = repaired
 		}
-		if !planContainsAction(actions, "open_file_canvas") {
-			actions = ensureOpenCanvasTerminalAction(actions)
+		if !planContainsAction(classification.Actions, "open_file_canvas") {
+			classification.Actions = ensureOpenCanvasTerminalAction(classification.Actions)
 		}
-		if !planContainsAction(actions, "open_file_canvas") {
-			return nil, nil
+		if !planContainsAction(classification.Actions, "open_file_canvas") {
+			return intentPlanClassification{}, nil
 		}
 	}
-	if len(actions) == 0 {
+	return classification, nil
+}
+
+func (a *App) classifyIntentPlanWithLLM(ctx context.Context, text string) ([]*SystemAction, error) {
+	classification, err := a.classifyIntentPlanWithLLMResult(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	if len(classification.Actions) == 0 {
 		return nil, nil
 	}
-	return actions, nil
+	return classification.Actions, nil
 }
 
 func (a *App) classifyIntentWithLLM(ctx context.Context, text string) (*SystemAction, error) {

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -284,6 +284,10 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 	if !handled && !localOnly {
 		return false
 	}
+	if handled && suppressLocalAssistantResponse(actionPayloads) {
+		a.finishCompanionPendingTurn(sessionID, "assistant_turn_suppressed")
+		return true
+	}
 	runID := randomToken()
 	a.broadcastChatEvent(sessionID, map[string]interface{}{
 		"type":    "turn_started",
@@ -325,6 +329,18 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 		outputMode,
 	)
 	return true
+}
+
+func suppressLocalAssistantResponse(payloads []map[string]interface{}) bool {
+	for _, payload := range payloads {
+		if payload == nil {
+			continue
+		}
+		if suppress, ok := parseOptionalBool(payload["suppress_response"]); ok && suppress {
+			return true
+		}
+	}
+	return false
 }
 
 // runAssistantTurnLegacy is the single-shot fallback when persistent session


### PR DESCRIPTION
## Summary
- add Meeting-mode addressedness instructions and parsing to the local intent LLM path
- suppress assistant replies for unaddressed Meeting turns before local/system execution continues
- cover addressedness parsing, Meeting suppression, Dialogue bypass, and explicit direct-address override

## Verification
- Local brain returns addressedness classification in one pass: `TestParseIntentPlanClassificationReadsAddressedField` and `TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness` in `go test ./internal/web -run 'Test(ParseIntentPlanClassificationReadsAddressedField|ClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness|RunAssistantTurnSuppressesUnaddressedMeetingTurn|RunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification|RunAssistantTurnDialogueIgnoresAddressedFlag)$' 2>&1 | tee /tmp/tabura-issue-519-test.log`.
- Meeting mode respects addressedness before responding: `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn` verifies an unaddressed Meeting utterance produces no assistant message.
- Dialogue mode bypasses addressedness check: `TestRunAssistantTurnDialogueIgnoresAddressedFlag` verifies the same `addressed:false` payload still executes in Dialogue mode.
- Explicit name mention is always treated as addressed: `TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification` verifies `Tabura, ...` executes even when the mock LLM returns `addressed:false`.
- Non-addressed Meeting utterances are captured but not responded to: `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn` exercises the full `runAssistantTurn` path and leaves the user message without any assistant reply.
- Command output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.049s` (from `/tmp/tabura-issue-519-test.log`).
