### PR TITLE
fix: Implement parallel Qwen+Spark turn execution with commitment sta (fixes #531)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -34,6 +34,35 @@ type intentPlanClassification struct {
 	LocalAnswer *intentLocalAnswer
 }
 
+type localTurnEvaluation struct {
+	handled               bool
+	text                  string
+	payloads              []map[string]interface{}
+	localAnswerConfidence string
+}
+
+func (e localTurnEvaluation) suppressesResponse() bool {
+	return suppressLocalAssistantResponse(e.payloads)
+}
+
+func (e localTurnEvaluation) isCommand() bool {
+	return e.handled && len(e.payloads) > 0 && !e.suppressesResponse()
+}
+
+func (e localTurnEvaluation) isHighConfidenceLocalAnswer() bool {
+	return e.handled &&
+		len(e.payloads) == 0 &&
+		strings.TrimSpace(e.text) != "" &&
+		e.localAnswerConfidence == "high"
+}
+
+func (e localTurnEvaluation) fallbackText() string {
+	if strings.TrimSpace(e.text) == "" {
+		return ""
+	}
+	return strings.TrimSpace(e.text)
+}
+
 const systemActionLastShellPathPlaceholder = "$last_shell_path"
 
 func extractEmbeddedJSON(raw string) string {
@@ -521,35 +550,55 @@ func (a *App) classifyAndExecuteSystemActionWithCursor(ctx context.Context, sess
 }
 
 func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, sessionID string, session store.ChatSession, text string, cursor *chatCursorContext, captureMode string) (string, []map[string]interface{}, bool) {
+	evaluation := a.evaluateLocalTurn(ctx, sessionID, session, text, cursor, captureMode)
+	return evaluation.text, evaluation.payloads, evaluation.handled
+}
+
+func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session store.ChatSession, text string, cursor *chatCursorContext, captureMode string) localTurnEvaluation {
 	trimmedText := strings.TrimSpace(text)
 	if trimmedText == "" {
-		return "", nil, false
+		return localTurnEvaluation{}
 	}
 	intentText := trimmedText
 	livePolicy := a.LivePolicy()
 	assumeAddressed := livePolicy.Config().AssumeAddressed
-	tryExecutePlan := func(actions []*SystemAction) (string, []map[string]interface{}, bool) {
+	tryExecutePlan := func(actions []*SystemAction) localTurnEvaluation {
 		enforced := enforceRoutingPolicy(trimmedText, actions)
 		if len(enforced) == 0 {
-			return "", nil, false
+			return localTurnEvaluation{}
 		}
 		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
 		if err != nil {
-			return "", nil, false
+			return localTurnEvaluation{}
 		}
-		return message, payloads, true
+		return localTurnEvaluation{
+			handled:  true,
+			text:     message,
+			payloads: payloads,
+		}
 	}
 
 	if pending := a.popPendingActionConfirmation(sessionID); pending != nil {
 		if isExplicitDangerConfirm(trimmedText) {
 			message, payloads, err := a.executeSystemActionPlanUnsafe(sessionID, session, pending.UserText, pending.Actions)
 			if err != nil {
-				return fmt.Sprintf("Confirmation failed: %v", err), nil, true
+				return localTurnEvaluation{
+					handled: true,
+					text:    fmt.Sprintf("Confirmation failed: %v", err),
+				}
 			}
-			return message, payloads, true
+			return localTurnEvaluation{
+				handled:  true,
+				text:     message,
+				payloads: payloads,
+			}
 		}
 		if isExplicitDangerDecline(trimmedText) {
-			return pendingConfirmationCanceledMessage(pending.Kind), []map[string]interface{}{{"type": "confirmation_canceled"}}, true
+			return localTurnEvaluation{
+				handled:  true,
+				text:     pendingConfirmationCanceledMessage(pending.Kind),
+				payloads: []map[string]interface{}{{"type": "confirmation_canceled"}},
+			}
 		}
 	}
 
@@ -571,7 +620,11 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 	}
 	if assumeAddressed {
 		if message, payloads, handled := tryDeterministicPlan(); handled {
-			return message, payloads, true
+			return localTurnEvaluation{
+				handled:  true,
+				text:     message,
+				payloads: payloads,
+			}
 		}
 	}
 	intentText = a.contextualizeClarificationReplyForSession(sessionID, trimmedText)
@@ -579,45 +632,67 @@ func (a *App) classifyAndExecuteSystemActionForTurn(ctx context.Context, session
 		classification, llmErr := a.classifyIntentPlanWithLLMResultForTurn(ctx, sessionID, session, intentText)
 		if llmErr == nil {
 			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed); known && !addressed {
-				return "", []map[string]interface{}{{
-					"type":              "meeting_capture",
-					"addressed":         false,
-					"suppress_response": true,
-				}}, true
+				return localTurnEvaluation{
+					handled: true,
+					payloads: []map[string]interface{}{{
+						"type":              "meeting_capture",
+						"addressed":         false,
+						"suppress_response": true,
+					}},
+				}
 			}
 			if classification.LocalAnswer != nil && strings.TrimSpace(classification.LocalAnswer.Text) != "" {
-				return classification.LocalAnswer.Text, nil, true
+				return localTurnEvaluation{
+					handled:               true,
+					text:                  classification.LocalAnswer.Text,
+					localAnswerConfidence: classification.LocalAnswer.Confidence,
+				}
 			}
-			if message, payloads, ok := tryExecutePlan(classification.Actions); ok {
-				return message, payloads, true
+			if evaluation := tryExecutePlan(classification.Actions); evaluation.handled {
+				return evaluation
 			}
 			if !assumeAddressed {
 				if message, payloads, handled := tryDeterministicPlan(); handled {
-					return message, payloads, true
+					return localTurnEvaluation{
+						handled:  true,
+						text:     message,
+						payloads: payloads,
+					}
 				}
 			}
 		}
 		if requestRequiresOpenCanvasAction(intentText) {
 			if fallbackPlan := buildOpenCanvasFallbackPlan(intentText); len(fallbackPlan) > 0 {
-				if message, payloads, ok := tryExecutePlan(fallbackPlan); ok {
-					return message, payloads, true
+				if evaluation := tryExecutePlan(fallbackPlan); evaluation.handled {
+					return evaluation
 				}
 			}
-			return "I couldn't open that file on canvas. Please provide an exact relative path (for example: docs/CLAUDE.md).", nil, true
+			return localTurnEvaluation{
+				handled: true,
+				text:    "I couldn't open that file on canvas. Please provide an exact relative path (for example: docs/CLAUDE.md).",
+			}
 		}
 	}
 	if !assumeAddressed && isCompanionDirectAddress(intentText) {
 		if message, payloads, handled := tryDeterministicPlan(); handled {
-			return message, payloads, true
+			return localTurnEvaluation{
+				handled:  true,
+				text:     message,
+				payloads: payloads,
+			}
 		}
 	}
 
 	if cursor != nil && cursor.hasPointedItem() && looksLikeStandaloneSystemRequest(trimmedText) {
 		if message, payloads, ok := a.suggestCanonicalActionsForCursorItem(cursor); ok {
-			return message, payloads, true
+			return localTurnEvaluation{
+				handled:  true,
+				text:     message,
+				payloads: payloads,
+			}
 		}
 	}
-	return "", nil, false
+	return localTurnEvaluation{}
 }
 
 func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool) (bool, bool) {

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -29,6 +29,9 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	positionCtx := a.chatCanvasPositions.consume(sessionID)
 	cursorCtx := turn.cursor
 	userText := queuedUserMessage(messages, turn.messageID)
+	if a.runAssistantTurnParallel(sessionID, session, messages, userText, cursorCtx, inkCtx, positionCtx, turn) {
+		return
+	}
 	if a.tryRunLocalSystemActionTurn(sessionID, session, userText, cursorCtx, turn.captureMode, turn.outputMode, turn.localOnly) {
 		return
 	}

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -1,0 +1,391 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/appserver"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	defaultParallelTurnSparkDeadline = 5 * time.Second
+	parallelTurnAckDelay             = 500 * time.Millisecond
+)
+
+type sparkTurnResult struct {
+	text     string
+	threadID string
+	err      error
+	latency  time.Duration
+}
+
+func (a *App) sparkTurnDeadline() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("TABURA_SPARK_DEADLINE"))
+	if raw == "" {
+		return defaultParallelTurnSparkDeadline
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		return defaultParallelTurnSparkDeadline
+	}
+	return parsed
+}
+
+func (a *App) emitTurnStage(sessionID, eventType, turnID, source, text string) {
+	payload := map[string]interface{}{
+		"type":    strings.TrimSpace(eventType),
+		"turn_id": strings.TrimSpace(turnID),
+	}
+	if cleanSource := normalizeAssistantProvider(source); cleanSource != "" {
+		payload["source"] = cleanSource
+		payload["source_label"] = assistantProviderDisplayLabel(cleanSource)
+	}
+	if cleanText := strings.TrimSpace(text); cleanText != "" {
+		payload["text"] = cleanText
+	}
+	a.broadcastChatEvent(sessionID, payload)
+}
+
+func (a *App) emitParallelProvisional(sessionID, turnID, outputMode, text string, metadata assistantResponseMetadata) {
+	payload := map[string]interface{}{
+		"type":        "assistant_message",
+		"turn_id":     strings.TrimSpace(turnID),
+		"output_mode": normalizeTurnOutputMode(outputMode),
+		"message":     strings.TrimSpace(text),
+	}
+	metadata.applyToPayload(payload)
+	a.broadcastChatEvent(sessionID, payload)
+}
+
+func defaultParallelTurnAck(userText string) string {
+	trimmed := strings.TrimSpace(userText)
+	if trimmed == "" {
+		return "One moment."
+	}
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "what "), strings.HasPrefix(lower, "how "), strings.HasPrefix(lower, "why "):
+		return "Let me check."
+	case strings.HasPrefix(lower, "please "), strings.HasPrefix(lower, "run "), strings.HasPrefix(lower, "open "):
+		return "On it."
+	default:
+		return "Let me think."
+	}
+}
+
+func (a *App) runSparkTurn(ctx context.Context, sessionID string, appSess *appserver.Session, prompt string, profile appServerModelProfile) sparkTurnResult {
+	startedAt := time.Now()
+	latestMessage := ""
+	appResp, err := appSess.SendTurnWithParams(ctx, prompt, profile.Model, profile.TurnParams, func(ev appserver.StreamEvent) {
+		switch ev.Type {
+		case "assistant_message", "turn_completed":
+			if strings.TrimSpace(ev.Message) != "" {
+				latestMessage = strings.TrimSpace(ev.Message)
+			}
+		case "approval_request":
+			decision, decisionErr := a.requestAppServerApproval(ctx, sessionID, ev)
+			if decisionErr != nil {
+				if ev.Respond != nil {
+					_ = ev.Respond("cancel")
+				}
+				return
+			}
+			if ev.Respond != nil {
+				_ = ev.Respond(decision)
+			}
+		}
+	})
+	result := sparkTurnResult{
+		err:     err,
+		latency: time.Since(startedAt),
+	}
+	if appResp != nil {
+		result.threadID = appResp.ThreadID
+		result.text = strings.TrimSpace(appResp.Message)
+	}
+	if result.text == "" {
+		result.text = latestMessage
+	}
+	return result
+}
+
+func (a *App) runAssistantTurnParallel(
+	sessionID string,
+	session store.ChatSession,
+	messages []store.ChatMessage,
+	userText string,
+	cursorCtx *chatCursorContext,
+	inkCtx []*chatCanvasInkEvent,
+	positionCtx []*chatCanvasPositionEvent,
+	turn dequeuedTurn,
+) bool {
+	if a == nil || a.appServerClient == nil || turn.localOnly {
+		return false
+	}
+
+	cwd, err := a.effectiveWorkspaceDirForChatSession(session)
+	if err != nil {
+		return false
+	}
+	profile := a.appServerModelProfileForProjectKey(session.ProjectKey)
+	if strings.TrimSpace(userText) != "" {
+		profile = routeProfileForRouting(
+			classifyRoutingRoute(userText),
+			profile,
+			a.appServerSparkReasoningEffort,
+		)
+	}
+	profile = a.appServerProfileForChatSession(session, profile)
+	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
+
+	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
+	if sessErr != nil {
+		return false
+	}
+
+	canvasCtx := a.resolveCanvasContext(session.ProjectKey)
+	companionCtx := a.loadCompanionPromptContext(session.ProjectKey)
+	var prompt string
+	if resumed {
+		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
+	} else {
+		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
+		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
+	}
+	prompt = appendChatCursorPrompt(prompt, cursorCtx)
+	prompt = appendCanvasInkPrompt(prompt, inkCtx)
+	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
+	if strings.TrimSpace(prompt) == "" {
+		return false
+	}
+	prompt = a.applyWorkspacePromptContext(session.ProjectKey, prompt)
+	prompt, err = a.applyPreAssistantPromptHook(context.Background(), sessionID, session.ProjectKey, turn.outputMode, session.Mode, prompt)
+	if err != nil || strings.TrimSpace(prompt) == "" {
+		return false
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	turnID := randomToken()
+	a.registerActiveChatTurn(sessionID, turnID, cancel)
+	defer func() {
+		cancel()
+		a.unregisterActiveChatTurn(sessionID, turnID)
+	}()
+
+	go a.watchCanvasFile(ctx, session.ProjectKey)
+
+	localCh := make(chan localTurnEvaluation, 1)
+	sparkCh := make(chan sparkTurnResult, 1)
+
+	startSpark := func() {
+		go func() {
+			sparkCtx, sparkCancel := context.WithCancel(ctx)
+			defer sparkCancel()
+			sparkCh <- a.runSparkTurn(sparkCtx, sessionID, appSess, prompt, profile)
+		}()
+	}
+
+	policy := normalizeLivePolicy(a.LivePolicy().String())
+	var precomputedLocal *localTurnEvaluation
+	if policy == LivePolicyMeeting {
+		evaluation := a.evaluateLocalTurn(context.Background(), sessionID, session, userText, cursorCtx, turn.captureMode)
+		precomputedLocal = &evaluation
+		if evaluation.suppressesResponse() {
+			a.finishCompanionPendingTurn(sessionID, "assistant_turn_suppressed")
+			return true
+		}
+	}
+
+	a.broadcastChatEvent(sessionID, map[string]interface{}{
+		"type":        "turn_started",
+		"turn_id":     turnID,
+		"output_mode": turn.outputMode,
+	})
+	a.markCompanionThinking(sessionID, session.ProjectKey, turnID, turn.outputMode, "assistant_turn_started")
+
+	if precomputedLocal != nil {
+		localCh <- *precomputedLocal
+		startSpark()
+	} else {
+		go func() {
+			localCh <- a.evaluateLocalTurn(context.Background(), sessionID, session, userText, cursorCtx, turn.captureMode)
+		}()
+		startSpark()
+	}
+
+	ackTimer := time.NewTimer(parallelTurnAckDelay)
+	defer ackTimer.Stop()
+	deadlineTimer := time.NewTimer(a.sparkTurnDeadline())
+	defer deadlineTimer.Stop()
+
+	persistedAssistantID := int64(0)
+	persistedAssistantText := ""
+	localReady := false
+	localEvaluation := localTurnEvaluation{}
+	provisionalEmitted := false
+	provisionalText := ""
+	commandPayloadsBroadcast := false
+	sparkDone := false
+	sparkResult := sparkTurnResult{}
+
+	localMetadata := newAssistantResponseMetadata(assistantProviderLocal, a.localAssistantModelLabel(), 0)
+
+	commitFinal := func(text string, metadata assistantResponseMetadata, source string, threadID string) {
+		a.emitTurnStage(sessionID, "turn_committed", turnID, source, text)
+		a.emitTurnStage(sessionID, "turn_source", turnID, source, "")
+		a.finalizeAssistantResponseWithMetadata(
+			sessionID,
+			session.ProjectKey,
+			text,
+			&persistedAssistantID,
+			&persistedAssistantText,
+			turnID,
+			turnID,
+			threadID,
+			turn.outputMode,
+			metadata,
+		)
+	}
+
+	for {
+		select {
+		case evaluation := <-localCh:
+			localReady = true
+			localEvaluation = evaluation
+			if evaluation.suppressesResponse() {
+				a.finishCompanionPendingTurn(sessionID, "assistant_turn_suppressed")
+				return true
+			}
+			if evaluation.isHighConfidenceLocalAnswer() {
+				a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderLocal, evaluation.text)
+				commitFinal(evaluation.text, localMetadata, assistantProviderLocal, "")
+				return true
+			}
+			if evaluation.isCommand() {
+				nextText := strings.TrimSpace(evaluation.text)
+				if nextText == "" {
+					nextText = "Done."
+				}
+				previousText := provisionalText
+				provisionalText = nextText
+				if !commandPayloadsBroadcast {
+					for _, actionPayload := range evaluation.payloads {
+						if actionPayload == nil {
+							continue
+						}
+						eventType := "system_action"
+						actionType, _ := actionPayload["type"].(string)
+						if strings.EqualFold(strings.TrimSpace(actionType), "confirmation_required") {
+							eventType = "system_action_confirmation_required"
+						}
+						a.broadcastChatEvent(sessionID, map[string]interface{}{
+							"type":   eventType,
+							"action": actionPayload,
+						})
+					}
+					commandPayloadsBroadcast = true
+				}
+				if !provisionalEmitted || previousText != nextText {
+					a.emitTurnStage(sessionID, "turn_provisional", turnID, assistantProviderLocal, provisionalText)
+					a.emitParallelProvisional(sessionID, turnID, turn.outputMode, provisionalText, localMetadata)
+					provisionalEmitted = true
+				}
+				if sparkDone && (sparkResult.err != nil || strings.TrimSpace(sparkResult.text) == "") {
+					commitFinal(provisionalText, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+			} else if sparkDone {
+				if sparkResult.err == nil && strings.TrimSpace(sparkResult.text) != "" {
+					commitFinal(sparkResult.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, sparkResult.latency), responseMeta.Provider, sparkResult.threadID)
+					return true
+				}
+				if fallback := evaluation.fallbackText(); fallback != "" {
+					commitFinal(fallback, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+			}
+		case result := <-sparkCh:
+			sparkDone = true
+			sparkResult = result
+			if !localReady {
+				continue
+			}
+			if result.err == nil && strings.TrimSpace(result.text) != "" {
+				commitFinal(result.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, result.latency), responseMeta.Provider, result.threadID)
+				return true
+			}
+			if localReady {
+				if localEvaluation.isCommand() {
+					finalText := provisionalText
+					if finalText == "" {
+						finalText = "Done."
+					}
+					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+				if fallback := localEvaluation.fallbackText(); fallback != "" {
+					commitFinal(fallback, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+			}
+			if result.err != nil && errors.Is(result.err, context.Canceled) {
+				return true
+			}
+			if result.err != nil {
+				a.closeAppSession(sessionID)
+				a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+				errText := normalizeAssistantError(result.err)
+				_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+				a.broadcastChatEvent(sessionID, map[string]interface{}{
+					"type":    "error",
+					"error":   errText,
+					"turn_id": turnID,
+				})
+				return true
+			}
+		case <-ackTimer.C:
+			if provisionalEmitted || sparkDone {
+				continue
+			}
+			if localReady && (localEvaluation.isHighConfidenceLocalAnswer() || localEvaluation.isCommand()) {
+				continue
+			}
+			provisionalText = defaultParallelTurnAck(userText)
+			a.emitTurnStage(sessionID, "turn_provisional", turnID, assistantProviderLocal, provisionalText)
+			a.emitParallelProvisional(sessionID, turnID, turn.outputMode, provisionalText, localMetadata)
+			provisionalEmitted = true
+		case <-deadlineTimer.C:
+			if localReady {
+				if localEvaluation.isCommand() {
+					finalText := provisionalText
+					if finalText == "" {
+						finalText = strings.TrimSpace(localEvaluation.text)
+					}
+					if finalText == "" {
+						finalText = "Done."
+					}
+					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+				if fallback := localEvaluation.fallbackText(); fallback != "" {
+					commitFinal(fallback, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+			}
+			a.closeAppSession(sessionID)
+			a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+			errText := "assistant request timed out"
+			_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+			a.broadcastChatEvent(sessionID, map[string]interface{}{
+				"type":    "error",
+				"error":   errText,
+				"turn_id": turnID,
+			})
+			return true
+		}
+	}
+}

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -1,0 +1,366 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type mockParallelAppServerState struct {
+	mu          sync.Mutex
+	turnStarts  int
+	writeErrors int
+}
+
+func (s *mockParallelAppServerState) recordTurnStart() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.turnStarts++
+}
+
+func (s *mockParallelAppServerState) recordWriteError() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writeErrors++
+}
+
+func (s *mockParallelAppServerState) snapshot() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.turnStarts, s.writeErrors
+}
+
+func setupMockParallelAppServer(t *testing.T, delay time.Duration, finalMessage string) (*httptest.Server, *mockParallelAppServerState) {
+	t.Helper()
+	state := &mockParallelAppServerState{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("decode app-server message: %v", err)
+			}
+			method := strings.TrimSpace(strFromAny(msg["method"]))
+			switch method {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id":     msg["id"],
+					"result": map[string]interface{}{"userAgent": "parallel-test"},
+				})
+			case "thread/start":
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"thread": map[string]interface{}{"id": "thread-parallel"},
+					},
+				})
+			case "turn/start":
+				state.recordTurnStart()
+				_ = conn.WriteJSON(map[string]interface{}{
+					"id": msg["id"],
+					"result": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-parallel"},
+					},
+				})
+				time.Sleep(delay)
+				if err := conn.WriteJSON(map[string]interface{}{
+					"method": "item/completed",
+					"params": map[string]interface{}{
+						"item": map[string]interface{}{
+							"type": "agentMessage",
+							"text": finalMessage,
+						},
+					},
+				}); err != nil {
+					state.recordWriteError()
+				}
+				if err := conn.WriteJSON(map[string]interface{}{
+					"method": "turn/completed",
+					"params": map[string]interface{}{
+						"turn": map[string]interface{}{"id": "turn-parallel", "status": "completed"},
+					},
+				}); err != nil {
+					state.recordWriteError()
+				}
+				return
+			}
+		}
+	}))
+	return server, state
+}
+
+func newParallelTestApp(t *testing.T, appServerURL string) *App {
+	t.Helper()
+	app, err := New(t.TempDir(), "", "", appServerURL, "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+	return app
+}
+
+func collectWSJSONTypesUntil(t *testing.T, clientConn *websocket.Conn, timeout time.Duration, terminalType string) []map[string]interface{} {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var out []map[string]interface{}
+	for time.Now().Before(deadline) {
+		if err := clientConn.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		mt, data, err := clientConn.ReadMessage()
+		if err != nil {
+			if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
+				continue
+			}
+			t.Fatalf("ReadMessage: %v", err)
+		}
+		if mt != websocket.TextMessage {
+			continue
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			continue
+		}
+		out = append(out, payload)
+		if strings.TrimSpace(strFromAny(payload["type"])) == terminalType {
+			return out
+		}
+	}
+	t.Fatalf("timed out waiting for websocket message type %q", terminalType)
+	return nil
+}
+
+func wsTypes(payloads []map[string]interface{}) []string {
+	out := make([]string, 0, len(payloads))
+	for _, payload := range payloads {
+		out = append(out, strings.TrimSpace(strFromAny(payload["type"])))
+	}
+	return out
+}
+
+func countAssistantMessages(t *testing.T, app *App, sessionID string) int {
+	t.Helper()
+	messages, err := app.store.ListChatMessages(sessionID, 20)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	count := 0
+	for _, msg := range messages {
+		if strings.EqualFold(strings.TrimSpace(msg.Role), "assistant") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn(t *testing.T) {
+	appServer, serverState := setupMockParallelAppServer(t, 200*time.Millisecond, "Spark fallback.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"You are in the active workspace.","confidence":"high"}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "what workspace am I in?", "what workspace am I in?", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "You are in the active workspace." {
+		t.Fatalf("assistant message = %q, want local high-confidence reply", got)
+	}
+	if got := countAssistantMessages(t, app, session.ID); got != 1 {
+		t.Fatalf("assistant message count = %d, want 1", got)
+	}
+
+	payloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
+	types := strings.Join(wsTypes(payloads), ",")
+	if !strings.Contains(types, "turn_claimed") || !strings.Contains(types, "turn_committed") {
+		t.Fatalf("websocket types = %s, want turn_claimed and turn_committed", types)
+	}
+
+	starts, _ := serverState.snapshot()
+	if starts != 1 {
+		t.Fatalf("spark turn starts = %d, want 1", starts)
+	}
+}
+
+func TestRunAssistantTurnParallelPrefersSparkForMediumConfidenceLocalAnswer(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 25*time.Millisecond, "Spark wins the turn.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "how does routing work?", "how does routing work?", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Spark wins the turn." {
+		t.Fatalf("assistant message = %q, want Spark final reply", got)
+	}
+	if got := countAssistantMessages(t, app, session.ID); got != 1 {
+		t.Fatalf("assistant message count = %d, want 1", got)
+	}
+
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Provider != assistantProviderOpenAI {
+		t.Fatalf("provider = %q, want %q", assistant.Provider, assistantProviderOpenAI)
+	}
+}
+
+func TestRunAssistantTurnParallelCommandEmitsProvisionalThenSparkFinal(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 75*time.Millisecond, "Focused on Focused.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"action":"focus_workspace","workspace":"Focused"}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	focus, err := app.store.CreateWorkspace("Focused", t.TempDir())
+	if err != nil {
+		t.Fatalf("CreateWorkspace(Focused): %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "focus on focused", "focus on focused", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	focusedID, err := app.store.FocusedWorkspaceID()
+	if err != nil {
+		t.Fatalf("FocusedWorkspaceID(): %v", err)
+	}
+	if focusedID != focus.ID {
+		t.Fatalf("focused workspace id = %d, want %d", focusedID, focus.ID)
+	}
+	if got := latestAssistantMessage(t, app, session.ID); got != "Focused on Focused." {
+		t.Fatalf("assistant message = %q, want Spark narration", got)
+	}
+	if got := countAssistantMessages(t, app, session.ID); got != 1 {
+		t.Fatalf("assistant message count = %d, want 1", got)
+	}
+
+	payloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
+	types := strings.Join(wsTypes(payloads), ",")
+	if !strings.Contains(types, "system_action") || !strings.Contains(types, "turn_provisional") || !strings.Contains(types, "assistant_message") {
+		t.Fatalf("websocket types = %s, want system_action, turn_provisional, assistant_message", types)
+	}
+}
+
+func TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 650*time.Millisecond, "Spark caught up.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"dialogue"}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "what changed?", "what changed?", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Spark caught up." {
+		t.Fatalf("assistant message = %q, want Spark final reply", got)
+	}
+
+	payloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
+	var provisionalText string
+	for _, payload := range payloads {
+		if strings.TrimSpace(strFromAny(payload["type"])) != "assistant_message" {
+			continue
+		}
+		provisionalText = strings.TrimSpace(strFromAny(payload["message"]))
+	}
+	if provisionalText != "Let me check." {
+		t.Fatalf("provisional assistant_message = %q, want %q", provisionalText, "Let me check.")
+	}
+}

--- a/tests/playwright/provider-attribution.spec.ts
+++ b/tests/playwright/provider-attribution.spec.ts
@@ -58,3 +58,32 @@ test('unknown provider falls back to Assistant', async ({ page }) => {
   const label = page.locator('.chat-message.chat-assistant .chat-assistant-label').last();
   await expect(label).toHaveText('Assistant');
 });
+
+test('provisional assistant message is replaced by final output for the same turn', async ({ page }) => {
+  await waitReady(page);
+
+  await injectChatEvent(page, { type: 'turn_started', turn_id: 'provider-turn-3' });
+  await injectChatEvent(page, {
+    type: 'assistant_message',
+    role: 'assistant',
+    turn_id: 'provider-turn-3',
+    message: 'Let me check.',
+    provider: 'local',
+    provider_label: 'Local',
+    provider_model: 'qwen3.5-9b',
+  });
+  await injectChatEvent(page, {
+    type: 'assistant_output',
+    role: 'assistant',
+    turn_id: 'provider-turn-3',
+    message: 'Final grounded answer.',
+    provider: 'openai',
+    provider_label: 'OpenAI',
+    provider_model: 'gpt-5.3-codex-spark',
+  });
+
+  const rows = page.locator('.chat-message.chat-assistant');
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first().locator('.chat-assistant-content')).toContainText('Final grounded answer.');
+  await expect(rows.first().locator('.chat-assistant-label')).toHaveText('OpenAI');
+});


### PR DESCRIPTION
## Summary
- run local intent evaluation and Spark in parallel for normal assistant turns, with meeting-mode addressedness still suppressing unaddressed turns before Spark starts
- add commitment-stage events and provisional local responses for commands and slow turns, while committing exactly one persisted assistant message per turn
- cover the new chat flow with focused Go tests and a Playwright harness check for provisional-to-final single-row replacement

## Verification
- High-confidence local claim and commitment stages: `go test ./internal/web -run 'TestRunAssistantTurnParallel|TestRunAssistantTurnPersistsLocalAnswer|TestRunAssistantTurnSuppressesUnaddressedMeetingTurn|TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification|TestRunAssistantTurnDialogueIgnoresAddressedFlag'`
  - Evidence: `ok   github.com/krystophny/tabura/internal/web 0.832s`
  - Covered by `TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn`, which verifies a local high-confidence answer claims the turn and persists a single assistant message.
- Spark preference for non-high-confidence local answers: same Go test command above
  - Covered by `TestRunAssistantTurnParallelPrefersSparkForMediumConfidenceLocalAnswer`, which verifies a medium-confidence local answer does not win over Spark and the stored provider is `openai`.
- Provisional local execution for commands and slow-turn acknowledgment: same Go test command above
  - Covered by `TestRunAssistantTurnParallelCommandEmitsProvisionalThenSparkFinal` and `TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment`, which verify provisional `assistant_message` output before final Spark commit.
- UI replacement behavior for provisional -> final output on one chat row: `npx playwright test tests/playwright/provider-attribution.spec.ts`
  - Evidence: `3 passed (1.4s)`
  - Covered by `provisional assistant message is replaced by final output for the same turn`.
- Meeting-mode guard retained: same Go test command above
  - Covered by `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn`, which verifies unaddressed meeting speech still suppresses assistant output.
