### PR TITLE
fix: Add Gemini search tier in Daily Workspace (fixes #552)

### DIFF
--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -1,0 +1,378 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultBaseURL   = "https://generativelanguage.googleapis.com"
+	DefaultModel     = "gemini-3-flash-preview"
+	defaultMaxTokens = 512
+	defaultBackoff   = 5 * time.Minute
+)
+
+var ErrUnavailable = errors.New("gemini unavailable")
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type CompletionRequest struct {
+	Messages              []Message
+	MaxTokens             int
+	Temperature           float64
+	EnableSearchGrounding bool
+}
+
+type GroundingSource struct {
+	Title string
+	URI   string
+}
+
+type GroundingSupport struct {
+	Text          string
+	StartIndex    int
+	EndIndex      int
+	SourceIndices []int
+}
+
+type GroundingMetadata struct {
+	SearchQueries []string
+	Sources       []GroundingSource
+	Supports      []GroundingSupport
+}
+
+type CompletionResponse struct {
+	Text              string
+	GroundingMetadata *GroundingMetadata
+	TokensUsed        int
+	Latency           time.Duration
+}
+
+type Client struct {
+	BaseURL          string
+	APIKey           string
+	Model            string
+	HTTPClient       *http.Client
+	UnavailableAfter time.Duration
+
+	now func() time.Time
+
+	mu               sync.Mutex
+	unavailableUntil time.Time
+}
+
+type requestContent struct {
+	Role  string        `json:"role,omitempty"`
+	Parts []requestPart `json:"parts"`
+}
+
+type requestPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+type requestBody struct {
+	SystemInstruction *requestContent        `json:"system_instruction,omitempty"`
+	Contents          []requestContent       `json:"contents"`
+	Tools             []map[string]any       `json:"tools,omitempty"`
+	GenerationConfig  map[string]interface{} `json:"generationConfig,omitempty"`
+}
+
+type responseBody struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+		GroundingMetadata *struct {
+			WebSearchQueries []string `json:"webSearchQueries"`
+			GroundingChunks  []struct {
+				Web struct {
+					URI   string `json:"uri"`
+					Title string `json:"title"`
+				} `json:"web"`
+			} `json:"groundingChunks"`
+			GroundingSupports []struct {
+				Segment struct {
+					StartIndex int    `json:"startIndex"`
+					EndIndex   int    `json:"endIndex"`
+					Text       string `json:"text"`
+				} `json:"segment"`
+				GroundingChunkIndices []int `json:"groundingChunkIndices"`
+			} `json:"groundingSupports"`
+		} `json:"groundingMetadata"`
+	} `json:"candidates"`
+	UsageMetadata struct {
+		TotalTokenCount int `json:"totalTokenCount"`
+	} `json:"usageMetadata"`
+}
+
+func NewClient(baseURL, apiKey, model string) *Client {
+	return &Client{
+		BaseURL:          strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:           strings.TrimSpace(apiKey),
+		Model:            strings.TrimSpace(model),
+		UnavailableAfter: defaultBackoff,
+		now:              time.Now,
+	}
+}
+
+func (c *Client) IsAvailable() bool {
+	if c == nil {
+		return false
+	}
+	if strings.TrimSpace(c.BaseURL) == "" || strings.TrimSpace(c.APIKey) == "" || strings.TrimSpace(c.Model) == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.unavailableUntil.IsZero() && c.now().Before(c.unavailableUntil) {
+		return false
+	}
+	return true
+}
+
+func (c *Client) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	if c == nil || !c.IsAvailable() {
+		return nil, ErrUnavailable
+	}
+	if len(req.Messages) == 0 {
+		return nil, errors.New("gemini request requires at least one message")
+	}
+	payload, err := buildRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := c.BaseURL + "/v1beta/models/" + url.PathEscape(c.Model) + ":generateContent"
+	startedAt := time.Now()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", c.APIKey)
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		c.markUnavailable()
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+		c.markUnavailable()
+		return nil, ErrUnavailable
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("gemini completion failed: status %d", resp.StatusCode)
+	}
+
+	var decoded responseBody
+	if err := json.Unmarshal(respBody, &decoded); err != nil {
+		return nil, err
+	}
+	if len(decoded.Candidates) == 0 {
+		return nil, errors.New("gemini completion missing candidates")
+	}
+
+	candidate := decoded.Candidates[0]
+	text := extractText(candidate.Content.Parts)
+	if text == "" {
+		return nil, errors.New("gemini completion missing text")
+	}
+
+	return &CompletionResponse{
+		Text:              text,
+		GroundingMetadata: parseGroundingMetadata(candidate.GroundingMetadata),
+		TokensUsed:        decoded.UsageMetadata.TotalTokenCount,
+		Latency:           time.Since(startedAt),
+	}, nil
+}
+
+func buildRequestBody(req CompletionRequest) (requestBody, error) {
+	system, contents := buildContents(req.Messages)
+	if len(contents) == 0 {
+		return requestBody{}, errors.New("gemini request requires at least one non-system message")
+	}
+	body := requestBody{
+		SystemInstruction: system,
+		Contents:          contents,
+		GenerationConfig: map[string]interface{}{
+			"maxOutputTokens": resolveMaxTokens(req.MaxTokens),
+			"temperature":     req.Temperature,
+		},
+	}
+	if req.EnableSearchGrounding {
+		body.Tools = []map[string]any{
+			{"google_search": map[string]any{}},
+		}
+	}
+	return body, nil
+}
+
+func buildContents(messages []Message) (*requestContent, []requestContent) {
+	systemParts := make([]requestPart, 0, len(messages))
+	contents := make([]requestContent, 0, len(messages))
+	for _, message := range messages {
+		text := strings.TrimSpace(message.Content)
+		if text == "" {
+			continue
+		}
+		switch normalizeRole(message.Role) {
+		case "system":
+			systemParts = append(systemParts, requestPart{Text: text})
+		case "model":
+			contents = append(contents, requestContent{
+				Role:  "model",
+				Parts: []requestPart{{Text: text}},
+			})
+		default:
+			contents = append(contents, requestContent{
+				Role:  "user",
+				Parts: []requestPart{{Text: text}},
+			})
+		}
+	}
+	if len(systemParts) == 0 {
+		return nil, contents
+	}
+	return &requestContent{Parts: systemParts}, contents
+}
+
+func normalizeRole(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "system":
+		return "system"
+	case "assistant", "model":
+		return "model"
+	default:
+		return "user"
+	}
+}
+
+func resolveMaxTokens(value int) int {
+	if value > 0 {
+		return value
+	}
+	return defaultMaxTokens
+}
+
+func extractText(parts []struct {
+	Text string `json:"text"`
+}) string {
+	var b strings.Builder
+	for _, part := range parts {
+		if text := strings.TrimSpace(part.Text); text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(text)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func parseGroundingMetadata(raw *struct {
+	WebSearchQueries []string `json:"webSearchQueries"`
+	GroundingChunks  []struct {
+		Web struct {
+			URI   string `json:"uri"`
+			Title string `json:"title"`
+		} `json:"web"`
+	} `json:"groundingChunks"`
+	GroundingSupports []struct {
+		Segment struct {
+			StartIndex int    `json:"startIndex"`
+			EndIndex   int    `json:"endIndex"`
+			Text       string `json:"text"`
+		} `json:"segment"`
+		GroundingChunkIndices []int `json:"groundingChunkIndices"`
+	} `json:"groundingSupports"`
+}) *GroundingMetadata {
+	if raw == nil {
+		return nil
+	}
+	metadata := &GroundingMetadata{
+		SearchQueries: make([]string, 0, len(raw.WebSearchQueries)),
+		Sources:       make([]GroundingSource, 0, len(raw.GroundingChunks)),
+		Supports:      make([]GroundingSupport, 0, len(raw.GroundingSupports)),
+	}
+	for _, query := range raw.WebSearchQueries {
+		if clean := strings.TrimSpace(query); clean != "" {
+			metadata.SearchQueries = append(metadata.SearchQueries, clean)
+		}
+	}
+	for _, chunk := range raw.GroundingChunks {
+		uri := strings.TrimSpace(chunk.Web.URI)
+		title := strings.TrimSpace(chunk.Web.Title)
+		if uri == "" {
+			continue
+		}
+		metadata.Sources = append(metadata.Sources, GroundingSource{
+			Title: title,
+			URI:   uri,
+		})
+	}
+	for _, support := range raw.GroundingSupports {
+		indices := make([]int, 0, len(support.GroundingChunkIndices))
+		for _, idx := range support.GroundingChunkIndices {
+			if idx >= 0 {
+				indices = append(indices, idx)
+			}
+		}
+		metadata.Supports = append(metadata.Supports, GroundingSupport{
+			Text:          strings.TrimSpace(support.Segment.Text),
+			StartIndex:    support.Segment.StartIndex,
+			EndIndex:      support.Segment.EndIndex,
+			SourceIndices: indices,
+		})
+	}
+	if len(metadata.SearchQueries) == 0 && len(metadata.Sources) == 0 && len(metadata.Supports) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func (c *Client) markUnavailable() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	until := c.now().Add(c.unavailableFor())
+	if until.After(c.unavailableUntil) {
+		c.unavailableUntil = until
+	}
+}
+
+func (c *Client) unavailableFor() time.Duration {
+	if c == nil || c.UnavailableAfter <= 0 {
+		return defaultBackoff
+	}
+	return c.UnavailableAfter
+}

--- a/internal/gemini/client_test.go
+++ b/internal/gemini/client_test.go
@@ -1,0 +1,144 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientCompleteUsesGoogleSearchGrounding(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := strings.TrimSpace(r.URL.Path); got != "/v1beta/models/gemini-3-flash-preview:generateContent" {
+			t.Fatalf("path = %q, want generateContent path", got)
+		}
+		if got := strings.TrimSpace(r.Header.Get("x-goog-api-key")); got != "token-gemini" {
+			t.Fatalf("x-goog-api-key = %q, want token-gemini", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{
+				{
+					"content": map[string]any{
+						"parts": []map[string]any{
+							{"text": "Kernel 6.20 landed changes."},
+						},
+					},
+					"groundingMetadata": map[string]any{
+						"webSearchQueries": []string{"linux kernel latest changes"},
+						"groundingChunks": []map[string]any{
+							{
+								"web": map[string]any{
+									"uri":   "https://example.com/kernel",
+									"title": "Kernel Notes",
+								},
+							},
+						},
+						"groundingSupports": []map[string]any{
+							{
+								"segment": map[string]any{
+									"text":       "Kernel 6.20 landed changes.",
+									"startIndex": 0,
+									"endIndex":   28,
+								},
+								"groundingChunkIndices": []int{0},
+							},
+						},
+					},
+				},
+			},
+			"usageMetadata": map[string]any{
+				"totalTokenCount": 73,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-gemini", DefaultModel)
+	client.HTTPClient = server.Client()
+
+	resp, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{
+			{Role: "system", Content: "Answer with grounded links only."},
+			{Role: "user", Content: "What changed in Linux?"},
+		},
+		MaxTokens:             321,
+		Temperature:           0.2,
+		EnableSearchGrounding: true,
+	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+	if got := strings.TrimSpace(resp.Text); got != "Kernel 6.20 landed changes." {
+		t.Fatalf("Text = %q, want grounded response", got)
+	}
+	if resp.GroundingMetadata == nil {
+		t.Fatal("GroundingMetadata = nil, want grounded metadata")
+	}
+	if got := resp.GroundingMetadata.SearchQueries; len(got) != 1 || got[0] != "linux kernel latest changes" {
+		t.Fatalf("SearchQueries = %#v, want query", got)
+	}
+	if got := resp.GroundingMetadata.Sources; len(got) != 1 || got[0].URI != "https://example.com/kernel" {
+		t.Fatalf("Sources = %#v, want source URI", got)
+	}
+	if got := intFromAny(payload["generationConfig"].(map[string]any)["maxOutputTokens"]); got != 321 {
+		t.Fatalf("maxOutputTokens = %d, want 321", got)
+	}
+	tools, ok := payload["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %#v, want google_search tool", payload["tools"])
+	}
+	systemInstruction, ok := payload["system_instruction"].(map[string]any)
+	if !ok {
+		t.Fatalf("system_instruction = %#v, want object", payload["system_instruction"])
+	}
+	parts, ok := systemInstruction["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("system_instruction.parts = %#v, want single part", systemInstruction["parts"])
+	}
+}
+
+func TestClientCompleteBacksOffAfterServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream failure"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-gemini", DefaultModel)
+	client.HTTPClient = server.Client()
+	client.UnavailableAfter = time.Minute
+
+	_, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "latest news"}},
+	})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want unavailable error")
+	}
+	if err != ErrUnavailable {
+		t.Fatalf("Complete() error = %v, want ErrUnavailable", err)
+	}
+	if client.IsAvailable() {
+		t.Fatal("IsAvailable() = true, want false during backoff")
+	}
+}
+
+func intFromAny(value any) int {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed)
+	case int:
+		return typed
+	default:
+		return 0
+	}
+}

