### PR TITLE
fix: Epic: Formalize deterministic fast paths alongside the unified l (fixes #517)

### DIFF
--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -121,6 +121,21 @@ Execution is workspace-aware. System commands operate at system level (switch wo
 
 There is no hub entity. System commands are available from any workspace.
 
+### Deterministic fast paths
+
+Deterministic fast paths run before semantic routing and must not invoke the local intent model.
+
+The registered fast-path families include:
+
+- source sync and external sync commands
+- calendar and briefing requests
+- cursor, titled-item, item, workspace, and project commands
+- GitHub issue and artifact-linking commands
+- runtime control commands such as `toggle_silent`, `toggle_live_dialogue`, `cancel_work`, `show_status`, and `switch_model`
+- direct UI loopback controls for `system_action` events and push-to-talk hold/release
+
+The backend registry in `internal/web/chat_intent_fast.go` is authoritative for these boundaries.
+
 ## Authoritative Live Model
 
 Tabura exposes exactly two live runtime modes:

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -542,7 +542,7 @@ func TestRunAssistantTurnExecutesHighConfidenceLocalIntent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("project session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "please go silent now", "please go silent now", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 
@@ -574,7 +574,7 @@ func TestRunAssistantTurnExecutesHighConfidenceLocalIntentInProjectSession(t *te
 	if err != nil {
 		t.Fatalf("chat session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "please go silent now", "please go silent now", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 
@@ -721,7 +721,7 @@ func TestRunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable(t *testing
 	if err != nil {
 		t.Fatalf("project session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "help me with the plasma analysis", "help me with the plasma analysis", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 
@@ -753,7 +753,7 @@ func TestRunAssistantTurnUsesIntentLLMPlanForSystemAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("project session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "please go silent now", "please go silent now", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 

--- a/internal/web/chat_intent_addressed_test.go
+++ b/internal/web/chat_intent_addressed_test.go
@@ -235,11 +235,11 @@ func TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassificati
 	if err != nil {
 		t.Fatalf("project session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "Tabura, be quiet", "Tabura, be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "Tabura, please go silent now", "Tabura, please go silent now", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 
-	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "Tabura, be quiet", nil, "")
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "Tabura, please go silent now", nil, "")
 	if !handled {
 		t.Fatal("expected explicit direct address to be handled")
 	}
@@ -267,11 +267,11 @@ func TestRunAssistantTurnDialogueIgnoresAddressedFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("project session: %v", err)
 	}
-	if _, err := app.store.AddChatMessage(session.ID, "user", "be quiet", "be quiet", "text"); err != nil {
+	if _, err := app.store.AddChatMessage(session.ID, "user", "please go silent now", "please go silent now", "text"); err != nil {
 		t.Fatalf("add user message: %v", err)
 	}
 
-	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "be quiet", nil, "")
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "please go silent now", nil, "")
 	if !handled {
 		t.Fatal("expected dialogue mode to ignore addressed flag")
 	}

--- a/internal/web/chat_intent_fast.go
+++ b/internal/web/chat_intent_fast.go
@@ -21,14 +21,26 @@ type deterministicFastPathMatch struct {
 	FailureMessage func(userText string, enforced []*SystemAction, err error) string
 }
 
+type deterministicFastPathSpec struct {
+	Name     string
+	Route    string
+	Actions  []string
+	Triggers []string
+}
+
 type deterministicFastPathParser struct {
-	Name  string
+	Spec  deterministicFastPathSpec
 	Parse func(text string, ctx deterministicFastPathContext) *deterministicFastPathMatch
 }
 
 var deterministicFastPaths = []deterministicFastPathParser{
 	{
-		Name: "source_sync",
+		Spec: deterministicFastPathSpec{
+			Name:     "source_sync",
+			Route:    "text",
+			Actions:  []string{"sync_sources"},
+			Triggers: []string{"sync all sources"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineSourceSyncIntent(text)
 			if action == nil {
@@ -38,7 +50,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "calendar",
+		Spec: deterministicFastPathSpec{
+			Name:     "calendar",
+			Route:    "text",
+			Actions:  []string{"show_calendar"},
+			Triggers: []string{"show calendar"},
+		},
 		Parse: func(text string, ctx deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineCalendarIntent(text, ctx.Now)
 			if action == nil {
@@ -48,7 +65,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "briefing",
+		Spec: deterministicFastPathSpec{
+			Name:     "briefing",
+			Route:    "text",
+			Actions:  []string{"show_briefing"},
+			Triggers: []string{"show briefing"},
+		},
 		Parse: func(text string, ctx deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineBriefingIntent(text, ctx.Now)
 			if action == nil {
@@ -58,7 +80,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "todoist",
+		Spec: deterministicFastPathSpec{
+			Name:     "todoist",
+			Route:    "text",
+			Actions:  []string{"map_todoist_project", "sync_todoist", "create_todoist_task"},
+			Triggers: []string{"sync todoist"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineTodoistIntent(text)
 			if action == nil {
@@ -68,7 +95,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "evernote",
+		Spec: deterministicFastPathSpec{
+			Name:     "evernote",
+			Route:    "text",
+			Actions:  []string{"sync_evernote"},
+			Triggers: []string{"sync evernote"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineEvernoteIntent(text)
 			if action == nil {
@@ -78,7 +110,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "bear",
+		Spec: deterministicFastPathSpec{
+			Name:     "bear",
+			Route:    "text",
+			Actions:  []string{"sync_bear", "promote_bear_checklist"},
+			Triggers: []string{"sync bear"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineBearIntent(text)
 			if action == nil {
@@ -88,7 +125,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "zotero",
+		Spec: deterministicFastPathSpec{
+			Name:     "zotero",
+			Route:    "text",
+			Actions:  []string{"sync_zotero"},
+			Triggers: []string{"sync zotero"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineZoteroIntent(text)
 			if action == nil {
@@ -98,7 +140,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "cursor",
+		Spec: deterministicFastPathSpec{
+			Name:     "cursor",
+			Route:    "text",
+			Actions:  []string{"cursor_open_item", "cursor_triage_item", "cursor_open_path"},
+			Triggers: []string{"open this"},
+		},
 		Parse: func(text string, ctx deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineCursorIntent(text, ctx.Cursor)
 			if action == nil {
@@ -108,7 +155,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "titled_item",
+		Spec: deterministicFastPathSpec{
+			Name:     "titled_item",
+			Route:    "text",
+			Actions:  []string{"triage_item_by_title"},
+			Triggers: []string{`move the item "Budget" back to the inbox`},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			intent := parseInlineTitledItemIntent(text)
 			if intent == nil {
@@ -124,7 +176,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "item",
+		Spec: deterministicFastPathSpec{
+			Name:     "item",
+			Route:    "text",
+			Actions:  []string{canonicalActionTrackItem, "make_item", "delegate_item", "snooze_item", "split_items", "capture_idea", "refine_idea_note", "promote_idea", "apply_idea_promotion", "review_someday", "triage_someday", "promote_someday", "toggle_someday_review_nudge", "show_filtered_items", "print_item", "reassign_workspace", "reassign_project", "clear_workspace", "clear_project"},
+			Triggers: []string{"idea: better swipe triage"},
+		},
 		Parse: func(text string, ctx deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineItemIntentWithCaptureMode(text, ctx.Now, ctx.CaptureMode)
 			if action == nil {
@@ -134,7 +191,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "github_issue",
+		Spec: deterministicFastPathSpec{
+			Name:     "github_issue",
+			Route:    "text",
+			Actions:  []string{canonicalActionDispatchExecute, "create_github_issue", "create_github_issue_split"},
+			Triggers: []string{"create a GitHub issue from this"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			actions := parseInlineGitHubIssueActions(text)
 			if len(actions) == 0 {
@@ -144,7 +206,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "artifact_link",
+		Spec: deterministicFastPathSpec{
+			Name:     "artifact_link",
+			Route:    "text",
+			Actions:  []string{"link_workspace_artifact", "list_linked_artifacts"},
+			Triggers: []string{"show linked artifacts"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineArtifactLinkIntent(text)
 			if action == nil {
@@ -154,7 +221,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "batch",
+		Spec: deterministicFastPathSpec{
+			Name:     "batch",
+			Route:    "text",
+			Actions:  []string{"batch_work", "batch_configure", "review_policy", "batch_limit", "batch_status"},
+			Triggers: []string{"show me progress"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineBatchIntent(text)
 			if action == nil {
@@ -164,7 +236,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "workspace",
+		Spec: deterministicFastPathSpec{
+			Name:     "workspace",
+			Route:    "text",
+			Actions:  []string{"switch_workspace", "focus_workspace", "clear_focus", "list_workspace_items", "list_workspaces", "create_workspace", "create_workspace_from_git", "rename_workspace", "delete_workspace", "show_workspace_details", "workspace_watch_start", "workspace_watch_stop", "workspace_watch_status", "show_busy_state"},
+			Triggers: []string{"list workspaces"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineWorkspaceIntent(text)
 			if action == nil {
@@ -174,7 +251,12 @@ var deterministicFastPaths = []deterministicFastPathParser{
 		},
 	},
 	{
-		Name: "project",
+		Spec: deterministicFastPathSpec{
+			Name:     "project",
+			Route:    "text",
+			Actions:  []string{"assign_workspace_project", "show_workspace_project", "create_project", "list_project_workspaces", "sync_project"},
+			Triggers: []string{"what project is this?"},
+		},
 		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
 			action := parseInlineProjectIntent(text)
 			if action == nil {
@@ -183,6 +265,55 @@ var deterministicFastPaths = []deterministicFastPathParser{
 			return fastPathSingleAction("project", action, fixedFastPathFailure("I couldn't resolve the project request: "))
 		},
 	},
+	{
+		Spec: deterministicFastPathSpec{
+			Name:     "runtime_control",
+			Route:    "text",
+			Actions:  []string{"toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "switch_model"},
+			Triggers: []string{"be quiet", "toggle live dialogue", "cancel work", "status?", "switch model to gpt high"},
+		},
+		Parse: func(text string, _ deterministicFastPathContext) *deterministicFastPathMatch {
+			action := parseInlineRuntimeControlIntent(text)
+			if action == nil {
+				return nil
+			}
+			return fastPathSingleAction("runtime_control", action, fixedFastPathFailure("I couldn't resolve the runtime control request: "))
+		},
+	},
+}
+
+var deterministicFastPathUIControls = []deterministicFastPathSpec{
+	{
+		Name:     "ui_runtime_controls",
+		Route:    "ui",
+		Actions:  []string{"toggle_silent", "toggle_live_dialogue", "switch_model"},
+		Triggers: []string{"system_action:toggle_silent", "system_action:toggle_live_dialogue", "system_action:switch_model"},
+	},
+	{
+		Name:     "ui_push_to_talk",
+		Route:    "ui",
+		Triggers: []string{"ctrl_long_press", "ctrl_release"},
+	},
+}
+
+func deterministicFastPathCatalog() []deterministicFastPathSpec {
+	specs := make([]deterministicFastPathSpec, 0, len(deterministicFastPaths)+len(deterministicFastPathUIControls))
+	for _, parser := range deterministicFastPaths {
+		if strings.TrimSpace(parser.Spec.Name) == "" {
+			continue
+		}
+		spec := parser.Spec
+		spec.Actions = append([]string(nil), spec.Actions...)
+		spec.Triggers = append([]string(nil), spec.Triggers...)
+		specs = append(specs, spec)
+	}
+	for _, spec := range deterministicFastPathUIControls {
+		copied := spec
+		copied.Actions = append([]string(nil), copied.Actions...)
+		copied.Triggers = append([]string(nil), copied.Triggers...)
+		specs = append(specs, copied)
+	}
+	return specs
 }
 
 func fastPathSingleAction(name string, action *SystemAction, failure func(string, []*SystemAction, error) string) *deterministicFastPathMatch {
@@ -239,7 +370,7 @@ func tryDeterministicFastPath(text string, ctx deterministicFastPathContext) *de
 		}
 		if match := parser.Parse(trimmed, ctx); match != nil {
 			if strings.TrimSpace(match.Name) == "" {
-				match.Name = parser.Name
+				match.Name = parser.Spec.Name
 			}
 			return match
 		}

--- a/internal/web/chat_intent_fast_test.go
+++ b/internal/web/chat_intent_fast_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,6 +37,9 @@ func TestTryDeterministicFastPathRegistry(t *testing.T) {
 		{name: "workspace", text: "list workspaces", wantMatch: "workspace", wantAction: "list_workspaces"},
 		{name: "workspace focus", text: "open the plasma workspace", wantMatch: "workspace", wantAction: "focus_workspace"},
 		{name: "project", text: "what project is this?", wantMatch: "project", wantAction: "show_workspace_project"},
+		{name: "runtime silent", text: "be quiet", wantMatch: "runtime_control", wantAction: "toggle_silent"},
+		{name: "runtime status", text: "status?", wantMatch: "runtime_control", wantAction: "show_status"},
+		{name: "runtime model", text: "switch model to gpt high", wantMatch: "runtime_control", wantAction: "switch_model"},
 	}
 
 	for _, tc := range tests {
@@ -73,6 +77,53 @@ func TestTryDeterministicFastPathNoMatch(t *testing.T) {
 	}
 }
 
+func TestDeterministicFastPathCatalogIncludesRuntimeAndUIControls(t *testing.T) {
+	catalog := deterministicFastPathCatalog()
+	find := func(name string) *deterministicFastPathSpec {
+		t.Helper()
+		for i := range catalog {
+			if catalog[i].Name == name {
+				return &catalog[i]
+			}
+		}
+		return nil
+	}
+
+	runtime := find("runtime_control")
+	if runtime == nil {
+		t.Fatal("expected runtime_control catalog entry")
+	}
+	if runtime.Route != "text" {
+		t.Fatalf("runtime route = %q, want text", runtime.Route)
+	}
+	for _, action := range []string{"toggle_silent", "toggle_live_dialogue", "cancel_work", "show_status", "switch_model"} {
+		if !containsExactString(runtime.Actions, action) {
+			t.Fatalf("runtime actions = %#v, missing %q", runtime.Actions, action)
+		}
+	}
+
+	ui := find("ui_runtime_controls")
+	if ui == nil {
+		t.Fatal("expected ui_runtime_controls catalog entry")
+	}
+	if ui.Route != "ui" {
+		t.Fatalf("ui route = %q, want ui", ui.Route)
+	}
+	if !containsExactString(ui.Triggers, "system_action:toggle_live_dialogue") {
+		t.Fatalf("ui triggers = %#v, missing live dialogue system action", ui.Triggers)
+	}
+
+	ptt := find("ui_push_to_talk")
+	if ptt == nil {
+		t.Fatal("expected ui_push_to_talk catalog entry")
+	}
+	for _, trigger := range []string{"ctrl_long_press", "ctrl_release"} {
+		if !containsExactString(ptt.Triggers, trigger) {
+			t.Fatalf("ptt triggers = %#v, missing %q", ptt.Triggers, trigger)
+		}
+	}
+}
+
 func TestClassifyAndExecuteSystemActionFastPathBypassesIntentLLM(t *testing.T) {
 	app := newAuthedTestApp(t)
 	project, err := app.ensureDefaultProjectRecord()
@@ -102,4 +153,136 @@ func TestClassifyAndExecuteSystemActionFastPathBypassesIntentLLM(t *testing.T) {
 	if got := message; got == "" || got == "I can only handle system actions in local-only mode." {
 		t.Fatalf("message = %q, want fast-path execution result", got)
 	}
+}
+
+func TestClassifyAndExecuteSystemActionRuntimeControlBypassesIntentLLM(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	var llmCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		llmCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	app.intentLLMURL = server.URL
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "be quiet")
+	if !handled {
+		t.Fatal("expected runtime control fast path to handle be quiet")
+	}
+	if llmCalls.Load() != 0 {
+		t.Fatalf("intent llm calls = %d, want 0", llmCalls.Load())
+	}
+	if message != "Toggled silent mode." {
+		t.Fatalf("message = %q, want %q", message, "Toggled silent mode.")
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "toggle_silent" {
+		t.Fatalf("payloads = %#v, want toggle_silent payload", payloads)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionSwitchModelFastPathBypassesIntentLLM(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	var llmCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		llmCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	app.intentLLMURL = server.URL
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "switch model to gpt high")
+	if !handled {
+		t.Fatal("expected runtime control fast path to switch model")
+	}
+	if llmCalls.Load() != 0 {
+		t.Fatalf("intent llm calls = %d, want 0", llmCalls.Load())
+	}
+	if !strings.Contains(message, "Model for ") {
+		t.Fatalf("message = %q, want model switch confirmation", message)
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "switch_model" {
+		t.Fatalf("payloads = %#v, want switch_model payload", payloads)
+	}
+	updatedProject, err := app.store.GetProjectByProjectKey(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("reload project: %v", err)
+	}
+	if updatedProject.ChatModel != "gpt" {
+		t.Fatalf("chat model = %q, want gpt", updatedProject.ChatModel)
+	}
+	if updatedProject.ChatModelReasoningEffort != "high" {
+		t.Fatalf("reasoning effort = %q, want high", updatedProject.ChatModelReasoningEffort)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionStatusFastPathBypassesIntentLLM(t *testing.T) {
+	wsServer := setupMockAppServerStatusServer(t, "Agent healthy.")
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	app, err := New(t.TempDir(), "", "", wsURL, "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	var llmCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		llmCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	app.intentLLMURL = server.URL
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "status?")
+	if !handled {
+		t.Fatal("expected runtime control fast path to handle status")
+	}
+	if llmCalls.Load() != 0 {
+		t.Fatalf("intent llm calls = %d, want 0", llmCalls.Load())
+	}
+	if message != "Agent healthy." {
+		t.Fatalf("message = %q, want %q", message, "Agent healthy.")
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads = %#v, want none", payloads)
+	}
+}
+
+func containsExactString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/web/chat_intent_plan_test.go
+++ b/internal/web/chat_intent_plan_test.go
@@ -525,7 +525,7 @@ func TestClassifyAndExecuteSystemActionFallsThroughWhenLLMUnavailable(t *testing
 		t.Fatalf("chat session: %v", err)
 	}
 
-	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "be quiet")
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "please go silent now")
 	if handled {
 		t.Fatalf("expected request to remain unhandled, got message %q and %d payloads", message, len(payloads))
 	}

--- a/internal/web/chat_runtime_controls.go
+++ b/internal/web/chat_runtime_controls.go
@@ -1,0 +1,79 @@
+package web
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/modelprofile"
+)
+
+var switchModelPrefixPattern = regexp.MustCompile(`(?i)^(?:switch\s+model\s+to|switch\s+to)\s+(.+)$`)
+
+func parseInlineRuntimeControlIntent(text string) *SystemAction {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	if action := parseInlineSwitchModelIntent(trimmed); action != nil {
+		return action
+	}
+
+	lower := strings.ToLower(trimmed)
+	switch lower {
+	case "be quiet", "quiet please", "go quiet", "toggle silent mode":
+		return &SystemAction{Action: "toggle_silent", Params: map[string]interface{}{}}
+	case "toggle live dialogue", "toggle dialogue mode", "toggle dialogue":
+		return &SystemAction{Action: "toggle_live_dialogue", Params: map[string]interface{}{}}
+	case "cancel work", "cancel current work", "stop work", "stop current work", "stop current task", "abort current task":
+		return &SystemAction{Action: "cancel_work", Params: map[string]interface{}{}}
+	case "status", "status?", "show status", "show me status", "what's your status", "what is your status":
+		return &SystemAction{Action: "show_status", Params: map[string]interface{}{}}
+	default:
+		return nil
+	}
+}
+
+func parseInlineSwitchModelIntent(text string) *SystemAction {
+	matches := switchModelPrefixPattern.FindStringSubmatch(strings.TrimSpace(text))
+	if len(matches) != 2 {
+		return nil
+	}
+	body := strings.TrimSpace(matches[1])
+	if body == "" {
+		return nil
+	}
+	parts := strings.Fields(body)
+	if len(parts) == 0 {
+		return nil
+	}
+	alias := modelprofile.ResolveAlias(parts[0], "")
+	if alias == "" {
+		return nil
+	}
+
+	params := map[string]interface{}{"alias": alias}
+	if len(parts) == 1 {
+		return &SystemAction{Action: "switch_model", Params: params}
+	}
+
+	remainder := strings.ToLower(strings.Join(parts[1:], " "))
+	remainder = strings.NewReplacer(
+		"extra high", modelprofile.ReasoningExtraHigh,
+		"extra_high", modelprofile.ReasoningExtraHigh,
+		"with ", "",
+		"reasoning", "",
+		"effort", "",
+	).Replace(remainder)
+	remainder = strings.TrimSpace(remainder)
+	if remainder == "" {
+		return &SystemAction{Action: "switch_model", Params: params}
+	}
+	for _, candidate := range modelprofile.ReasoningEffortsForAlias(alias) {
+		if remainder != candidate {
+			continue
+		}
+		params["effort"] = candidate
+		break
+	}
+	return &SystemAction{Action: "switch_model", Params: params}
+}


### PR DESCRIPTION
## Summary
- register runtime control fast paths for silent mode, live dialogue, cancel work, status, and model switching
- add an explicit deterministic fast-path catalog that also documents UI `system_action` loopbacks and push-to-talk hold/release controls
- document the fast-path boundary in `docs/interaction-grammar.md` and keep semantic fallback coverage in place for non-fast-path turns

## Verification
- Fast paths do not invoke the local semantic model: `go test ./internal/web -run 'Test(TryDeterministicFastPathRegistry|TryDeterministicFastPathNoMatch|DeterministicFastPathCatalogIncludesRuntimeAndUIControls|ClassifyAndExecuteSystemActionFastPathBypassesIntentLLM|ClassifyAndExecuteSystemActionRuntimeControlBypassesIntentLLM|ClassifyAndExecuteSystemActionSwitchModelFastPathBypassesIntentLLM|ClassifyAndExecuteSystemActionStatusFastPathBypassesIntentLLM|ClassifyAndExecuteSystemActionFallsThroughWhenLLMUnavailable|RunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification|RunAssistantTurnDialogueIgnoresAddressedFlag|RunAssistantTurnExecutesHighConfidenceLocalIntent|RunAssistantTurnExecutesHighConfidenceLocalIntentInProjectSession|RunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable|RunAssistantTurnUsesIntentLLMPlanForSystemAction)' 2>&1 | tee /tmp/test.log` -> `ok   github.com/krystophny/tabura/internal/web 0.323s`; covered by `TestClassifyAndExecuteSystemActionFastPathBypassesIntentLLM`, `TestClassifyAndExecuteSystemActionRuntimeControlBypassesIntentLLM`, `TestClassifyAndExecuteSystemActionSwitchModelFastPathBypassesIntentLLM`, and `TestClassifyAndExecuteSystemActionStatusFastPathBypassesIntentLLM`.
- Clear routing boundary exists between deterministic and semantic paths: the same command passed `TestTryDeterministicFastPathRegistry`, `TestDeterministicFastPathCatalogIncludesRuntimeAndUIControls`, and `TestClassifyAndExecuteSystemActionFallsThroughWhenLLMUnavailable`; the registry now lives in `internal/web/chat_intent_fast.go` and the runtime-control parser in `internal/web/chat_runtime_controls.go`.
- Mode switching, PTT, and explicit UI commands are fast paths: the same command passed `TestDeterministicFastPathCatalogIncludesRuntimeAndUIControls`, and the catalog now registers `switch_model`, `toggle_silent`, `toggle_live_dialogue`, `system_action:*`, `ctrl_long_press`, and `ctrl_release`.
- Architecture remains compatible with the one-local-brain principle: the same command passed `TestRunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable` and `TestRunAssistantTurnUsesIntentLLMPlanForSystemAction`, showing non-fast-path turns still fall through to semantic routing when needed.
- Fast-path actions are documented/registered, not scattered inline matches: the same command passed `TestDeterministicFastPathCatalogIncludesRuntimeAndUIControls`; the catalog is in `internal/web/chat_intent_fast.go` and the product contract is documented in `docs/interaction-grammar.md`.
