### PR TITLE
fix: Epic: Model Dialogue and Meeting as two policies on one live run (fixes #512)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -712,7 +712,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 }
 
 func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool) (bool, bool) {
-	if normalizeLivePolicy(policy.String()) != LivePolicyMeeting {
+	if !policy.RequiresExplicitAddress() {
 		return true, true
 	}
 	if isCompanionDirectAddress(text) {

--- a/internal/web/chat_intent_layers.go
+++ b/internal/web/chat_intent_layers.go
@@ -143,7 +143,7 @@ For annotate_capture or compose on idea notes include target="idea_note".
 For bundle_review on someday work include target="someday" and operation.
 For dispatch_execute issue filing include target="github_issue" and mode="split" when local items are also required.
 Prefer case-insensitive filename search (for example -iname) and use single quotes inside JSON command strings.`
-	if normalizeLivePolicy(policy.String()) == LivePolicyMeeting {
+	if policy.RequiresExplicitAddress() {
 		prompt += `
 Meeting mode: include an "addressed" boolean on every JSON response indicating whether the utterance is directed at Tabura.
 If the user explicitly mentions "Tabura" or "assistant", set "addressed":true.

--- a/internal/web/chat_meeting_capture.go
+++ b/internal/web/chat_meeting_capture.go
@@ -150,7 +150,7 @@ func (a *App) captureMeetingNotesForSegment(participantSessionID string, seg sto
 	if a == nil || a.store == nil || seg.ID == 0 {
 		return
 	}
-	if normalizeLivePolicy(a.LivePolicy().String()) != LivePolicyMeeting {
+	if !a.LivePolicy().CapturesMeetingNotes() {
 		return
 	}
 	text := strings.TrimSpace(seg.Text)

--- a/internal/web/chat_participant.go
+++ b/internal/web/chat_participant.go
@@ -42,7 +42,7 @@ func handleParticipantStart(a *App, conn *chatWSConn, chatSessionID string) {
 	if projectKey == "" {
 		projectKey = "default"
 	}
-	if !cfg.CompanionEnabled || !a.livePolicyConfig().CaptureDecisions {
+	if !cfg.CompanionEnabled || !a.LivePolicy().UsesParticipantCapture() {
 		_ = conn.writeJSON(participantMessage{Type: "participant_error", Error: "meeting mode is disabled"})
 		return
 	}
@@ -281,7 +281,7 @@ func (a *App) maybeTriggerCompanionResponse(participantSessionID string, seg sto
 		return
 	}
 	cfg := a.loadCompanionConfig(project)
-	if !a.livePolicyConfig().CaptureDecisions || !cfg.CompanionEnabled || !cfg.DirectedSpeechGateEnabled {
+	if !a.LivePolicy().RequiresExplicitAddress() || !cfg.CompanionEnabled || !cfg.DirectedSpeechGateEnabled {
 		return
 	}
 	segments, err := a.store.ListParticipantSegments(participantSessionID, 0, 0)

--- a/internal/web/chat_participant_test.go
+++ b/internal/web/chat_participant_test.go
@@ -116,6 +116,41 @@ func assertNoParticipantMessage(t *testing.T, clientConn *websocket.Conn, timeou
 	}
 }
 
+func TestParticipantStartRequiresCapturePolicy(t *testing.T) {
+	app := newAuthedTestApp(t)
+	project, err := app.ensureDefaultProjectRecord()
+	if err != nil {
+		t.Fatalf("ensureDefaultProjectRecord: %v", err)
+	}
+	projectRecord, err := app.store.GetProjectByProjectKey(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetProjectByProjectKey: %v", err)
+	}
+	cfg := app.loadCompanionConfig(projectRecord)
+	cfg.CompanionEnabled = true
+	if err := app.saveCompanionConfig(projectRecord.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	setLivePolicyForTest(t, app, LivePolicyDialogue)
+
+	session, err := app.store.GetOrCreateChatSession(project.ProjectKey)
+	if err != nil {
+		t.Fatalf("GetOrCreateChatSession: %v", err)
+	}
+	conn, clientConn, cleanup := newParticipantTestWSConn(t)
+	defer cleanup()
+
+	handleParticipantStart(app, conn, session.ID)
+
+	msg := readParticipantMessage(t, clientConn, 2*time.Second)
+	if msg.Type != "participant_error" {
+		t.Fatalf("message type = %q, want participant_error", msg.Type)
+	}
+	if msg.Error != "meeting mode is disabled" {
+		t.Fatalf("error = %q, want meeting mode is disabled", msg.Error)
+	}
+}
+
 func TestParticipantConfigGetRequiresAuth(t *testing.T) {
 	app := newAuthedTestApp(t)
 

--- a/internal/web/chat_turn_parallel.go
+++ b/internal/web/chat_turn_parallel.go
@@ -315,9 +315,9 @@ func (a *App) runAssistantTurnParallel(
 		}()
 	}
 
-	policy := normalizeLivePolicy(a.LivePolicy().String())
+	policy := a.LivePolicy()
 	var precomputedLocal *localTurnEvaluation
-	if policy == LivePolicyMeeting {
+	if policy.RequiresExplicitAddress() {
 		evaluation := a.evaluateLocalTurn(context.Background(), sessionID, session, userText, cursorCtx, turn.captureMode)
 		precomputedLocal = &evaluation
 		if evaluation.suppressesResponse() {

--- a/internal/web/live_policy.go
+++ b/internal/web/live_policy.go
@@ -23,6 +23,14 @@ type LivePolicyConfig struct {
 	InterruptionAllowed bool `json:"interruption_allowed"`
 }
 
+func (c LivePolicyConfig) RequiresExplicitAddress() bool {
+	return !c.AssumeAddressed
+}
+
+func (c LivePolicyConfig) CapturesMeetingNotes() bool {
+	return c.CaptureDecisions || c.CaptureActionItems
+}
+
 type livePolicyRequest struct {
 	Policy string `json:"policy"`
 }
@@ -69,6 +77,18 @@ func (p LivePolicy) Config() LivePolicyConfig {
 			InterruptionAllowed: true,
 		}
 	}
+}
+
+func (p LivePolicy) RequiresExplicitAddress() bool {
+	return p.Config().RequiresExplicitAddress()
+}
+
+func (p LivePolicy) CapturesMeetingNotes() bool {
+	return p.Config().CapturesMeetingNotes()
+}
+
+func (p LivePolicy) UsesParticipantCapture() bool {
+	return p.RequiresExplicitAddress() || p.CapturesMeetingNotes()
 }
 
 func (a *App) initializeLivePolicy() error {
@@ -180,7 +200,7 @@ func (a *App) handleLivePolicyPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if changed {
-		if current == LivePolicyMeeting && policy != LivePolicyMeeting {
+		if current.UsesParticipantCapture() && !policy.UsesParticipantCapture() {
 			a.disableLiveMeetingCapture()
 		}
 		a.broadcastLivePolicyChanged(policy)

--- a/internal/web/live_policy_test.go
+++ b/internal/web/live_policy_test.go
@@ -24,6 +24,12 @@ func TestLivePolicyConfig(t *testing.T) {
 	if !dialogue.InterruptionAllowed {
 		t.Fatal("dialogue interruption_allowed = false, want true")
 	}
+	if dialogue.RequiresExplicitAddress() {
+		t.Fatal("dialogue requires explicit address = true, want false")
+	}
+	if dialogue.CapturesMeetingNotes() {
+		t.Fatal("dialogue captures meeting notes = true, want false")
+	}
 
 	meeting := LivePolicyMeeting.Config()
 	if meeting.AssumeAddressed {
@@ -40,6 +46,33 @@ func TestLivePolicyConfig(t *testing.T) {
 	}
 	if meeting.InterruptionAllowed {
 		t.Fatal("meeting interruption_allowed = true, want false")
+	}
+	if !meeting.RequiresExplicitAddress() {
+		t.Fatal("meeting requires explicit address = false, want true")
+	}
+	if !meeting.CapturesMeetingNotes() {
+		t.Fatal("meeting captures meeting notes = false, want true")
+	}
+}
+
+func TestLivePolicyCapabilities(t *testing.T) {
+	if LivePolicyDialogue.RequiresExplicitAddress() {
+		t.Fatal("dialogue RequiresExplicitAddress = true, want false")
+	}
+	if LivePolicyDialogue.CapturesMeetingNotes() {
+		t.Fatal("dialogue CapturesMeetingNotes = true, want false")
+	}
+	if LivePolicyDialogue.UsesParticipantCapture() {
+		t.Fatal("dialogue UsesParticipantCapture = true, want false")
+	}
+	if !LivePolicyMeeting.RequiresExplicitAddress() {
+		t.Fatal("meeting RequiresExplicitAddress = false, want true")
+	}
+	if !LivePolicyMeeting.CapturesMeetingNotes() {
+		t.Fatal("meeting CapturesMeetingNotes = false, want true")
+	}
+	if !LivePolicyMeeting.UsesParticipantCapture() {
+		t.Fatal("meeting UsesParticipantCapture = false, want true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize live-policy capabilities behind `LivePolicy` helpers instead of scattered `meeting` checks
- route participant capture, meeting-note capture, addressedness gating, and parallel-turn suppression through those helpers
- add focused policy and participant-capture coverage for Dialogue vs Meeting behavior

## Verification
- One live runtime, not separate subsystems for Dialogue and Meeting: `internal/web/live_policy.go` now exposes `RequiresExplicitAddress`, `CapturesMeetingNotes`, and `UsesParticipantCapture`, and the remaining runtime branches now call those helpers instead of hard-coding `meeting`.
- Switching modes changes policy, not the architecture: `TestLivePolicyPostStopsActiveParticipantSession` exercises `POST /api/live-policy` and verifies the existing participant session is stopped when the policy leaves capture mode.
- Global mode switch available at any time: the same `POST /api/live-policy` path remains the switch point, and the targeted test above proves it works against an active runtime session.
- Both modes share the same execution backend and workspace semantics: `TestRunAssistantTurnDialogueIgnoresAddressedFlag` and `TestRunAssistantTurnSuppressesUnaddressedMeetingTurn` cover the shared assistant-turn path, while `TestParticipantStartRequiresCapturePolicy` verifies participant capture is policy-gated rather than split into a separate runtime.
- Policy type is a first-class type in code, not scattered conditionals: `TestLivePolicyConfig` and `TestLivePolicyCapabilities` cover the new policy capability helpers directly.
- Command: `go test ./internal/web -run 'Test(LivePolicy|ParticipantStartRequiresCapturePolicy|LivePolicyPostStopsActiveParticipantSession|ClassifyIntentPlanWithLLMMeetingPromptRequestsAddressedness|RunAssistantTurnDialogueIgnoresAddressedFlag|RunAssistantTurnSuppressesUnaddressedMeetingTurn)' 2>&1 | tee /tmp/test.log`
- Output excerpt: `ok   github.com/krystophny/tabura/internal/web  0.106s`
