### PR TITLE
fix: Add Cerebras inference client as smart-fast middle tier using GP (fixes #537)

### DIFF
--- a/internal/cerebras/client.go
+++ b/internal/cerebras/client.go
@@ -1,0 +1,300 @@
+package cerebras
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultBaseURL         = "https://api.cerebras.ai"
+	DefaultModel           = "gpt-oss-120b"
+	DefaultReasoningEffort = "medium"
+	defaultMaxTokens       = 512
+	defaultBackoff         = 5 * time.Minute
+)
+
+var (
+	ErrQuotaExhausted = errors.New("cerebras quota exhausted")
+	ErrUnavailable    = errors.New("cerebras unavailable")
+)
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type CompletionRequest struct {
+	Messages    []Message
+	MaxTokens   int
+	Temperature float64
+}
+
+type CompletionResponse struct {
+	Text       string
+	Confidence string
+	TokensUsed int
+	Latency    time.Duration
+}
+
+type Client struct {
+	BaseURL          string
+	APIKey           string
+	Model            string
+	ReasoningEffort  string
+	HTTPClient       *http.Client
+	UnavailableAfter time.Duration
+
+	now func() time.Time
+
+	mu               sync.Mutex
+	quotaExhausted   bool
+	exhaustedAt      time.Time
+	unavailableUntil time.Time
+}
+
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		TotalTokens int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+type structuredCompletion struct {
+	Text       string `json:"text"`
+	Confidence string `json:"confidence"`
+}
+
+func NewClient(baseURL, apiKey, model, reasoningEffort string) *Client {
+	return &Client{
+		BaseURL:          strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:           strings.TrimSpace(apiKey),
+		Model:            strings.TrimSpace(model),
+		ReasoningEffort:  normalizeReasoningEffort(reasoningEffort),
+		UnavailableAfter: defaultBackoff,
+		now:              time.Now,
+	}
+}
+
+func (c *Client) IsAvailable() bool {
+	if c == nil {
+		return false
+	}
+	if strings.TrimSpace(c.BaseURL) == "" || strings.TrimSpace(c.APIKey) == "" || strings.TrimSpace(c.Model) == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maybeResetQuotaLocked()
+	if c.quotaExhausted {
+		return false
+	}
+	if !c.unavailableUntil.IsZero() && c.now().Before(c.unavailableUntil) {
+		return false
+	}
+	return true
+}
+
+func (c *Client) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	if c == nil {
+		return nil, ErrUnavailable
+	}
+	if !c.IsAvailable() {
+		if c.isQuotaExhausted() {
+			return nil, ErrQuotaExhausted
+		}
+		return nil, ErrUnavailable
+	}
+	if len(req.Messages) == 0 {
+		return nil, errors.New("cerebras request requires at least one message")
+	}
+
+	requestBody, err := json.Marshal(map[string]any{
+		"model":            c.Model,
+		"messages":         req.Messages,
+		"max_tokens":       resolveMaxTokens(req.MaxTokens),
+		"temperature":      req.Temperature,
+		"reasoning_effort": c.reasoningEffort(),
+		"response_format": map[string]any{
+			"type": "json_object",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	startedAt := time.Now()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		c.markUnavailable()
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		c.markQuotaExhausted()
+		return nil, ErrQuotaExhausted
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		if resp.StatusCode >= http.StatusInternalServerError {
+			c.markUnavailable()
+		}
+		return nil, fmt.Errorf("cerebras completion failed: status %d", resp.StatusCode)
+	}
+
+	var decoded chatCompletionResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, err
+	}
+	if len(decoded.Choices) == 0 {
+		return nil, errors.New("cerebras completion missing choices")
+	}
+	text, confidence := parseStructuredContent(decoded.Choices[0].Message.Content)
+	if text == "" {
+		return nil, errors.New("cerebras completion missing text")
+	}
+	return &CompletionResponse{
+		Text:       text,
+		Confidence: confidence,
+		TokensUsed: decoded.Usage.TotalTokens,
+		Latency:    time.Since(startedAt),
+	}, nil
+}
+
+func (c *Client) reasoningEffort() string {
+	if c == nil {
+		return DefaultReasoningEffort
+	}
+	if effort := normalizeReasoningEffort(c.ReasoningEffort); effort != "" {
+		return effort
+	}
+	return DefaultReasoningEffort
+}
+
+func normalizeReasoningEffort(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "minimal", "low", "medium", "high":
+		return strings.ToLower(strings.TrimSpace(raw))
+	default:
+		return ""
+	}
+}
+
+func parseStructuredContent(raw string) (string, string) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", ""
+	}
+	var parsed structuredCompletion
+	if json.Unmarshal([]byte(trimmed), &parsed) == nil {
+		text := strings.TrimSpace(parsed.Text)
+		if text != "" {
+			return text, normalizeConfidence(parsed.Confidence)
+		}
+	}
+	if start := strings.Index(trimmed, "{"); start >= 0 {
+		if end := strings.LastIndex(trimmed, "}"); end > start {
+			var embedded structuredCompletion
+			if json.Unmarshal([]byte(trimmed[start:end+1]), &embedded) == nil {
+				text := strings.TrimSpace(embedded.Text)
+				if text != "" {
+					return text, normalizeConfidence(embedded.Confidence)
+				}
+			}
+		}
+	}
+	return trimmed, "medium"
+}
+
+func normalizeConfidence(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "high":
+		return "high"
+	case "medium":
+		return "medium"
+	case "low":
+		return "low"
+	default:
+		return ""
+	}
+}
+
+func resolveMaxTokens(raw int) int {
+	if raw > 0 {
+		return raw
+	}
+	return defaultMaxTokens
+}
+
+func (c *Client) markQuotaExhausted() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.quotaExhausted = true
+	c.exhaustedAt = c.now().UTC()
+}
+
+func (c *Client) maybeResetQuotaLocked() {
+	if !c.quotaExhausted {
+		return
+	}
+	now := c.now().UTC()
+	yearA, monthA, dayA := now.Date()
+	yearB, monthB, dayB := c.exhaustedAt.UTC().Date()
+	if yearA == yearB && monthA == monthB && dayA == dayB {
+		return
+	}
+	c.quotaExhausted = false
+	c.exhaustedAt = time.Time{}
+}
+
+func (c *Client) isQuotaExhausted() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maybeResetQuotaLocked()
+	return c.quotaExhausted
+}
+
+func (c *Client) markUnavailable() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	backoff := c.UnavailableAfter
+	if backoff <= 0 {
+		backoff = defaultBackoff
+	}
+	c.unavailableUntil = c.now().Add(backoff)
+}

