### PR TITLE
fix: Epic: Three-tier parallel inference with Cerebras middle tier an (fixes #536)

### DIFF
--- a/internal/cerebras/client.go
+++ b/internal/cerebras/client.go
@@ -54,10 +54,11 @@ type Client struct {
 
 	now func() time.Time
 
-	mu               sync.Mutex
-	quotaExhausted   bool
-	exhaustedAt      time.Time
-	unavailableUntil time.Time
+	mu                 sync.Mutex
+	quotaExhausted     bool
+	quotaNoticePending bool
+	exhaustedAt        time.Time
+	unavailableUntil   time.Time
 }
 
 type chatCompletionResponse struct {
@@ -258,7 +259,12 @@ func (c *Client) markQuotaExhausted() {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.maybeResetQuotaLocked()
+	if c.quotaExhausted {
+		return
+	}
 	c.quotaExhausted = true
+	c.quotaNoticePending = true
 	c.exhaustedAt = c.now().UTC()
 }
 
@@ -273,6 +279,7 @@ func (c *Client) maybeResetQuotaLocked() {
 		return
 	}
 	c.quotaExhausted = false
+	c.quotaNoticePending = false
 	c.exhaustedAt = time.Time{}
 }
 
@@ -284,6 +291,20 @@ func (c *Client) isQuotaExhausted() bool {
 	defer c.mu.Unlock()
 	c.maybeResetQuotaLocked()
 	return c.quotaExhausted
+}
+
+func (c *Client) ConsumeQuotaExhaustedNotice() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maybeResetQuotaLocked()
+	if !c.quotaNoticePending {
+		return false
+	}
+	c.quotaNoticePending = false
+	return true
 }
 
 func (c *Client) markUnavailable() {

--- a/internal/cerebras/client_test.go
+++ b/internal/cerebras/client_test.go
@@ -107,6 +107,46 @@ func TestClientQuotaExhaustionResetsOnNextUTCDay(t *testing.T) {
 	}
 }
 
