### PR TITLE
fix: Epic: Introduce persistent Daily Workspace as the default active (fixes #513)

### DIFF
--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -644,7 +644,7 @@ func (a *App) executeDeleteWorkspaceAction(session store.ChatSession, action *Sy
 	if err != nil {
 		return "", nil, err
 	}
-	if err := a.store.DeleteWorkspace(workspace.ID); err != nil {
+	if err := a.deleteWorkspaceAndRepairState(workspace.ID); err != nil {
 		return "", nil, err
 	}
 	return fmt.Sprintf("Deleted workspace %s.", workspace.Name), map[string]interface{}{

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -536,6 +536,10 @@ func TestClassifyAndExecuteSystemActionWorkspaceManagement(t *testing.T) {
 		t.Fatalf("renamed.Name = %q, want %q", renamed.Name, "Research Notes")
 	}
 
+	if err := app.setActiveWorkspaceTracked(workspaceID, "workspace_switch"); err != nil {
+		t.Fatalf("setActiveWorkspaceTracked() error: %v", err)
+	}
+
 	message, payloads, handled = app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "delete workspace Research Notes")
 	if !handled {
 		t.Fatal("expected delete workspace command to be handled")
@@ -548,6 +552,19 @@ func TestClassifyAndExecuteSystemActionWorkspaceManagement(t *testing.T) {
 	}
 	if _, err := app.store.GetWorkspace(workspaceID); err == nil {
 		t.Fatal("expected deleted workspace to be gone")
+	}
+	active, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("ActiveWorkspace() after delete error: %v", err)
+	}
+	if active.ID == workspaceID {
+		t.Fatalf("active workspace id = %d, want deleted workspace to be replaced", active.ID)
+	}
+	if !active.IsDaily {
+		t.Fatalf("active workspace is_daily = %v, want true", active.IsDaily)
+	}
+	if _, err := app.store.GetChatSessionByWorkspaceID(active.ID); err != nil {
+		t.Fatalf("GetChatSessionByWorkspaceID(active) error: %v", err)
 	}
 }
 

--- a/internal/web/workspaces.go
+++ b/internal/web/workspaces.go
@@ -169,6 +169,37 @@ func (a *App) handleWorkspaceGet(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (a *App) deleteWorkspaceAndRepairState(workspaceID int64) error {
+	active, activeErr := a.store.ActiveWorkspace()
+	switch {
+	case activeErr == nil:
+	case isNoRows(activeErr):
+	default:
+		return activeErr
+	}
+	repairActiveWorkspace := (activeErr == nil && active.ID == workspaceID) || isNoRows(activeErr)
+	focusedID, err := a.store.FocusedWorkspaceID()
+	if err != nil {
+		return err
+	}
+	deletedFocusedWorkspace := focusedID == workspaceID
+	if err := a.store.DeleteWorkspace(workspaceID); err != nil {
+		return err
+	}
+	if deletedFocusedWorkspace {
+		if err := a.setFocusedWorkspace(0); err != nil {
+			return err
+		}
+		a.broadcastWorkspaceFocusChanged()
+	}
+	if repairActiveWorkspace {
+		if _, err := a.ensureStartupWorkspace(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (a *App) handleWorkspaceDelete(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
@@ -178,7 +209,7 @@ func (a *App) handleWorkspaceDelete(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if err := a.store.DeleteWorkspace(workspaceID); err != nil {
+	if err := a.deleteWorkspaceAndRepairState(workspaceID); err != nil {
 		writeDomainStoreError(w, err)
 		return
 	}

--- a/internal/web/workspaces_test.go
+++ b/internal/web/workspaces_test.go
@@ -107,6 +107,19 @@ func TestWorkspaceCRUDAPI(t *testing.T) {
 	if rrMissing.Code != http.StatusNotFound {
 		t.Fatalf("deleted workspace status = %d, want 404: %s", rrMissing.Code, rrMissing.Body.String())
 	}
+	active, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("ActiveWorkspace() after delete error: %v", err)
+	}
+	if active.ID == workspaceID {
+		t.Fatalf("active workspace id = %d, want deleted workspace to be replaced", active.ID)
+	}
+	if !active.IsDaily {
+		t.Fatalf("active workspace is_daily = %v, want true", active.IsDaily)
+	}
+	if _, err := app.store.GetChatSessionByWorkspaceID(active.ID); err != nil {
+		t.Fatalf("GetChatSessionByWorkspaceID(active) error: %v", err)
+	}
 }
 
 func TestWorkspaceListFiltersBySphere(t *testing.T) {


### PR DESCRIPTION
## Summary
- repair workspace deletion through a shared app-level helper so deleting the active workspace immediately restores a valid startup workspace
- route both the HTTP workspace delete endpoint and chat-driven workspace deletion through the same repair path
- add regression coverage proving deletion preserves an active workspace and an attached chat session binding

## Verification
- There is always an active workspace.
  - Command: `go test ./internal/store ./internal/web -run 'Test(EnsureDailyWorkspaceLinksDateContextHierarchy|EnsureDailyWorkspaceIsIdempotentAndRenamePromotesIt|ProjectsListUsesDailyWorkspaceWhenNoneExist|ResolveChatSessionTargetRollsOverDailyWorkspace|NewAppReusesPersistedDailyWorkspace|WorkspaceCRUDAPI|ClassifyAndExecuteSystemActionWorkspaceManagement)$'`
  - Output excerpt:
    ```text
    ok   github.com/krystophny/tabura/internal/store (cached)
    ok   github.com/krystophny/tabura/internal/web 0.097s
    ```
  - Evidence: `TestWorkspaceCRUDAPI` and `TestClassifyAndExecuteSystemActionWorkspaceManagement` now delete the active workspace, then assert `ActiveWorkspace()` returns a replacement workspace and `GetChatSessionByWorkspaceID(active.ID)` succeeds.
- If none is explicitly open, the current day's workspace is auto-selected or auto-created.
  - Command: same `go test` invocation above.
  - Evidence: `TestProjectsListUsesDailyWorkspaceWhenNoneExist` and `TestResolveChatSessionTargetRollsOverDailyWorkspace` passed in the same run.
- Every Daily Workspace receives the hierarchical context `YYYY/MM/DD`.
  - Command: same `go test` invocation above.
  - Evidence: `TestEnsureDailyWorkspaceLinksDateContextHierarchy` passed in the same run.
- Daily Workspaces are persistent by default.
  - Command: same `go test` invocation above.
  - Evidence: `TestNewAppReusesPersistedDailyWorkspace` passed in the same run.
- Users can promote, rename, or reorganize them.
  - Command: same `go test` invocation above.
  - Evidence: `TestEnsureDailyWorkspaceIsIdempotentAndRenamePromotesIt` passed in the same run.
- Codex app-server always attaches to the active workspace.
  - Command: same `go test` invocation above.
  - Evidence: the repaired delete path calls `ensureStartupWorkspace()`, which restores the active workspace binding through `GetOrCreateChatSessionForWorkspace()`. `TestWorkspaceCRUDAPI` and `TestClassifyAndExecuteSystemActionWorkspaceManagement` assert that binding exists immediately after repair.