--- a/internal/cerebras/client_test.go
+++ b/internal/cerebras/client_test.go
@@ -1,0 +1,135 @@
+package cerebras
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientCompleteSendsOpenAICompatibleRequest(t *testing.T) {
+	var seenAuth string
+	var seenPayload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		seenAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&seenPayload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": `{"text":"Cerebras answer.","confidence":"high"}`,
+					},
+				},
+			},
+			"usage": map[string]any{
+				"total_tokens": 77,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-123", DefaultModel, DefaultReasoningEffort)
+	client.HTTPClient = server.Client()
+
+	resp, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{
+			{Role: "system", Content: "Return JSON."},
+			{Role: "user", Content: "How does routing work?"},
+		},
+		MaxTokens:   321,
+		Temperature: 0.1,
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if seenAuth != "Bearer token-123" {
+		t.Fatalf("Authorization = %q, want Bearer token-123", seenAuth)
+	}
+	if got := seenPayload["model"]; got != DefaultModel {
+		t.Fatalf("model = %#v, want %q", got, DefaultModel)
+	}
+	if got := seenPayload["reasoning_effort"]; got != DefaultReasoningEffort {
+		t.Fatalf("reasoning_effort = %#v, want %q", got, DefaultReasoningEffort)
+	}
+	if got := int(seenPayload["max_tokens"].(float64)); got != 321 {
+		t.Fatalf("max_tokens = %d, want 321", got)
+	}
+	if resp.Text != "Cerebras answer." {
+		t.Fatalf("Text = %q, want Cerebras answer.", resp.Text)
+	}
+	if resp.Confidence != "high" {
+		t.Fatalf("Confidence = %q, want high", resp.Confidence)
+	}
+	if resp.TokensUsed != 77 {
+		t.Fatalf("TokensUsed = %d, want 77", resp.TokensUsed)
+	}
+	if resp.Latency < 0 {
+		t.Fatalf("Latency = %v, want >= 0", resp.Latency)
+	}
+}
+
+func TestClientQuotaExhaustionResetsOnNextUTCDay(t *testing.T) {
+	clock := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-123", DefaultModel, DefaultReasoningEffort)
+	client.HTTPClient = server.Client()
+	client.now = func() time.Time { return clock }
+
+	_, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if !errors.Is(err, ErrQuotaExhausted) {
+		t.Fatalf("Complete() error = %v, want ErrQuotaExhausted", err)
+	}
+	if client.IsAvailable() {
+		t.Fatal("IsAvailable() = true, want false after 429")
+	}
+
+	clock = clock.Add(13 * time.Hour)
+	if !client.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true on next UTC day")
+	}
+}
+
+func TestClientBacksOffAfterServerError(t *testing.T) {
+	clock := time.Date(2026, 3, 11, 9, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary failure", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-123", DefaultModel, DefaultReasoningEffort)
+	client.HTTPClient = server.Client()
+	client.now = func() time.Time { return clock }
+
+	_, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want backoff-triggering error")
+	}
+	if client.IsAvailable() {
+		t.Fatal("IsAvailable() = true, want false during backoff")
+	}
+
+	clock = clock.Add(defaultBackoff + time.Second)
+	if !client.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true after backoff")
+	}
+}