+func TestClientQuotaExhaustionNoticeIsConsumedOncePerDay(t *testing.T) {
+	clock := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token-123", DefaultModel, DefaultReasoningEffort)
+	client.HTTPClient = server.Client()
+	client.now = func() time.Time { return clock }
+
+	_, err := client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if !errors.Is(err, ErrQuotaExhausted) {
+		t.Fatalf("Complete() error = %v, want ErrQuotaExhausted", err)
+	}
+	if !client.ConsumeQuotaExhaustedNotice() {
+		t.Fatal("ConsumeQuotaExhaustedNotice() = false, want true after first exhaustion")
+	}
+	if client.ConsumeQuotaExhaustedNotice() {
+		t.Fatal("ConsumeQuotaExhaustedNotice() = true, want false after notice consumed")
+	}
+
+	clock = clock.Add(13 * time.Hour)
+	if !client.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true after UTC reset")
+	}
+
+	_, err = client.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello again"}},
+	})
+	if !errors.Is(err, ErrQuotaExhausted) {
+		t.Fatalf("second Complete() error = %v, want ErrQuotaExhausted", err)
+	}
+	if !client.ConsumeQuotaExhaustedNotice() {
+		t.Fatal("ConsumeQuotaExhaustedNotice() = false, want true after next-day exhaustion")
+	}
+}
+
 func TestClientBacksOffAfterServerError(t *testing.T) {
 	clock := time.Date(2026, 3, 11, 9, 0, 0, 0, time.UTC)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/chat_turn_cerebras.go
+++ b/internal/web/chat_turn_cerebras.go
@@ -14,6 +14,8 @@ Return a compact JSON object with:
 - confidence: one of high, medium, low
 Do not include markdown fences.`
 
+const cerebrasQuotaNoticeMessage = "Cerebras daily quota exhausted. Falling back to Local + OpenAI until next UTC day."
+
 type cerebrasTurnResult struct {
 	text       string
 	confidence string
@@ -67,4 +69,16 @@ func (a *App) runCerebrasTurn(ctx context.Context, prompt string) cerebrasTurnRe
 		confidence: strings.TrimSpace(resp.Confidence),
 		latency:    resp.Latency,
 	}
+}
+
+func (a *App) notifyCerebrasQuotaExhausted(sessionID string) {
+	if a == nil || a.cerebrasClient == nil || !a.cerebrasClient.ConsumeQuotaExhaustedNotice() {
+		return
+	}
+	_, _ = a.store.AddChatMessage(sessionID, "system", cerebrasQuotaNoticeMessage, cerebrasQuotaNoticeMessage, "text")
+	a.broadcastChatEvent(sessionID, map[string]interface{}{
+		"type":    "system_notice",
+		"message": cerebrasQuotaNoticeMessage,
+		"source":  assistantProviderCerebras,
+	})
 }

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/krystophny/tabura/internal/appserver"
+	"github.com/krystophny/tabura/internal/cerebras"
 	"github.com/krystophny/tabura/internal/store"
 )
 
@@ -430,6 +431,9 @@ func (a *App) runAssistantTurnParallel(
 			}
 		case result := <-cerebrasCh:
 			cerebrasResult = result
+			if errors.Is(result.err, cerebras.ErrQuotaExhausted) {
+				a.notifyCerebrasQuotaExhausted(sessionID)
+			}
 			if !localReady || localEvaluation.isCommand() || localEvaluation.isHighConfidenceLocalAnswer() {
 				continue
 			}

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -777,12 +777,21 @@ func TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay(t *t
 	if err != nil {
 		t.Fatalf("GetOrCreateChatSession: %v", err)
 	}
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
 	if _, err := app.store.AddChatMessage(session.ID, "user", "first turn", "first turn", "text"); err != nil {
 		t.Fatalf("AddChatMessage(user): %v", err)
 	}
 	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+	firstPayloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
 	if app.cerebrasClient.IsAvailable() {
 		t.Fatal("cerebrasClient.IsAvailable() = true, want false after 429")
+	}
+	firstTypes := strings.Join(wsTypes(firstPayloads), ",")
+	if !strings.Contains(firstTypes, "system_notice") {
+		t.Fatalf("first websocket types = %s, want system_notice", firstTypes)
 	}
 	app.closeAppSession(session.ID)
 
@@ -790,6 +799,11 @@ func TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay(t *t
 		t.Fatalf("AddChatMessage(user): %v", err)
 	}
 	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+	secondPayloads := collectWSJSONTypesUntil(t, clientConn, 2*time.Second, "assistant_output")
+	secondTypes := strings.Join(wsTypes(secondPayloads), ",")
+	if strings.Contains(secondTypes, "system_notice") {
+		t.Fatalf("second websocket types = %s, want no duplicate system_notice", secondTypes)
+	}
 
 	if got := latestAssistantMessage(t, app, session.ID); got != "Spark handles the turn." {
 		t.Fatalf("assistant message = %q, want Spark final reply", got)
@@ -801,9 +815,20 @@ func TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay(t *t
 	if err != nil {
 		t.Fatalf("ListChatMessages: %v", err)
 	}
+	noticeCount := 0
 	for _, message := range messages {
-		if strings.EqualFold(strings.TrimSpace(message.Role), "system") && strings.Contains(strings.ToLower(message.ContentPlain), "cerebras") {
+		if !strings.EqualFold(strings.TrimSpace(message.Role), "system") {
+			continue
+		}
+		if strings.TrimSpace(message.ContentPlain) == cerebrasQuotaNoticeMessage {
+			noticeCount++
+			continue
+		}
+		if strings.Contains(strings.ToLower(message.ContentPlain), "cerebras") {
 			t.Fatalf("unexpected user-visible Cerebras error: %q", message.ContentPlain)
 		}
+	}
+	if noticeCount != 1 {
+		t.Fatalf("quota notice count = %d, want 1", noticeCount)
 	}
 }

--- a/internal/web/static/app-chat-transport.ts
+++ b/internal/web/static/app-chat-transport.ts
@@ -834,6 +834,12 @@ export function handleChatEvent(payload) {
     return;
   }
 
+  if (type === 'system_notice') {
+    const message = String(payload.message || '').trim();
+    if (message) appendPlainMessage('system', message);
+    return;
+  }
+
   if (type === 'error') {
     state.voiceAwaitingTurn = false;
     const turnID = String(payload.turn_id || '').trim();

--- a/tests/playwright/provider-attribution.spec.ts
+++ b/tests/playwright/provider-attribution.spec.ts
@@ -59,6 +59,20 @@ test('unknown provider falls back to Assistant', async ({ page }) => {
   await expect(label).toHaveText('Assistant');
 });
 
+test('system notice appends a system chat row', async ({ page }) => {
+  await waitReady(page);
+
+  await injectChatEvent(page, {
+    type: 'system_notice',
+    message: 'Cerebras daily quota exhausted. Falling back to Local + OpenAI until next UTC day.',
+  });
+
+  const row = page.locator('.chat-message.chat-system').last();
+  await expect(row.locator('.chat-bubble')).toHaveText(
+    'Cerebras daily quota exhausted. Falling back to Local + OpenAI until next UTC day.',
+  );
+});
+
 test('provisional assistant message is replaced by final output for the same turn', async ({ page }) => {
   await waitReady(page);
 


### PR DESCRIPTION
## Summary

Closes the remaining `#536` quota-degradation gap by emitting a single Daily chat notice when Cerebras hits its daily quota, while keeping the existing same-day disable and next-UTC-day reset behavior.

## Verification

- Graceful degradation on quota exhaustion: `go test ./internal/cerebras ./internal/web -run 'Test(ClientQuotaExhaustionResetsOnNextUTCDay|ClientQuotaExhaustionNoticeIsConsumedOncePerDay|RunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay)$' 2>&1 | tee /tmp/tabura-issue-536-go.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/cerebras` and `ok   github.com/krystophny/tabura/internal/web`.
  Covered by `TestRunAssistantTurnParallelQuotaExhaustedDisablesCerebrasForRestOfDay`: first turn emits one live `system_notice`, falls back to Spark, and second turn makes no second Cerebras request.

- Automatic re-enable on daily quota reset: same Go command above.
  Covered by `TestClientQuotaExhaustionResetsOnNextUTCDay` and `TestClientQuotaExhaustionNoticeIsConsumedOncePerDay`: availability returns on the next UTC day and the quota notice re-arms only after a new day's exhaustion.

- Daily chat notice is visible in the UI: `npx playwright test tests/playwright/provider-attribution.spec.ts --grep 'system notice appends a system chat row' 2>&1 | tee /tmp/tabura-issue-536-playwright.log`
  Output excerpt: `1 passed (1.4s)`.
  The spec verifies the live `system_notice` event renders a system chat row with the quota fallback message.
