### PR TITLE
fix: Implement Meeting policy: passive capture, addressedness gating, (fixes #522)

### DIFF
--- a/internal/web/chat_meeting_capture.go
+++ b/internal/web/chat_meeting_capture.go
@@ -1,0 +1,365 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const meetingCaptureItemSource = "meeting_capture"
+
+type meetingNotesSnapshot struct {
+	Participants []string
+	Decisions    []string
+	ActionItems  []meetingNotesActionItem
+	KeyTopics    []string
+}
+
+type meetingNotesActionItem struct {
+	ActorName string
+	ItemTitle string
+	ItemID    int64
+}
+
+var (
+	meetingDecisionGoWithPattern   = regexp.MustCompile(`(?i)^(?:ok(?:ay)?[, ]+)?(?:let us|let's)\s+go with\s+(.+)$`)
+	meetingDecisionDecidedTo       = regexp.MustCompile(`(?i)^(?:we\s+)?decided\s+to\s+(.+)$`)
+	meetingDecisionDecidedOn       = regexp.MustCompile(`(?i)^(?:we\s+)?decided\s+on\s+(.+)$`)
+	meetingDecisionAgreement       = regexp.MustCompile(`(?i)^(?:we\s+)?agreed\s+to\s+(.+)$`)
+	meetingDecisionExplicitPattern = regexp.MustCompile(`(?i)^decision\s*[:\-]\s*(.+)$`)
+)
+
+var ignoredMeetingTopics = map[string]struct{}{
+	"assistant response cancelled":   {},
+	"assistant response completed":   {},
+	"assistant response failed":      {},
+	"assistant response interrupted": {},
+	"assistant response triggered":   {},
+	"session started":                {},
+	"session stopped":                {},
+}
+
+func meetingCaptureKey(raw string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(raw))), " ")
+}
+
+func normalizeMeetingDecisionText(raw string) string {
+	text := strings.TrimSpace(raw)
+	text = strings.Trim(text, " \t\r\n-:;,.!?")
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	first := strings.ToUpper(string(runes[0]))
+	if len(runes) == 1 {
+		return first
+	}
+	return first + string(runes[1:])
+}
+
+func parseMeetingDecisionCandidate(raw string) (string, bool) {
+	evidence := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	if evidence == "" || strings.HasPrefix(evidence, "#") {
+		return "", false
+	}
+	text := strings.TrimSpace(itemTitlePrefixPattern.ReplaceAllString(evidence, ""))
+	switch {
+	case meetingDecisionGoWithPattern.MatchString(text):
+		match := meetingDecisionGoWithPattern.FindStringSubmatch(text)
+		return normalizeMeetingDecisionText("Go with " + match[1]), true
+	case meetingDecisionDecidedTo.MatchString(text):
+		match := meetingDecisionDecidedTo.FindStringSubmatch(text)
+		return normalizeMeetingDecisionText("Decided to " + match[1]), true
+	case meetingDecisionDecidedOn.MatchString(text):
+		match := meetingDecisionDecidedOn.FindStringSubmatch(text)
+		return normalizeMeetingDecisionText("Decided on " + match[1]), true
+	case meetingDecisionAgreement.MatchString(text):
+		match := meetingDecisionAgreement.FindStringSubmatch(text)
+		return normalizeMeetingDecisionText("Agreed to " + match[1]), true
+	case meetingDecisionExplicitPattern.MatchString(text):
+		match := meetingDecisionExplicitPattern.FindStringSubmatch(text)
+		return normalizeMeetingDecisionText(match[1]), true
+	default:
+		return "", false
+	}
+}
+
+func extractMeetingDecisions(text string) []string {
+	candidates := splitMeetingSummaryCandidates(text)
+	if len(candidates) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		decision, ok := parseMeetingDecisionCandidate(candidate)
+		if !ok {
+			continue
+		}
+		key := meetingCaptureKey(decision)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, decision)
+	}
+	return out
+}
+
+func meetingCaptureItemTitle(item proposedMeetingItem) string {
+	if strings.TrimSpace(item.ActorName) == "" {
+		return item.Title
+	}
+	return fmt.Sprintf("%s: %s", item.ActorName, item.Title)
+}
+
+func meetingCaptureSourceRef(sessionID string, item proposedMeetingItem) string {
+	return strings.TrimSpace(sessionID) + ":" + meetingCaptureKey(item.ActorName) + ":" + meetingCaptureKey(item.Title)
+}
+
+func parseMeetingCapturePayload(raw string) map[string]any {
+	clean := strings.TrimSpace(raw)
+	if clean == "" {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(clean), &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func meetingCapturePayloadString(payload map[string]any, key string) string {
+	if payload == nil {
+		return ""
+	}
+	value := strings.TrimSpace(fmt.Sprint(payload[key]))
+	if value == "<nil>" {
+		return ""
+	}
+	return value
+}
+
+func (a *App) captureMeetingNotesForSegment(participantSessionID string, seg store.ParticipantSegment) {
+	if a == nil || a.store == nil || seg.ID == 0 {
+		return
+	}
+	if normalizeLivePolicy(a.LivePolicy().String()) != LivePolicyMeeting {
+		return
+	}
+	text := strings.TrimSpace(seg.Text)
+	if text == "" || isCompanionDirectAddress(text) {
+		return
+	}
+	session, err := a.store.GetParticipantSession(participantSessionID)
+	if err != nil {
+		log.Printf("meeting capture session lookup error: %v", err)
+		return
+	}
+	events, err := a.store.ListParticipantEvents(participantSessionID)
+	if err != nil {
+		log.Printf("meeting capture event lookup error: %v", err)
+		return
+	}
+
+	decisionKeys := map[string]struct{}{}
+	actionRefs := map[string]struct{}{}
+	for _, event := range events {
+		payload := parseMeetingCapturePayload(event.PayloadJSON)
+		switch strings.TrimSpace(event.EventType) {
+		case "meeting_decision_captured":
+			if key := meetingCaptureKey(meetingCapturePayloadString(payload, "decision")); key != "" {
+				decisionKeys[key] = struct{}{}
+			}
+		case "meeting_action_item_captured":
+			if sourceRef := strings.TrimSpace(meetingCapturePayloadString(payload, "source_ref")); sourceRef != "" {
+				actionRefs[sourceRef] = struct{}{}
+			}
+		}
+	}
+
+	if a.livePolicyConfig().CaptureDecisions {
+		for _, decision := range extractMeetingDecisions(text) {
+			key := meetingCaptureKey(decision)
+			if _, exists := decisionKeys[key]; exists {
+				continue
+			}
+			payload, err := json.Marshal(map[string]any{
+				"decision": decision,
+				"text":     decision,
+			})
+			if err != nil {
+				continue
+			}
+			if err := a.store.AddParticipantEvent(participantSessionID, seg.ID, "meeting_decision_captured", string(payload)); err == nil {
+				decisionKeys[key] = struct{}{}
+			}
+		}
+	}
+
+	if !a.livePolicyConfig().CaptureActionItems || session.WorkspaceID <= 0 {
+		return
+	}
+	workspaceID := session.WorkspaceID
+	for _, item := range a.extractMeetingItems(text) {
+		sourceRef := meetingCaptureSourceRef(participantSessionID, item)
+		if _, exists := actionRefs[sourceRef]; exists {
+			continue
+		}
+		created, err := a.store.UpsertItemFromSource(meetingCaptureItemSource, sourceRef, meetingCaptureItemTitle(item), &workspaceID)
+		if err != nil {
+			log.Printf("meeting capture item upsert error: %v", err)
+			continue
+		}
+		payload, err := json.Marshal(map[string]any{
+			"actor_name": item.ActorName,
+			"item_id":    created.ID,
+			"item_title": created.Title,
+			"source_ref": sourceRef,
+			"text":       created.Title,
+			"title":      item.Title,
+		})
+		if err != nil {
+			continue
+		}
+		if err := a.store.AddParticipantEvent(participantSessionID, seg.ID, "meeting_action_item_captured", string(payload)); err == nil {
+			actionRefs[sourceRef] = struct{}{}
+		}
+	}
+}
+
+func participantsFromSegments(segments []store.ParticipantSegment) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		name := strings.TrimSpace(seg.Speaker)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func decisionsFromParticipantEvents(events []store.ParticipantEvent) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(events))
+	for _, event := range events {
+		if strings.TrimSpace(event.EventType) != "meeting_decision_captured" {
+			continue
+		}
+		payload := parseMeetingCapturePayload(event.PayloadJSON)
+		decision := normalizeMeetingDecisionText(meetingCapturePayloadString(payload, "decision"))
+		if decision == "" {
+			decision = normalizeMeetingDecisionText(meetingCapturePayloadString(payload, "text"))
+		}
+		if decision == "" {
+			continue
+		}
+		key := meetingCaptureKey(decision)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, decision)
+	}
+	return out
+}
+
+func actionItemsFromParticipantEvents(events []store.ParticipantEvent) []meetingNotesActionItem {
+	seen := map[string]struct{}{}
+	out := make([]meetingNotesActionItem, 0, len(events))
+	for _, event := range events {
+		if strings.TrimSpace(event.EventType) != "meeting_action_item_captured" {
+			continue
+		}
+		payload := parseMeetingCapturePayload(event.PayloadJSON)
+		itemTitle := strings.TrimSpace(meetingCapturePayloadString(payload, "item_title"))
+		if itemTitle == "" {
+			itemTitle = meetingCaptureItemTitle(proposedMeetingItem{
+				ActorName: meetingCapturePayloadString(payload, "actor_name"),
+				Title:     meetingCapturePayloadString(payload, "title"),
+			})
+		}
+		if itemTitle == "" {
+			continue
+		}
+		key := meetingCaptureKey(itemTitle)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		item := meetingNotesActionItem{
+			ActorName: strings.TrimSpace(meetingCapturePayloadString(payload, "actor_name")),
+			ItemTitle: itemTitle,
+		}
+		if rawID := meetingCapturePayloadString(payload, "item_id"); rawID != "" {
+			fmt.Sscan(rawID, &item.ItemID)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func distinctMeetingTopics(items []any, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, limit)
+	for _, item := range items {
+		topic := strings.TrimSpace(formatCompanionTopicTimelineItem(item))
+		if topic == "" {
+			continue
+		}
+		key := strings.ToLower(topic)
+		if _, ignore := ignoredMeetingTopics[key]; ignore {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, topic)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+func buildMeetingNotesSnapshot(segments []store.ParticipantSegment, events []store.ParticipantEvent, memory companionRoomMemory) meetingNotesSnapshot {
+	return meetingNotesSnapshot{
+		Participants: participantsFromSegments(segments),
+		Decisions:    decisionsFromParticipantEvents(events),
+		ActionItems:  actionItemsFromParticipantEvents(events),
+		KeyTopics:    distinctMeetingTopics(memory.TopicTimeline, 5),
+	}
+}
+
+func (a *App) loadMeetingNotesSnapshot(sessionID string, memory companionRoomMemory) (meetingNotesSnapshot, error) {
+	if a == nil || a.store == nil || strings.TrimSpace(sessionID) == "" {
+		return meetingNotesSnapshot{}, nil
+	}
+	segments, err := a.store.ListParticipantSegments(sessionID, 0, 0)
+	if err != nil {
+		return meetingNotesSnapshot{}, err
+	}
+	events, err := a.store.ListParticipantEvents(sessionID)
+	if err != nil {
+		return meetingNotesSnapshot{}, err
+	}
+	return buildMeetingNotesSnapshot(segments, events, memory), nil
+}

--- a/internal/web/chat_meeting_items.go
+++ b/internal/web/chat_meeting_items.go
@@ -15,9 +15,10 @@ import (
 const meetingSummaryItemSource = "meeting_summary"
 
 var (
-	meetingItemExplicitPrefixPattern = regexp.MustCompile(`(?i)^(?:action(?:\s+item)?|todo|follow[- ]?up|next\s+step|owner)\s*[:\-]\s*(.+)$`)
-	meetingItemActorActionPattern    = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s+(?:will|should|can|must|needs?\s+to|is\s+going\s+to|to)\s+(.+)$`)
-	meetingItemActorLabelPattern     = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s*[:\-]\s*(.+)$`)
+	meetingItemExplicitPrefixPattern  = regexp.MustCompile(`(?i)^(?:action(?:\s+item)?|todo|follow[- ]?up|next\s+step|owner)\s*[:\-]\s*(.+)$`)
+	meetingItemActorActionPattern     = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s+(?:will|should|can|must|needs?\s+to|is\s+going\s+to|to)\s+(.+)$`)
+	meetingItemActorLabelPattern      = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s*[:\-]\s*(.+)$`)
+	meetingItemAssigneeRequestPattern = regexp.MustCompile(`^([A-Z][\pL0-9'’.-]*(?:\s+[A-Z][\pL0-9'’.-]*){0,2})\s*,\s*(?:can|could|will|would)\s+you\s+(.+)$`)
 )
 
 type proposedMeetingItem struct {
@@ -149,7 +150,10 @@ func parseMeetingItemCandidate(raw string) (proposedMeetingItem, bool) {
 	}
 
 	actorName := ""
-	if match := meetingItemActorActionPattern.FindStringSubmatch(text); len(match) == 3 {
+	if match := meetingItemAssigneeRequestPattern.FindStringSubmatch(text); len(match) == 3 {
+		actorName = strings.TrimSpace(match[1])
+		text = strings.TrimSpace(match[2])
+	} else if match := meetingItemActorActionPattern.FindStringSubmatch(text); len(match) == 3 {
 		actorName = strings.TrimSpace(match[1])
 		text = strings.TrimSpace(match[2])
 	} else if match := meetingItemActorLabelPattern.FindStringSubmatch(text); len(match) == 3 && looksLikeMeetingAction(match[2]) {

--- a/internal/web/chat_meeting_items_test.go
+++ b/internal/web/chat_meeting_items_test.go
@@ -19,12 +19,13 @@ func TestExtractMeetingItemsSupportsMixedSummaryFormats(t *testing.T) {
 		"- ACTION: Alice will draft the revised agenda.",
 		"1. TODO: review the budget appendix.",
 		"Bob: send the follow-up email.",
+		"Alice, can you prepare the budget by Friday?",
 		"Discussion: the budget is tight.",
 	}, "\n")
 
 	proposed := app.extractMeetingItems(summary)
-	if len(proposed) != 3 {
-		t.Fatalf("extractMeetingItems() len = %d, want 3", len(proposed))
+	if len(proposed) != 4 {
+		t.Fatalf("extractMeetingItems() len = %d, want 4", len(proposed))
 	}
 
 	if proposed[0].Title != "Draft the revised agenda" || proposed[0].ActorName != "Alice" {
@@ -36,9 +37,25 @@ func TestExtractMeetingItemsSupportsMixedSummaryFormats(t *testing.T) {
 	if proposed[2].Title != "Send the follow-up email" || proposed[2].ActorName != "Bob" {
 		t.Fatalf("third proposal = %#v", proposed[2])
 	}
+	if proposed[3].Title != "Prepare the budget by Friday" || proposed[3].ActorName != "Alice" {
+		t.Fatalf("fourth proposal = %#v", proposed[3])
+	}
 
 	if got := app.extractMeetingItems("The meeting covered current status only."); len(got) != 0 {
 		t.Fatalf("extractMeetingItems(no actions) len = %d, want 0", len(got))
+	}
+}
+
+func TestExtractMeetingDecisionsRecognizesDecisionLanguage(t *testing.T) {
+	decisions := extractMeetingDecisions("OK, let us go with option B for the timeline. We decided to revisit staffing next week.")
+	if len(decisions) != 2 {
+		t.Fatalf("extractMeetingDecisions() len = %d, want 2", len(decisions))
+	}
+	if decisions[0] != "Go with option B for the timeline" {
+		t.Fatalf("first decision = %q", decisions[0])
+	}
+	if decisions[1] != "Decided to revisit staffing next week" {
+		t.Fatalf("second decision = %q", decisions[1])
 	}
 }
 

--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -212,6 +212,7 @@ func transcribeParticipantChunk(a *App, conn *chatWSConn, sessionID string, buf 
 	}
 
 	_ = a.store.AddParticipantEvent(sessionID, seg.ID, "segment_committed", fmt.Sprintf(`{"text":%q}`, text))
+	a.captureMeetingNotesForSegment(sessionID, seg)
 	a.syncProjectCompanionArtifactsBySessionID(sessionID)
 	if projectKey != "" {
 		a.broadcastCompanionTranscriptEvent(projectKey, map[string]interface{}{

--- a/internal/web/chat_participant_test.go
+++ b/internal/web/chat_participant_test.go
@@ -686,6 +686,75 @@ func TestParticipantBinaryChunkTranscribesWAVSegmentImmediately(t *testing.T) {
 	}
 }
 
+func TestParticipantBinaryChunkCapturesMeetingNotesAndInboxItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	t.Setenv("PATH", t.TempDir())
+
+	sttSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"OK, let us go with option B for the timeline. Alice, can you prepare the budget by Friday?"}`))
+	}))
+	defer sttSrv.Close()
+	app.sttURL = sttSrv.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	chatSession, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, chatSession.ID)
+	started := readParticipantMessage(t, clientConn, 2*time.Second)
+	if started.Type != "participant_started" {
+		t.Fatalf("start message type = %q, want participant_started", started.Type)
+	}
+
+	handleParticipantBinaryChunk(app, conn, buildParticipantSpeechWAV(240, 16000))
+
+	segmentMsg := readParticipantMessage(t, clientConn, 2*time.Second)
+	if segmentMsg.Type != "participant_segment_text" {
+		t.Fatalf("message type = %q, want participant_segment_text", segmentMsg.Type)
+	}
+
+	participantSession, err := app.store.GetParticipantSession(started.SessionID)
+	if err != nil {
+		t.Fatalf("GetParticipantSession: %v", err)
+	}
+	items, err := app.store.ListItemsFiltered(store.ItemListFilter{
+		Source:      meetingCaptureItemSource,
+		WorkspaceID: &participantSession.WorkspaceID,
+	})
+	if err != nil {
+		t.Fatalf("ListItemsFiltered: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("meeting capture items = %d, want 1", len(items))
+	}
+	if items[0].Title != "Alice: Prepare the budget by Friday" {
+		t.Fatalf("captured item title = %q", items[0].Title)
+	}
+
+	summaryPath := filepath.Join(project.RootPath, ".tabura", "artifacts", "companion", started.SessionID, "summary.md")
+	summaryBody, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary artifact: %v", err)
+	}
+	summaryText := string(summaryBody)
+	if !strings.Contains(summaryText, "## Decisions") || !strings.Contains(summaryText, "Go with option B for the timeline") {
+		t.Fatalf("summary artifact missing decision capture: %q", summaryText)
+	}
+	if !strings.Contains(summaryText, "## Action Items") || !strings.Contains(summaryText, "Alice: Prepare the budget by Friday") {
+		t.Fatalf("summary artifact missing action-item capture: %q", summaryText)
+	}
+}
+
 func TestParticipantBinaryChunkTranscribeFailureSendsParticipantError(t *testing.T) {
 	app := newAuthedTestApp(t)
 	t.Setenv("PATH", t.TempDir())
@@ -1050,6 +1119,58 @@ func TestParticipantConfigPutDisableStopsActiveSession(t *testing.T) {
 	}
 	if persisted.EndedAt == 0 {
 		t.Fatal("participant session should be ended after disabling companion")
+	}
+}
+
+func TestLivePolicyPostStopsActiveParticipantSession(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	enableCompanionForTestProject(t, app, project.ProjectKey)
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	conn, cleanup := newTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	handleParticipantStart(app, conn, session.ID)
+
+	conn.participantMu.Lock()
+	participantSessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if participantSessionID == "" {
+		t.Fatal("expected participant session id")
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/live-policy", map[string]any{
+		"policy": "dialogue",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST live-policy status = %d, want 200", rr.Code)
+	}
+
+	conn.participantMu.Lock()
+	active := conn.participantActive
+	currentSessionID := conn.participantSessionID
+	conn.participantMu.Unlock()
+	if active {
+		t.Fatal("participantActive = true, want false after switching to dialogue")
+	}
+	if currentSessionID != "" {
+		t.Fatalf("participantSessionID = %q, want empty after switching to dialogue", currentSessionID)
+	}
+
+	persisted, err := app.store.GetParticipantSession(participantSessionID)
+	if err != nil {
+		t.Fatalf("GetParticipantSession: %v", err)
+	}
+	if persisted.EndedAt == 0 {
+		t.Fatal("participant session should be ended after leaving meeting mode")
 	}
 }
 

--- a/internal/web/live_policy.go
+++ b/internal/web/live_policy.go
@@ -173,12 +173,16 @@ func (a *App) handleLivePolicyPost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
+	current := a.LivePolicy()
 	changed, err := a.setLivePolicy(policy)
 	if err != nil {
 		http.Error(w, "failed to save live policy", http.StatusInternalServerError)
 		return
 	}
 	if changed {
+		if current == LivePolicyMeeting && policy != LivePolicyMeeting {
+			a.disableLiveMeetingCapture()
+		}
 		a.broadcastLivePolicyChanged(policy)
 	}
 	writeJSON(w, map[string]interface{}{

--- a/internal/web/projects_companion.go
+++ b/internal/web/projects_companion.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -336,49 +337,68 @@ func (a *App) handleProjectCompanionState(w http.ResponseWriter, r *http.Request
 	})
 }
 
+func (a *App) stopParticipantCaptureSessions(match func(store.ParticipantSession) bool, reason, errMsg string) {
+	if a == nil || a.store == nil || match == nil {
+		return
+	}
+	affectedProjectKeys := map[string]struct{}{}
+	if a.hub != nil {
+		a.hub.forEachChatConn(func(conn *chatWSConn) {
+			conn.participantMu.Lock()
+			sessionID := strings.TrimSpace(conn.participantSessionID)
+			active := conn.participantActive
+			conn.participantMu.Unlock()
+			if !active || sessionID == "" {
+				return
+			}
+			session, err := a.store.GetParticipantSession(sessionID)
+			if err != nil || !match(session) {
+				return
+			}
+			affectedProjectKeys[session.ProjectKey] = struct{}{}
+			stoppedSessionID, ok := releaseParticipantSession(a, conn)
+			if !ok {
+				return
+			}
+			_ = conn.writeJSON(participantMessage{Type: "participant_stopped", SessionID: stoppedSessionID})
+			_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: errMsg})
+		})
+	}
+
+	sessions, err := a.store.ListParticipantSessions("")
+	if err != nil {
+		return
+	}
+	for _, session := range sessions {
+		if session.EndedAt != 0 || !match(session) {
+			continue
+		}
+		affectedProjectKeys[session.ProjectKey] = struct{}{}
+		_ = a.store.EndParticipantSession(session.ID)
+		_ = a.store.AddParticipantEvent(session.ID, 0, "session_stopped", fmt.Sprintf(`{"reason":%q}`, strings.TrimSpace(reason)))
+		a.syncProjectCompanionArtifactsBySessionID(session.ID)
+	}
+	for projectKey := range affectedProjectKeys {
+		a.broadcastCompanionRuntimeState(projectKey, companionRuntimeSnapshot{
+			State:      companionRuntimeStateIdle,
+			Reason:     strings.TrimSpace(reason),
+			ProjectKey: projectKey,
+		})
+	}
+}
+
 func (a *App) disableCompanionCapture(projectKey string) {
 	cleanProjectKey := strings.TrimSpace(projectKey)
 	if cleanProjectKey == "" {
 		return
 	}
-	a.hub.forEachChatConn(func(conn *chatWSConn) {
-		conn.participantMu.Lock()
-		sessionID := strings.TrimSpace(conn.participantSessionID)
-		active := conn.participantActive
-		conn.participantMu.Unlock()
-		if !active || sessionID == "" {
-			return
-		}
-		session, err := a.store.GetParticipantSession(sessionID)
-		if err != nil || session.ProjectKey != cleanProjectKey {
-			return
-		}
-		stoppedSessionID, ok := releaseParticipantSession(a, conn)
-		if !ok {
-			return
-		}
-		_ = conn.writeJSON(participantMessage{Type: "participant_stopped", SessionID: stoppedSessionID})
-		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "meeting mode is disabled"})
-	})
+	a.stopParticipantCaptureSessions(func(session store.ParticipantSession) bool {
+		return session.ProjectKey == cleanProjectKey
+	}, "companion_disabled", "meeting mode is disabled")
+}
 
-	project, err := a.store.GetProjectByProjectKey(cleanProjectKey)
-	if err != nil {
-		return
-	}
-	sessions, err := a.store.ListParticipantSessionsForProject(project.ID)
-	if err != nil {
-		return
-	}
-	for _, session := range sessions {
-		if session.EndedAt != 0 {
-			continue
-		}
-		_ = a.store.EndParticipantSession(session.ID)
-		_ = a.store.AddParticipantEvent(session.ID, 0, "session_stopped", `{"reason":"companion_disabled"}`)
-	}
-	a.broadcastCompanionRuntimeState(cleanProjectKey, companionRuntimeSnapshot{
-		State:      companionRuntimeStateIdle,
-		Reason:     "companion_disabled",
-		ProjectKey: cleanProjectKey,
-	})
+func (a *App) disableLiveMeetingCapture() {
+	a.stopParticipantCaptureSessions(func(session store.ParticipantSession) bool {
+		return true
+	}, "live_policy_disabled", "meeting mode is disabled")
 }

--- a/internal/web/projects_companion_artifacts.go
+++ b/internal/web/projects_companion_artifacts.go
@@ -321,13 +321,18 @@ func (a *App) syncProjectCompanionArtifacts(project store.Project, session *stor
 	if err != nil {
 		return err
 	}
+	events, err := a.store.ListParticipantEvents(session.ID)
+	if err != nil {
+		return err
+	}
 	memory, err := a.loadCompanionRoomMemory(session.ID)
 	if err != nil {
 		return err
 	}
+	notes := buildMeetingNotesSnapshot(segments, events, memory)
 	files := map[string]string{
 		"transcript.md": renderCompanionTranscriptMarkdown(session, segments),
-		"summary.md":    renderCompanionSummaryMarkdown(session, memory.SummaryText, memory.UpdatedAt),
+		"summary.md":    renderCompanionSummaryMarkdown(session, memory.SummaryText, memory.UpdatedAt, notes),
 		"references.md": renderCompanionReferencesMarkdown(session, memory.Entities, memory.TopicTimeline),
 	}
 	for name, content := range files {
@@ -412,7 +417,77 @@ func renderCompanionTranscriptText(session *store.ParticipantSession, segments [
 	return b.String()
 }
 
-func renderCompanionSummaryMarkdown(session *store.ParticipantSession, summary string, updatedAt int64) string {
+func appendMeetingNotesMarkdown(b *strings.Builder, notes meetingNotesSnapshot) {
+	b.WriteString("## Participants\n\n")
+	if len(notes.Participants) == 0 {
+		b.WriteString("_No participants captured yet._\n")
+	} else {
+		for _, participant := range notes.Participants {
+			fmt.Fprintf(b, "- %s\n", participant)
+		}
+	}
+	b.WriteString("\n## Decisions\n\n")
+	if len(notes.Decisions) == 0 {
+		b.WriteString("_No decisions captured yet._\n")
+	} else {
+		for _, decision := range notes.Decisions {
+			fmt.Fprintf(b, "- %s\n", decision)
+		}
+	}
+	b.WriteString("\n## Action Items\n\n")
+	if len(notes.ActionItems) == 0 {
+		b.WriteString("_No action items captured yet._\n")
+	} else {
+		for _, item := range notes.ActionItems {
+			fmt.Fprintf(b, "- %s\n", item.ItemTitle)
+		}
+	}
+	b.WriteString("\n## Key Topics\n\n")
+	if len(notes.KeyTopics) == 0 {
+		b.WriteString("_No key topics captured yet._\n")
+		return
+	}
+	for _, topic := range notes.KeyTopics {
+		fmt.Fprintf(b, "- %s\n", topic)
+	}
+}
+
+func appendMeetingNotesText(b *strings.Builder, notes meetingNotesSnapshot) {
+	b.WriteString("Participants\n")
+	if len(notes.Participants) == 0 {
+		b.WriteString("- none\n")
+	} else {
+		for _, participant := range notes.Participants {
+			fmt.Fprintf(b, "- %s\n", participant)
+		}
+	}
+	b.WriteString("\nDecisions\n")
+	if len(notes.Decisions) == 0 {
+		b.WriteString("- none\n")
+	} else {
+		for _, decision := range notes.Decisions {
+			fmt.Fprintf(b, "- %s\n", decision)
+		}
+	}
+	b.WriteString("\nAction Items\n")
+	if len(notes.ActionItems) == 0 {
+		b.WriteString("- none\n")
+	} else {
+		for _, item := range notes.ActionItems {
+			fmt.Fprintf(b, "- %s\n", item.ItemTitle)
+		}
+	}
+	b.WriteString("\nKey Topics\n")
+	if len(notes.KeyTopics) == 0 {
+		b.WriteString("- none\n")
+		return
+	}
+	for _, topic := range notes.KeyTopics {
+		fmt.Fprintf(b, "- %s\n", topic)
+	}
+}
+
+func renderCompanionSummaryMarkdown(session *store.ParticipantSession, summary string, updatedAt int64, notes meetingNotesSnapshot) string {
 	var b strings.Builder
 	b.WriteString("# Meeting Summary\n\n")
 	if session == nil {
@@ -427,14 +502,16 @@ func renderCompanionSummaryMarkdown(session *store.ParticipantSession, summary s
 	text := strings.TrimSpace(summary)
 	if text == "" {
 		b.WriteString("_No summary text available._\n")
-		return b.String()
+	} else {
+		b.WriteString(text)
+		b.WriteString("\n")
 	}
-	b.WriteString(text)
 	b.WriteString("\n")
+	appendMeetingNotesMarkdown(&b, notes)
 	return b.String()
 }
 
-func renderCompanionSummaryText(session *store.ParticipantSession, summary string, updatedAt int64) string {
+func renderCompanionSummaryText(session *store.ParticipantSession, summary string, updatedAt int64, notes meetingNotesSnapshot) string {
 	if session == nil {
 		return "No summary is available for this project yet.\n"
 	}
@@ -447,10 +524,12 @@ func renderCompanionSummaryText(session *store.ParticipantSession, summary strin
 	text := strings.TrimSpace(summary)
 	if text == "" {
 		b.WriteString("No summary text available.\n")
-		return b.String()
+	} else {
+		b.WriteString(text)
+		b.WriteString("\n")
 	}
-	b.WriteString(text)
 	b.WriteString("\n")
+	appendMeetingNotesText(&b, notes)
 	return b.String()
 }
 
@@ -554,6 +633,7 @@ func (a *App) handleProjectCompanionSummary(w http.ResponseWriter, r *http.Reque
 	}
 	summaryText := ""
 	updatedAt := int64(0)
+	notes := meetingNotesSnapshot{}
 	if session != nil {
 		memory, err := a.loadCompanionRoomMemory(session.ID)
 		if err != nil {
@@ -562,6 +642,11 @@ func (a *App) handleProjectCompanionSummary(w http.ResponseWriter, r *http.Reque
 		}
 		summaryText = memory.SummaryText
 		updatedAt = memory.UpdatedAt
+		notes, err = a.loadMeetingNotesSnapshot(session.ID, memory)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	payload := companionSummaryResponse{
 		OK:          true,
@@ -575,7 +660,7 @@ func (a *App) handleProjectCompanionSummary(w http.ResponseWriter, r *http.Reque
 	if err := a.syncProjectCompanionArtifacts(project, session); err != nil {
 		log.Printf("companion artifact sync failed for project %s summary view: %v", project.ID, err)
 	}
-	respondCompanionArtifact(w, r.URL.Query().Get("format"), payload, renderCompanionSummaryMarkdown(session, summaryText, updatedAt), renderCompanionSummaryText(session, summaryText, updatedAt))
+	respondCompanionArtifact(w, r.URL.Query().Get("format"), payload, renderCompanionSummaryMarkdown(session, summaryText, updatedAt, notes), renderCompanionSummaryText(session, summaryText, updatedAt, notes))
 }
 
 func (a *App) handleProjectCompanionReferences(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- capture unaddressed meeting decisions and action items directly from participant transcripts
- write captured decisions, action items, participants, and key topics into the meeting summary artifact
- stop active participant capture immediately when live policy leaves Meeting mode

## Verification

- Meeting mode captures decisions and action items without interrupting: `go test ./internal/web -run 'TestParticipantBinaryChunkCapturesMeetingNotesAndInboxItems|TestLivePolicyPostStopsActiveParticipantSession|TestExtractMeetingDecisionsRecognizesDecisionLanguage|TestExtractMeetingItemsSupportsMixedSummaryFormats|TestRunAssistantTurnSuppressesUnaddressedMeetingTurn|TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification' -v` -> `PASS`; `TestParticipantBinaryChunkCapturesMeetingNotesAndInboxItems` commits an unaddressed transcript and verifies both captures land without requiring an assistant turn.
- Captured items are created in inbox with workspace context: same command; `TestParticipantBinaryChunkCapturesMeetingNotesAndInboxItems` asserts `ListItemsFiltered(store.ItemListFilter{Source: meetingCaptureItemSource, WorkspaceID: &participantSession.WorkspaceID})` returns `Alice: Prepare the budget by Friday`.
- Meeting notes accumulate as a workspace artifact: same command; `TestParticipantBinaryChunkCapturesMeetingNotesAndInboxItems` reads `.tabura/artifacts/companion/<session-id>/summary.md` and verifies `## Decisions` plus `## Action Items` content.
- Addressed questions get responses; unaddressed speech is captured only: same command; `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn` and `TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification` both pass.
- Switching away from Meeting mode finalizes notes: same command; `TestLivePolicyPostStopsActiveParticipantSession` posts `/api/live-policy` with `dialogue` and verifies the participant session is ended immediately.
- Decision and action-item parsing covers the meeting phrasing from the issue examples: same command; `TestExtractMeetingDecisionsRecognizesDecisionLanguage` and `TestExtractMeetingItemsSupportsMixedSummaryFormats` both pass.
- Broad package check after the change: `go test ./internal/web 2>&1 | tee /tmp/tabura-issue522-test.log`; this surfaced an unrelated existing failure, `TestSyncEmailAccountRemoteInboxReopensDoneItems`, while the Meeting-policy paths above passed on targeted rerun.