--- a/internal/web/chat_turn_cerebras.go
+++ b/internal/web/chat_turn_cerebras.go
@@ -1,0 +1,70 @@
+package web
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/cerebras"
+)
+
+const cerebrasTurnSystemPrompt = `You are Tabura's smart-fast middle-tier assistant.
+Return a compact JSON object with:
+- text: the user-facing answer
+- confidence: one of high, medium, low
+Do not include markdown fences.`
+
+type cerebrasTurnResult struct {
+	text       string
+	confidence string
+	err        error
+	latency    time.Duration
+}
+
+func (r cerebrasTurnResult) canClaim() bool {
+	return strings.TrimSpace(r.text) != "" && r.confidence == "high"
+}
+
+func (r cerebrasTurnResult) canFallback() bool {
+	return strings.TrimSpace(r.text) != ""
+}
+
+func (a *App) cerebrasModelLabel() string {
+	if a == nil || a.cerebrasClient == nil {
+		return cerebras.DefaultModel
+	}
+	if model := strings.TrimSpace(a.cerebrasClient.Model); model != "" {
+		return model
+	}
+	return cerebras.DefaultModel
+}
+
+func buildCerebrasTurnMessages(prompt string) []cerebras.Message {
+	trimmed := strings.TrimSpace(prompt)
+	if trimmed == "" {
+		return nil
+	}
+	return []cerebras.Message{
+		{Role: "system", Content: cerebrasTurnSystemPrompt},
+		{Role: "user", Content: trimmed},
+	}
+}
+
+func (a *App) runCerebrasTurn(ctx context.Context, prompt string) cerebrasTurnResult {
+	if a == nil || a.cerebrasClient == nil {
+		return cerebrasTurnResult{}
+	}
+	resp, err := a.cerebrasClient.Complete(ctx, cerebras.CompletionRequest{
+		Messages:    buildCerebrasTurnMessages(prompt),
+		MaxTokens:   512,
+		Temperature: 0.1,
+	})
+	if err != nil {
+		return cerebrasTurnResult{err: err}
+	}
+	return cerebrasTurnResult{
+		text:       strings.TrimSpace(resp.Text),
+		confidence: strings.TrimSpace(resp.Confidence),
+		latency:    resp.Latency,
+	}
+}

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -179,6 +179,7 @@ func (a *App) runAssistantTurnParallel(
 	go a.watchCanvasFile(ctx, session.ProjectKey)
 
 	localCh := make(chan localTurnEvaluation, 1)
+	cerebrasCh := make(chan cerebrasTurnResult, 1)
 	sparkCh := make(chan sparkTurnResult, 1)
 
 	startSpark := func() {
@@ -186,6 +187,14 @@ func (a *App) runAssistantTurnParallel(
 			sparkCtx, sparkCancel := context.WithCancel(ctx)
 			defer sparkCancel()
 			sparkCh <- a.runSparkTurn(sparkCtx, sessionID, appSess, prompt, profile)
+		}()
+	}
+	startCerebras := func() {
+		if a.cerebrasClient == nil || !a.cerebrasClient.IsAvailable() {
+			return
+		}
+		go func() {
+			cerebrasCh <- a.runCerebrasTurn(ctx, prompt)
 		}()
 	}
 
@@ -209,11 +218,13 @@ func (a *App) runAssistantTurnParallel(
 
 	if precomputedLocal != nil {
 		localCh <- *precomputedLocal
+		startCerebras()
 		startSpark()
 	} else {
 		go func() {
 			localCh <- a.evaluateLocalTurn(context.Background(), sessionID, session, userText, cursorCtx, turn.captureMode)
 		}()
+		startCerebras()
 		startSpark()
 	}
 
@@ -226,6 +237,8 @@ func (a *App) runAssistantTurnParallel(
 	persistedAssistantText := ""
 	localReady := false
 	localEvaluation := localTurnEvaluation{}
+	cerebrasDone := false
+	cerebrasResult := cerebrasTurnResult{}
 	provisionalEmitted := false
 	provisionalText := ""
 	commandPayloadsBroadcast := false
@@ -233,6 +246,7 @@ func (a *App) runAssistantTurnParallel(
 	sparkResult := sparkTurnResult{}
 
 	localMetadata := newAssistantResponseMetadata(assistantProviderLocal, a.localAssistantModelLabel(), 0)
+	cerebrasMetadata := newAssistantResponseMetadata(assistantProviderCerebras, a.cerebrasModelLabel(), 0)
 
 	commitFinal := func(text string, metadata assistantResponseMetadata, source string, threadID string) {
 		a.emitTurnStage(sessionID, "turn_committed", turnID, source, text)
@@ -299,8 +313,17 @@ func (a *App) runAssistantTurnParallel(
 					return true
 				}
 			} else if sparkDone {
+				if cerebrasDone && cerebrasResult.canClaim() {
+					a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, cerebrasResult.text)
+					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+					return true
+				}
 				if sparkResult.err == nil && strings.TrimSpace(sparkResult.text) != "" {
 					commitFinal(sparkResult.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, sparkResult.latency), responseMeta.Provider, sparkResult.threadID)
+					return true
+				}
+				if cerebrasDone && cerebrasResult.canFallback() {
+					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
 					return true
 				}
 				if fallback := evaluation.fallbackText(); fallback != "" {
@@ -308,11 +331,27 @@ func (a *App) runAssistantTurnParallel(
 					return true
 				}
 			}
+		case result := <-cerebrasCh:
+			cerebrasDone = true
+			cerebrasResult = result
+			if !localReady || localEvaluation.isCommand() || localEvaluation.isHighConfidenceLocalAnswer() {
+				continue
+			}
+			if result.canClaim() {
+				a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, result.text)
+				commitFinal(result.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, result.latency), assistantProviderCerebras, "")
+				return true
+			}
 		case result := <-sparkCh:
 			sparkDone = true
 			sparkResult = result
 			if !localReady {
 				continue
+			}
+			if cerebrasDone && cerebrasResult.canClaim() && !localEvaluation.isCommand() {
+				a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, cerebrasResult.text)
+				commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+				return true
 			}
 			if result.err == nil && strings.TrimSpace(result.text) != "" {
 				commitFinal(result.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, result.latency), responseMeta.Provider, result.threadID)
