### PR TITLE
fix: Add workspace focus switching commands to intent system (fixes #535)

### DIFF
--- a/internal/web/chat_intent_fast_test.go
+++ b/internal/web/chat_intent_fast_test.go
@@ -34,6 +34,7 @@ func TestTryDeterministicFastPathRegistry(t *testing.T) {
 		{name: "artifact", text: "show linked artifacts", wantMatch: "artifact_link", wantAction: "list_linked_artifacts"},
 		{name: "batch", text: "show me progress", wantMatch: "batch", wantAction: "batch_status"},
 		{name: "workspace", text: "list workspaces", wantMatch: "workspace", wantAction: "list_workspaces"},
+		{name: "workspace focus", text: "open the plasma workspace", wantMatch: "workspace", wantAction: "focus_workspace"},
 		{name: "project", text: "what project is this?", wantMatch: "project", wantAction: "show_workspace_project"},
 	}
 

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -19,6 +19,7 @@ var (
 	workspaceRenamePattern        = regexp.MustCompile(`(?i)^rename\s+workspace\s+(.+?)\s+to\s+(.+?)$`)
 	workspaceDeletePattern        = regexp.MustCompile(`(?i)^(?:delete|remove)\s+workspace\s+(.+?)$`)
 	workspaceDetailsPattern       = regexp.MustCompile(`(?i)^(?:show\s+)?workspace\s+details(?:\s+for\s+(.+?))?$`)
+	workspaceFocusOpenPattern     = regexp.MustCompile(`(?i)^open\s+(?:the\s+)?(.+?)\s+workspace$`)
 )
 
 func parseInlineWorkspaceIntent(text string) *SystemAction {
@@ -81,6 +82,11 @@ func parseInlineWorkspaceIntent(text string) *SystemAction {
 		pathRef := cleanWorkspaceReference(match[1])
 		if pathRef != "" && !strings.HasPrefix(strings.ToLower(pathRef), "from ") {
 			return &SystemAction{Action: "create_workspace", Params: map[string]interface{}{"path": pathRef}}
+		}
+	}
+	if match := workspaceFocusOpenPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		if name := cleanWorkspaceReference(match[1]); name != "" {
+			return &SystemAction{Action: "focus_workspace", Params: map[string]interface{}{"workspace": name}}
 		}
 	}
 	if name, ok := cutPrefixedWorkspaceReference(trimmed, "focus on "); ok {
@@ -257,30 +263,62 @@ func (a *App) resolveWorkspaceReference(projectKey string, raw string) (store.Wo
 	if err != nil {
 		return store.Workspace{}, err
 	}
-	var matches []store.Workspace
+	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferenceExactMatch); err != nil || ok {
+		return workspace, err
+	}
+	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferencePrefixMatch); err != nil || ok {
+		return workspace, err
+	}
+	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferenceContainsMatch); err != nil || ok {
+		return workspace, err
+	}
+	return store.Workspace{}, fmt.Errorf("workspace %q not found", ref)
+}
+
+type workspaceReferenceMatchMode int
+
+const (
+	workspaceReferenceExactMatch workspaceReferenceMatchMode = iota
+	workspaceReferencePrefixMatch
+	workspaceReferenceContainsMatch
+)
+
+func resolveWorkspaceMatch(workspaces []store.Workspace, ref, expanded string, mode workspaceReferenceMatchMode) (store.Workspace, bool, error) {
+	matches := make([]store.Workspace, 0, len(workspaces))
 	for _, workspace := range workspaces {
-		switch {
-		case strings.EqualFold(workspace.Name, ref):
-			matches = append(matches, workspace)
-		case strings.EqualFold(filepath.Base(workspace.DirPath), ref):
-			matches = append(matches, workspace)
-		case strings.EqualFold(workspace.DirPath, expanded):
+		if workspaceReferenceMatches(workspace, ref, expanded, mode) {
 			matches = append(matches, workspace)
 		}
 	}
-	if len(matches) == 1 {
-		return matches[0], nil
-	}
-	if len(matches) > 1 {
+	switch len(matches) {
+	case 0:
+		return store.Workspace{}, false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
 		sort.Slice(matches, func(i, j int) bool {
-			if matches[i].IsActive != matches[j].IsActive {
-				return matches[i].IsActive
-			}
 			return strings.ToLower(matches[i].Name) < strings.ToLower(matches[j].Name)
 		})
-		return store.Workspace{}, fmt.Errorf("workspace %q is ambiguous", ref)
+		return store.Workspace{}, true, fmt.Errorf("workspace %q is ambiguous", ref)
 	}
-	return store.Workspace{}, fmt.Errorf("workspace %q not found", ref)
+}
+
+func workspaceReferenceMatches(workspace store.Workspace, ref, expanded string, mode workspaceReferenceMatchMode) bool {
+	name := strings.ToLower(strings.TrimSpace(workspace.Name))
+	base := strings.ToLower(strings.TrimSpace(filepath.Base(workspace.DirPath)))
+	dirPath := strings.ToLower(strings.TrimSpace(workspace.DirPath))
+	refLower := strings.ToLower(strings.TrimSpace(ref))
+	expandedLower := strings.ToLower(strings.TrimSpace(expanded))
+	switch mode {
+	case workspaceReferenceExactMatch:
+		return name == refLower || base == refLower || dirPath == expandedLower
+	case workspaceReferencePrefixMatch:
+		return strings.HasPrefix(name, refLower) || strings.HasPrefix(base, refLower)
+	case workspaceReferenceContainsMatch:
+		return strings.Contains(name, refLower) || strings.Contains(base, refLower)
+	default:
+		return false
+	}
 }
 
 func (a *App) listOpenWorkspaceItems(workspaceID int64) ([]store.Item, error) {

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -23,7 +23,9 @@ func TestParseInlineWorkspaceIntent(t *testing.T) {
 		wantAll       bool
 	}{
 		{text: "focus on Alpha", wantAction: "focus_workspace", wantWorkspace: "Alpha"},
+		{text: "focus stellarator", wantAction: "focus_workspace", wantWorkspace: "stellarator"},
 		{text: "work in Beta", wantAction: "focus_workspace", wantWorkspace: "Beta"},
+		{text: "open the Plasma workspace", wantAction: "focus_workspace", wantWorkspace: "Plasma"},
 		{text: "clear focus", wantAction: "clear_focus"},
 		{text: "open workspace Alpha", wantAction: "switch_workspace", wantWorkspace: "Alpha"},
 		{text: "switch to workspace Beta", wantAction: "switch_workspace", wantWorkspace: "Beta"},
@@ -119,6 +121,88 @@ func TestClassifyAndExecuteSystemActionSwitchWorkspace(t *testing.T) {
 	}
 	if !updated.IsActive {
 		t.Fatal("expected beta workspace to be active")
+	}
+}
+
+func TestClassifyAndExecuteSystemActionFocusWorkspaceUsesFuzzyNameMatching(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	anchor, err := app.ensureTodayDailyWorkspace()
+	if err != nil {
+		t.Fatalf("ensureTodayDailyWorkspace: %v", err)
+	}
+	focus, err := app.store.CreateWorkspace("stellarator-rmp-analysis", filepath.Join(t.TempDir(), "stellarator-rmp-analysis"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(focus) error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "open the stellarator workspace")
+	if !handled {
+		t.Fatal("expected focus workspace command to be handled")
+	}
+	if message != "Focused on stellarator-rmp-analysis." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "focus_workspace" {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := int64FromAny(payloads[0]["workspace_id"]); got != focus.ID {
+		t.Fatalf("payload workspace_id = %d, want %d", got, focus.ID)
+	}
+	focusedID, err := app.store.FocusedWorkspaceID()
+	if err != nil {
+		t.Fatalf("FocusedWorkspaceID() error: %v", err)
+	}
+	if focusedID != focus.ID {
+		t.Fatalf("focused workspace = %d, want %d", focusedID, focus.ID)
+	}
+	active, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("ActiveWorkspace() error: %v", err)
+	}
+	if active.ID != anchor.ID {
+		t.Fatalf("active workspace = %d, want anchor %d", active.ID, anchor.ID)
+	}
+}
+
+func TestResolveWorkspaceReferenceRejectsAmbiguousFuzzyMatch(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	for _, name := range []string{"plasma-core", "plasma-response"} {
+		if _, err := app.store.CreateWorkspace(name, filepath.Join(t.TempDir(), name)); err != nil {
+			t.Fatalf("CreateWorkspace(%s) error: %v", name, err)
+		}
+	}
+
+	_, err := app.resolveWorkspaceReference("", "plasma")
+	if err == nil || !strings.Contains(err.Error(), `workspace "plasma" is ambiguous`) {
+		t.Fatalf("resolveWorkspaceReference() error = %v, want ambiguous match", err)
+	}
+}
+
+func TestResolveWorkspaceReferenceMatchesContainedName(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspace, err := app.store.CreateWorkspace("stellarator-rmp-analysis", filepath.Join(t.TempDir(), "stellarator-rmp-analysis"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	resolved, err := app.resolveWorkspaceReference("", "rmp")
+	if err != nil {
+		t.Fatalf("resolveWorkspaceReference() error: %v", err)
+	}
+	if resolved.ID != workspace.ID {
+		t.Fatalf("resolved workspace = %d, want %d", resolved.ID, workspace.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- finish workspace-focus fast-path parsing for `open the <name> workspace`
- resolve workspace references by exact, prefix, then contains matching while rejecting ambiguous fuzzy hits
- add targeted coverage for new focus grammar and fuzzy matching behavior

## Verification
- Focus switchable by name with the new text command shape: `go test ./internal/web -run 'Test(ParseInlineWorkspaceIntent|ClassifyAndExecuteSystemActionSwitchWorkspace|ClassifyAndExecuteSystemActionFocusWorkspaceUsesFuzzyNameMatching|ResolveWorkspaceReferenceRejectsAmbiguousFuzzyMatch|ResolveWorkspaceReferenceMatchesContainedName|TryDeterministicFastPathRegistry)$' 2>&1 | tee /tmp/tabura-issue-535-test.log` -> `ok   github.com/krystophny/tabura/internal/web	0.061s`; exercised by `TestParseInlineWorkspaceIntent` and `TestClassifyAndExecuteSystemActionFocusWorkspaceUsesFuzzyNameMatching`
- Fast-path focus parsing works without falling back to the LLM: same command; exercised by `TestTryDeterministicFastPathRegistry`
- `back to daily` and `clear focus` remain accepted workspace commands: same command; exercised by `TestParseInlineWorkspaceIntent`
- Prefix and contains fuzzy matching resolve the intended workspace: same command; exercised by `TestClassifyAndExecuteSystemActionFocusWorkspaceUsesFuzzyNameMatching` and `TestResolveWorkspaceReferenceMatchesContainedName`
- Ambiguous fuzzy names do not silently switch to the wrong workspace: same command; exercised by `TestResolveWorkspaceReferenceRejectsAmbiguousFuzzyMatch`