### PR TITLE
fix: Epic: Add hierarchical date contexts and date-based retrieval (fixes #514)

### DIFF
--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -108,6 +108,8 @@ Inbox is a global view accessible from any workspace sidebar. It shows all items
 
 Starting without an explicit workspace activates today's Daily Workspace. It is a persistent directory under `<data-dir>/daily/YYYY/MM/DD/`, and it is reused across restarts for the same day.
 
+Daily Workspaces also carry stable date contexts in the same hierarchy: `YYYY`, `YYYY/MM`, and `YYYY/MM/DD`. Those date contexts combine with topic contexts, for example `2026/03/11 + work/plasma`.
+
 - **Day rollover**: the next interaction after midnight creates and activates a new Daily Workspace for the new date.
 - **Promote**: renaming the Daily Workspace turns it into a normal explicit workspace while retaining its recorded date.
 

--- a/internal/store/store_context_query.go
+++ b/internal/store/store_context_query.go
@@ -259,13 +259,24 @@ func (s *Store) ListArtifactsByContextPrefix(prefix string) ([]Artifact, error) 
 	if cleanPrefix == "" {
 		return nil, errors.New("context is required")
 	}
-	contextIDs, err := s.resolveContextQueryIDs(cleanPrefix)
-	if err != nil {
-		return nil, err
-	}
 	artifacts, err := s.ListArtifacts()
 	if err != nil {
 		return nil, err
 	}
-	return s.filterArtifactsByContextIDs(artifacts, contextIDs)
+	terms := splitContextQueryTerms(cleanPrefix)
+	filtered := artifacts
+	for _, term := range terms {
+		contextIDs, err := s.resolveContextQueryIDs(term)
+		if err != nil {
+			return nil, err
+		}
+		filtered, err = s.filterArtifactsByContextIDs(filtered, contextIDs)
+		if err != nil {
+			return nil, err
+		}
+		if len(filtered) == 0 {
+			return []Artifact{}, nil
+		}
+	}
+	return filtered, nil
 }

--- a/internal/store/store_context_query_test.go
+++ b/internal/store/store_context_query_test.go
@@ -175,3 +175,66 @@ func TestContextPrefixQueriesMatchFlatContextNames(t *testing.T) {
 		t.Fatalf("ListItemsByContextPrefix(2026/03/11) = %+v, want item %d", exact, march11Item.ID)
 	}
 }
+
+func TestArtifactContextPrefixQueriesCanCombineDateAndTopicContexts(t *testing.T) {
+	s := newTestStore(t)
+
+	plasmaWorkspace, err := s.EnsureDailyWorkspace("2026-03-11", filepath.Join(t.TempDir(), "daily", "2026", "03", "11", "plasma"))
+	if err != nil {
+		t.Fatalf("EnsureDailyWorkspace(plasma) error: %v", err)
+	}
+	healthWorkspace, err := s.CreateWorkspace("Health notes", filepath.Join(t.TempDir(), "health"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(health) error: %v", err)
+	}
+
+	workRootID := contextIDByNameForTest(t, s, "work")
+	workRoot, err := s.GetContext(workRootID)
+	if err != nil {
+		t.Fatalf("GetContext(work) error: %v", err)
+	}
+	privateRootID := contextIDByNameForTest(t, s, "private")
+	privateRoot, err := s.GetContext(privateRootID)
+	if err != nil {
+		t.Fatalf("GetContext(private) error: %v", err)
+	}
+	plasmaContext, err := s.CreateContext("work/plasma", &workRoot.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(work/plasma) error: %v", err)
+	}
+	healthContext, err := s.CreateContext("private/health", &privateRoot.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(private/health) error: %v", err)
+	}
+	marchDay := mustGetContextByName(t, s, "2026/03/11")
+	if err := s.LinkContextToWorkspace(plasmaContext.ID, plasmaWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(plasma) error: %v", err)
+	}
+	if err := s.LinkContextToWorkspace(marchDay.ID, healthWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(march day) error: %v", err)
+	}
+	if err := s.LinkContextToWorkspace(healthContext.ID, healthWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(health) error: %v", err)
+	}
+
+	plasmaPath := filepath.Join(plasmaWorkspace.DirPath, "plan.md")
+	plasmaTitle := "Plasma plan"
+	plasmaArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, &plasmaPath, nil, &plasmaTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(plasma) error: %v", err)
+	}
+	healthPath := filepath.Join(healthWorkspace.DirPath, "notes.md")
+	healthTitle := "Health notes"
+	_, err = s.CreateArtifact(ArtifactKindMarkdown, &healthPath, nil, &healthTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(health) error: %v", err)
+	}
+
+	artifacts, err := s.ListArtifactsByContextPrefix("2026/03/11 + work/plasma")
+	if err != nil {
+		t.Fatalf("ListArtifactsByContextPrefix(combined) error: %v", err)
+	}
+	if len(artifacts) != 1 || artifacts[0].ID != plasmaArtifact.ID {
+		t.Fatalf("ListArtifactsByContextPrefix(combined) = %+v, want artifact %d", artifacts, plasmaArtifact.ID)
+	}
+}

--- a/internal/web/context_filters_test.go
+++ b/internal/web/context_filters_test.go
@@ -121,3 +121,76 @@ func TestItemContextQueryRejectsContextAndContextIDTogether(t *testing.T) {
 		t.Fatalf("conflicting context filters status = %d, want 400: %s", rr.Code, rr.Body.String())
 	}
 }