--- a/internal/web/chat_turn_gemini.go
+++ b/internal/web/chat_turn_gemini.go
@@ -1,0 +1,201 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/gemini"
+)
+
+const geminiTurnSystemPrompt = `You are Tabura's grounded web assistant.
+Answer the user directly.
+Only use links supplied by grounding metadata.`
+
+type geminiTurnResult struct {
+	text     string
+	grounded bool
+	err      error
+	latency  time.Duration
+}
+
+func (r geminiTurnResult) canClaim() bool {
+	return strings.TrimSpace(r.text) != "" && r.grounded
+}
+
+func (r geminiTurnResult) canFallback() bool {
+	return strings.TrimSpace(r.text) != ""
+}
+
+func (a *App) geminiModelLabel() string {
+	if a == nil || a.geminiClient == nil {
+		return gemini.DefaultModel
+	}
+	if model := strings.TrimSpace(a.geminiClient.Model); model != "" {
+		return model
+	}
+	return gemini.DefaultModel
+}
+
+func buildGeminiTurnMessages(prompt string) []gemini.Message {
+	trimmed := strings.TrimSpace(prompt)
+	if trimmed == "" {
+		return nil
+	}
+	return []gemini.Message{
+		{Role: "system", Content: geminiTurnSystemPrompt},
+		{Role: "user", Content: trimmed},
+	}
+}
+
+func (a *App) runGeminiTurn(ctx context.Context, prompt string) geminiTurnResult {
+	if a == nil || a.geminiClient == nil {
+		return geminiTurnResult{}
+	}
+	resp, err := a.geminiClient.Complete(ctx, gemini.CompletionRequest{
+		Messages:              buildGeminiTurnMessages(prompt),
+		MaxTokens:             512,
+		Temperature:           0.2,
+		EnableSearchGrounding: true,
+	})
+	if err != nil {
+		return geminiTurnResult{err: err}
+	}
+	grounded := resp.GroundingMetadata != nil && len(resp.GroundingMetadata.Sources) > 0
+	return geminiTurnResult{
+		text:     strings.TrimSpace(renderGeminiGroundedMarkdown(resp.Text, resp.GroundingMetadata)),
+		grounded: grounded,
+		latency:  resp.Latency,
+	}
+}
+
+func renderGeminiGroundedMarkdown(text string, metadata *gemini.GroundingMetadata) string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" || metadata == nil || len(metadata.Sources) == 0 {
+		return trimmed
+	}
+
+	numbers := buildGeminiCitationNumbers(metadata)
+	inlineText, used := injectGeminiInlineCitations(trimmed, metadata, numbers)
+	if len(used) == 0 {
+		for idx := range metadata.Sources {
+			used = append(used, idx)
+		}
+	}
+	sort.Slice(used, func(i, j int) bool {
+		return numbers[used[i]] < numbers[used[j]]
+	})
+
+	var b strings.Builder
+	b.WriteString(strings.TrimSpace(inlineText))
+	b.WriteString("\n\nSources:\n")
+	for _, idx := range used {
+		if idx < 0 || idx >= len(metadata.Sources) {
+			continue
+		}
+		source := metadata.Sources[idx]
+		title := strings.TrimSpace(source.Title)
+		if title == "" {
+			title = strings.TrimSpace(source.URI)
+		}
+		fmt.Fprintf(&b, "%d. [%s](%s)\n", numbers[idx], title, source.URI)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func buildGeminiCitationNumbers(metadata *gemini.GroundingMetadata) map[int]int {
+	numbers := make(map[int]int, len(metadata.Sources))
+	next := 1
+	for _, support := range metadata.Supports {
+		for _, idx := range support.SourceIndices {
+			if idx < 0 || idx >= len(metadata.Sources) {
+				continue
+			}
+			if numbers[idx] != 0 {
+				continue
+			}
+			numbers[idx] = next
+			next++
+		}
+	}
+	for idx := range metadata.Sources {
+		if numbers[idx] != 0 {
+			continue
+		}
+		numbers[idx] = next
+		next++
+	}
+	return numbers
+}
+
+func injectGeminiInlineCitations(text string, metadata *gemini.GroundingMetadata, numbers map[int]int) (string, []int) {
+	if len(metadata.Supports) == 0 {
+		return text, nil
+	}
+
+	insertions := map[int][]int{}
+	used := map[int]struct{}{}
+	for _, support := range metadata.Supports {
+		if support.EndIndex <= 0 || support.EndIndex > len(text) {
+			continue
+		}
+		for _, idx := range support.SourceIndices {
+			if idx < 0 || idx >= len(metadata.Sources) {
+				continue
+			}
+			insertions[support.EndIndex] = appendUniqueInt(insertions[support.EndIndex], idx)
+			used[idx] = struct{}{}
+		}
+	}
+	if len(insertions) == 0 {
+		return text, nil
+	}
+
+	positions := make([]int, 0, len(insertions))
+	for pos := range insertions {
+		positions = append(positions, pos)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(positions)))
+
+	out := text
+	for _, pos := range positions {
+		indices := insertions[pos]
+		sort.Slice(indices, func(i, j int) bool {
+			return numbers[indices[i]] < numbers[indices[j]]
+		})
+		out = out[:pos] + renderGeminiCitationLinks(indices, metadata, numbers) + out[pos:]
+	}
+
+	orderedUsed := make([]int, 0, len(used))
+	for idx := range used {
+		orderedUsed = append(orderedUsed, idx)
+	}
+	sort.Ints(orderedUsed)
+	return out, orderedUsed
+}
+
+func renderGeminiCitationLinks(indices []int, metadata *gemini.GroundingMetadata, numbers map[int]int) string {
+	var b strings.Builder
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(metadata.Sources) {
+			continue
+		}
+		uri := strings.TrimSpace(metadata.Sources[idx].URI)
+		if uri == "" {
+			continue
+		}
+		fmt.Fprintf(&b, " [%d](%s)", numbers[idx], uri)
+	}
+	return b.String()
+}
+
+func appendUniqueInt(values []int, value int) []int {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -223,6 +223,7 @@ func (a *App) runAssistantTurnParallel(
 
 	localCh := make(chan localTurnEvaluation, 1)
 	cerebrasCh := make(chan cerebrasTurnResult, 1)
+	geminiCh := make(chan geminiTurnResult, 1)
 	sparkCh := make(chan sparkTurnResult, 1)
 
 	startSpark := func() {
@@ -238,6 +239,14 @@ func (a *App) runAssistantTurnParallel(
 		}
 		go func() {
 			cerebrasCh <- a.runCerebrasTurn(ctx, prompt)
+		}()
+	}
+	startGemini := func() {
+		if a.geminiClient == nil || !a.geminiClient.IsAvailable() {
+			return
+		}
+		go func() {
+			geminiCh <- a.runGeminiTurn(ctx, prompt)
 		}()
 	}
 
@@ -262,12 +271,14 @@ func (a *App) runAssistantTurnParallel(
 	if precomputedLocal != nil {
 		localCh <- *precomputedLocal
 		startCerebras()
+		startGemini()
 		startSpark()
 	} else {
 		go func() {
 			localCh <- a.evaluateLocalTurn(context.Background(), sessionID, session, userText, cursorCtx, turn.captureMode)
 		}()
 		startCerebras()
+		startGemini()
 		startSpark()
 	}
 
@@ -280,8 +291,9 @@ func (a *App) runAssistantTurnParallel(
 	persistedAssistantText := ""
 	localReady := false
 	localEvaluation := localTurnEvaluation{}
-	cerebrasDone := false
 	cerebrasResult := cerebrasTurnResult{}
+	geminiDone := false
+	geminiResult := geminiTurnResult{}
 	provisionalEmitted := false
 	provisionalText := ""
 	commandPayloadsBroadcast := false
@@ -290,7 +302,7 @@ func (a *App) runAssistantTurnParallel(
 
 	localMetadata := newAssistantResponseMetadata(assistantProviderLocal, a.localAssistantModelLabel(), 0)
 	cerebrasMetadata := newAssistantResponseMetadata(assistantProviderCerebras, a.cerebrasModelLabel(), 0)
-
+	geminiMetadata := newAssistantResponseMetadata(assistantProviderGoogle, a.geminiModelLabel(), 0)
 	commitFinal := func(text string, metadata assistantResponseMetadata, source string, threadID string) {
 		a.emitTurnStage(sessionID, "turn_committed", turnID, source, text)
 		a.emitTurnStage(sessionID, "turn_source", turnID, source, "")
@@ -306,6 +318,46 @@ func (a *App) runAssistantTurnParallel(
 			turn.outputMode,
 			metadata,
 		)
+	}
+	geminiPending := func() bool {
+		return a.geminiClient != nil && a.geminiClient.IsAvailable() && !geminiDone
+	}
+	tryCommitGeminiClaim := func() bool {
+		if !localReady || localEvaluation.isCommand() || localEvaluation.isHighConfidenceLocalAnswer() || !geminiResult.canClaim() {
+			return false
+		}
+		a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderGoogle, geminiResult.text)
+		commitFinal(geminiResult.text, newAssistantResponseMetadata(geminiMetadata.Provider, geminiMetadata.ProviderModel, geminiResult.latency), assistantProviderGoogle, "")
+		return true
+	}
+	tryCommitCerebrasClaim := func() bool {
+		if !localReady || localEvaluation.isCommand() || !cerebrasResult.canClaim() {
+			return false
+		}
+		a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, cerebrasResult.text)
+		commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+		return true
+	}
+	tryCommitSpark := func() bool {
+		if sparkResult.err != nil || strings.TrimSpace(sparkResult.text) == "" {
+			return false
+		}
+		commitFinal(sparkResult.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, sparkResult.latency), responseMeta.Provider, sparkResult.threadID)
+		return true
+	}
+	tryCommitCerebrasFallback := func() bool {
+		if !cerebrasResult.canFallback() {
+			return false
+		}
+		commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+		return true
+	}
+	tryCommitGeminiFallback := func() bool {
+		if !geminiResult.canFallback() {
+			return false
+		}
+		commitFinal(geminiResult.text, newAssistantResponseMetadata(geminiMetadata.Provider, geminiMetadata.ProviderModel, geminiResult.latency), assistantProviderGoogle, "")
+		return true
 	}
 
 	for {
@@ -353,17 +405,22 @@ func (a *App) runAssistantTurnParallel(
 					return true
 				}
 			} else if sparkDone {
-				if cerebrasDone && cerebrasResult.canClaim() {
-					a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, cerebrasResult.text)
-					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+				if tryCommitGeminiClaim() {
 					return true
 				}
-				if sparkResult.err == nil && strings.TrimSpace(sparkResult.text) != "" {
-					commitFinal(sparkResult.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, sparkResult.latency), responseMeta.Provider, sparkResult.threadID)
+				if geminiPending() {
+					continue
+				}
+				if tryCommitCerebrasClaim() {
 					return true
 				}
-				if cerebrasDone && cerebrasResult.canFallback() {
-					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+				if tryCommitSpark() {
+					return true
+				}
+				if tryCommitCerebrasFallback() {
+					return true
+				}
+				if tryCommitGeminiFallback() {
 					return true
 				}
 				if fallback := evaluation.fallbackText(); fallback != "" {
@@ -372,15 +429,62 @@ func (a *App) runAssistantTurnParallel(
 				}
 			}
 		case result := <-cerebrasCh:
-			cerebrasDone = true
 			cerebrasResult = result
 			if !localReady || localEvaluation.isCommand() || localEvaluation.isHighConfidenceLocalAnswer() {
 				continue
 			}
-			if result.canClaim() {
-				a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, result.text)
-				commitFinal(result.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, result.latency), assistantProviderCerebras, "")
+			if tryCommitGeminiClaim() {
 				return true
+			}
+			if result.canClaim() {
+				if geminiPending() {
+					continue
+				}
+				if tryCommitCerebrasClaim() {
+					return true
+				}
+			}
+			if sparkDone {
+				if tryCommitSpark() {
+					return true
+				}
+				if tryCommitCerebrasFallback() {
+					return true
+				}
+				if tryCommitGeminiFallback() {
+					return true
+				}
+				if fallback := localEvaluation.fallbackText(); fallback != "" {
+					commitFinal(fallback, localMetadata, assistantProviderLocal, "")
+					return true
+				}
+			}
+		case result := <-geminiCh:
+			geminiDone = true
+			geminiResult = result
+			if !localReady || localEvaluation.isCommand() || localEvaluation.isHighConfidenceLocalAnswer() {
+				continue
+			}
+			if tryCommitGeminiClaim() {
+				return true
+			}
+			if tryCommitCerebrasClaim() {
+				return true
+			}
+			if sparkDone {
+				if tryCommitSpark() {
+					return true
+				}
+				if tryCommitCerebrasFallback() {
+					return true
+				}
+				if tryCommitGeminiFallback() {
+					return true
+				}
+				if fallback := localEvaluation.fallbackText(); fallback != "" {
+					commitFinal(fallback, localMetadata, assistantProviderLocal, "")
+					return true
+				}
 			}
 		case result := <-sparkCh:
 			sparkDone = true
@@ -388,13 +492,16 @@ func (a *App) runAssistantTurnParallel(
 			if !localReady {
 				continue
 			}
-			if cerebrasDone && cerebrasResult.canClaim() && !localEvaluation.isCommand() {
-				a.emitTurnStage(sessionID, "turn_claimed", turnID, assistantProviderCerebras, cerebrasResult.text)
-				commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+			if tryCommitGeminiClaim() {
 				return true
 			}
-			if result.err == nil && strings.TrimSpace(result.text) != "" {
-				commitFinal(result.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, result.latency), responseMeta.Provider, result.threadID)
+			if geminiPending() && !localEvaluation.isCommand() {
+				continue
+			}
+			if tryCommitCerebrasClaim() {
+				return true
+			}
+			if tryCommitSpark() {
 				return true
 			}
 			if localReady {
@@ -402,8 +509,10 @@ func (a *App) runAssistantTurnParallel(
 					commitFinal(finalParallelCommandText(localEvaluation, provisionalText), localMetadata, assistantProviderLocal, "")
 					return true
 				}
-				if cerebrasDone && cerebrasResult.canFallback() {
-					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+				if tryCommitCerebrasFallback() {
+					return true
+				}
+				if tryCommitGeminiFallback() {
 					return true
 				}
 				if fallback := localEvaluation.fallbackText(); fallback != "" {
@@ -443,8 +552,13 @@ func (a *App) runAssistantTurnParallel(
 					commitFinal(finalParallelCommandText(localEvaluation, provisionalText), localMetadata, assistantProviderLocal, "")
 					return true
 				}
-				if cerebrasDone && cerebrasResult.canFallback() {
-					commitFinal(cerebrasResult.text, newAssistantResponseMetadata(cerebrasMetadata.Provider, cerebrasMetadata.ProviderModel, cerebrasResult.latency), assistantProviderCerebras, "")
+				if tryCommitGeminiClaim() {
+					return true
+				}
+				if tryCommitCerebrasFallback() {
+					return true
+				}
+				if tryCommitGeminiFallback() {
 					return true
 				}
 				if fallback := localEvaluation.fallbackText(); fallback != "" {

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/krystophny/tabura/internal/cerebras"
+	"github.com/krystophny/tabura/internal/gemini"
 )
 
 type mockParallelAppServerState struct {
@@ -147,6 +148,75 @@ func setupMockCerebrasServer(t *testing.T, status int, delay time.Duration, cont
 			return
 		}
 		_, _ = w.Write([]byte("upstream error"))
+	}))
+	return server, &requests
+}
+
+func setupMockGeminiServer(t *testing.T, status int, delay time.Duration, grounded bool, text string) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if !strings.HasSuffix(strings.TrimSpace(r.URL.Path), ":generateContent") {
+			t.Fatalf("path = %s, want generateContent path", r.URL.Path)
+		}
+		if got := strings.TrimSpace(r.Header.Get("x-goog-api-key")); got != "token-gemini" {
+			t.Fatalf("x-goog-api-key = %q, want token-gemini", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		tools, ok := payload["tools"].([]any)
+		if !ok || len(tools) != 1 {
+			t.Fatalf("tools = %#v, want google_search tool", payload["tools"])
+		}
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status != http.StatusOK {
+			_, _ = w.Write([]byte("upstream error"))
+			return
+		}
+		candidate := map[string]any{
+			"content": map[string]any{
+				"parts": []map[string]any{
+					{"text": text},
+				},
+			},
+		}
+		if grounded {
+			candidate["groundingMetadata"] = map[string]any{
+				"webSearchQueries": []string{"latest linux kernel changes"},
+				"groundingChunks": []map[string]any{
+					{
+						"web": map[string]any{
+							"uri":   "https://example.com/source-1",
+							"title": "Source One",
+						},
+					},
+				},
+				"groundingSupports": []map[string]any{
+					{
+						"segment": map[string]any{
+							"text":       text,
+							"startIndex": 0,
+							"endIndex":   len(text),
+						},
+						"groundingChunkIndices": []int{0},
+					},
+				},
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{candidate},
+			"usageMetadata": map[string]any{
+				"totalTokenCount": 42,
+			},
+		})
 	}))
 	return server, &requests
 }
@@ -526,6 +596,160 @@ func TestRunAssistantTurnParallelCerebrasClaimsTurn(t *testing.T) {
 	}
 	if *requests != 1 {
 		t.Fatalf("cerebras requests = %d, want 1", *requests)
+	}
+}
+
+func TestRunAssistantTurnParallelGroundedGeminiClaimsTurn(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 250*time.Millisecond, "Spark fallback.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	cerebrasServer, cerebrasRequests := setupMockCerebrasServer(t, http.StatusOK, 20*time.Millisecond, `{"text":"Cerebras answer.","confidence":"high"}`)
+	defer cerebrasServer.Close()
+	geminiServer, geminiRequests := setupMockGeminiServer(t, http.StatusOK, 40*time.Millisecond, true, "Linux kernel 6.20 landed changes.")
+	defer geminiServer.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+	app.cerebrasClient = cerebras.NewClient(cerebrasServer.URL, "token-cerebras", cerebras.DefaultModel, cerebras.DefaultReasoningEffort)
+	app.cerebrasClient.HTTPClient = cerebrasServer.Client()
+	app.geminiClient = gemini.NewClient(geminiServer.URL, "token-gemini", gemini.DefaultModel)
+	app.geminiClient.HTTPClient = geminiServer.Client()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "what were the latest Linux kernel changes?", "what were the latest Linux kernel changes?", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	got := latestAssistantMessage(t, app, session.ID)
+	if !strings.Contains(got, "Linux kernel 6.20 landed changes.") {
+		t.Fatalf("assistant message = %q, want Gemini grounded reply", got)
+	}
+	if !strings.Contains(got, "[1](https://example.com/source-1)") {
+		t.Fatalf("assistant message = %q, want inline citation link", got)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Provider != assistantProviderGoogle {
+		t.Fatalf("provider = %q, want %q", assistant.Provider, assistantProviderGoogle)
+	}
+	if assistant.ProviderModel != gemini.DefaultModel {
+		t.Fatalf("provider_model = %q, want %q", assistant.ProviderModel, gemini.DefaultModel)
+	}
+	if *cerebrasRequests != 1 {
+		t.Fatalf("cerebras requests = %d, want 1", *cerebrasRequests)
+	}
+	if *geminiRequests != 1 {
+		t.Fatalf("gemini requests = %d, want 1", *geminiRequests)
+	}
+}
+
+func TestRunAssistantTurnParallelUngroundedGeminiDoesNotBeatCerebras(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 250*time.Millisecond, "Spark fallback.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	cerebrasServer, _ := setupMockCerebrasServer(t, http.StatusOK, 40*time.Millisecond, `{"text":"Cerebras wins the turn.","confidence":"high"}`)
+	defer cerebrasServer.Close()
+	geminiServer, _ := setupMockGeminiServer(t, http.StatusOK, 20*time.Millisecond, false, "Gemini answered without citations.")
+	defer geminiServer.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+	app.cerebrasClient = cerebras.NewClient(cerebrasServer.URL, "token-cerebras", cerebras.DefaultModel, cerebras.DefaultReasoningEffort)
+	app.cerebrasClient.HTTPClient = cerebrasServer.Client()
+	app.geminiClient = gemini.NewClient(geminiServer.URL, "token-gemini", gemini.DefaultModel)
+	app.geminiClient.HTTPClient = geminiServer.Client()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "explain the routing policy", "explain the routing policy", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Cerebras wins the turn." {
+		t.Fatalf("assistant message = %q, want Cerebras final reply", got)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Provider != assistantProviderCerebras {
+		t.Fatalf("provider = %q, want %q", assistant.Provider, assistantProviderCerebras)
+	}
+}
+
+func TestRunAssistantTurnParallelGeminiFailureFallsBackSilently(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 25*time.Millisecond, "Spark handles the turn.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"kind":"local_answer","text":"Possible short answer.","confidence":"medium"}`)
+	defer llm.Close()
+
+	geminiServer, requests := setupMockGeminiServer(t, http.StatusBadGateway, 0, false, "")
+	defer geminiServer.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+	app.geminiClient = gemini.NewClient(geminiServer.URL, "token-gemini", gemini.DefaultModel)
+	app.geminiClient.HTTPClient = geminiServer.Client()
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "latest news", "latest news", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Spark handles the turn." {
+		t.Fatalf("assistant message = %q, want Spark final reply", got)
+	}
+	if *requests != 1 {
+		t.Fatalf("gemini requests = %d, want 1", *requests)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 20)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	for _, message := range messages {
+		if strings.EqualFold(strings.TrimSpace(message.Role), "system") && strings.Contains(strings.ToLower(message.ContentPlain), "gemini") {
+			t.Fatalf("unexpected user-visible Gemini error: %q", message.ContentPlain)
+		}
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/krystophny/tabura/internal/cerebras"
 	"github.com/krystophny/tabura/internal/email"
 	"github.com/krystophny/tabura/internal/extensions"
+	"github.com/krystophny/tabura/internal/gemini"
 	"github.com/krystophny/tabura/internal/ics"
 	"github.com/krystophny/tabura/internal/modelprofile"
 	"github.com/krystophny/tabura/internal/plugins"
@@ -39,6 +40,7 @@ const (
 	DefaultSTTPreVADThresholdDB = -58.0
 	DefaultSTTPreVADMinSpeechMS = 120
 	DefaultCerebrasSecretFile   = "cerebras-api-key"
+	DefaultGeminiSecretFile     = "gemini-api-key"
 	SessionCookie               = "tabura_session"
 	cookieMaxAgeSec             = 60 * 60 * 24 * 365
 	DaemonPort                  = 9420
@@ -68,6 +70,7 @@ type App struct {
 	appServerSparkReasoningEffort string
 	cerebrasClient                *cerebras.Client
 	cerebrasReasoningEffort       string
+	geminiClient                  *gemini.Client
 	intentLLMURL                  string
 	intentLLMModel                string
 	intentLLMProfile              string
@@ -205,6 +208,28 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 			resolvedCerebrasReasoningEffort,
 		)
 	}
+	resolvedGeminiURL := strings.TrimSpace(os.Getenv("TABURA_GEMINI_URL"))
+	if strings.EqualFold(resolvedGeminiURL, "off") {
+		resolvedGeminiURL = ""
+	} else if resolvedGeminiURL == "" {
+		resolvedGeminiURL = gemini.DefaultBaseURL
+	}
+	resolvedGeminiAPIKey := strings.TrimSpace(os.Getenv("TABURA_GEMINI_API_KEY"))
+	if resolvedGeminiAPIKey == "" {
+		resolvedGeminiAPIKey = readOptionalSecretFile(defaultSecretPath(DefaultGeminiSecretFile))
+	}
+	resolvedGeminiModel := strings.TrimSpace(os.Getenv("TABURA_GEMINI_MODEL"))
+	if resolvedGeminiModel == "" {
+		resolvedGeminiModel = gemini.DefaultModel
+	}
+	var geminiClient *gemini.Client
+	if resolvedGeminiURL != "" && resolvedGeminiAPIKey != "" {
+		geminiClient = gemini.NewClient(
+			resolvedGeminiURL,
+			resolvedGeminiAPIKey,
+			resolvedGeminiModel,
+		)
+	}
 	resolvedIntentLLMModel := strings.TrimSpace(os.Getenv("TABURA_INTENT_LLM_MODEL"))
 	if strings.EqualFold(resolvedIntentLLMModel, "off") {
 		resolvedIntentLLMModel = ""
@@ -295,6 +320,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		appServerSparkReasoningEffort: resolvedSparkReasoningEffort,
 		cerebrasClient:                cerebrasClient,
 		cerebrasReasoningEffort:       resolvedCerebrasReasoningEffort,
+		geminiClient:                  geminiClient,
 		intentLLMURL:                  resolvedIntentLLMURL,
 		intentLLMModel:                resolvedIntentLLMModel,
 		intentLLMProfile:              resolvedIntentLLMProfile,

--- a/internal/web/server_gemini_test.go
+++ b/internal/web/server_gemini_test.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/krystophny/tabura/internal/gemini"
+)
+
+func TestNewLoadsGeminiAPIKeyFromSecretFile(t *testing.T) {
+	home := t.TempDir()
+	secretDir := filepath.Join(home, ".config", "tabura", "secrets")
+	if err := os.MkdirAll(secretDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(secretDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secretDir, DefaultGeminiSecretFile), []byte("secret-from-file\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(secret): %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("TABURA_GEMINI_URL", "https://gemini.example")
+	t.Setenv("TABURA_GEMINI_API_KEY", "")
+	t.Setenv("TABURA_GEMINI_MODEL", "")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.geminiClient == nil {
+		t.Fatal("geminiClient = nil, want configured client")
+	}
+	if got := app.geminiClient.APIKey; got != "secret-from-file" {
+		t.Fatalf("APIKey = %q, want secret-from-file", got)
+	}
+	if got := app.geminiClient.Model; got != gemini.DefaultModel {
+		t.Fatalf("Model = %q, want %q", got, gemini.DefaultModel)
+	}
+}
+
+func TestNewLoadsGeminiAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("TABURA_GEMINI_URL", "https://gemini.example")
+	t.Setenv("TABURA_GEMINI_API_KEY", "secret-from-env")
+	t.Setenv("TABURA_GEMINI_MODEL", "gemini-2.5-flash")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.geminiClient == nil {
+		t.Fatal("geminiClient = nil, want configured client")
+	}
+	if got := app.geminiClient.APIKey; got != "secret-from-env" {
+		t.Fatalf("APIKey = %q, want secret-from-env", got)
+	}
+	if got := app.geminiClient.Model; got != "gemini-2.5-flash" {
+		t.Fatalf("Model = %q, want gemini-2.5-flash", got)
+	}
+}
+
+func TestNewDisablesGeminiWhenURLIsOff(t *testing.T) {
+	t.Setenv("TABURA_GEMINI_URL", "off")
+	t.Setenv("TABURA_GEMINI_API_KEY", "ignored")
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() {
+		_ = app.Shutdown(context.Background())
+	}()
+
+	if app.geminiClient != nil {
+		t.Fatal("geminiClient != nil, want nil when TABURA_GEMINI_URL=off")
+	}
+}


### PR DESCRIPTION
## Summary

Add a Google Gemini search-grounded tier to the existing parallel turn pipeline.

## Verification

- Requirement: Gemini requests use Google Search Grounding and parse grounded sources.
  Evidence: `go test -v ./internal/gemini -run "TestClientCompleteUsesGoogleSearchGrounding|TestClientCompleteBacksOffAfterServerError"`
  Output excerpt:
  ```text
  === RUN   TestClientCompleteUsesGoogleSearchGrounding
  --- PASS: TestClientCompleteUsesGoogleSearchGrounding (0.00s)
  === RUN   TestClientCompleteBacksOffAfterServerError
  --- PASS: TestClientCompleteBacksOffAfterServerError (0.00s)
  ```

- Requirement: API key loads from `TABURA_GEMINI_API_KEY` or the local secret file, and `TABURA_GEMINI_URL=off` disables the tier.
  Evidence: `go test -v ./internal/web -run "TestNewLoadsGeminiAPIKeyFromSecretFile|TestNewLoadsGeminiAPIKeyFromEnv|TestNewDisablesGeminiWhenURLIsOff"`
  Output excerpt:
  ```text
  === RUN   TestNewLoadsGeminiAPIKeyFromSecretFile
  --- PASS: TestNewLoadsGeminiAPIKeyFromSecretFile (0.01s)
  === RUN   TestNewLoadsGeminiAPIKeyFromEnv
  --- PASS: TestNewLoadsGeminiAPIKeyFromEnv (0.01s)
  === RUN   TestNewDisablesGeminiWhenURLIsOff
  --- PASS: TestNewDisablesGeminiWhenURLIsOff (0.01s)
  ```

- Requirement: Gemini races alongside the existing tiers, grounded responses beat Cerebras/Spark, inline citations are rendered into chat content, and provider attribution is `Google:`.
  Evidence: `go test -v ./internal/web -run "TestRunAssistantTurnParallelGroundedGeminiClaimsTurn"`
  Output excerpt:
  ```text
  === RUN   TestRunAssistantTurnParallelGroundedGeminiClaimsTurn
  --- PASS: TestRunAssistantTurnParallelGroundedGeminiClaimsTurn (0.06s)
  ```
  Test assertions cover the stored provider as `google`, the configured model label, and an inline citation link in the final assistant message.

- Requirement: Non-grounded Gemini responses do not get the search-preference boost.
  Evidence: `go test -v ./internal/web -run "TestRunAssistantTurnParallelUngroundedGeminiDoesNotBeatCerebras"`
  Output excerpt:
  ```text
  === RUN   TestRunAssistantTurnParallelUngroundedGeminiDoesNotBeatCerebras
  --- PASS: TestRunAssistantTurnParallelUngroundedGeminiDoesNotBeatCerebras (0.06s)
  ```

- Requirement: Gemini API failures degrade silently with backoff and no user-visible provider error.
  Evidence: `go test -v ./internal/web -run "TestRunAssistantTurnParallelGeminiFailureFallsBackSilently"`
  Output excerpt:
  ```text
  === RUN   TestRunAssistantTurnParallelGeminiFailureFallsBackSilently
  --- PASS: TestRunAssistantTurnParallelGeminiFailureFallsBackSilently (0.04s)
  ```

- Requirement: repo test suite stays green after the change.
  Evidence: `go test ./... 2>&1 | tee /tmp/tabura-go-test.log`
  Output excerpt:
  ```text
  ok   github.com/krystophny/tabura/internal/gemini  (cached)
  ok   github.com/krystophny/tabura/internal/web     12.499s
  ok   github.com/krystophny/tabura/tests/services   (cached)
  ```
