### PR TITLE
fix: Add provider attribution labels to chat messages in Daily Worksp (fixes #538)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,6 +52,9 @@ type ChatMessage struct {
 	ContentPlain    string `json:"content_plain"`
 	RenderFormat    string `json:"render_format"`
 	ThreadKey       string `json:"thread_key,omitempty"`
+	Provider        string `json:"provider,omitempty"`
+	ProviderModel   string `json:"provider_model,omitempty"`
+	ProviderLatency int    `json:"provider_latency_ms,omitempty"`
 	CreatedAt       int64  `json:"created_at"`
 }
 
@@ -193,6 +196,10 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   content_markdown TEXT NOT NULL DEFAULT '',
   content_plain TEXT NOT NULL DEFAULT '',
   render_format TEXT NOT NULL DEFAULT 'markdown',
+  thread_key TEXT NOT NULL DEFAULT '',
+  provider TEXT NOT NULL DEFAULT '',
+  provider_model TEXT NOT NULL DEFAULT '',
+  provider_latency_ms INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_chat_messages_session_created
@@ -310,6 +317,9 @@ func (s *Store) migrateProjectColumns() error {
 		{Table: "projects", Name: "updated_at", SQL: `ALTER TABLE projects ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`},
 		{Table: "projects", Name: "last_opened_at", SQL: `ALTER TABLE projects ADD COLUMN last_opened_at INTEGER NOT NULL DEFAULT 0`},
 		{Table: "chat_messages", Name: "thread_key", SQL: `ALTER TABLE chat_messages ADD COLUMN thread_key TEXT NOT NULL DEFAULT ''`},
+		{Table: "chat_messages", Name: "provider", SQL: `ALTER TABLE chat_messages ADD COLUMN provider TEXT NOT NULL DEFAULT ''`},
+		{Table: "chat_messages", Name: "provider_model", SQL: `ALTER TABLE chat_messages ADD COLUMN provider_model TEXT NOT NULL DEFAULT ''`},
+		{Table: "chat_messages", Name: "provider_latency_ms", SQL: `ALTER TABLE chat_messages ADD COLUMN provider_latency_ms INTEGER NOT NULL DEFAULT 0`},
 	}
 
 	tableColumns := map[string]map[string]bool{}

--- a/internal/store/store_chat.go
+++ b/internal/store/store_chat.go
@@ -332,15 +332,21 @@ func (s *Store) AddChatMessage(sessionID, role, contentMarkdown, contentPlain, r
 		fn(&o)
 	}
 	threadKey := strings.TrimSpace(o.threadKey)
+	provider := normalizeChatMessageProvider(o.provider)
+	providerModel := strings.TrimSpace(o.providerModel)
+	providerLatency := normalizeChatMessageProviderLatency(o.providerLatency)
 	now := time.Now().Unix()
 	res, err := s.db.Exec(
-		`INSERT INTO chat_messages (session_id, role, content_markdown, content_plain, render_format, thread_key, created_at) VALUES (?,?,?,?,?,?,?)`,
+		`INSERT INTO chat_messages (session_id, role, content_markdown, content_plain, render_format, thread_key, provider, provider_model, provider_latency_ms, created_at) VALUES (?,?,?,?,?,?,?,?,?,?)`,
 		strings.TrimSpace(sessionID),
 		role,
 		contentMarkdown,
 		contentPlain,
 		renderFormat,
 		threadKey,
+		provider,
+		providerModel,
+		providerLatency,
 		now,
 	)
 	if err != nil {
@@ -358,12 +364,18 @@ func (s *Store) AddChatMessage(sessionID, role, contentMarkdown, contentPlain, r
 		ContentPlain:    contentPlain,
 		RenderFormat:    renderFormat,
 		ThreadKey:       threadKey,
+		Provider:        provider,
+		ProviderModel:   providerModel,
+		ProviderLatency: providerLatency,
 		CreatedAt:       now,
 	}, nil
 }
 
 type chatMessageOpts struct {
-	threadKey string
+	threadKey       string
+	provider        string
+	providerModel   string
+	providerLatency int
 }
 
 type ChatMessageOption func(*chatMessageOpts)
@@ -374,16 +386,45 @@ func WithThreadKey(key string) ChatMessageOption {
 	}
 }
 