+
+func TestArtifactContextQueryCombinesDateAndTopicFilters(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	plasmaWorkspace, err := app.store.EnsureDailyWorkspace("2026-03-11", filepath.Join(t.TempDir(), "daily", "2026", "03", "11", "plasma"))
+	if err != nil {
+		t.Fatalf("EnsureDailyWorkspace(plasma) error: %v", err)
+	}
+	healthWorkspace, err := app.store.CreateWorkspace("Health notes", filepath.Join(t.TempDir(), "health"))
+	if err != nil {
+		t.Fatalf("CreateWorkspace(health) error: %v", err)
+	}
+
+	workRoot := contextByNameForTest(t, app, "work")
+	privateRoot := contextByNameForTest(t, app, "private")
+	plasmaContext, err := app.store.CreateContext("work/plasma", &workRoot.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(work/plasma) error: %v", err)
+	}
+	healthContext, err := app.store.CreateContext("private/health", &privateRoot.ID)
+	if err != nil {
+		t.Fatalf("CreateContext(private/health) error: %v", err)
+	}
+	marchDay := contextByNameForTest(t, app, "2026/03/11")
+	if err := app.store.LinkContextToWorkspace(plasmaContext.ID, plasmaWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(plasma) error: %v", err)
+	}
+	if err := app.store.LinkContextToWorkspace(marchDay.ID, healthWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(march day) error: %v", err)
+	}
+	if err := app.store.LinkContextToWorkspace(healthContext.ID, healthWorkspace.ID); err != nil {
+		t.Fatalf("LinkContextToWorkspace(health) error: %v", err)
+	}
+
+	plasmaPath := filepath.Join(plasmaWorkspace.DirPath, "plan.md")
+	plasmaTitle := "Plasma plan"
+	plasmaArtifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &plasmaPath, nil, &plasmaTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(plasma) error: %v", err)
+	}
+	healthPath := filepath.Join(healthWorkspace.DirPath, "notes.md")
+	healthTitle := "Health notes"
+	if _, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &healthPath, nil, &healthTitle, nil); err != nil {
+		t.Fatalf("CreateArtifact(health) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/artifacts?context=2026/03/11%20%2B%20work/plasma", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("artifact combined context status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	artifacts, ok := decodeJSONDataResponse(t, rr)["artifacts"].([]any)
+	if !ok || len(artifacts) != 1 {
+		t.Fatalf("artifact combined context payload = %#v", decodeJSONDataResponse(t, rr))
+	}
+	if got := int64(artifacts[0].(map[string]any)["id"].(float64)); got != plasmaArtifact.ID {
+		t.Fatalf("artifact combined context id = %d, want %d", got, plasmaArtifact.ID)
+	}
+}
+
+func contextByNameForTest(t *testing.T, app *App, name string) store.Context {
+	t.Helper()
+	contexts, err := app.store.ListContexts()
+	if err != nil {
+		t.Fatalf("ListContexts() error: %v", err)
+	}
+	for _, context := range contexts {
+		if context.Name == name {
+			return context
+		}
+	}
+	t.Fatalf("context %q not found", name)
+	return store.Context{}
+}


### PR DESCRIPTION
## Summary
- apply combined context-term filtering to artifacts so `date + topic` queries work the same way as workspace and item filters
- add store and API regressions for `YYYY/MM/DD + topic` artifact lookups
- document the stable Daily Workspace date-context hierarchy and combination syntax

## Verification
- Date contexts auto-created as `YYYY`, `YYYY/MM`, `YYYY/MM/DD` in the context tree:
  - Existing coverage: `TestEnsureDailyWorkspaceLinksDateContextHierarchy` in `internal/store/store_context_date_test.go`
- Daily Workspaces auto-linked to their date context:
  - Existing coverage: `TestEnsureDailyWorkspaceLinksDateContextHierarchy` in `internal/store/store_context_date_test.go`
- Prefix filtering works for year, month, and day granularity:
  - Existing coverage: `TestContextPrefixQueriesMatchFlatContextNames` in `internal/store/store_context_query_test.go`
  - Command: `go test ./internal/store ./internal/web -run 'Test(ArtifactContextPrefixQueriesCanCombineDateAndTopicContexts|ArtifactContextQueryCombinesDateAndTopicFilters|ContextPrefixQueriesMatchFlatContextNames|ContextQueryFiltersWorkspaceItemAndArtifactAPIs)$' 2>&1 | tee /tmp/tabura-issue-514-test.log`
  - Output excerpt:
    - `ok   github.com/krystophny/tabura/internal/store 0.030s`
    - `ok   github.com/krystophny/tabura/internal/web 0.036s`
- Combined filtering (date + topic) works:
  - New store regression: `TestArtifactContextPrefixQueriesCanCombineDateAndTopicContexts`
  - New API regression: `TestArtifactContextQueryCombinesDateAndTopicFilters`
  - Command/output: same `go test ...` invocation and passing output above
- Items in Daily Workspaces inherit date context:
  - Existing coverage: `TestDailyWorkspaceItemsInheritAndRefreshDateContexts` in `internal/store/store_context_date_test.go`
- Date context format is consistent and documented:
  - Updated `docs/interaction-grammar.md` to state that Daily Workspaces carry stable `YYYY`, `YYYY/MM`, and `YYYY/MM/DD` contexts and that they combine with topic contexts such as `2026/03/11 + work/plasma`
