### PR TITLE
fix: Add short local response generation to unified brain (fixes #520)

### DIFF
--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -164,12 +164,18 @@ func TestIntentPromptsSeparateSystemCommandsFromCanonicalActions(t *testing.T) {
 		if !strings.Contains(prompt, "kind\":\"canonical_action") {
 			t.Fatalf("%s prompt missing canonical_action schema", name)
 		}
+		if !strings.Contains(prompt, "kind\":\"local_answer") {
+			t.Fatalf("%s prompt missing local_answer schema", name)
+		}
 		lowerPrompt := strings.ToLower(prompt)
 		if !strings.Contains(lowerPrompt, "do not emit legacy artifact intents such as") {
 			t.Fatalf("%s prompt missing legacy-intent rejection", name)
 		}
 		if !strings.Contains(lowerPrompt, "triage_item_by_title") {
 			t.Fatalf("%s prompt should explicitly forbid triage_item_by_title", name)
+		}
+		if !strings.Contains(lowerPrompt, "file/code inspection") {
+			t.Fatalf("%s prompt should forbid local answers for file inspection", name)
 		}
 	}
 }
@@ -576,6 +582,39 @@ func TestRunAssistantTurnExecutesHighConfidenceLocalIntentInProjectSession(t *te
 
 	if got := latestAssistantMessage(t, app, session.ID); got != "Toggled silent mode." {
 		t.Fatalf("assistant message = %q, want %q", got, "Toggled silent mode.")
+	}
+}
+
+func TestRunAssistantTurnPersistsLocalAnswer(t *testing.T) {
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	reply := "You are in " + project.RootPath + "."
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"`+reply+`","confidence":"high"}`)
+	defer llm.Close()
+	app.intentLLMURL = llm.URL
+
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "what workspace am I in?", "what workspace am I in?", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != reply {
+		t.Fatalf("assistant message = %q, want %q", got, reply)
 	}
 }
 

--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -29,8 +29,9 @@ type SystemAction struct {
 }
 
 type intentPlanClassification struct {
-	Actions   []*SystemAction
-	Addressed *bool
+	Actions     []*SystemAction
+	Addressed   *bool
+	LocalAnswer *intentLocalAnswer
 }
 
 const systemActionLastShellPathPlaceholder = "$last_shell_path"
@@ -575,7 +576,7 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 	}
 	intentText = a.contextualizeClarificationReplyForSession(sessionID, trimmedText)
 	if strings.TrimSpace(a.intentLLMURL) != "" {
-		classification, llmErr := a.classifyIntentPlanWithLLMResult(ctx, intentText)
+		classification, llmErr := a.classifyIntentPlanWithLLMResultForTurn(ctx, sessionID, session, intentText)
 		if llmErr == nil {
 			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed); known && !addressed {
 				return "", []map[string]interface{}{{
@@ -583,6 +584,9 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 					"addressed":         false,
 					"suppress_response": true,
 				}}, true
+			}
+			if classification.LocalAnswer != nil && strings.TrimSpace(classification.LocalAnswer.Text) != "" {
+				return classification.LocalAnswer.Text, nil, true
 			}
 			if message, payloads, ok := tryExecutePlan(classification.Actions); ok {
 				return message, payloads, true

--- a/internal/web/chat_intent_addressed_test.go
+++ b/internal/web/chat_intent_addressed_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/krystophny/tabura/internal/store"
 )
 
 func TestParseIntentPlanClassificationReadsAddressedField(t *testing.T) {
@@ -25,6 +27,22 @@ func TestParseIntentPlanClassificationReadsAddressedField(t *testing.T) {
 	}
 	if classification.Actions[0].Action != "toggle_silent" {
 		t.Fatalf("action = %q, want toggle_silent", classification.Actions[0].Action)
+	}
+}
+
+func TestParseIntentPlanClassificationReadsLocalAnswer(t *testing.T) {
+	classification, err := parseIntentPlanClassification(`{"kind":"local_answer","text":"Paris.","confidence":"high"}`)
+	if err != nil {
+		t.Fatalf("parseIntentPlanClassification returned error: %v", err)
+	}
+	if classification.LocalAnswer == nil {
+		t.Fatal("expected local answer classification")
+	}
+	if classification.LocalAnswer.Text != "Paris." {
+		t.Fatalf("local answer text = %q, want Paris.", classification.LocalAnswer.Text)
+	}
+	if classification.LocalAnswer.Confidence != "high" {
+		t.Fatalf("local answer confidence = %q, want high", classification.LocalAnswer.Confidence)
 	}
 }
 
@@ -67,6 +85,83 @@ func TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness(t *testing.
 	}
 	if !strings.Contains(systemPrompt, `include an "addressed" boolean`) {
 		t.Fatalf("system prompt = %q, want addressedness instruction", systemPrompt)
+	}
+}
+
+func TestClassifyIntentPlanWithLLMIncludesRuntimeContextForLocalAnswers(t *testing.T) {
+	var userPrompt string
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode llm request: %v", err)
+		}
+		messages, _ := payload["messages"].([]interface{})
+		if len(messages) < 2 {
+			t.Fatalf("messages length = %d, want >= 2", len(messages))
+		}
+		userMessage, _ := messages[1].(map[string]interface{})
+		userPrompt = strings.TrimSpace(strFromAny(userMessage["content"]))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": `{"kind":"local_answer","text":"You are in the default workspace.","confidence":"high"}`,
+					},
+				},
+			},
+		})
+	}))
+	defer llm.Close()
+
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+	workspace, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("active workspace: %v", err)
+	}
+	if _, err := app.store.CreateItem("Review parser follow-up", store.ItemOptions{WorkspaceID: &workspace.ID}); err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "review the parser plan", "review the parser plan", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "assistant", "Which workspace do you mean?", "Which workspace do you mean?", "text"); err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+	app.registerActiveChatTurn(session.ID, "run-ctx", func() {})
+	defer app.unregisterActiveChatTurn(session.ID, "run-ctx")
+
+	classification, err := app.classifyIntentPlanWithLLMResultForTurn(context.Background(), session.ID, session, "what workspace am I in?")
+	if err != nil {
+		t.Fatalf("classifyIntentPlanWithLLMResultForTurn returned error: %v", err)
+	}
+	if classification.LocalAnswer == nil || classification.LocalAnswer.Confidence != "high" {
+		t.Fatalf("local answer = %#v, want high-confidence local answer", classification.LocalAnswer)
+	}
+	if !strings.Contains(userPrompt, "Runtime context:") {
+		t.Fatalf("user prompt = %q, want runtime context header", userPrompt)
+	}
+	if !strings.Contains(userPrompt, workspace.Name) || !strings.Contains(userPrompt, workspace.DirPath) {
+		t.Fatalf("user prompt = %q, want active workspace details", userPrompt)
+	}
+	if !strings.Contains(userPrompt, "Open items in active workspace: 1") {
+		t.Fatalf("user prompt = %q, want workspace item count", userPrompt)
+	}
+	if !strings.Contains(userPrompt, "Running tasks: 1 active, 0 queued") {
+		t.Fatalf("user prompt = %q, want running task count", userPrompt)
+	}
+	if !strings.Contains(userPrompt, "USER: review the parser plan") || !strings.Contains(userPrompt, "ASSISTANT: Which workspace do you mean?") {
+		t.Fatalf("user prompt = %q, want recent conversation summary", userPrompt)
 	}
 }
 

--- a/internal/web/chat_intent_layers.go
+++ b/internal/web/chat_intent_layers.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	intentKindSystemCommand   = "system_command"
 	intentKindCanonicalAction = "canonical_action"
+	intentKindLocalAnswer     = "local_answer"
 	intentKindDialogue        = "dialogue"
 
 	canonicalActionOpenShow        = "open_show"
@@ -98,6 +99,8 @@ func normalizeIntentResponseKind(raw string) string {
 		return intentKindSystemCommand
 	case intentKindCanonicalAction:
 		return intentKindCanonicalAction
+	case intentKindLocalAnswer:
+		return intentKindLocalAnswer
 	case intentKindDialogue:
 		return intentKindDialogue
 	default:
@@ -116,9 +119,15 @@ Canonical artifact actions: ` + strings.Join(artifactTaxonomy.CanonicalActionOrd
 Return exactly one of:
 - {"kind":"system_command","action":"<system_command>", ...params}
 - {"kind":"canonical_action","action":"<canonical_action>", ...params}
+- {"kind":"local_answer","text":"<short reply>","confidence":"high|medium|low"}
 - {"actions":[{"action":"shell",...},{"action":"open_file_canvas","path":"..."}]}
 - {"kind":"dialogue"}
 Use {"kind":"dialogue"} unless the user clearly requests a system command or canonical artifact action.
+Use {"kind":"local_answer"} for short complete replies you can answer from the provided runtime context without tools: greetings, acknowledgments, brief social turns, and simple workspace/status questions.
+Local answers must stay within 1-3 sentences.
+Use confidence="high" only when the answer is complete and correct.
+Use confidence="medium" when a plausible short answer exists but a richer model should answer.
+Use {"kind":"dialogue"} for anything requiring file/code inspection, internet/current information, multi-step reasoning, or longer-form writing.
 Use canonical_action for artifact/item work and do not emit legacy artifact intents such as ` + strings.Join(legacyArtifactIntentNames, ", ") + `.
 Composite operations must be expressed as a canonical action plus parameters or as a multi-step system-command plan.
 For current-information requests (weather, web search, news, prices, schedules, latest/current updates), use {"kind":"dialogue"} and MUST NOT use shell.

--- a/internal/web/chat_intent_llm.go
+++ b/internal/web/chat_intent_llm.go
@@ -8,6 +8,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
 )
 
 var intentLLMSystemPrompt = buildIntentLLMSystemPrompt()