@@ -325,6 +364,10 @@ func (a *App) runAssistantTurnParallel(
 						finalText = "Done."
 					}
 					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+				if cerebrasDone && cerebrasResult.canFallback() {
+					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
 					return true
 				}
 				if fallback := localEvaluation.fallbackText(); fallback != "" {
@@ -369,6 +412,10 @@ func (a *App) runAssistantTurnParallel(
 						finalText = "Done."
 					}
 					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+				if cerebrasDone && cerebrasResult.canFallback() {
+					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
 					return true
 				}
 				if fallback := localEvaluation.fallbackText(); fallback != "" {

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/krystophny/tabura/internal/cerebras"
 )
 
 type mockParallelAppServerState struct {
@@ -104,6 +105,50 @@ func setupMockParallelAppServer(t *testing.T, delay time.Duration, finalMessage 
 		}
 	}))
 	return server, state
+}
+
+func setupMockCerebrasServer(t *testing.T, status int, delay time.Duration, content string) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			t.Fatalf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := strings.TrimSpace(r.Header.Get("Authorization")); got != "Bearer token-cerebras" {
+			t.Fatalf("Authorization = %q, want Bearer token-cerebras", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if got := strings.TrimSpace(strFromAny(payload["reasoning_effort"])); got != cerebras.DefaultReasoningEffort {
+			t.Fatalf("reasoning_effort = %q, want %q", got, cerebras.DefaultReasoningEffort)
+		}
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
+					{
+						"message": map[string]any{
+							"content": content,
+						},
+					},
+				},
+				"usage": map[string]any{
+					"total_tokens": 64,
+				},
+			})
+			return
+		}
+		_, _ = w.Write([]byte("upstream error"))
+	}))
+	return server, &requests
 }
 
 func newParallelTestApp(t *testing.T, appServerURL string) *App {
@@ -362,5 +407,109 @@ func TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment(t *testing.T) {
 	}
 	if provisionalText != "Let me check." {
 		t.Fatalf("provisional assistant_message = %q, want %q", provisionalText, "Let me check.")
+	}
+}
+
+func TestRunAssistantTurnParallelCerebrasClaimsTurn(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 250*time.Millisecond, "Spark fallback.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	cerebrasServer, requests := setupMockCerebrasServer(t, http.StatusOK, 20*time.Millisecond, `{"text":"Cerebras wins the turn.","confidence":"high"}`)
+	defer cerebrasServer.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+	app.cerebrasClient = cerebras.NewClient(cerebrasServer.URL, "token-cerebras", cerebras.DefaultModel, cerebras.DefaultReasoningEffort)
+	app.cerebrasClient.HTTPClient = cerebrasServer.Client()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "explain the routing policy", "explain the routing policy", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Cerebras wins the turn." {
+		t.Fatalf("assistant message = %q, want Cerebras final reply", got)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Provider != assistantProviderCerebras {
+		t.Fatalf("provider = %q, want %q", assistant.Provider, assistantProviderCerebras)
+	}
+	if assistant.ProviderModel != cerebras.DefaultModel {
+		t.Fatalf("provider_model = %q, want %q", assistant.ProviderModel, cerebras.DefaultModel)
+	}
+	if *requests != 1 {
+		t.Fatalf("cerebras requests = %d, want 1", *requests)
+	}
+}
+
+func TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 25*time.Millisecond, "Spark handles the turn.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	cerebrasServer, requests := setupMockCerebrasServer(t, http.StatusTooManyRequests, 0, "")
+	defer cerebrasServer.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+	app.cerebrasClient = cerebras.NewClient(cerebrasServer.URL, "token-cerebras", cerebras.DefaultModel, cerebras.DefaultReasoningEffort)
+	app.cerebrasClient.HTTPClient = cerebrasServer.Client()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "first turn", "first turn", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+	if app.cerebrasClient.IsAvailable() {
+		t.Fatal("cerebrasClient.IsAvailable() = true, want false after 429")
+	}
+	app.closeAppSession(session.ID)
+
+	if _, err := app.store.AddChatMessage(session.ID, "user", "second turn", "second turn", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Spark handles the turn." {
+		t.Fatalf("assistant message = %q, want Spark final reply", got)
+	}
+	if *requests != 1 {
+		t.Fatalf("cerebras requests = %d, want 1 after quota disable", *requests)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 20)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	for _, message := range messages {
+		if strings.EqualFold(strings.TrimSpace(message.Role), "system") && strings.Contains(strings.ToLower(message.ContentPlain), "cerebras") {
+			t.Fatalf("unexpected user-visible Cerebras error: %q", message.ContentPlain)
+		}
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/appserver"
 	tabcalendar "github.com/krystophny/tabura/internal/calendar"
+	"github.com/krystophny/tabura/internal/cerebras"
 	"github.com/krystophny/tabura/internal/email"
 	"github.com/krystophny/tabura/internal/extensions"
 	"github.com/krystophny/tabura/internal/ics"
@@ -37,6 +38,7 @@ const (
 	DefaultSTTFallbackLanguage  = "en"
 	DefaultSTTPreVADThresholdDB = -58.0
 	DefaultSTTPreVADMinSpeechMS = 120
+	DefaultCerebrasSecretFile   = "cerebras-api-key"
 	SessionCookie               = "tabura_session"
 	cookieMaxAgeSec             = 60 * 60 * 24 * 365
 	DaemonPort                  = 9420
@@ -64,6 +66,8 @@ type App struct {
 	appServerURL                  string
 	appServerModel                string
 	appServerSparkReasoningEffort string
+	cerebrasClient                *cerebras.Client
+	cerebrasReasoningEffort       string
 	intentLLMURL                  string
 	intentLLMModel                string
 	intentLLMProfile              string
@@ -174,6 +178,33 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	} else if resolvedIntentLLMURL == "" {
 		resolvedIntentLLMURL = DefaultIntentLLMURL
 	}
+	resolvedCerebrasURL := strings.TrimSpace(os.Getenv("TABURA_CEREBRAS_URL"))
+	if strings.EqualFold(resolvedCerebrasURL, "off") {
+		resolvedCerebrasURL = ""
+	} else if resolvedCerebrasURL == "" {
+		resolvedCerebrasURL = cerebras.DefaultBaseURL
+	}
+	resolvedCerebrasAPIKey := strings.TrimSpace(os.Getenv("TABURA_CEREBRAS_API_KEY"))
+	if resolvedCerebrasAPIKey == "" {
+		resolvedCerebrasAPIKey = readOptionalSecretFile(defaultSecretPath(DefaultCerebrasSecretFile))
+	}
+	resolvedCerebrasModel := strings.TrimSpace(os.Getenv("TABURA_CEREBRAS_MODEL"))
+	if resolvedCerebrasModel == "" {
+		resolvedCerebrasModel = cerebras.DefaultModel
+	}
+	resolvedCerebrasReasoningEffort := strings.TrimSpace(os.Getenv("TABURA_CEREBRAS_REASONING_EFFORT"))
+	if resolvedCerebrasReasoningEffort == "" {
+		resolvedCerebrasReasoningEffort = cerebras.DefaultReasoningEffort
+	}
+	var cerebrasClient *cerebras.Client
+	if resolvedCerebrasURL != "" && resolvedCerebrasAPIKey != "" {
+		cerebrasClient = cerebras.NewClient(
+			resolvedCerebrasURL,
+			resolvedCerebrasAPIKey,
+			resolvedCerebrasModel,
+			resolvedCerebrasReasoningEffort,
+		)
+	}
 	resolvedIntentLLMModel := strings.TrimSpace(os.Getenv("TABURA_INTENT_LLM_MODEL"))
 	if strings.EqualFold(resolvedIntentLLMModel, "off") {
 		resolvedIntentLLMModel = ""
@@ -262,6 +293,8 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		appServerURL:                  appServerURL,
 		appServerModel:                resolvedModel,
 		appServerSparkReasoningEffort: resolvedSparkReasoningEffort,
+		cerebrasClient:                cerebrasClient,
+		cerebrasReasoningEffort:       resolvedCerebrasReasoningEffort,
 		intentLLMURL:                  resolvedIntentLLMURL,
 		intentLLMModel:                resolvedIntentLLMModel,
 		intentLLMProfile:              resolvedIntentLLMProfile,
@@ -353,6 +386,25 @@ func persistedDefaultChatModel(s *store.Store) string {
 
 func randomToken() string {
 	return strconv.FormatInt(time.Now().UnixNano(), 16) + "-" + strconv.FormatInt(time.Now().Unix()%99991, 16)
+}
+
+func defaultSecretPath(fileName string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "tabura", "secrets", fileName)
+}
+
+func readOptionalSecretFile(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func isHTTPS(r *http.Request) bool {

--- a/internal/web/server_cerebras_test.go
+++ b/internal/web/server_cerebras_test.go
@@ -1,0 +1,84 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/cerebras"
+)
+
+func TestNewLoadsCerebrasAPIKeyFromSecretFile(t *testing.T) {
+	home := t.TempDir()
+	secretDir := filepath.Join(home, ".config", "tabura", "secrets")
+	if err := os.MkdirAll(secretDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(secretDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secretDir, DefaultCerebrasSecretFile), []byte("secret-from-file\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(secret): %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("TABURA_CEREBRAS_URL", "https://api.cerebras.example")
+	t.Setenv("TABURA_CEREBRAS_API_KEY", "")
+	t.Setenv("TABURA_CEREBRAS_MODEL", "gpt-oss-120b")
+	t.Setenv("TABURA_CEREBRAS_REASONING_EFFORT", "medium")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.cerebrasClient == nil {
+		t.Fatal("cerebrasClient = nil, want configured client")
+	}
+	if got := app.cerebrasClient.APIKey; got != "secret-from-file" {
+		t.Fatalf("APIKey = %q, want secret-from-file", got)
+	}
+	if got := app.cerebrasClient.Model; got != cerebras.DefaultModel {
+		t.Fatalf("Model = %q, want %q", got, cerebras.DefaultModel)
+	}
+}
+
+func TestNewLoadsCerebrasAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("TABURA_CEREBRAS_URL", "https://api.cerebras.example")
+	t.Setenv("TABURA_CEREBRAS_API_KEY", "secret-from-env")
+	t.Setenv("TABURA_CEREBRAS_MODEL", "gpt-oss-120b")
+	t.Setenv("TABURA_CEREBRAS_REASONING_EFFORT", "medium")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.cerebrasClient == nil {
+		t.Fatal("cerebrasClient = nil, want configured client")
+	}
+	if got := app.cerebrasClient.APIKey; got != "secret-from-env" {
+		t.Fatalf("APIKey = %q, want secret-from-env", got)
+	}
+}
+
+func TestNewDisablesCerebrasWhenURLIsOff(t *testing.T) {
+	t.Setenv("TABURA_CEREBRAS_URL", "off")
+	t.Setenv("TABURA_CEREBRAS_API_KEY", "ignored")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.cerebrasClient != nil {
+		t.Fatal("cerebrasClient != nil, want nil when TABURA_CEREBRAS_URL=off")
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/cerebras` as an OpenAI-compatible middle-tier client with quota rollover and temporary backoff
- wire Cerebras into parallel assistant turns with provider metadata and high-confidence claiming
- load Cerebras config from env or `~/.config/tabura/secrets/cerebras-api-key` and cover the new paths with focused tests

## Verification
- Requirement: Cerebras client sends OpenAI-compatible requests to the Cerebras API.
  Evidence: `TestClientCompleteSendsOpenAICompatibleRequest` validates `POST /v1/chat/completions`, bearer auth, `model=gpt-oss-120b`, `reasoning_effort=medium`, and parsed `text`/`confidence`.
- Requirement: API key configured via `TABURA_CEREBRAS_API_KEY`.
  Evidence: `TestNewLoadsCerebrasAPIKeyFromEnv`.
- Requirement: local config can source `/home/ert/.config/tabura/secrets/cerebras-api-key` without storing the secret in repo files.
  Evidence: `TestNewLoadsCerebrasAPIKeyFromSecretFile`.
- Requirement: Cerebras races alongside Local and Spark in parallel turn with `gpt-oss-120b` and `reasoning_effort=medium`.
  Evidence: `internal/web/chat_turn_parallel.go` starts Cerebras beside local + Spark; `TestRunAssistantTurnParallelCerebrasClaimsTurn` asserts the Cerebras request is issued and committed with provider `cerebras` / model `gpt-oss-120b`.
- Requirement: Cerebras can claim turn with high-confidence response while running reasoning at `medium`.
  Evidence: `TestRunAssistantTurnParallelCerebrasClaimsTurn`.
- Requirement: quota exhaustion silently disables Cerebras for the rest of the day.
  Evidence: `TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay` verifies only one Cerebras request is made across two turns and no user-visible Cerebras error is persisted.
- Requirement: automatic re-enable on UTC day rollover.
  Evidence: `TestClientQuotaExhaustionResetsOnNextUTCDay`.
- Requirement: `TABURA_CEREBRAS_URL=off` disables the tier entirely.
  Evidence: `TestNewDisablesCerebrasWhenURLIsOff`.
- Requirement: Spark path runs with `reasoning_effort=high`.
  Evidence: existing Spark routing remains in `internal/web/routing_policy.go`; this change does not alter Spark effort selection, and the full `go test ./...` pass kept that path green.
- Requirement: Local tier remains reasoning-off for fast control decisions.
  Evidence: existing local intent LLM request still sets `chat_template_kwargs.enable_thinking=false` in `internal/web/chat_intent_llm.go`; this change only adds the Cerebras branch.
- Requirement: API errors handled gracefully (backoff, no user-visible errors).
  Evidence: `TestClientBacksOffAfterServerError` covers backoff; `TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay` covers the no-user-visible-error path.
- Requirement: `go test ./...` passes.
  Evidence:
  - Command: `go test ./... 2>&1 | tee /tmp/tabura-issue-537-full.log`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/cerebras 0.007s`
  - Output excerpt: `ok   github.com/krystophny/tabura/internal/web 10.891s`
  - Output excerpt: `ok   github.com/krystophny/tabura/tests/services (cached)`
