### PR TITLE
fix: Epic: Ensure Codex app-server always operates within an active w (fixes #515)

### DIFF
--- a/internal/store/store_chat.go
+++ b/internal/store/store_chat.go
@@ -78,15 +78,6 @@ func (s *Store) resolveChatSessionWorkspace(ref string) (Workspace, error) {
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return Workspace{}, err
 	}
-	if activeProjectID, err := s.ActiveProjectID(); err != nil {
-		return Workspace{}, err
-	} else if strings.TrimSpace(activeProjectID) != "" {
-		project, err := s.GetProject(activeProjectID)
-		if err != nil {
-			return Workspace{}, err
-		}
-		return s.workspaceForProject(project)
-	}
 	return Workspace{}, sql.ErrNoRows
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -337,13 +337,17 @@ func TestStoreChatSessionMessageAndThreading(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateProject() error: %v", err)
 	}
-	if err := s.SetActiveProjectID(project.ID); err != nil {
-		t.Fatalf("SetActiveProjectID() error: %v", err)
+	workspace, err := s.workspaceForProject(project)
+	if err != nil {
+		t.Fatalf("workspaceForProject() error: %v", err)
+	}
+	if err := s.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
 	}
 
 	session, err := s.GetOrCreateChatSession("  ")
 	if err != nil {
-		t.Fatalf("GetOrCreateChatSession(active project) error: %v", err)
+		t.Fatalf("GetOrCreateChatSession(active workspace) error: %v", err)
 	}
 	if session.ProjectKey != project.ProjectKey {
 		t.Fatalf("project key = %q, want %q", session.ProjectKey, project.ProjectKey)
@@ -558,6 +562,25 @@ func TestStoreChatSessionsKeyToWorkspace(t *testing.T) {
 	}
 	if sessionCount != 1 {
 		t.Fatalf("chat session count for workspace %d = %d, want 1", session.WorkspaceID, sessionCount)
+	}
+}
+
+func TestGetOrCreateChatSessionBlankRefRequiresActiveWorkspace(t *testing.T) {
+	s := newTestStore(t)
+	root := filepath.Join(t.TempDir(), "workspace-default")
+	project, err := s.CreateProject("Default", root, root, "managed", "", "", true)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if err := s.SetActiveProjectID(project.ID); err != nil {
+		t.Fatalf("SetActiveProjectID() error: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE workspaces SET is_active = 0`); err != nil {
+		t.Fatalf("clear active workspace: %v", err)
+	}
+
+	if _, err := s.GetOrCreateChatSession("  "); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetOrCreateChatSession(blank) error = %v, want sql.ErrNoRows", err)
 	}
 }
 

--- a/internal/web/chat_queue.go
+++ b/internal/web/chat_queue.go
@@ -484,53 +484,54 @@ type chatTurnOptions struct {
 	cursor      *chatCursorContext
 }
 
-func (a *App) getOrCreateAppSession(sessionID string, cwd string, profile appServerModelProfile) (*appserver.Session, bool, error) {
-	resolvedCWD, err := a.effectiveWorkspaceDirForChatSessionID(sessionID)
+func (a *App) getOrCreateAppSession(sessionID string, cwd string, profile appServerModelProfile) (*appserver.Session, string, bool, error) {
+	bindingSession, workspace, err := a.appSessionBindingForChatSessionID(sessionID)
 	if err != nil {
-		return nil, false, err
+		return nil, "", false, err
 	}
-	cwd = resolvedCWD
+	cwd = strings.TrimSpace(workspace.DirPath)
+	appSessionKey := bindingSession.ID
 	a.mu.Lock()
-	s := a.chatAppSessions[sessionID]
+	s := a.chatAppSessions[appSessionKey]
 	a.mu.Unlock()
 	if s != nil && s.IsOpen() && s.MatchesConfig(cwd, profile.Model, profile.ThreadParams) {
-		return s, true, nil
+		return s, appSessionKey, true, nil
 	}
 	if s != nil {
 		_ = s.Close()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	var existingThreadID string
-	if sess, err := a.store.GetChatSession(sessionID); err == nil {
-		existingThreadID = strings.TrimSpace(sess.AppThreadID)
-	}
+	existingThreadID := strings.TrimSpace(bindingSession.AppThreadID)
 	var newSess *appserver.Session
 	var resumed bool
 	if existingThreadID != "" {
 		rs, ok, err := a.appServerClient.ResumeSessionWithParams(ctx, cwd, profile.Model, profile.ThreadParams, existingThreadID)
 		if err != nil {
-			return nil, false, err
+			return nil, "", false, err
 		}
 		newSess = rs
 		resumed = ok
 	} else {
 		rs, err := a.appServerClient.OpenSessionWithParams(ctx, cwd, profile.Model, profile.ThreadParams)
 		if err != nil {
-			return nil, false, err
+			return nil, "", false, err
 		}
 		newSess = rs
 	}
 	a.mu.Lock()
-	if old := a.chatAppSessions[sessionID]; old != nil {
+	if old := a.chatAppSessions[appSessionKey]; old != nil {
 		_ = old.Close()
 	}
-	a.chatAppSessions[sessionID] = newSess
+	a.chatAppSessions[appSessionKey] = newSess
 	a.mu.Unlock()
-	return newSess, resumed, nil
+	return newSess, appSessionKey, resumed, nil
 }
 
 func (a *App) closeAppSession(sessionID string) {
+	if bindingSession, _, err := a.appSessionBindingForChatSessionID(sessionID); err == nil {
+		sessionID = bindingSession.ID
+	}
 	a.mu.Lock()
 	s := a.chatAppSessions[sessionID]
 	delete(a.chatAppSessions, sessionID)

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -60,7 +60,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	profile = a.appServerProfileForChatSession(session, profile)
 	turnStartedAt := time.Now()
 	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
-	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
+	appSess, bindingSessionID, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
 		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, turn.outputMode, profile)
 		return
@@ -73,7 +73,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
 	} else {
 		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
-		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
+		_ = a.store.UpdateChatSessionThread(bindingSessionID, appSess.ThreadID())
 	}
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	prompt = appendCanvasInkPrompt(prompt, inkCtx)
@@ -374,12 +374,13 @@ func suppressLocalAssistantResponse(payloads []map[string]interface{}) bool {
 // runAssistantTurnLegacy is the single-shot fallback when persistent session
 // fails to connect. Each call creates a new WS + thread.
 func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string, profile appServerModelProfile) {
-	cwd, err := a.effectiveWorkspaceDirForChatSession(session)
+	bindingSession, workspace, err := a.appSessionBindingForChatSessionID(sessionID)
 	if err != nil {
 		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
 		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
 		return
 	}
+	cwd := workspace.DirPath
 	profile = a.appServerProfileForChatSession(session, profile)
 	turnStartedAt := time.Now()
 	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
@@ -488,7 +489,7 @@ func (a *App) runAssistantTurnLegacy(sessionID string, session store.ChatSession
 		switch ev.Type {
 		case "thread_started":
 			if strings.TrimSpace(ev.ThreadID) != "" {
-				_ = a.store.UpdateChatSessionThread(sessionID, ev.ThreadID)
+				_ = a.store.UpdateChatSessionThread(bindingSession.ID, ev.ThreadID)
 			}
 		case "turn_started":
 			if strings.TrimSpace(ev.TurnID) != "" {

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -185,7 +185,7 @@ func (a *App) runAssistantTurnParallel(
 	profile = a.appServerProfileForChatSession(session, profile)
 	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(profile), profile.Model, 0)
 
-	appSess, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
+	appSess, bindingSessionID, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, profile)
 	if sessErr != nil {
 		return false
 	}
@@ -197,7 +197,7 @@ func (a *App) runAssistantTurnParallel(
 		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
 	} else {
 		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, turn.outputMode, profile.Alias)
-		_ = a.store.UpdateChatSessionThread(sessionID, appSess.ThreadID())
+		_ = a.store.UpdateChatSessionThread(bindingSessionID, appSess.ThreadID())
 	}
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	prompt = appendCanvasInkPrompt(prompt, inkCtx)

--- a/internal/web/workspace_focus.go
+++ b/internal/web/workspace_focus.go
@@ -1,7 +1,9 @@
 package web
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/krystophny/tabura/internal/store"
 )
@@ -96,6 +98,25 @@ func (a *App) effectiveWorkspaceDirForChatSessionID(sessionID string) (string, e
 		return "", err
 	}
 	return a.effectiveWorkspaceDirForChatSession(session)
+}
+
+func (a *App) appSessionBindingForChatSessionID(sessionID string) (store.ChatSession, store.Workspace, error) {
+	session, err := a.store.GetChatSession(sessionID)
+	if err != nil {
+		return store.ChatSession{}, store.Workspace{}, err
+	}
+	workspace, err := a.effectiveWorkspaceForChatSession(session)
+	if err != nil {
+		return store.ChatSession{}, store.Workspace{}, err
+	}
+	if strings.TrimSpace(workspace.DirPath) == "" {
+		return store.ChatSession{}, store.Workspace{}, errors.New("workspace path is required")
+	}
+	bindingSession, err := a.store.GetOrCreateChatSessionForWorkspace(workspace.ID)
+	if err != nil {
+		return store.ChatSession{}, store.Workspace{}, err
+	}
+	return bindingSession, workspace, nil
 }
 
 func (a *App) broadcastWorkspaceFocusChanged() {

--- a/internal/web/workspace_focus_test.go
+++ b/internal/web/workspace_focus_test.go
@@ -1,13 +1,19 @@
 package web
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/store"
 )
 
@@ -233,6 +239,161 @@ func TestIntentPromptSystemCommandsIncludeFocusActions(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "clear_focus") {
 		t.Fatalf("prompt missing clear_focus: %q", prompt)
+	}
+}
+
+type appSessionStartRequest struct {
+	CWD      string
+	ThreadID string
+}
+
+func setupAppSessionBindingServer(t *testing.T) (*httptest.Server, *[]appSessionStartRequest) {
+	t.Helper()
+	var mu sync.Mutex
+	starts := make([]appSessionStartRequest, 0, 4)
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg map[string]any
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("decode app-server message: %v", err)
+			}
+			switch strings.TrimSpace(strFromAny(msg["method"])) {
+			case "initialize":
+				_ = conn.WriteJSON(map[string]any{
+					"id":     msg["id"],
+					"result": map[string]any{"userAgent": "binding-test"},
+				})
+			case "thread/start":
+				params, _ := msg["params"].(map[string]any)
+				start := appSessionStartRequest{
+					CWD:      strings.TrimSpace(strFromAny(params["cwd"])),
+					ThreadID: strings.TrimSpace(strFromAny(params["threadId"])),
+				}
+				mu.Lock()
+				starts = append(starts, start)
+				index := len(starts)
+				mu.Unlock()
+				threadID := start.ThreadID
+				if threadID == "" {
+					threadID = "thread-new-" + strconv.Itoa(index)
+				}
+				_ = conn.WriteJSON(map[string]any{
+					"id": msg["id"],
+					"result": map[string]any{
+						"thread": map[string]any{"id": threadID},
+					},
+				})
+			}
+		}
+	}))
+	return server, &starts
+}
+
+func TestGetOrCreateAppSessionFollowsFocusedWorkspaceThreadBinding(t *testing.T) {
+	server, starts := setupAppSessionBindingServer(t)
+	defer server.Close()
+
+	app, err := New(t.TempDir(), "", "", "ws"+strings.TrimPrefix(server.URL, "http"), "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	anchor, err := app.ensureTodayDailyWorkspace()
+	if err != nil {
+		t.Fatalf("ensureTodayDailyWorkspace: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSessionForWorkspace(anchor.ID)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSessionForWorkspace(anchor): %v", err)
+	}
+	alphaPath := filepath.Join(t.TempDir(), "alpha")
+	betaPath := filepath.Join(t.TempDir(), "beta")
+	for _, dir := range []string{alphaPath, betaPath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+	alpha, err := app.store.CreateWorkspace("Alpha", alphaPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(alpha): %v", err)
+	}
+	beta, err := app.store.CreateWorkspace("Beta", betaPath)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(beta): %v", err)
+	}
+	alphaSession, err := app.store.GetOrCreateChatSessionForWorkspace(alpha.ID)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSessionForWorkspace(alpha): %v", err)
+	}
+	betaSession, err := app.store.GetOrCreateChatSessionForWorkspace(beta.ID)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSessionForWorkspace(beta): %v", err)
+	}
+	if err := app.store.UpdateChatSessionThread(alphaSession.ID, "thread-alpha"); err != nil {
+		t.Fatalf("UpdateChatSessionThread(alpha): %v", err)
+	}
+	if err := app.store.UpdateChatSessionThread(betaSession.ID, "thread-beta"); err != nil {
+		t.Fatalf("UpdateChatSessionThread(beta): %v", err)
+	}
+
+	profile := appServerModelProfile{Model: "gpt-test"}
+
+	if err := app.setFocusedWorkspace(alpha.ID); err != nil {
+		t.Fatalf("setFocusedWorkspace(alpha): %v", err)
+	}
+	alphaAppSession, bindingSessionID, resumed, err := app.getOrCreateAppSession(session.ID, "", profile)
+	if err != nil {
+		t.Fatalf("getOrCreateAppSession(alpha): %v", err)
+	}
+	if !resumed {
+		t.Fatal("resumed(alpha) = false, want true")
+	}
+	if bindingSessionID != alphaSession.ID {
+		t.Fatalf("binding session id = %q, want %q", bindingSessionID, alphaSession.ID)
+	}
+	if alphaAppSession.ThreadID() != "thread-alpha" {
+		t.Fatalf("alpha thread id = %q, want %q", alphaAppSession.ThreadID(), "thread-alpha")
+	}
+
+	if err := app.setFocusedWorkspace(beta.ID); err != nil {
+		t.Fatalf("setFocusedWorkspace(beta): %v", err)
+	}
+	betaAppSession, bindingSessionID, resumed, err := app.getOrCreateAppSession(session.ID, "", profile)
+	if err != nil {
+		t.Fatalf("getOrCreateAppSession(beta): %v", err)
+	}
+	if !resumed {
+		t.Fatal("resumed(beta) = false, want true")
+	}
+	if bindingSessionID != betaSession.ID {
+		t.Fatalf("binding session id = %q, want %q", bindingSessionID, betaSession.ID)
+	}
+	if betaAppSession.ThreadID() != "thread-beta" {
+		t.Fatalf("beta thread id = %q, want %q", betaAppSession.ThreadID(), "thread-beta")
+	}
+
+	if len(*starts) != 2 {
+		t.Fatalf("thread/start calls = %d, want 2", len(*starts))
+	}
+	if (*starts)[0].CWD != alphaPath || (*starts)[0].ThreadID != "thread-alpha" {
+		t.Fatalf("first thread/start = %#v, want cwd=%q thread=%q", (*starts)[0], alphaPath, "thread-alpha")
+	}
+	if (*starts)[1].CWD != betaPath || (*starts)[1].ThreadID != "thread-beta" {
+		t.Fatalf("second thread/start = %#v, want cwd=%q thread=%q", (*starts)[1], betaPath, "thread-beta")
 	}
 }
 

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -457,6 +457,53 @@ func TestCreateActivateProjectAffectsChatSessionCreation(t *testing.T) {
 	}
 }
 