-func (s *Store) UpdateChatMessageContent(id int64, contentMarkdown, contentPlain, renderFormat string) error {
+func WithProviderMetadata(provider, model string, latencyMS int) ChatMessageOption {
+	return func(o *chatMessageOpts) {
+		o.provider = provider
+		o.providerModel = model
+		o.providerLatency = latencyMS
+	}
+}
+
+func normalizeChatMessageProvider(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func normalizeChatMessageProviderLatency(raw int) int {
+	if raw < 0 {
+		return 0
+	}
+	return raw
+}
+
+func (s *Store) UpdateChatMessageContent(id int64, contentMarkdown, contentPlain, renderFormat string, opts ...ChatMessageOption) error {
 	if id <= 0 {
 		return errors.New("message id is required")
 	}
 	renderFormat = normalizeRenderFormat(renderFormat)
+	var o chatMessageOpts
+	for _, fn := range opts {
+		fn(&o)
+	}
 	_, err := s.db.Exec(
-		`UPDATE chat_messages SET content_markdown = ?, content_plain = ?, render_format = ? WHERE id = ?`,
+		`UPDATE chat_messages
+		 SET content_markdown = ?, content_plain = ?, render_format = ?,
+		     provider = ?, provider_model = ?, provider_latency_ms = ?
+		 WHERE id = ?`,
 		contentMarkdown,
 		contentPlain,
 		renderFormat,
+		normalizeChatMessageProvider(o.provider),
+		strings.TrimSpace(o.providerModel),
+		normalizeChatMessageProviderLatency(o.providerLatency),
 		id,
 	)
 	return err
@@ -399,7 +440,7 @@ func (s *Store) ListChatMessages(sessionID string, limit int, opts ...ChatMessag
 	}
 	threadKey := strings.TrimSpace(o.threadKey)
 	rows, err := s.db.Query(
-		`SELECT id, session_id, role, content_markdown, content_plain, render_format, thread_key, created_at
+		`SELECT id, session_id, role, content_markdown, content_plain, render_format, thread_key, provider, provider_model, provider_latency_ms, created_at
 		 FROM chat_messages WHERE session_id = ? AND thread_key = ? ORDER BY id ASC LIMIT ?`,
 		strings.TrimSpace(sessionID), threadKey, limit,
 	)
@@ -418,12 +459,18 @@ func (s *Store) ListChatMessages(sessionID string, limit int, opts ...ChatMessag
 			&item.ContentPlain,
 			&item.RenderFormat,
 			&item.ThreadKey,
+			&item.Provider,
+			&item.ProviderModel,
+			&item.ProviderLatency,
 			&item.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
 		item.Role = normalizeChatRole(item.Role)
 		item.RenderFormat = normalizeRenderFormat(item.RenderFormat)
+		item.Provider = normalizeChatMessageProvider(item.Provider)
+		item.ProviderModel = strings.TrimSpace(item.ProviderModel)
+		item.ProviderLatency = normalizeChatMessageProviderLatency(item.ProviderLatency)
 		out = append(out, item)
 	}
 	return out, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -410,6 +410,27 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	if msg2.ThreadKey != "thread-a" {
 		t.Fatalf("msg2 thread key = %q, want thread-a", msg2.ThreadKey)
 	}
+	msg3, err := s.AddChatMessage(
+		session.ID,
+		"assistant",
+		"m3",
+		"p3",
+		"markdown",
+		WithThreadKey("thread-b"),
+		WithProviderMetadata("OpenAI", "gpt-5.3-codex-spark", 321),
+	)
+	if err != nil {
+		t.Fatalf("AddChatMessage(msg3) error: %v", err)
+	}
+	if msg3.Provider != "openai" {
+		t.Fatalf("msg3 provider = %q, want openai", msg3.Provider)
+	}
+	if msg3.ProviderModel != "gpt-5.3-codex-spark" {
+		t.Fatalf("msg3 provider_model = %q, want gpt-5.3-codex-spark", msg3.ProviderModel)
+	}
+	if msg3.ProviderLatency != 321 {
+		t.Fatalf("msg3 provider_latency = %d, want 321", msg3.ProviderLatency)
+	}
 
 	defaultThreadMessages, err := s.ListChatMessages(session.ID, 10)
 	if err != nil {
@@ -426,8 +447,18 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	if len(threadMessages) != 1 || threadMessages[0].ID != msg2.ID {
 		t.Fatalf("thread-a message selection mismatch")
 	}
+	threadMessages, err = s.ListChatMessages(session.ID, 10, WithThreadKey("thread-b"))
+	if err != nil {
+		t.Fatalf("ListChatMessages(thread-b) error: %v", err)
+	}
+	if len(threadMessages) != 1 || threadMessages[0].ID != msg3.ID {
+		t.Fatalf("thread-b message selection mismatch")
+	}
+	if threadMessages[0].Provider != "openai" {
+		t.Fatalf("thread-b provider = %q, want openai", threadMessages[0].Provider)
+	}
 
-	if err := s.UpdateChatMessageContent(msg2.ID, "m2-updated", "p2-updated", "canvas"); err != nil {
+	if err := s.UpdateChatMessageContent(msg2.ID, "m2-updated", "p2-updated", "canvas", WithProviderMetadata("local", "qwen3.5-9b", 27)); err != nil {
 		t.Fatalf("UpdateChatMessageContent() error: %v", err)
 	}
 	threadMessages, err = s.ListChatMessages(session.ID, 10, WithThreadKey("thread-a"))
@@ -436,6 +467,15 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	}
 	if threadMessages[0].RenderFormat != "text" {
 		t.Fatalf("updated message render format = %q, want text", threadMessages[0].RenderFormat)
+	}
+	if threadMessages[0].Provider != "local" {
+		t.Fatalf("updated message provider = %q, want local", threadMessages[0].Provider)
+	}
+	if threadMessages[0].ProviderModel != "qwen3.5-9b" {
+		t.Fatalf("updated message provider_model = %q, want qwen3.5-9b", threadMessages[0].ProviderModel)
+	}
+	if threadMessages[0].ProviderLatency != 27 {
+		t.Fatalf("updated message provider_latency = %d, want 27", threadMessages[0].ProviderLatency)
 	}
 	if err := s.UpdateChatMessageContent(0, "x", "y", "markdown"); err == nil {
 		t.Fatalf("expected invalid message id validation error")
@@ -606,6 +646,9 @@ func TestStoreSchemaAndHelperNormalizers(t *testing.T) {
 	chatMessageCols := strings.Join(columns["chat_messages"], ",")
 	if !strings.Contains(chatMessageCols, "thread_key") {
 		t.Fatalf("chat_messages missing thread_key column: %q", chatMessageCols)
+	}
+	if !strings.Contains(chatMessageCols, "provider") || !strings.Contains(chatMessageCols, "provider_model") || !strings.Contains(chatMessageCols, "provider_latency_ms") {
+		t.Fatalf("chat_messages missing provider columns: %q", chatMessageCols)
 	}
 	projectCols := strings.Join(columns["projects"], ",")
 	if !strings.Contains(projectCols, "canvas_session_id") {

--- a/internal/web/chat_provider.go
+++ b/internal/web/chat_provider.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/modelprofile"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	assistantProviderLocal    = "local"
+	assistantProviderCerebras = "cerebras"
+	assistantProviderGoogle   = "google"
+	assistantProviderOpenAI   = "openai"
+)
+
+type assistantResponseMetadata struct {
+	Provider        string
+	ProviderModel   string
+	ProviderLatency int
+}
+
+func newAssistantResponseMetadata(provider, model string, latency time.Duration) assistantResponseMetadata {
+	latencyMS := int(latency / time.Millisecond)
+	if latencyMS < 0 {
+		latencyMS = 0
+	}
+	return assistantResponseMetadata{
+		Provider:        normalizeAssistantProvider(provider),
+		ProviderModel:   strings.TrimSpace(model),
+		ProviderLatency: latencyMS,
+	}
+}
+
+func normalizeAssistantProvider(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case assistantProviderLocal:
+		return assistantProviderLocal
+	case assistantProviderCerebras:
+		return assistantProviderCerebras
+	case assistantProviderGoogle:
+		return assistantProviderGoogle
+	case assistantProviderOpenAI:
+		return assistantProviderOpenAI
+	default:
+		return ""
+	}
+}
+
+func assistantProviderDisplayLabel(provider string) string {
+	switch normalizeAssistantProvider(provider) {
+	case assistantProviderLocal:
+		return "Local"
+	case assistantProviderCerebras:
+		return "Cerebras"
+	case assistantProviderGoogle:
+		return "Google"
+	case assistantProviderOpenAI:
+		return "OpenAI"
+	default:
+		return "Assistant"
+	}
+}
+
+func (m assistantResponseMetadata) storeOptions() []store.ChatMessageOption {
+	return []store.ChatMessageOption{
+		store.WithProviderMetadata(m.Provider, m.ProviderModel, m.ProviderLatency),
+	}
+}
+
+func (m assistantResponseMetadata) applyToPayload(payload map[string]interface{}) {
+	payload["provider"] = m.Provider
+	payload["provider_label"] = assistantProviderDisplayLabel(m.Provider)
+	payload["provider_model"] = m.ProviderModel
+	payload["provider_latency_ms"] = m.ProviderLatency
+}
+
+func providerForAppServerProfile(profile appServerModelProfile) string {
+	switch modelprofile.ResolveAlias(profile.Alias, profile.Model) {
+	case modelprofile.AliasCodex, modelprofile.AliasGPT, modelprofile.AliasSpark:
+		return assistantProviderOpenAI
+	default:
+		return ""
+	}
+}
+
+func (a *App) localAssistantModelLabel() string {
+	if a == nil {
+		return DefaultIntentLLMProfile
+	}
+	if profile := strings.TrimSpace(a.intentLLMProfile); profile != "" {
+		return profile
+	}
+	if model := strings.TrimSpace(a.localIntentLLMModel()); model != "" {
+		return model
+	}
+	return DefaultIntentLLMProfile
+}

--- a/internal/web/chat_provider_test.go
+++ b/internal/web/chat_provider_test.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestLocalSystemActionTurnPublishesLocalProviderMetadata(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	if handled := app.tryRunLocalSystemActionTurn(session.ID, session, "clear focus", nil, "", turnOutputModeVoice, false); !handled {
+		t.Fatal("expected local system action turn to be handled")
+	}
+
+	payload := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "assistant_output")
+	if got := strFromAny(payload["provider"]); got != assistantProviderLocal {
+		t.Fatalf("provider = %q, want %q", got, assistantProviderLocal)
+	}
+	if got := strFromAny(payload["provider_label"]); got != "Local" {
+		t.Fatalf("provider_label = %q, want Local", got)
+	}
+	if got := strFromAny(payload["provider_model"]); got != app.localAssistantModelLabel() {
+		t.Fatalf("provider_model = %q, want %q", got, app.localAssistantModelLabel())
+	}
+	if got := intFromAny(payload["provider_latency_ms"], -1); got < 0 {
+		t.Fatalf("provider_latency_ms = %d, want >= 0", got)
+	}
+
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(messages))
+	}
+	if got := messages[0].Provider; got != assistantProviderLocal {
+		t.Fatalf("stored provider = %q, want %q", got, assistantProviderLocal)
+	}
+	if got := messages[0].ProviderModel; got != app.localAssistantModelLabel() {
+		t.Fatalf("stored provider_model = %q, want %q", got, app.localAssistantModelLabel())
+	}
+}
+
+func TestFinalizeAssistantResponseWithMetadataPublishesProviderMetadata(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	persistedAssistantID := int64(0)
+	persistedAssistantText := ""
+	metadata := assistantResponseMetadata{
+		Provider:        assistantProviderOpenAI,
+		ProviderModel:   "gpt-5.3-codex-spark",
+		ProviderLatency: 321,
+	}
+	response := app.finalizeAssistantResponseWithMetadata(
+		session.ID,
+		project.ProjectKey,
+		"OpenAI reply.",
+		&persistedAssistantID,
+		&persistedAssistantText,
+		"turn-openai",
+		"",
+		"thread-openai",
+		turnOutputModeVoice,
+		metadata,
+	)
+	if response != "OpenAI reply." {
+		t.Fatalf("response = %q, want OpenAI reply.", response)
+	}
+
+	payload := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "assistant_output")
+	if got := strFromAny(payload["provider"]); got != assistantProviderOpenAI {
+		t.Fatalf("provider = %q, want %q", got, assistantProviderOpenAI)
+	}
+	if got := strFromAny(payload["provider_label"]); got != "OpenAI" {
+		t.Fatalf("provider_label = %q, want OpenAI", got)
+	}
+	if got := strFromAny(payload["provider_model"]); got != metadata.ProviderModel {
+		t.Fatalf("provider_model = %q, want %q", got, metadata.ProviderModel)
+	}
+	if got := intFromAny(payload["provider_latency_ms"], -1); got != metadata.ProviderLatency {
+		t.Fatalf("provider_latency_ms = %d, want %d", got, metadata.ProviderLatency)
+	}
+
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(messages))
+	}
+	if got := messages[0].Provider; got != assistantProviderOpenAI {
+		t.Fatalf("stored provider = %q, want %q", got, assistantProviderOpenAI)
+	}
+	if got := messages[0].ProviderModel; got != metadata.ProviderModel {
+		t.Fatalf("stored provider_model = %q, want %q", got, metadata.ProviderModel)
+	}
+	if got := messages[0].ProviderLatency; got != metadata.ProviderLatency {
+		t.Fatalf("stored provider_latency = %d, want %d", got, metadata.ProviderLatency)
+	}
+}
+
+func TestChatSessionHistoryIncludesProviderMetadata(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(
+		session.ID,
+		"assistant",
+		"History reply.",
+		"History reply.",
+		"markdown",
+		store.WithProviderMetadata(assistantProviderOpenAI, "gpt-5.3-codex", 123),
+	); err != nil {
+		t.Fatalf("AddChatMessage: %v", err)
+	}
+
+	rr := doAuthedRequest(t, app.Router(), http.MethodGet, "/api/chat/sessions/"+session.ID+"/history")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET history status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	messages, ok := payload["messages"].([]any)
+	if !ok || len(messages) != 1 {
+		t.Fatalf("messages payload = %#v, want one message", payload["messages"])
+	}
+	msg, ok := messages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("message payload = %#v", messages[0])
+	}
+	if got := strFromAny(msg["provider"]); got != assistantProviderOpenAI {
+		t.Fatalf("history provider = %q, want %q", got, assistantProviderOpenAI)
+	}
+	if got := strFromAny(msg["provider_model"]); got != "gpt-5.3-codex" {
+		t.Fatalf("history provider_model = %q, want gpt-5.3-codex", got)
+	}
+	if got := intFromAny(msg["provider_latency_ms"], -1); got != 123 {
+		t.Fatalf("history provider_latency_ms = %d, want 123", got)
+	}
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/krystophny/tabura/internal/appserver"
 	"github.com/krystophny/tabura/internal/plugins"
@@ -54,6 +55,8 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		)
 	}
 	profile = a.appServerProfileForChatSession(session, profile)
+	turnStartedAt := time.Now()
+	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
 	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
 		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, turn.outputMode, profile)
@@ -106,6 +109,11 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	persistedAssistantPlain := ""
 	persistedAssistantFormat := ""
 	persistWriteFailed := false
+	snapshotOpts := func() []store.ChatMessageOption {
+		meta := responseMeta
+		meta.ProviderLatency = int(time.Since(turnStartedAt) / time.Millisecond)
+		return meta.storeOptions()
+	}
 
 	persistAssistantSnapshot := func(text string, renderOnCanvas bool, autoCanvas bool) {
 		candidateMarkdown, candidatePlain, candidateFormat := assistantSnapshotContent(text, renderOnCanvas, autoCanvas)
@@ -113,7 +121,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			return
 		}
 		if persistedAssistantID == 0 {
-			storedAssistant, storeErr := a.store.AddChatMessage(sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat)
+			storedAssistant, storeErr := a.store.AddChatMessage(sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...)
 			if storeErr != nil {
 				if !persistWriteFailed {
 					persistWriteFailed = true
@@ -135,7 +143,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			candidateFormat == persistedAssistantFormat {
 			return
 		}
-		if storeErr := a.store.UpdateChatMessageContent(persistedAssistantID, candidateMarkdown, candidatePlain, candidateFormat); storeErr != nil {
+		if storeErr := a.store.UpdateChatMessageContent(persistedAssistantID, candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...); storeErr != nil {
 			if !persistWriteFailed {
 				persistWriteFailed = true
 				a.broadcastChatEvent(sessionID, map[string]interface{}{
@@ -276,8 +284,18 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		assistantText = "(assistant returned no content)"
 	}
 
-	assistantText = a.finalizeAssistantResponse(sessionID, session.ProjectKey, assistantText,
-		&persistedAssistantID, &persistedAssistantText, appResp.TurnID, latestTurnID, appResp.ThreadID, turn.outputMode)
+	assistantText = a.finalizeAssistantResponseWithMetadata(
+		sessionID,
+		session.ProjectKey,
+		assistantText,
+		&persistedAssistantID,
+		&persistedAssistantText,
+		appResp.TurnID,
+		latestTurnID,
+		appResp.ThreadID,
+		turn.outputMode,
+		newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, time.Since(turnStartedAt)),
+	)
 	_ = assistantText
 }
 
@@ -285,6 +303,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 	if strings.TrimSpace(userText) == "" {
 		return false
 	}
+	turnStartedAt := time.Now()
 	actionMessage, actionPayloads, handled := a.classifyAndExecuteSystemActionForTurn(context.Background(), sessionID, session, userText, cursorCtx, captureMode)
 	if !handled && !localOnly {
 		return false
@@ -322,7 +341,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 	}
 	persistedAssistantID := int64(0)
 	persistedAssistantText := ""
-	a.finalizeAssistantResponse(
+	a.finalizeAssistantResponseWithMetadata(
 		sessionID,
 		session.ProjectKey,
 		assistantText,
@@ -332,6 +351,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 		runID,
 		"",
 		outputMode,
+		newAssistantResponseMetadata(assistantProviderLocal, a.localAssistantModelLabel(), time.Since(turnStartedAt)),
 	)
 	return true
 }
@@ -358,6 +378,8 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 		return
 	}
 	profile = a.appServerProfileForChatSession(session, profile)
+	turnStartedAt := time.Now()
+	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
 	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
 	prompt := buildPromptFromHistoryForSessionWithPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, outputMode, profile.Alias)
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
@@ -397,13 +419,18 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 	persistedAssistantPlain := ""
 	persistedAssistantFormat := ""
 	persistWriteFailed := false
+	snapshotOpts := func() []store.ChatMessageOption {
+		meta := responseMeta
+		meta.ProviderLatency = int(time.Since(turnStartedAt) / time.Millisecond)
+		return meta.storeOptions()
+	}
 	persistAssistantSnapshot := func(text string, renderOnCanvas bool, autoCanvas bool) {
 		candidateMarkdown, candidatePlain, candidateFormat := assistantSnapshotContent(text, renderOnCanvas, autoCanvas)
 		if candidateMarkdown == "" && candidatePlain == "" {
 			return
 		}
 		if persistedAssistantID == 0 {
-			storedAssistant, storeErr := a.store.AddChatMessage(sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat)
+			storedAssistant, storeErr := a.store.AddChatMessage(sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...)
 			if storeErr != nil {
 				if !persistWriteFailed {
 					persistWriteFailed = true
@@ -425,7 +452,7 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 			candidateFormat == persistedAssistantFormat {
 			return
 		}
-		if storeErr := a.store.UpdateChatMessageContent(persistedAssistantID, candidateMarkdown, candidatePlain, candidateFormat); storeErr != nil {
+		if storeErr := a.store.UpdateChatMessageContent(persistedAssistantID, candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...); storeErr != nil {
 			if !persistWriteFailed {
 				persistWriteFailed = true
 				a.broadcastChatEvent(sessionID, map[string]interface{}{
@@ -550,8 +577,18 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 		assistantText = "(assistant returned no content)"
 	}
 
-	assistantText = a.finalizeAssistantResponse(sessionID, session.ProjectKey, assistantText,
-		&persistedAssistantID, &persistedAssistantText, appResp.TurnID, latestTurnID, appResp.ThreadID, outputMode)
+	assistantText = a.finalizeAssistantResponseWithMetadata(
+		sessionID,
+		session.ProjectKey,
+		assistantText,
+		&persistedAssistantID,
+		&persistedAssistantText,
+		appResp.TurnID,
+		latestTurnID,
+		appResp.ThreadID,
+		outputMode,
+		newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, time.Since(turnStartedAt)),
+	)
 	_ = assistantText
 }
 
@@ -563,6 +600,27 @@ func (a *App) finalizeAssistantResponse(
 	persistedID *int64, persistedText *string,
 	turnID, fallbackTurnID, threadID string,
 	outputMode string,
+) string {
+	return a.finalizeAssistantResponseWithMetadata(
+		sessionID,
+		projectKey,
+		text,
+		persistedID,
+		persistedText,
+		turnID,
+		fallbackTurnID,
+		threadID,
+		outputMode,
+		assistantResponseMetadata{},
+	)
+}
+
+func (a *App) finalizeAssistantResponseWithMetadata(
+	sessionID, projectKey, text string,
+	persistedID *int64, persistedText *string,
+	turnID, fallbackTurnID, threadID string,
+	outputMode string,
+	metadata assistantResponseMetadata,
 ) string {
 	postResult := a.applyPluginHook(context.Background(), plugins.HookRequest{
 		Hook:       plugins.HookChatPostAssistantReply,
@@ -631,7 +689,7 @@ func (a *App) finalizeAssistantResponse(
 	a.refreshCanvasFromDisk(projectKey)
 
 	if *persistedID == 0 {
-		stored, err := a.store.AddChatMessage(sessionID, "assistant", chatMarkdown, chatPlain, renderFormat)
+		stored, err := a.store.AddChatMessage(sessionID, "assistant", chatMarkdown, chatPlain, renderFormat, metadata.storeOptions()...)
 		if err != nil {
 			a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
 			a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
@@ -640,7 +698,7 @@ func (a *App) finalizeAssistantResponse(
 		*persistedID = stored.ID
 		*persistedText = chatMarkdown
 	} else {
-		if err := a.store.UpdateChatMessageContent(*persistedID, chatMarkdown, chatPlain, renderFormat); err != nil {
+		if err := a.store.UpdateChatMessageContent(*persistedID, chatMarkdown, chatPlain, renderFormat, metadata.storeOptions()...); err != nil {
 			a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
 			a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
 			return chatMarkdown
@@ -662,6 +720,7 @@ func (a *App) finalizeAssistantResponse(
 		"message":          chatMarkdown,
 		"render_on_canvas": renderOnCanvas,
 	}
+	metadata.applyToPayload(payload)
 	if autoCanvas {
 		payload["auto_canvas"] = true
 	}

--- a/internal/web/static/app-chat-transport.ts
+++ b/internal/web/static/app-chat-transport.ts
@@ -672,6 +672,11 @@ export function handleChatEvent(payload) {
     if (String(payload.role || '') !== 'assistant') return;
     const turnID = String(payload.turn_id || '').trim();
     const md = String(payload.message || '');
+    const providerOptions = {
+      provider: payload.provider,
+      providerLabel: payload.provider_label,
+      providerModel: payload.provider_model,
+    };
     const autoCanvas = Boolean(payload.auto_canvas);
     const lastTTSText = getTTSLastSpeakText();
     const inferredText = md || lastTTSText;
@@ -682,11 +687,12 @@ export function handleChatEvent(payload) {
     const mobileSilent = isMobileSilent();
     const row = takePendingRow(turnID);
     if (row && hasDisplayMd) {
-      updateAssistantRow(row, displayMd, false);
+      updateAssistantRow(row, displayMd, false, providerOptions);
     } else if (row) {
       row.classList.remove('is-pending');
+      updateAssistantRow(row, '', false, providerOptions);
     } else if (hasDisplayMd) {
-      appendRenderedAssistant(displayMd);
+      appendRenderedAssistant(displayMd, providerOptions);
     }
     const shouldSpeakTurn = isVoiceOutputModePayload(payload) || (turnID ? state.voiceTurns.has(turnID) : false) || isVoiceTurn();
     trackAssistantTurnFinished(turnID);

--- a/internal/web/static/app-chat-ui.ts
+++ b/internal/web/static/app-chat-ui.ts
@@ -274,6 +274,48 @@ export function resolveApprovalRequestCard(requestID, decision) {
   status.textContent = approvalDecisionLabel(decision);
 }
 
+function normalizeAssistantProvider(provider) {
+  const value = String(provider || '').trim().toLowerCase();
+  if (value === 'local' || value === 'cerebras' || value === 'google' || value === 'openai') return value;
+  return '';
+}
+
+function assistantProviderLabel(provider, explicitLabel = '') {
+  const label = String(explicitLabel || '').trim();
+  if (label) return label;
+  switch (normalizeAssistantProvider(provider)) {
+    case 'local':
+      return 'Local';
+    case 'cerebras':
+      return 'Cerebras';
+    case 'google':
+      return 'Google';
+    case 'openai':
+      return 'OpenAI';
+    default:
+      return 'Assistant';
+  }
+}
+
+function setAssistantRowProvider(row, options: Record<string, any> = {}) {
+  if (!(row instanceof HTMLElement)) return;
+  const meta = row.querySelector('.chat-message-meta');
+  if (meta instanceof HTMLElement) meta.textContent = '';
+  const label = row.querySelector('.chat-assistant-label');
+  if (!(label instanceof HTMLElement)) return;
+  const provider = normalizeAssistantProvider(options.provider);
+  const display = assistantProviderLabel(provider, options.providerLabel);
+  label.textContent = display;
+  label.dataset.provider = provider || 'assistant';
+  row.dataset.provider = provider;
+  const model = String(options.providerModel || '').trim();
+  if (model) {
+    label.title = model;
+  } else {
+    label.removeAttribute('title');
+  }
+}
+
 export function appendRenderedAssistant(markdownText, options: Record<string, any> = {}) {
   const host = chatHistoryEl();
   if (!host) return null;
@@ -286,7 +328,6 @@ export function appendRenderedAssistant(markdownText, options: Record<string, an
 
   const meta = document.createElement('div');
   meta.className = 'chat-message-meta';
-  meta.textContent = 'assistant';
 
   const bubble = document.createElement('div');
   bubble.className = 'chat-bubble markdown';
@@ -294,21 +335,30 @@ export function appendRenderedAssistant(markdownText, options: Record<string, an
   progress.className = 'chat-bubble-progress';
   const body = document.createElement('div');
   body.className = 'chat-bubble-body';
+  const label = document.createElement('div');
+  label.className = 'chat-assistant-label';
+  const content = document.createElement('div');
+  content.className = 'chat-assistant-content';
   const { text: markdownBody, stash: mathSegments } = extractMathSegments(markdownText);
   const rendered = marked.parse(markdownBody || '');
-  body.innerHTML = restoreMathSegments(sanitizeHtml(rendered), mathSegments);
+  content.innerHTML = restoreMathSegments(sanitizeHtml(rendered), mathSegments);
+  body.appendChild(label);
+  body.appendChild(content);
   bubble.appendChild(progress);
   bubble.appendChild(body);
   row.appendChild(meta);
   row.appendChild(bubble);
   host.appendChild(row);
+  setAssistantRowProvider(row, options);
   syncChatScroll(host);
-  void typesetMath(body).finally(() => syncChatScroll(host));
+  void typesetMath(content).finally(() => syncChatScroll(host));
   return row;
 }
 
 export function assistantRowBodyEl(row) {
   if (!(row instanceof HTMLElement)) return null;
+  const content = row.querySelector('.chat-assistant-content');
+  if (content instanceof HTMLElement) return content;
   const body = row.querySelector('.chat-bubble-body');
   if (body instanceof HTMLElement) return body;
   const bubble = row.querySelector('.chat-bubble');
@@ -390,10 +440,11 @@ export function appendAssistantProgressForTurn(turnID, text) {
   appendAssistantProgressLine(row, line);
 }
 
-export function updateAssistantRow(row, markdownText, pending = true) {
+export function updateAssistantRow(row, markdownText, pending = true, options: Record<string, any> = {}) {
   if (!row) return;
   const host = chatHistoryEl();
   row.classList.toggle('is-pending', pending);
+  setAssistantRowProvider(row, options);
   const body = assistantRowBodyEl(row);
   if (!(body instanceof HTMLElement)) return;
   const { text: markdownBody, stash: mathSegments } = extractMathSegments(markdownText);

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -766,7 +766,10 @@ export async function loadChatHistory() {
     const plain = String(msg.content_plain || markdown);
     if (role === 'assistant') {
       if (!shouldRenderAssistantHistoryInChat(renderFormat, markdown, plain)) continue;
-      appendRenderedAssistant(markdown || plain);
+      appendRenderedAssistant(markdown || plain, {
+        provider: msg.provider,
+        providerModel: msg.provider_model,
+      });
     } else {
       appendPlainMessage(role, plain);
     }

--- a/internal/web/static/chat.css
+++ b/internal/web/static/chat.css
@@ -36,6 +36,10 @@
   color: #4b5563;
 }
 
+.chat-message-meta:empty {
+  display: none;
+}
+
 .chat-bubble {
   border: 1px solid #d1d5db;
   border-radius: 8px;
@@ -70,6 +74,37 @@
 }
 
 .chat-bubble-body {
+  min-width: 0;
+}
+
+.chat-assistant-label {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0.35rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #4b5563;
+}
+
+.chat-assistant-label[data-provider="local"] {
+  color: #4b5563;
+}
+
+.chat-assistant-label[data-provider="cerebras"] {
+  color: #1d4ed8;
+}
+
+.chat-assistant-label[data-provider="google"] {
+  color: #c2410c;
+}
+
+.chat-assistant-label[data-provider="openai"] {
+  color: #047857;
+}
+
+.chat-assistant-content {
   min-width: 0;
 }
 

--- a/tests/playwright/provider-attribution.spec.ts
+++ b/tests/playwright/provider-attribution.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._taburaApp;
+    if (typeof app?.getState !== 'function') return false;
+    const state = app.getState();
+    return state.chatWs && state.chatWs.readyState === (window as any).WebSocket.OPEN;
+  }, null, { timeout: 5_000 });
+}
+
+async function injectChatEvent(page: Page, payload: Record<string, unknown>) {
+  await page.evaluate((eventPayload) => {
+    const app = (window as any)._taburaApp;
+    const sessionId = String(app?.getState?.().chatSessionId || '');
+    const sessions = (window as any).__mockWsSessions || [];
+    const chatWs = sessions.find((ws: any) => typeof ws.url === 'string'
+      && ws.url.includes('/ws/chat/')
+      && (!sessionId || ws.url.includes(`/ws/chat/${sessionId}`)));
+    if (chatWs?.injectEvent) {
+      chatWs.injectEvent(eventPayload);
+    }
+  }, payload);
+}
+
+test('assistant output shows provider label and model metadata', async ({ page }) => {
+  await waitReady(page);
+
+  await injectChatEvent(page, { type: 'turn_started', turn_id: 'provider-turn-1' });
+  await injectChatEvent(page, {
+    type: 'assistant_output',
+    role: 'assistant',
+    turn_id: 'provider-turn-1',
+    message: 'Using the cloud tier.',
+    provider: 'openai',
+    provider_label: 'OpenAI',
+    provider_model: 'gpt-5.3-codex-spark',
+  });
+
+  const row = page.locator('.chat-message.chat-assistant').last();
+  const label = row.locator('.chat-assistant-label');
+  await expect(label).toHaveText('OpenAI');
+  await expect(label).toHaveAttribute('title', 'gpt-5.3-codex-spark');
+  await expect(row).toHaveAttribute('data-provider', 'openai');
+});
+
+test('unknown provider falls back to Assistant', async ({ page }) => {
+  await waitReady(page);
+
+  await injectChatEvent(page, {
+    type: 'assistant_output',
+    role: 'assistant',
+    turn_id: 'provider-turn-2',
+    message: 'Fallback label works.',
+  });
+
+  const label = page.locator('.chat-message.chat-assistant .chat-assistant-label').last();
+  await expect(label).toHaveText('Assistant');
+});


### PR DESCRIPTION
## Summary
- persist assistant provider, model, and latency on chat messages and expose them through chat history
- stamp current assistant paths with provider metadata: `local` for local system turns and `openai` for app-server turns
- render provider badges in chat with an `Assistant` fallback, and cover the UI with a focused Playwright spec

## Verification
- Provider metadata is stored in `chat_messages` and survives updates/migration:
  `go test ./internal/store ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/store 2.041s`
  Tests: `TestStoreChatSessionMessageAndThreading`, `TestStoreSchemaAndHelperNormalizers`
- Local assistant turns publish provider metadata over WebSocket and persistence:
  `go test ./internal/web`
  Excerpt: `ok   github.com/krystophny/tabura/internal/web 9.986s`
  Tests: `TestLocalSystemActionTurnPublishesLocalProviderMetadata`, `TestFinalizeAssistantResponseWithMetadataPublishesProviderMetadata`
- Chat history/API responses include provider fields:
  `go test ./internal/web`
  Test: `TestChatSessionHistoryIncludesProviderMetadata`
- Assistant messages render provider labels and unknown providers fall back to `Assistant`:
  `./scripts/playwright.sh tests/playwright/provider-attribution.spec.ts`
  Excerpt: `2 passed (1.3s)`
  Spec: `tests/playwright/provider-attribution.spec.ts`
