### PR TITLE
fix: Add Qwen acknowledgment emission for latency masking (fixes #532)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -32,6 +32,7 @@ type intentPlanClassification struct {
 	Actions     []*SystemAction
 	Addressed   *bool
 	LocalAnswer *intentLocalAnswer
+	Ack         string
 }
 
 type localTurnEvaluation struct {
@@ -39,6 +40,7 @@ type localTurnEvaluation struct {
 	text                  string
 	payloads              []map[string]interface{}
 	localAnswerConfidence string
+	ack                   string
 }
 
 func (e localTurnEvaluation) suppressesResponse() bool {
@@ -562,7 +564,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	intentText := trimmedText
 	livePolicy := a.LivePolicy()
 	assumeAddressed := livePolicy.Config().AssumeAddressed
-	tryExecutePlan := func(actions []*SystemAction) localTurnEvaluation {
+	tryExecutePlan := func(actions []*SystemAction, ack string) localTurnEvaluation {
 		enforced := enforceRoutingPolicy(trimmedText, actions)
 		if len(enforced) == 0 {
 			return localTurnEvaluation{}
@@ -575,6 +577,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 			handled:  true,
 			text:     message,
 			payloads: payloads,
+			ack:      strings.TrimSpace(ack),
 		}
 	}
 
@@ -607,6 +610,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	if a != nil && a.calendarNow != nil {
 		now = a.calendarNow().UTC()
 	}
+	pendingAck := ""
 	tryDeterministicPlan := func() (string, []map[string]interface{}, bool) {
 		match := tryDeterministicFastPath(trimmedText, deterministicFastPathContext{
 			Now:         now,
@@ -631,6 +635,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	if strings.TrimSpace(a.intentLLMURL) != "" {
 		classification, llmErr := a.classifyIntentPlanWithLLMResultForTurn(ctx, sessionID, session, intentText)
 		if llmErr == nil {
+			pendingAck = classification.Ack
 			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed); known && !addressed {
 				return localTurnEvaluation{
 					handled: true,
@@ -646,9 +651,10 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 					handled:               true,
 					text:                  classification.LocalAnswer.Text,
 					localAnswerConfidence: classification.LocalAnswer.Confidence,
+					ack:                   classification.Ack,
 				}
 			}
-			if evaluation := tryExecutePlan(classification.Actions); evaluation.handled {
+			if evaluation := tryExecutePlan(classification.Actions, classification.Ack); evaluation.handled {
 				return evaluation
 			}
 			if !assumeAddressed {
@@ -663,7 +669,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 		}
 		if requestRequiresOpenCanvasAction(intentText) {
 			if fallbackPlan := buildOpenCanvasFallbackPlan(intentText); len(fallbackPlan) > 0 {
-				if evaluation := tryExecutePlan(fallbackPlan); evaluation.handled {
+				if evaluation := tryExecutePlan(fallbackPlan, pendingAck); evaluation.handled {
 					return evaluation
 				}
 			}
@@ -692,7 +698,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 			}
 		}
 	}
-	return localTurnEvaluation{}
+	return localTurnEvaluation{ack: pendingAck}
 }
 
 func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool) (bool, bool) {

--- a/internal/web/chat_intent_addressed_test.go
+++ b/internal/web/chat_intent_addressed_test.go
@@ -47,6 +47,16 @@ func TestParseIntentPlanClassificationReadsLocalAnswer(t *testing.T) {
 	}
 }
 
+func TestParseIntentPlanClassificationReadsAckField(t *testing.T) {
+	classification, err := parseIntentPlanClassification(`{"kind":"dialogue","ack":"  Checking   now.  "}`)
+	if err != nil {
+		t.Fatalf("parseIntentPlanClassification returned error: %v", err)
+	}
+	if classification.Ack != "Checking now." {
+		t.Fatalf("ack = %q, want %q", classification.Ack, "Checking now.")
+	}
+}
+
 func TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness(t *testing.T) {
 	var systemPrompt string
 	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/chat_intent_layers.go
+++ b/internal/web/chat_intent_layers.go
@@ -124,6 +124,7 @@ Return exactly one of:
 - {"kind":"local_answer","text":"<short reply>","confidence":"high|medium|low"}
 - {"actions":[{"action":"shell",...},{"action":"open_file_canvas","path":"..."}]}
 - {"kind":"dialogue"}
+Optional top-level field: "ack":"<short acknowledgment>" for dialogue or command turns that may need a brief provisional reply while a richer response is still running.
 Use {"kind":"dialogue"} unless the user clearly requests a system command or canonical artifact action.
 Use {"kind":"local_answer"} for short complete replies you can answer from the provided runtime context without tools: greetings, acknowledgments, brief social turns, and simple workspace/status questions.
 Local answers must stay within 1-3 sentences.

--- a/internal/web/chat_intent_llm.go
+++ b/internal/web/chat_intent_llm.go
@@ -32,6 +32,14 @@ type intentLocalAnswer struct {
 	Confidence string
 }
 
+func normalizeIntentAck(raw string) string {
+	clean := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	if clean == "" {
+		return ""
+	}
+	return clean
+}
+
 func parseIntentLLMProfileOptions(raw string) []string {
 	clean := strings.TrimSpace(raw)
 	if clean == "" {
@@ -131,6 +139,7 @@ func parseIntentPlanClassification(raw string) (intentPlanClassification, error)
 		Actions: collectSystemActionsFromDecoded(decoded),
 	}
 	if obj, ok := decoded.(map[string]interface{}); ok {
+		result.Ack = normalizeIntentAck(fmt.Sprint(obj["ack"]))
 		if normalizeIntentResponseKind(fmt.Sprint(obj["kind"])) == intentKindLocalAnswer {
 			if text := strings.TrimSpace(fmt.Sprint(obj["text"])); text != "" {
 				result.LocalAnswer = &intentLocalAnswer{

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -61,13 +61,36 @@ func (a *App) emitParallelProvisional(sessionID, turnID, outputMode, text string
 	a.broadcastChatEvent(sessionID, payload)
 }
 
-func defaultParallelTurnAck(userText string) string {
+func looksLikeParallelTurnStatusQuery(lower string) bool {
+	switch {
+	case strings.HasPrefix(lower, "status"),
+		strings.HasPrefix(lower, "what's running"),
+		strings.HasPrefix(lower, "whats running"),
+		strings.HasPrefix(lower, "what is running"),
+		strings.HasPrefix(lower, "are you"),
+		strings.HasPrefix(lower, "can you"),
+		strings.HasPrefix(lower, "did you"),
+		strings.HasPrefix(lower, "have you"):
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultParallelTurnAck(userText string, evaluation localTurnEvaluation) string {
+	if ack := strings.TrimSpace(evaluation.ack); ack != "" {
+		return ack
+	}
 	trimmed := strings.TrimSpace(userText)
 	if trimmed == "" {
 		return "One moment."
 	}
 	lower := strings.ToLower(trimmed)
 	switch {
+	case evaluation.isCommand():
+		return "On it."
+	case looksLikeParallelTurnStatusQuery(lower):
+		return "One moment."
 	case strings.HasPrefix(lower, "what "), strings.HasPrefix(lower, "how "), strings.HasPrefix(lower, "why "):
 		return "Let me check."
 	case strings.HasPrefix(lower, "please "), strings.HasPrefix(lower, "run "), strings.HasPrefix(lower, "open "):
@@ -75,6 +98,26 @@ func defaultParallelTurnAck(userText string) string {
 	default:
 		return "Let me think."
 	}
+}
+
+func commandParallelTurnProvisionalText(userText string, evaluation localTurnEvaluation) string {
+	if ack := strings.TrimSpace(evaluation.ack); ack != "" {
+		return ack
+	}
+	if text := strings.TrimSpace(evaluation.text); text != "" {
+		return text
+	}
+	return defaultParallelTurnAck(userText, evaluation)
+}
+
+func finalParallelCommandText(evaluation localTurnEvaluation, provisionalText string) string {
+	if text := evaluation.fallbackText(); text != "" {
+		return text
+	}
+	if text := strings.TrimSpace(provisionalText); text != "" {
+		return text
+	}
+	return "Done."
 }
 
 func (a *App) runSparkTurn(ctx context.Context, sessionID string, appSess *appserver.Session, prompt string, profile appServerModelProfile) sparkTurnResult {
@@ -280,10 +323,7 @@ func (a *App) runAssistantTurnParallel(
 				return true
 			}
 			if evaluation.isCommand() {
-				nextText := strings.TrimSpace(evaluation.text)
-				if nextText == "" {
-					nextText = "Done."
-				}
+				nextText := commandParallelTurnProvisionalText(userText, evaluation)
 				previousText := provisionalText
 				provisionalText = nextText
 				if !commandPayloadsBroadcast {
@@ -309,7 +349,7 @@ func (a *App) runAssistantTurnParallel(
 					provisionalEmitted = true
 				}
 				if sparkDone && (sparkResult.err != nil || strings.TrimSpace(sparkResult.text) == "") {
-					commitFinal(provisionalText, localMetadata, assistantProviderLocal, "")
+					commitFinal(finalParallelCommandText(evaluation, provisionalText), localMetadata, assistantProviderLocal, "")
 					return true
 				}
 			} else if sparkDone {
@@ -359,11 +399,7 @@ func (a *App) runAssistantTurnParallel(
 			}
 			if localReady {
 				if localEvaluation.isCommand() {
-					finalText := provisionalText
-					if finalText == "" {
-						finalText = "Done."
-					}
-					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					commitFinal(finalParallelCommandText(localEvaluation, provisionalText), localMetadata, assistantProviderLocal, "")
 					return true
 				}
 				if cerebrasDone && cerebrasResult.canFallback() {
@@ -397,21 +433,14 @@ func (a *App) runAssistantTurnParallel(
 			if localReady && (localEvaluation.isHighConfidenceLocalAnswer() || localEvaluation.isCommand()) {
 				continue
 			}
-			provisionalText = defaultParallelTurnAck(userText)
+			provisionalText = defaultParallelTurnAck(userText, localEvaluation)
 			a.emitTurnStage(sessionID, "turn_provisional", turnID, assistantProviderLocal, provisionalText)
 			a.emitParallelProvisional(sessionID, turnID, turn.outputMode, provisionalText, localMetadata)
 			provisionalEmitted = true
 		case <-deadlineTimer.C:
 			if localReady {
 				if localEvaluation.isCommand() {
-					finalText := provisionalText
-					if finalText == "" {
-						finalText = strings.TrimSpace(localEvaluation.text)
-					}
-					if finalText == "" {
-						finalText = "Done."
-					}
-					commitFinal(finalText, localMetadata, assistantProviderLocal, "")
+					commitFinal(finalParallelCommandText(localEvaluation, provisionalText), localMetadata, assistantProviderLocal, "")
 					return true
 				}
 				if cerebrasDone && cerebrasResult.canFallback() {

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -217,6 +217,30 @@ func countAssistantMessages(t *testing.T, app *App, sessionID string) int {
 	return count
 }
 
+func TestFinalParallelCommandTextPrefersLocalFallbackOverAck(t *testing.T) {
+	evaluation := localTurnEvaluation{
+		handled:  true,
+		text:     "Focused on Focused.",
+		payloads: []map[string]interface{}{{"type": "focus_workspace"}},
+		ack:      "Switching to Focused.",
+	}
+	if got := finalParallelCommandText(evaluation, evaluation.ack); got != evaluation.text {
+		t.Fatalf("finalParallelCommandText() = %q, want %q", got, evaluation.text)
+	}
+}
+
+func TestCommandParallelTurnProvisionalTextPrefersExplicitAck(t *testing.T) {
+	evaluation := localTurnEvaluation{
+		handled:  true,
+		text:     "Focused on Focused.",
+		payloads: []map[string]interface{}{{"type": "focus_workspace"}},
+		ack:      "Switching to Focused.",
+	}
+	if got := commandParallelTurnProvisionalText("focus on focused", evaluation); got != evaluation.ack {
+		t.Fatalf("commandParallelTurnProvisionalText() = %q, want %q", got, evaluation.ack)
+	}
+}
+
 func TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn(t *testing.T) {
 	appServer, serverState := setupMockParallelAppServer(t, 200*time.Millisecond, "Spark fallback.")
 	defer appServer.Close()
@@ -368,7 +392,7 @@ func TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment(t *testing.T) {
 	defer appServer.Close()
 	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
 
-	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"dialogue"}`)
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"dialogue","ack":"Checking."}`)
 	defer llm.Close()
 
 	app := newParallelTestApp(t, wsURL)
@@ -405,8 +429,54 @@ func TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment(t *testing.T) {
 		}
 		provisionalText = strings.TrimSpace(strFromAny(payload["message"]))
 	}
-	if provisionalText != "Let me check." {
-		t.Fatalf("provisional assistant_message = %q, want %q", provisionalText, "Let me check.")
+	if provisionalText != "Checking." {
+		t.Fatalf("provisional assistant_message = %q, want %q", provisionalText, "Checking.")
+	}
+	if got := countAssistantMessages(t, app, session.ID); got != 1 {
+		t.Fatalf("assistant message count = %d, want 1", got)
+	}
+}
+
+func TestRunAssistantTurnParallelFastSparkSkipsAcknowledgment(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 25*time.Millisecond, "Spark wins quickly.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"dialogue","ack":"Checking."}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "what changed?", "what changed?", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Spark wins quickly." {
+		t.Fatalf("assistant message = %q, want Spark final reply", got)
+	}
+
+	payloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
+	for _, payload := range payloads {
+		if strings.TrimSpace(strFromAny(payload["type"])) != "assistant_message" {
+			continue
+		}
+		t.Fatalf("unexpected provisional assistant_message payload: %#v", payload)
 	}
 }
 


### PR DESCRIPTION
## Summary
- carry optional top-level `ack` text through local intent classification
- prefer explicit provisional acknowledgments in the parallel-turn path while keeping the final local fallback text separate
- cover slow-Spark ack emission, fast-Spark suppression, and provisional/final precedence with focused tests

## Verification
- Requirement: acknowledgment emitted within ~500ms when Spark is slow, and the stored message remains the final committed text.
  Evidence: `go test ./internal/web -run 'Test(ParseIntentPlanClassificationReadsAckField|FinalParallelCommandTextPrefersLocalFallbackOverAck|CommandParallelTurnProvisionalTextPrefersExplicitAck|RunAssistantTurnParallelSlowSparkEmitsAcknowledgment|RunAssistantTurnParallelFastSparkSkipsAcknowledgment)$'`
  Output excerpt: `/tmp/test.log` contains `ok   github.com/krystophny/tabura/internal/web	0.718s`.
- Requirement: no acknowledgment when Spark returns fast enough.
  Evidence: same focused `go test` command above includes `TestRunAssistantTurnParallelFastSparkSkipsAcknowledgment`.
  Output excerpt: `/tmp/test.log` contains `ok   github.com/krystophny/tabura/internal/web	0.718s`.
- Requirement: contextual/provisional ack selection can come from the local router, and command fallback text does not regress to the ack.
  Evidence: same focused `go test` command above includes `TestParseIntentPlanClassificationReadsAckField`, `TestCommandParallelTurnProvisionalTextPrefersExplicitAck`, and `TestFinalParallelCommandTextPrefersLocalFallbackOverAck`.
  Output excerpt: `/tmp/test.log` contains `ok   github.com/krystophny/tabura/internal/web	0.718s`.
- Requirement: final response replaces the provisional ack in chat UI.
  Evidence: `./scripts/playwright.sh tests/playwright/provider-attribution.spec.ts tests/playwright/canvas.spec.ts --grep 'provisional assistant message is replaced by final output for the same turn|voice TTS speaks first response immediately and final supersedes'`
  Output excerpt: `/tmp/test.log` contains `✓  1 [chromium] › tests/playwright/provider-attribution.spec.ts:62:5 › provisional assistant message is replaced by final output for the same turn (1.2s)`.
- Requirement: ack is spoken via TTS and the final response follows naturally.
  Evidence: same Playwright command above.
  Output excerpt: `/tmp/test.log` contains `✓  2 [chromium] › tests/playwright/canvas.spec.ts:673:7 › canvas - TTS voice output › voice TTS speaks first response immediately and final supersedes (1.8s)` and `2 passed (2.8s)`.
