### PR TITLE
fix: Epic: Add command single-flight, idempotency, and cooldown (fixes #516)

### DIFF
--- a/internal/web/chat_intent_flight_test.go
+++ b/internal/web/chat_intent_flight_test.go
@@ -169,3 +169,41 @@ func TestExecuteSystemActionSuppressesShellCooldownDuplicate(t *testing.T) {
 		t.Fatalf("marker file = %q, want single execution", got)
 	}
 }
+
+func TestBroadcastSystemActionEventEmitsSuppressedEventType(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+	app.hub.registerChat(session.ID, conn)
+	defer app.hub.unregisterChat(session.ID, conn)
+
+	env := newCommandEnvelope(&SystemAction{
+		Action: "shell",
+		Params: map[string]interface{}{"command": "printf 'hello-shell'"},
+	})
+	app.broadcastSystemActionEvent(session.ID, suppressedSystemActionPayload(env, "cooldown_suppressed", 1500*time.Millisecond))
+
+	payload := waitForWSJSONMessageType(t, clientConn, 2*time.Second, "system_action_suppressed")
+	action, ok := payload["action"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("action payload = %#v, want object", payload["action"])
+	}
+	if got := strFromAny(action["action_type"]); got != "shell" {
+		t.Fatalf("action_type = %q, want shell", got)
+	}
+	if got := strFromAny(action["status"]); got != "cooldown_suppressed" {
+		t.Fatalf("status = %q, want cooldown_suppressed", got)
+	}
+	if got := intFromAny(action["cooldown_ms"], 0); got != 1500 {
+		t.Fatalf("cooldown_ms = %d, want 1500", got)
+	}
+}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -329,15 +329,7 @@ func (a *App) tryRunLocalSystemActionTurn(sessionID string, session store.ChatSe
 			if actionPayload == nil {
 				continue
 			}
-			eventType := "system_action"
-			actionType, _ := actionPayload["type"].(string)
-			if strings.EqualFold(strings.TrimSpace(actionType), "confirmation_required") {
-				eventType = "system_action_confirmation_required"
-			}
-			a.broadcastChatEvent(sessionID, map[string]interface{}{
-				"type":   eventType,
-				"action": actionPayload,
-			})
+			a.broadcastSystemActionEvent(sessionID, actionPayload)
 		}
 	} else {
 		assistantText = "I can only handle system actions in local-only mode."
@@ -369,6 +361,28 @@ func suppressLocalAssistantResponse(payloads []map[string]interface{}) bool {
 		}
 	}
 	return false
+}
+
+func systemActionEventType(actionPayload map[string]interface{}) string {
+	actionType, _ := actionPayload["type"].(string)
+	switch strings.TrimSpace(actionType) {
+	case "confirmation_required":
+		return "system_action_confirmation_required"
+	case "system_action_suppressed":
+		return "system_action_suppressed"
+	default:
+		return "system_action"
+	}
+}
+
+func (a *App) broadcastSystemActionEvent(sessionID string, actionPayload map[string]interface{}) {
+	if a == nil || actionPayload == nil {
+		return
+	}
+	a.broadcastChatEvent(sessionID, map[string]interface{}{
+		"type":   systemActionEventType(actionPayload),
+		"action": actionPayload,
+	})
 }
 
 // runAssistantTurnLegacy is the single-shot fallback when persistent session

--- a/internal/web/static/app-chat-transport.ts
+++ b/internal/web/static/app-chat-transport.ts
@@ -146,6 +146,18 @@ function approvalRequestCanvasText(payload) {
   return lines.join('\n');
 }
 
