### PR TITLE
fix: Epic: Parallel Qwen+Spark inference with asymmetric authority an (fixes #529)

### DIFF
--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -121,6 +121,70 @@ func finalParallelCommandText(evaluation localTurnEvaluation, provisionalText st
 	return "Done."
 }
 
+func parallelCommandResponseMatchesState(evaluation localTurnEvaluation, responseText string) bool {
+	expected := normalizeParallelCommandComparisonText(evaluation.fallbackText())
+	actual := normalizeParallelCommandComparisonText(responseText)
+	if expected == "" || actual == "" {
+		return false
+	}
+	if actual == expected || strings.Contains(actual, expected) {
+		return true
+	}
+	expectedTokens := significantParallelCommandTokens(expected)
+	if len(expectedTokens) == 0 {
+		return false
+	}
+	actualTokens := significantParallelCommandTokens(actual)
+	for token := range expectedTokens {
+		if _, ok := actualTokens[token]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeParallelCommandComparisonText(raw string) string {
+	clean := strings.ToLower(strings.TrimSpace(raw))
+	if clean == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer(
+		".", " ",
+		",", " ",
+		";", " ",
+		":", " ",
+		"!", " ",
+		"?", " ",
+		"(", " ",
+		")", " ",
+		"[", " ",
+		"]", " ",
+		"{", " ",
+		"}", " ",
+		"\"", " ",
+		"'", " ",
+		"`", " ",
+		"/", " ",
+		"\\", " ",
+	)
+	return strings.Join(strings.Fields(replacer.Replace(clean)), " ")
+}
+
+func significantParallelCommandTokens(raw string) map[string]struct{} {
+	stopwords := map[string]struct{}{
+		"a": {}, "an": {}, "and": {}, "at": {}, "for": {}, "in": {}, "into": {}, "of": {}, "on": {}, "the": {}, "to": {}, "with": {},
+	}
+	tokens := strings.Fields(raw)
+	out := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		if _, skip := stopwords[token]; skip {
+			continue
+		}
+		out[token] = struct{}{}
+	}
+	return out
+}
+
 func (a *App) runSparkTurn(ctx context.Context, sessionID string, appSess *appserver.Session, prompt string, profile appServerModelProfile) sparkTurnResult {
 	startedAt := time.Now()
 	latestMessage := ""
@@ -341,6 +405,9 @@ func (a *App) runAssistantTurnParallel(
 	}
 	tryCommitSpark := func() bool {
 		if sparkResult.err != nil || strings.TrimSpace(sparkResult.text) == "" {
+			return false
+		}
+		if localReady && localEvaluation.isCommand() && !parallelCommandResponseMatchesState(localEvaluation, sparkResult.text) {
 			return false
 		}
 		commitFinal(sparkResult.text, newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, sparkResult.latency), responseMeta.Provider, sparkResult.threadID)

--- a/internal/web/chat_turn_parallel_test.go
+++ b/internal/web/chat_turn_parallel_test.go
@@ -311,6 +311,20 @@ func TestCommandParallelTurnProvisionalTextPrefersExplicitAck(t *testing.T) {
 	}
 }
 
+func TestParallelCommandResponseMatchesState(t *testing.T) {
+	evaluation := localTurnEvaluation{
+		handled:  true,
+		text:     "Focused on Focused.",
+		payloads: []map[string]interface{}{{"type": "focus_workspace"}},
+	}
+	if !parallelCommandResponseMatchesState(evaluation, "Focused on Focused.") {
+		t.Fatal("parallelCommandResponseMatchesState() = false, want true for matching command state")
+	}
+	if parallelCommandResponseMatchesState(evaluation, "I checked the repo status.") {
+		t.Fatal("parallelCommandResponseMatchesState() = true, want false for unrelated Spark response")
+	}
+}
+
 func TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn(t *testing.T) {
 	appServer, serverState := setupMockParallelAppServer(t, 200*time.Millisecond, "Spark fallback.")
 	defer appServer.Close()
@@ -402,7 +416,7 @@ func TestRunAssistantTurnParallelPrefersSparkForMediumConfidenceLocalAnswer(t *t
 	}
 }
 
-func TestRunAssistantTurnParallelCommandEmitsProvisionalThenSparkFinal(t *testing.T) {
+func TestRunAssistantTurnParallelCommandEmitsProvisionalThenFinalMessage(t *testing.T) {
 	appServer, _ := setupMockParallelAppServer(t, 75*time.Millisecond, "Focused on Focused.")
 	defer appServer.Close()
 	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
@@ -444,7 +458,7 @@ func TestRunAssistantTurnParallelCommandEmitsProvisionalThenSparkFinal(t *testin
 		t.Fatalf("focused workspace id = %d, want %d", focusedID, focus.ID)
 	}
 	if got := latestAssistantMessage(t, app, session.ID); got != "Focused on Focused." {
-		t.Fatalf("assistant message = %q, want Spark narration", got)
+		t.Fatalf("assistant message = %q, want command completion message", got)
 	}
 	if got := countAssistantMessages(t, app, session.ID); got != 1 {
 		t.Fatalf("assistant message count = %d, want 1", got)
@@ -454,6 +468,55 @@ func TestRunAssistantTurnParallelCommandEmitsProvisionalThenSparkFinal(t *testin
 	types := strings.Join(wsTypes(payloads), ",")
 	if !strings.Contains(types, "system_action") || !strings.Contains(types, "turn_provisional") || !strings.Contains(types, "assistant_message") {
 		t.Fatalf("websocket types = %s, want system_action, turn_provisional, assistant_message", types)
+	}
+}
+
+func TestRunAssistantTurnParallelCommandStateMismatchKeepsLocalOwner(t *testing.T) {
+	appServer, _ := setupMockParallelAppServer(t, 75*time.Millisecond, "I checked the repo status.")
+	defer appServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(appServer.URL, "http")
+
+	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"action":"focus_workspace","workspace":"Focused"}`)
+	defer llm.Close()
+
+	app := newParallelTestApp(t, wsURL)
+	app.intentLLMURL = llm.URL
+
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	focus, err := app.store.CreateWorkspace("Focused", t.TempDir())
+	if err != nil {
+		t.Fatalf("CreateWorkspace(Focused): %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "focus on focused", "focus on focused", "text"); err != nil {
+		t.Fatalf("AddChatMessage(user): %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	focusedID, err := app.store.FocusedWorkspaceID()
+	if err != nil {
+		t.Fatalf("FocusedWorkspaceID(): %v", err)
+	}
+	if focusedID != focus.ID {
+		t.Fatalf("focused workspace id = %d, want %d", focusedID, focus.ID)
+	}
+	if got := latestAssistantMessage(t, app, session.ID); got != "Focused on Focused." {
+		t.Fatalf("assistant message = %q, want local command owner reply", got)
+	}
+	messages, err := app.store.ListChatMessages(session.ID, 10)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Provider != assistantProviderLocal {
+		t.Fatalf("provider = %q, want %q when Spark ignores command state", assistant.Provider, assistantProviderLocal)
 	}
 }
 


### PR DESCRIPTION
## Summary
Tighten parallel-turn command arbitration so Spark only takes final response ownership when its text preserves the already-executed local command state.

## Verification
- Focused verification command: `go test ./internal/web -run 'TestParallelCommandResponseMatchesState|TestRunAssistantTurnParallelCommand(EmitsProvisionalThenFinalMessage|StateMismatchKeepsLocalOwner)' 2>&1 | tee /tmp/issue-529-command-ownership.log` -> `ok   github.com/krystophny/tabura/internal/web	0.058s`
- `Both Qwen and Spark start immediately for every Dialogue turn`: `internal/web/chat_turn_parallel.go:336-347` starts the local evaluator and `startSpark()` in the same turn setup; `TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn` also checks that Spark still starts when the local path claims the turn.
- `Qwen acts as provisional controller (commands, acknowledgments)`: `internal/web/chat_turn_parallel.go:445-469` emits system-action payloads and provisional assistant output; `TestRunAssistantTurnParallelCommandEmitsProvisionalThenFinalMessage` and `TestRunAssistantTurnParallelSlowSparkEmitsAcknowledgment` cover the command and acknowledgment paths.
- `Qwen can claim turn as final responder when confident`: `internal/web/chat_turn_parallel.go:440-443`; covered by `TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn`.
- `Spark acts as preferred final responder for complex/conversational turns`: `internal/web/chat_turn_parallel.go:406-414`; covered by `TestRunAssistantTurnParallelPrefersSparkForMediumConfidenceLocalAnswer`.
- `Exactly one response is committed per turn`: `TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn`, `TestRunAssistantTurnParallelPrefersSparkForMediumConfidenceLocalAnswer`, `TestRunAssistantTurnParallelCommandEmitsProvisionalThenFinalMessage`, and `TestRunAssistantTurnParallelCommandStateMismatchKeepsLocalOwner` each assert a single persisted assistant message.
- `Deadline-based arbitration with Qwen early-claim option`: `internal/web/chat_turn_parallel.go:350-353` and `internal/web/chat_turn_parallel.go:560-590` enforce the Spark deadline and local fallback path; `TestRunAssistantTurnParallelLocalHighConfidenceClaimsTurn` covers the early-claim branch.
- `Execution ownership constrains response ownership`: new command-state guard in `internal/web/chat_turn_parallel.go:124-143` and `internal/web/chat_turn_parallel.go:406-413`; covered by `TestParallelCommandResponseMatchesState` and `TestRunAssistantTurnParallelCommandStateMismatchKeepsLocalOwner`.
- `Configurable Spark deadline budget (default ~5s)`: `internal/web/chat_turn_parallel.go:15-37` keeps the 5s default and honors `TABURA_SPARK_DEADLINE` overrides.
- `Meeting mode: Qwen handles addressedness; Spark only invoked for addressed turns`: the meeting pre-check in `internal/web/chat_turn_parallel.go:316-327` suppresses unaddressed meeting turns before upstream launch; covered by `TestClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness`, `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn`, `TestRunAssistantTurnMeetingDirectAddressOverridesFalseAddressedClassification`, and `TestRunAssistantTurnDialogueIgnoresAddressedFlag`.