+func TestCreateChatSessionWithoutSelectionStaysOnActiveWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	anchor, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("ActiveWorkspace() error: %v", err)
+	}
+	if !anchor.IsDaily {
+		t.Fatal("anchor is_daily = false, want true")
+	}
+
+	linkedDir := filepath.Join(t.TempDir(), "linked-repo")
+	if err := os.MkdirAll(linkedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(linkedDir) error: %v", err)
+	}
+	project, err := app.store.CreateProject("linked-repo", "linked-repo", linkedDir, "linked", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateProject() error: %v", err)
+	}
+	if err := app.store.SetActiveProjectID(project.ID); err != nil {
+		t.Fatalf("SetActiveProjectID() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/chat/sessions", map[string]any{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chat session create status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		OK          bool   `json:"ok"`
+		SessionID   string `json:"session_id"`
+		WorkspaceID int64  `json:"workspace_id"`
+		ProjectID   string `json:"project_id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !payload.OK {
+		t.Fatal("expected ok=true")
+	}
+	if payload.WorkspaceID != anchor.ID {
+		t.Fatalf("workspace_id = %d, want anchor %d", payload.WorkspaceID, anchor.ID)
+	}
+	if payload.ProjectID != "" {
+		t.Fatalf("project_id = %q, want empty daily workspace binding", payload.ProjectID)
+	}
+}
+
 func TestProjectsListRehomesActiveProjectIntoActiveSphere(t *testing.T) {
 	app := newAuthedTestApp(t)
 


### PR DESCRIPTION
## Summary
- bind Codex app-server sessions and stored thread ids to the effective workspace chat session instead of the anchor conversation session
- require a real active workspace for blank chat-session resolution instead of falling back through `ActiveProjectID`
- keep no-selection chat-session creation on the active daily workspace and add focused regression coverage

## Verification
- Requirement: Codex app-server turns follow the focused workspace and preserve the prior workspace thread for resumption.
  Evidence: `go test ./internal/store ./internal/web -run 'Test(StoreChatSessionMessageAndThreading|GetOrCreateChatSessionBlankRefRequiresActiveWorkspace|CreateChatSessionWithoutSelectionStaysOnActiveWorkspace|GetOrCreateAppSessionFollowsFocusedWorkspaceThreadBinding|CreateActivateProjectAffectsChatSessionCreation|FocusedWorkspaceLeavesChatSessionAnchored)' 2>&1 | tee /tmp/tabura-issue-515-test.log`
  Evidence: `TestGetOrCreateAppSessionFollowsFocusedWorkspaceThreadBinding` asserts `thread/start` uses `alphaPath` with `thread-alpha`, then `betaPath` with `thread-beta`, proving the next turn binds to workspace B while workspace A's thread remains resumable.
- Requirement: default/no-selection chat sessions stay anchored to the current active workspace, with Daily Workspace as the fallback.
  Evidence: same command above.
  Evidence: `TestCreateChatSessionWithoutSelectionStaysOnActiveWorkspace` verifies `POST /api/chat/sessions` returns the active daily `workspace_id` and an empty `project_id` even when `ActiveProjectID` points at a linked project.
- Requirement: blank chat-session resolution must not bypass workspace ownership through legacy project fallback.
  Evidence: same command above.
  Evidence: `TestGetOrCreateChatSessionBlankRefRequiresActiveWorkspace` clears the active workspace and expects `sql.ErrNoRows`, proving blank refs no longer resolve through `ActiveProjectID`.
- Requirement: existing workspace-backed chat session behavior remains intact.
  Evidence: same command above.
  Evidence: `TestStoreChatSessionMessageAndThreading`, `TestCreateActivateProjectAffectsChatSessionCreation`, and `TestFocusedWorkspaceLeavesChatSessionAnchored` all passed.

Output excerpt:
```text
ok   github.com/krystophny/tabura/internal/store 0.024s
ok   github.com/krystophny/tabura/internal/web   0.349s
```