+function suppressedSystemActionStatusText(action) {
+  const actionType = String(action?.action_type || action?.type || 'command').trim().replace(/_/g, ' ');
+  const status = String(action?.status || '').trim();
+  if (status === 'already_executed') {
+    return `duplicate ${actionType} suppressed: already executing`;
+  }
+  if (status === 'cooldown_suppressed') {
+    return `duplicate ${actionType} suppressed during cooldown`;
+  }
+  return `duplicate ${actionType} suppressed`;
+}
+
 function renderApprovalRequestCanvas(payload) {
   const requestID = String(payload?.request_id || '').trim();
   if (!requestID) return;
@@ -538,6 +550,12 @@ export function handleChatEvent(payload) {
           showStatus(`live toggle failed: ${message}`);
         });
     }
+    return;
+  }
+
+  if (type === 'system_action_suppressed') {
+    const action = payload && typeof payload.action === 'object' ? payload.action : {};
+    showStatus(suppressedSystemActionStatusText(action));
     return;
   }
 

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -1598,6 +1598,20 @@ test.describe('project state persistence', () => {
 
     await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Dialogue');
   });
+
+  test('system_action_suppressed shows duplicate command status', async ({ page }) => {
+    await injectChatEvent(page, {
+      type: 'system_action_suppressed',
+      action: {
+        type: 'system_action_suppressed',
+        action_type: 'shell',
+        status: 'cooldown_suppressed',
+        cooldown_ms: 1500,
+      },
+    });
+
+    await expect(page.locator('#status-text')).toContainText('duplicate shell suppressed during cooldown');
+  });
 });
 
 


### PR DESCRIPTION
## Summary
- emit `system_action_suppressed` as a first-class chat WebSocket event for local system actions
- surface suppressed duplicate-command state in the browser status bar immediately
- cover the WebSocket and UI paths with targeted Go and Playwright tests

## Verification
- Duplicate execution is prevented across racing decision paths: `go test ./internal/web -run "TestExecuteSystemActionSuppressesShellCooldownDuplicate|TestBroadcastSystemActionEventEmitsSuppressedEventType" -count=1` -> `ok   github.com/krystophny/tabura/internal/web 0.069s`. `TestExecuteSystemActionSuppressesShellCooldownDuplicate` proves the second `shell` action returns `system_action_suppressed` and leaves `flight-marker.txt` as a single `x` in [internal/web/chat_intent_flight_test.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight_test.go#L115) using the cooldown logic in [internal/web/chat_intent_flight.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight.go#L105).
- Commands can declare idempotency semantics: the command envelope still derives `Idempotent` from the action allowlist in [internal/web/chat_intent_flight.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight.go#L29) and [internal/web/chat_intent_flight.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight.go#L51), which explicitly marks `shell` as non-idempotent and preserves idempotent command behavior.
- Non-idempotent commands have cooldown protection: the same Go test pass verifies `status = cooldown_suppressed` for duplicate `shell` execution in [internal/web/chat_intent_flight_test.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight_test.go#L148) and emits `cooldown_ms` from [internal/web/chat_intent_flight.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight.go#L166).
- UI responds immediately even when execution is suppressed: `npx playwright test tests/playwright/ui-system.spec.ts -g "system_action_suppressed shows duplicate command status"` -> `1 passed (1.5s)`. The browser test in [tests/playwright/ui-system.spec.ts](/home/ert/code/assi/tabula/tests/playwright/ui-system.spec.ts#L1602) asserts `#status-text` shows `duplicate shell suppressed during cooldown`, driven by [internal/web/static/app-chat-transport.ts](/home/ert/code/assi/tabula/internal/web/static/app-chat-transport.ts#L149).
- Command execution states are visible via WebSocket events: `TestBroadcastSystemActionEventEmitsSuppressedEventType` verifies the client receives a top-level `system_action_suppressed` event with `action_type=shell`, `status=cooldown_suppressed`, and `cooldown_ms=1500` via [internal/web/chat_turn.go](/home/ert/code/assi/tabula/internal/web/chat_turn.go#L366) and [internal/web/chat_intent_flight_test.go](/home/ert/code/assi/tabula/internal/web/chat_intent_flight_test.go#L173).

Captured log: `/tmp/issue-516-test.log`