@@ -22,6 +25,11 @@ type localIntentLLMChoice struct {
 
 type localIntentLLMMessage struct {
 	Content string `json:"content"`
+}
+
+type intentLocalAnswer struct {
+	Text       string
+	Confidence string
 }
 
 func parseIntentLLMProfileOptions(raw string) []string {
@@ -101,6 +109,19 @@ func parseOptionalBool(value interface{}) (bool, bool) {
 	}
 }
 
+func normalizeIntentLocalAnswerConfidence(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "high":
+		return "high"
+	case "medium":
+		return "medium"
+	case "low":
+		return "low"
+	default:
+		return ""
+	}
+}
+
 func parseIntentPlanClassification(raw string) (intentPlanClassification, error) {
 	decoded, ok := decodeSystemActionJSON(raw)
 	if !ok {
@@ -110,6 +131,14 @@ func parseIntentPlanClassification(raw string) (intentPlanClassification, error)
 		Actions: collectSystemActionsFromDecoded(decoded),
 	}
 	if obj, ok := decoded.(map[string]interface{}); ok {
+		if normalizeIntentResponseKind(fmt.Sprint(obj["kind"])) == intentKindLocalAnswer {
+			if text := strings.TrimSpace(fmt.Sprint(obj["text"])); text != "" {
+				result.LocalAnswer = &intentLocalAnswer{
+					Text:       text,
+					Confidence: normalizeIntentLocalAnswerConfidence(fmt.Sprint(obj["confidence"])),
+				}
+			}
+		}
 		if addressed, ok := parseOptionalBool(obj["addressed"]); ok {
 			result.Addressed = addressedBoolPtr(addressed)
 		}
@@ -118,6 +147,66 @@ func parseIntentPlanClassification(raw string) (intentPlanClassification, error)
 }
 
 func (a *App) classifyIntentPlanWithLLMResult(ctx context.Context, text string) (intentPlanClassification, error) {
+	return a.classifyIntentPlanWithLLMResultForTurn(ctx, "", store.ChatSession{}, text)
+}
+
+func truncateIntentPromptText(text string, limit int) string {
+	trimmed := strings.TrimSpace(text)
+	if limit <= 0 || len(trimmed) <= limit {
+		return trimmed
+	}
+	if limit <= 3 {
+		return trimmed[:limit]
+	}
+	return trimmed[:limit-3] + "..."
+}
+
+func (a *App) buildIntentLLMUserPrompt(sessionID string, session store.ChatSession, text string) string {
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return ""
+	}
+	var lines []string
+	now := time.Now().UTC()
+	if a != nil && a.calendarNow != nil {
+		now = a.calendarNow().UTC()
+	}
+	lines = append(lines, "Current UTC time: "+now.Format(time.RFC3339))
+
+	if a != nil {
+		if workspaceCtx := a.loadWorkspacePromptContext(session.ProjectKey); workspaceCtx != nil {
+			lines = append(lines, fmt.Sprintf("Active workspace: %s (%s)", workspaceCtx.Workspace.Name, workspaceCtx.Workspace.DirPath))
+			lines = append(lines, fmt.Sprintf("Open items in active workspace: %d", workspaceCtx.OpenItemCount))
+			lines = append(lines, "Focused target workspace: unavailable in current runtime; use the active workspace context.")
+		}
+		activeTurns := a.activeChatTurnCount(sessionID)
+		queuedTurns := a.queuedChatTurnCount(sessionID)
+		lines = append(lines, fmt.Sprintf("Running tasks: %d active, %d queued", activeTurns, queuedTurns))
+	}
+
+	if a != nil && a.store != nil && strings.TrimSpace(sessionID) != "" {
+		if messages, err := a.store.ListChatMessages(sessionID, 8); err == nil {
+			tail := recentConversationTail(messages, 3)
+			if len(tail) > 0 {
+				lines = append(lines, "Recent conversation:")
+				for _, msg := range tail {
+					role := strings.ToUpper(strings.TrimSpace(msg.Role))
+					if role == "" {
+						continue
+					}
+					lines = append(lines, fmt.Sprintf("- %s: %s", role, truncateIntentPromptText(chatMessageText(msg), 160)))
+				}
+			}
+		}
+	}
+
+	if len(lines) == 0 {
+		return trimmedText
+	}
+	return "Runtime context:\n" + strings.Join(lines, "\n") + "\n\nUser request:\n" + trimmedText
+}
+
+func (a *App) classifyIntentPlanWithLLMResultForTurn(ctx context.Context, sessionID string, session store.ChatSession, text string) (intentPlanClassification, error) {
 	baseURL := strings.TrimRight(strings.TrimSpace(a.intentLLMURL), "/")
 	if baseURL == "" {
 		return intentPlanClassification{}, nil
@@ -130,6 +219,10 @@ func (a *App) classifyIntentPlanWithLLMResult(ctx context.Context, text string) 
 	policy := LivePolicyDialogue
 	if a != nil {
 		policy = a.LivePolicy()
+	}
+	userPrompt := a.buildIntentLLMUserPrompt(sessionID, session, trimmedText)
+	if strings.TrimSpace(userPrompt) == "" {
+		userPrompt = trimmedText
 	}
 	requestPlan := func(systemPrompt string, userPrompt string) (intentPlanClassification, error) {
 		requestBody, _ := json.Marshal(map[string]interface{}{
@@ -197,7 +290,7 @@ func (a *App) classifyIntentPlanWithLLMResult(ctx context.Context, text string) 
 	if requiresOpenCanvas {
 		initialSystemPrompt += "\n\nConstraint: for explicit open/show/display file requests you MUST return an actions array whose final step is open_file_canvas. If path is uncertain, include a shell search step first and then use path=\"$last_shell_path\"."
 	}
-	classification, err := requestPlan(initialSystemPrompt, trimmedText)
+	classification, err := requestPlan(initialSystemPrompt, userPrompt)
 	if err != nil {
 		return intentPlanClassification{}, err
 	}


### PR DESCRIPTION
## Summary
Add `local_answer` handling to the intent LLM path so short high-confidence replies can complete locally, inject compact runtime context for workspace/status questions, and persist those replies through the normal assistant turn flow.

## Verification
- Local-answer parsing and confidence contract: `go test ./internal/web -run 'Test(ParseIntentPlanClassificationReadsLocalAnswer|IntentPromptsSeparateSystemCommandsFromCanonicalActions)$'` -> `ok   github.com/krystophny/tabura/internal/web`
- Meeting/addressedness contract preserved while extending the schema: `go test ./internal/web -run 'TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness$'` -> `ok   github.com/krystophny/tabura/internal/web`
- Existing high-confidence local intent execution still works after the classifier changes: `go test ./internal/web -run 'Test(RunAssistantTurnExecutesHighConfidenceLocalIntent|RunAssistantTurnExecutesHighConfidenceLocalIntentInProjectSession)$'` -> `ok   github.com/krystophny/tabura/internal/web`
- Runtime context for workspace/status questions now reaches the local intent model: `go test ./internal/web -run 'TestClassifyIntentPlanWithLLMIncludesRuntimeContextForLocalAnswers$'` -> verifies active workspace path, open-item count, running-task count, and recent-conversation context in the LLM prompt
- Local answers surface as assistant replies and persist in chat history without app-server fallback: `go test ./internal/web -run 'TestRunAssistantTurnPersistsLocalAnswer$'` -> `ok   github.com/krystophny/tabura/internal/web`