### PR TITLE
fix: sync bug report items when GitHub issues close

### DIFF
--- a/internal/web/items_github.go
+++ b/internal/web/items_github.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 )
 
 const githubIssueListTimeout = 60 * time.Second
+
+var githubIssueSourceRefPattern = regexp.MustCompile(`^([^#]+)#(\d+)$`)
 
 type itemGitHubSyncRequest struct {
 	WorkspaceID int64 `json:"workspace_id"`
@@ -61,6 +64,37 @@ func githubIssueSourceRef(ownerRepo string, number int) string {
 	return fmt.Sprintf("%s#%d", strings.TrimSpace(ownerRepo), number)
 }
 
+func parseGitHubIssueSourceRef(raw string) (string, int, bool) {
+	match := githubIssueSourceRefPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(match) != 3 {
+		return "", 0, false
+	}
+	ownerRepo := strings.TrimSpace(match[1])
+	if ownerRepo == "" {
+		return "", 0, false
+	}
+	number := 0
+	if _, err := fmt.Sscanf(match[2], "%d", &number); err != nil || number <= 0 {
+		return "", 0, false
+	}
+	return ownerRepo, number, true
+}
+
+func parseLegacyBugReportIssueSourceRef(raw string) (int, bool) {
+	number := 0
+	if _, err := fmt.Sscanf(strings.TrimSpace(raw), "issue:%d", &number); err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
+}
+
+func trimmedStringPointer(raw *string) string {
+	if raw == nil {
+		return ""
+	}
+	return strings.TrimSpace(*raw)
+}
+
 func githubIssueItemState(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "open":
@@ -101,21 +135,49 @@ func githubIssueArtifactMeta(ownerRepo string, issue ghIssueListItem) (*string, 
 	return &text, nil
 }
 
-func (a *App) listGitHubIssues(cwd string) ([]ghIssueListItem, error) {
+func githubIssueCommandDir(ownerRepo string, workspaceDirs []string) string {
+	if repoRoot := resolveCanonicalGitHubRepoRoot(ownerRepo); repoRoot != "" {
+		return repoRoot
+	}
+	for _, dir := range workspaceDirs {
+		if root := resolveGitRepoRoot(dir); root != "" {
+			return root
+		}
+	}
+	return "."
+}
+
+func validateGitHubIssue(issue ghIssueListItem) error {
+	if issue.Number <= 0 {
+		return errors.New("github issue number is required")
+	}
+	if strings.TrimSpace(issue.Title) == "" {
+		return fmt.Errorf("github issue #%d title is required", issue.Number)
+	}
+	return nil
+}
+
+func (a *App) listGitHubIssues(ctx context.Context, cwd, ownerRepo string) ([]ghIssueListItem, error) {
 	runner := a.ghCommandRunner
 	if runner == nil {
 		runner = runGitHubCLI
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), githubIssueListTimeout)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, githubIssueListTimeout)
 	defer cancel()
 
-	raw, err := runner(
-		ctx,
-		cwd,
+	args := withGitHubRepoArg([]string{
 		"issue", "list",
 		"--state", "all",
 		"--limit", "500",
 		"--json", "number,title,url,state,labels,assignees",
+	}, ownerRepo)
+	raw, err := runner(
+		ctx,
+		cwd,
+		args...,
 	)
 	if err != nil {
 		return nil, err
@@ -164,18 +226,216 @@ func (a *App) syncGitHubIssueArtifact(item store.Item, ownerRepo string, issue g
 	return err
 }
 
-func migrateLegacyBugReportIssue(a *App, workspaceID int64, ownerRepo string, issue ghIssueListItem) error {
-	legacy, err := a.store.GetItemBySource("bug_report", legacyBugReportIssueSourceRef(issue.Number))
+func (a *App) syncGitHubIssueState(sourceRef, currentState, remoteState string) (string, bool, error) {
+	desiredState, err := githubIssueItemState(remoteState)
+	if err != nil {
+		return "", false, err
+	}
+	if currentState == desiredState {
+		return desiredState, false, nil
+	}
+	switch desiredState {
+	case store.ItemStateDone:
+		if err := a.store.CompleteItemBySource("github", sourceRef); err != nil {
+			return "", false, err
+		}
+	case store.ItemStateInbox:
+		if err := a.store.SyncItemStateBySource("github", sourceRef, store.ItemStateInbox); err != nil {
+			return "", false, err
+		}
+	default:
+		return "", false, fmt.Errorf("unsupported item state %q", desiredState)
+	}
+	return desiredState, true, nil
+}
+
+func trackedGitHubIssueSource(item store.Item) (string, int, bool) {
+	switch strings.ToLower(trimmedStringPointer(item.Source)) {
+	case "github":
+		return parseGitHubIssueSourceRef(trimmedStringPointer(item.SourceRef))
+	case "bug_report":
+		number, ok := parseLegacyBugReportIssueSourceRef(trimmedStringPointer(item.SourceRef))
+		if !ok {
+			return "", 0, false
+		}
+		return taburaBugReportOwnerRepo, number, true
+	default:
+		return "", 0, false
+	}
+}
+
+func (a *App) syncTrackedGitHubIssueItem(item store.Item, ownerRepo string, issue ghIssueListItem) (bool, error) {
+	if err := validateGitHubIssue(issue); err != nil {
+		return false, err
+	}
+
+	sourceRef := githubIssueSourceRef(ownerRepo, issue.Number)
+	changed := false
+	if trimmedStringPointer(item.Source) != "github" || trimmedStringPointer(item.SourceRef) != sourceRef {
+		if err := a.store.UpdateItemSource(item.ID, "github", sourceRef); err != nil {
+			return false, err
+		}
+		item.Source = optionalTrimmedString("github")
+		item.SourceRef = optionalTrimmedString(sourceRef)
+		changed = true
+	}
+
+	originalTitle := strings.TrimSpace(item.Title)
+	originalState := item.State
+	hadArtifact := item.ArtifactID != nil
+
+	updated, err := a.store.UpsertItemFromSource("github", sourceRef, issue.Title, item.WorkspaceID)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(issue.Title) != originalTitle {
+		changed = true
+	}
+	if !hadArtifact {
+		changed = true
+	}
+	if err := a.syncGitHubIssueArtifact(updated, ownerRepo, issue); err != nil {
+		return false, err
+	}
+	nextState, stateChanged, err := a.syncGitHubIssueState(sourceRef, updated.State, issue.State)
+	if err != nil {
+		return false, err
+	}
+	if stateChanged || nextState != originalState {
+		changed = true
+	}
+	return changed, nil
+}
+
+func (a *App) findWorkspaceGitHubIssueItem(workspaceID int64, ownerRepo string, issueNumber int) (*store.Item, error) {
+	sourceRef := githubIssueSourceRef(ownerRepo, issueNumber)
+	item, err := a.store.GetItemBySource("github", sourceRef)
+	if err == nil {
+		return &item, nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	legacy, err := a.store.GetItemBySource("bug_report", legacyBugReportIssueSourceRef(issueNumber))
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if legacy.WorkspaceID == nil || *legacy.WorkspaceID != workspaceID {
-		return nil
+		return nil, nil
 	}
-	return a.store.UpdateItemSource(legacy.ID, "github", githubIssueSourceRef(ownerRepo, issue.Number))
+	return &legacy, nil
+}
+
+func (a *App) syncWorkspaceGitHubIssue(workspaceID int64, ownerRepo string, issue ghIssueListItem) (bool, error) {
+	existing, err := a.findWorkspaceGitHubIssueItem(workspaceID, ownerRepo, issue.Number)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil {
+		return a.syncTrackedGitHubIssueItem(*existing, ownerRepo, issue)
+	}
+	if err := validateGitHubIssue(issue); err != nil {
+		return false, err
+	}
+	sourceRef := githubIssueSourceRef(ownerRepo, issue.Number)
+	item, err := a.store.UpsertItemFromSource("github", sourceRef, issue.Title, &workspaceID)
+	if err != nil {
+		return false, err
+	}
+	if err := a.syncGitHubIssueArtifact(item, ownerRepo, issue); err != nil {
+		return false, err
+	}
+	if _, _, err := a.syncGitHubIssueState(sourceRef, item.State, issue.State); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (a *App) trackedGitHubIssueItems(workspaceID *int64) ([]store.Item, error) {
+	var all []store.Item
+	for _, source := range []string{"github", "bug_report"} {
+		items, err := a.store.ListItemsFiltered(store.ItemListFilter{Source: source})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+	}
+	if workspaceID == nil {
+		return all, nil
+	}
+	filtered := make([]store.Item, 0, len(all))
+	for _, item := range all {
+		if item.WorkspaceID == nil || *item.WorkspaceID != *workspaceID {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered, nil
+}
+
+func (a *App) syncTrackedGitHubIssues(ctx context.Context, workspaceID *int64, skipRepos map[string]struct{}) (int, error) {
+	items, err := a.trackedGitHubIssueItems(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	type repoGroup struct {
+		itemsByNumber map[int]store.Item
+		workspaceDirs []string
+	}
+	repos := map[string]*repoGroup{}
+	for _, item := range items {
+		ownerRepo, number, ok := trackedGitHubIssueSource(item)
+		if !ok {
+			continue
+		}
+		if _, skip := skipRepos[ownerRepo]; skip {
+			continue
+		}
+		group := repos[ownerRepo]
+		if group == nil {
+			group = &repoGroup{itemsByNumber: map[int]store.Item{}}
+			repos[ownerRepo] = group
+		}
+		group.itemsByNumber[number] = item
+		if item.WorkspaceID == nil {
+			continue
+		}
+		workspace, err := a.store.GetWorkspace(*item.WorkspaceID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return 0, err
+		}
+		if dir := strings.TrimSpace(workspace.DirPath); dir != "" {
+			group.workspaceDirs = append(group.workspaceDirs, dir)
+		}
+	}
+
+	changed := 0
+	for ownerRepo, group := range repos {
+		issues, err := a.listGitHubIssues(ctx, githubIssueCommandDir(ownerRepo, group.workspaceDirs), ownerRepo)
+		if err != nil {
+			return 0, err
+		}
+		for _, issue := range issues {
+			item, ok := group.itemsByNumber[issue.Number]
+			if !ok {
+				continue
+			}
+			itemChanged, err := a.syncTrackedGitHubIssueItem(item, ownerRepo, issue)
+			if err != nil {
+				return 0, err
+			}
+			if itemChanged {
+				changed++
+			}
+		}
+	}
+	return changed, nil
 }
 
 func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error) {
@@ -191,7 +451,7 @@ func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error
 		return itemGitHubSyncResponse{}, errors.New("workspace has no GitHub origin remote")
 	}
 
-	issues, err := a.listGitHubIssues(workspace.DirPath)
+	issues, err := a.listGitHubIssues(context.Background(), workspace.DirPath, repo)
 	if err != nil {
 		return itemGitHubSyncResponse{}, err
 	}
@@ -203,44 +463,24 @@ func (a *App) syncGitHubIssues(workspaceID int64) (itemGitHubSyncResponse, error
 		Synced:      len(issues),
 	}
 	for _, issue := range issues {
-		if issue.Number <= 0 {
-			return itemGitHubSyncResponse{}, errors.New("github issue number is required")
-		}
-		if strings.TrimSpace(issue.Title) == "" {
-			return itemGitHubSyncResponse{}, fmt.Errorf("github issue #%d title is required", issue.Number)
-		}
-		if err := migrateLegacyBugReportIssue(a, workspace.ID, repo, issue); err != nil {
+		if err := validateGitHubIssue(issue); err != nil {
 			return itemGitHubSyncResponse{}, err
 		}
-
-		item, err := a.store.UpsertItemFromSource("github", githubIssueSourceRef(repo, issue.Number), issue.Title, &workspace.ID)
-		if err != nil {
+		if _, err := a.syncWorkspaceGitHubIssue(workspace.ID, repo, issue); err != nil {
 			return itemGitHubSyncResponse{}, err
 		}
-		if err := a.syncGitHubIssueArtifact(item, repo, issue); err != nil {
-			return itemGitHubSyncResponse{}, err
-		}
-
-		desiredState, err := githubIssueItemState(issue.State)
-		if err != nil {
-			return itemGitHubSyncResponse{}, err
-		}
-		switch desiredState {
-		case store.ItemStateDone:
+		switch strings.ToLower(strings.TrimSpace(issue.State)) {
+		case "closed":
 			result.Closed++
-			if item.State != store.ItemStateDone {
-				if err := a.store.CompleteItemBySource("github", githubIssueSourceRef(repo, issue.Number)); err != nil {
-					return itemGitHubSyncResponse{}, err
-				}
-			}
-		case store.ItemStateInbox:
+		case "open":
 			result.Open++
-			if item.State == store.ItemStateDone {
-				if err := a.store.SyncItemStateBySource("github", githubIssueSourceRef(repo, issue.Number), store.ItemStateInbox); err != nil {
-					return itemGitHubSyncResponse{}, err
-				}
-			}
+		default:
+			return itemGitHubSyncResponse{}, fmt.Errorf("unsupported github issue state %q", issue.State)
 		}
+	}
+
+	if _, err := a.syncTrackedGitHubIssues(context.Background(), &workspace.ID, map[string]struct{}{repo: {}}); err != nil {
+		return itemGitHubSyncResponse{}, err
 	}
 	return result, nil
 }

--- a/internal/web/items_github_test.go
+++ b/internal/web/items_github_test.go
@@ -180,7 +180,7 @@ func TestGitHubIssueSyncMigratesLegacyBugReportItems(t *testing.T) {
 	app := newAuthedTestApp(t)
 
 	repoDir := filepath.Join(t.TempDir(), "workspace")
-	initGitHubWorkspaceRepo(t, repoDir, "https://github.com/owner/tabula.git")
+	initGitHubWorkspaceRepo(t, repoDir, "https://github.com/krystophny/tabura.git")
 	workspace, err := app.store.CreateWorkspace("Repo", repoDir)
 	if err != nil {
 		t.Fatalf("CreateWorkspace() error: %v", err)
@@ -196,12 +196,11 @@ func TestGitHubIssueSyncMigratesLegacyBugReportItems(t *testing.T) {
 		t.Fatalf("CreateItem(legacy bug report) error: %v", err)
 	}
 
+	var calls [][]string
 	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
-		if cwd != repoDir {
-			t.Fatalf("gh cwd = %q, want %q", cwd, repoDir)
-		}
+		calls = append(calls, append([]string(nil), args...))
 		return `[
-			{"number":77,"title":"Bug report: Inbox sync migration","url":"https://github.com/owner/tabula/issues/77","state":"CLOSED","labels":[{"name":"bug"}],"assignees":[]}
+			{"number":77,"title":"Bug report: Inbox sync migration","url":"https://github.com/krystophny/tabura/issues/77","state":"CLOSED","labels":[{"name":"bug"}],"assignees":[]}
 		]`, nil
 	}
 
@@ -212,7 +211,7 @@ func TestGitHubIssueSyncMigratesLegacyBugReportItems(t *testing.T) {
 		t.Fatalf("sync status = %d, want 200: %s", rr.Code, rr.Body.String())
 	}
 
-	migrated, err := app.store.GetItemBySource("github", "owner/tabula#77")
+	migrated, err := app.store.GetItemBySource("github", "krystophny/tabura#77")
 	if err != nil {
 		t.Fatalf("GetItemBySource(migrated) error: %v", err)
 	}
@@ -227,6 +226,75 @@ func TestGitHubIssueSyncMigratesLegacyBugReportItems(t *testing.T) {
 	}
 	if _, err := app.store.GetItemBySource("bug_report", "issue:77"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("legacy bug report source lookup error = %v, want sql.ErrNoRows", err)
+	}
+	if len(calls) == 0 {
+		t.Fatal("expected gh invocation")
+	}
+	command := strings.Join(calls[0], " ")
+	if !strings.Contains(command, "--repo "+taburaBugReportOwnerRepo) {
+		t.Fatalf("gh args = %q, want explicit repo %q", command, taburaBugReportOwnerRepo)
+	}
+}
+
+func TestTrackedGitHubIssueSyncUsesSourceRefRepo(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	workspaceDir := filepath.Join(t.TempDir(), "workspace")
+	initGitHubWorkspaceRepo(t, workspaceDir, "https://github.com/example/customer-project.git")
+	workspace, err := app.store.CreateWorkspace("Customer Repo", workspaceDir)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+
+	source := "github"
+	sourceRef := githubIssueSourceRef(taburaBugReportOwnerRepo, 77)
+	item, err := app.store.CreateItem("Bug report: stale sidebar entry", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Source:      &source,
+		SourceRef:   &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(tracked github issue) error: %v", err)
+	}
+
+	var calls [][]string
+	app.ghCommandRunner = func(_ context.Context, cwd string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return `[
+			{"number":77,"title":"Bug report: sidebar closes on sync","url":"https://github.com/krystophny/tabura/issues/77","state":"CLOSED","labels":[{"name":"bug"}],"assignees":[]}
+		]`, nil
+	}
+
+	changed, err := app.syncTrackedGitHubIssues(context.Background(), &workspace.ID, nil)
+	if err != nil {
+		t.Fatalf("syncTrackedGitHubIssues() error: %v", err)
+	}
+	if changed != 1 {
+		t.Fatalf("syncTrackedGitHubIssues() changed = %d, want 1", changed)
+	}
+
+	synced, err := app.store.GetItemBySource("github", sourceRef)
+	if err != nil {
+		t.Fatalf("GetItemBySource(synced) error: %v", err)
+	}
+	if synced.ID != item.ID {
+		t.Fatalf("synced item ID = %d, want %d", synced.ID, item.ID)
+	}
+	if synced.State != store.ItemStateDone {
+		t.Fatalf("synced item state = %q, want %q", synced.State, store.ItemStateDone)
+	}
+	if synced.Title != "Bug report: sidebar closes on sync" {
+		t.Fatalf("synced item title = %q, want synced title", synced.Title)
+	}
+	if synced.ArtifactID == nil {
+		t.Fatal("expected synced item artifact")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("gh call count = %d, want 1", len(calls))
+	}
+	command := strings.Join(calls[0], " ")
+	if !strings.Contains(command, "--repo "+taburaBugReportOwnerRepo) {
+		t.Fatalf("gh args = %q, want explicit repo %q", command, taburaBugReportOwnerRepo)
 	}
 }
 

--- a/internal/web/source_poller.go
+++ b/internal/web/source_poller.go
@@ -132,7 +132,7 @@ func (a *App) handleSourceSyncCount(account store.ExternalAccount, count int) {
 }
 
 func (a *App) startSourcePoller() {
-	if a == nil || a.shutdownCtx == nil || a.sourceSync == nil {
+	if a == nil || a.shutdownCtx == nil {
 		return
 	}
 	a.workerWG.Add(1)
@@ -143,22 +143,34 @@ func (a *App) startSourcePoller() {
 }
 
 func (a *App) runSourcePoller(ctx context.Context) {
-	if a == nil || a.sourceSync == nil {
+	if a == nil {
 		return
 	}
 	for {
-		result, err := a.sourceSync.RunOnce(ctx)
-		if err != nil {
+		delay := sourceSyncDefaultInterval
+		if a.sourceSync != nil {
+			result, err := a.sourceSync.RunOnce(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Printf("source poller: %v", err)
+				if err := sleepSourcePoller(ctx, sourceSyncDefaultInterval); err != nil {
+					return
+				}
+				continue
+			}
+			delay = nextSourceSyncDelay(result.NextDelay)
+		}
+		if changed, err := a.syncTrackedGitHubIssues(ctx, nil, nil); err != nil {
 			if ctx.Err() != nil {
 				return
 			}
-			log.Printf("source poller: %v", err)
-			if err := sleepSourcePoller(ctx, sourceSyncDefaultInterval); err != nil {
-				return
-			}
-			continue
+			log.Printf("source poller github issues: %v", err)
+		} else if changed > 0 {
+			a.broadcastItemsIngested(changed, "github")
 		}
-		if err := sleepSourcePoller(ctx, nextSourceSyncDelay(result.NextDelay)); err != nil {
+		if err := sleepSourcePoller(ctx, delay); err != nil {
 			return
 		}
 	}
@@ -186,10 +198,23 @@ func sleepSourcePoller(ctx context.Context, delay time.Duration) error {
 }
 
 func (a *App) syncSourcesNow(ctx context.Context) (tabsync.RunResult, error) {
-	if a == nil || a.sourceSync == nil {
+	if a == nil {
 		return tabsync.RunResult{}, fmt.Errorf("no external source poller is configured")
 	}
-	return a.sourceSync.RunNow(ctx)
+	result := tabsync.RunResult{}
+	if a.sourceSync != nil {
+		var err error
+		result, err = a.sourceSync.RunNow(ctx)
+		if err != nil {
+			return tabsync.RunResult{}, err
+		}
+	}
+	if changed, err := a.syncTrackedGitHubIssues(ctx, nil, nil); err != nil {
+		return tabsync.RunResult{}, err
+	} else if changed > 0 {
+		a.broadcastItemsIngested(changed, "github")
+	}
+	return result, nil
 }
 
 func summarizeSourceSyncResult(result tabsync.RunResult) string {

--- a/internal/web/static/app-chat-transport.ts
+++ b/internal/web/static/app-chat-transport.ts
@@ -412,6 +412,11 @@ export function handleChatEvent(payload) {
     return;
   }
 
+  if (type === 'items_ingested') {
+    refreshBatchItemSidebar();
+    return;
+  }
+
   if (type === 'mode_changed') {
     const nextMode = String(payload.mode || 'chat').trim().toLowerCase();
     setChatMode(nextMode);

--- a/tests/playwright/bug-report.spec.ts
+++ b/tests/playwright/bug-report.spec.ts
@@ -72,6 +72,56 @@ test.describe('bug report flow', () => {
     await expect(page.locator('#edge-left-tap')).toHaveAttribute('data-inbox-count', '3');
   });
 
+  test('closed bug report disappears from the open inbox after github ingest refresh', async ({ page }) => {
+    await waitReady(page);
+
+    await page.locator('#edge-left-tap').click();
+    await expect(page.locator('#pr-file-list')).toContainText('Review parser cleanup');
+
+    await page.locator('#bug-report-button').click();
+    await page.locator('#bug-report-note').fill('Harness github close refresh');
+    await page.locator('#bug-report-save').click();
+
+    await expect(page.locator('#pr-file-list')).toContainText('Bug report: Harness repro');
+    await expect(page.locator('#edge-left-tap')).toHaveAttribute('data-inbox-count', '3');
+
+    await page.evaluate(() => {
+      const data = (window as any).__itemSidebarData || {};
+      const inbox = Array.isArray(data.inbox)
+        ? data.inbox.filter((entry: any) => String(entry?.title || '') !== 'Bug report: Harness repro')
+        : [];
+      const done = Array.isArray(data.done) ? data.done.slice() : [];
+      done.unshift({
+        id: 103,
+        title: 'Bug report: Harness repro',
+        state: 'done',
+        sphere: 'private',
+        artifact_id: 0,
+        source: 'github',
+        source_ref: 'krystophny/tabura#77',
+        artifact_title: 'Bug report: Harness repro',
+        artifact_kind: 'github_issue',
+        actor_name: '',
+        created_at: '2026-03-08 15:04:05',
+        updated_at: '2026-03-11 09:00:00',
+      });
+      (window as any).__itemSidebarData = {
+        ...data,
+        inbox,
+        done,
+      };
+
+      const sessions = (window as any).__mockWsSessions || [];
+      const chatWs = sessions.find((entry: any) => String(entry?.url || '').includes('/chat/'));
+      if (chatWs && typeof chatWs.injectEvent === 'function') {
+        chatWs.injectEvent({ type: 'items_ingested', count: 1, source: 'github' });
+      }
+    });
+
+    await expect(page.locator('#pr-file-list')).not.toContainText('Bug report: Harness repro');
+    await expect(page.locator('#edge-left-tap')).toHaveAttribute('data-inbox-count', '2');
+  });
+
   test('keyboard shortcut opens the bug report sheet', async ({ page }) => {
     await waitReady(page);
 

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1533,7 +1533,7 @@
           sphere: 'private',
           artifact_id: 0,
           source: 'github',
-          source_ref: 'owner/tabula#77',
+          source_ref: 'krystophny/tabura#77',
           artifact_title: 'Bug report: Harness repro',
           artifact_kind: 'github_issue',
           actor_name: '',
@@ -1546,7 +1546,7 @@
           screenshot_path: '.tabura/artifacts/bugs/20260308-150405-abcd1234/screenshot.png',
           annotated_path: body.annotated_data_url ? '.tabura/artifacts/bugs/20260308-150405-abcd1234/annotated.png' : '',
           issue_number: 77,
-          issue_url: 'https://github.com/owner/tabula/issues/77',
+          issue_url: 'https://github.com/krystophny/tabura/issues/77',
           issue_title: 'Bug report: Harness repro',
           item_id: 501,
         }), { status: 200 });


### PR DESCRIPTION
## Summary
- reconcile tracked GitHub issue items by their stored source repo/reference instead of the active workspace remote
- run tracked GitHub issue reconciliation from source sync/poller flows and refresh the open item sidebar on items_ingested events
- add backend and Playwright regression coverage for bug reports disappearing from Inbox after GitHub closure

## Testing
- go test ./internal/web -run 'TestGitHubIssueSyncAPI|TestGitHubIssueSyncAPIRejectsWorkspaceWithoutGitHubRemote|TestGitHubIssueSyncMigratesLegacyBugReportItems|TestTrackedGitHubIssueSyncUsesSourceRefRepo|TestSourcePollerLoopRunsRunnerUntilCanceled|TestSyncNowCommandForcesImmediateRun|TestSyncSourcesNowPopulatesUnifiedInboxAcrossProviders|TestBroadcastItemsIngestedWebsocketNotification'
- npm run build:frontend
- npm run typecheck:frontend
- ./scripts/playwright.sh tests/playwright/bug-report.spec.ts