### PR TITLE
fix: add deploy/launchd/ template plists (fixes #577)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ archives:
       - README.md
       - scripts/piper_tts_server.py
       - scripts/setup-local-llm.sh
+      - deploy/launchd/*.plist
 
 checksum:
   name_template: checksums.txt

--- a/deploy/launchd/io.tabura.codex-app-server.plist
+++ b/deploy/launchd/io.tabura.codex-app-server.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.tabura.codex-app-server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@CODEX_PATH@@</string>
+    <string>app-server</string>
+    <string>--listen</string>
+    <string>ws://127.0.0.1:8787</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tabura-codex-app-server.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tabura-codex-app-server.log</string>
+</dict>
+</plist>

--- a/deploy/launchd/io.tabura.llm.plist
+++ b/deploy/launchd/io.tabura.llm.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.tabura.llm</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@LLM_SETUP_SCRIPT@@</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TABURA_LLM_MODEL_DIR</key>
+    <string>@@LLM_MODEL_DIR@@</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tabura-llm.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tabura-llm.log</string>
+</dict>
+</plist>

--- a/deploy/launchd/io.tabura.piper-tts.plist
+++ b/deploy/launchd/io.tabura.piper-tts.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.tabura.piper-tts</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@VENV_DIR@@/bin/uvicorn</string>
+    <string>piper_tts_server:app</string>
+    <string>--app-dir</string>
+    <string>@@SCRIPT_DIR@@</string>
+    <string>--host</string>
+    <string>127.0.0.1</string>
+    <string>--port</string>
+    <string>8424</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PIPER_MODEL_DIR</key>
+    <string>@@PIPER_MODEL_DIR@@</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tabura-piper-tts.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tabura-piper-tts.log</string>
+</dict>
+</plist>

--- a/deploy/launchd/io.tabura.stt.plist
+++ b/deploy/launchd/io.tabura.stt.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.tabura.stt</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@STT_SETUP_SCRIPT@@</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TABURA_STT_LANGUAGE</key>
+    <string>de,en</string>
+    <key>TABURA_STT_MODEL</key>
+    <string>large-v3-turbo</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tabura-stt.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tabura-stt.log</string>
+</dict>
+</plist>

--- a/deploy/launchd/io.tabura.web.plist
+++ b/deploy/launchd/io.tabura.web.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.tabura.web</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@BIN_PATH@@</string>
+    <string>server</string>
+    <string>--project-dir</string>
+    <string>@@PROJECT_DIR@@</string>
+    <string>--data-dir</string>
+    <string>@@WEB_DATA_DIR@@</string>
+    <string>--web-host</string>
+    <string>127.0.0.1</string>
+    <string>--web-port</string>
+    <string>8420</string>
+    <string>--mcp-host</string>
+    <string>127.0.0.1</string>
+    <string>--mcp-port</string>
+    <string>9420</string>
+    <string>--app-server-url</string>
+    <string>ws://127.0.0.1:8787</string>
+    <string>--tts-url</string>
+    <string>http://127.0.0.1:8424</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TABURA_INTENT_LLM_URL</key>
+    <string>http://127.0.0.1:8426</string>
+    <key>TABURA_INTENT_LLM_MODEL</key>
+    <string>local</string>
+    <key>TABURA_INTENT_LLM_PROFILE</key>
+    <string>qwen3.5-9b</string>
+    <key>TABURA_INTENT_LLM_PROFILE_OPTIONS</key>
+    <string>qwen3.5-9b,qwen3.5-4b</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tabura-web.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tabura-web.log</string>
+</dict>
+</plist>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,6 +27,7 @@ PIPER_SERVER_SCRIPT=""
 LLM_DIR=""
 LLM_MODEL_DIR=""
 LLM_SETUP_SCRIPT=""
+STT_SETUP_SCRIPT=""
 CODEX_PATH=""
 
 log() {
@@ -164,6 +165,7 @@ resolve_paths() {
     LLM_DIR="${DATA_ROOT}/llm"
     LLM_MODEL_DIR="${LLM_DIR}/models"
     LLM_SETUP_SCRIPT="${SCRIPT_DIR}/setup-local-llm.sh"
+    STT_SETUP_SCRIPT="${SCRIPT_DIR}/setup-voxtype-stt.sh"
 }
 
 require_codex_app_server() {
@@ -339,6 +341,10 @@ BIN
             echo "#!/usr/bin/env bash" >"${tmpdir}/setup-local-llm.sh"
         fi
         chmod +x "${tmpdir}/setup-local-llm.sh"
+        if [ -d "deploy/launchd" ]; then
+            mkdir -p "${tmpdir}/deploy/launchd"
+            cp deploy/launchd/*.plist "${tmpdir}/deploy/launchd/"
+        fi
         printf '%s\n' "$tag"
         return
     fi
@@ -643,9 +649,27 @@ install_services_linux() {
     run_cmd systemctl --user enable --now "${units[@]}"
 }
 
+substitute_launchd_template() {
+    local src="$1" dst="$2"
+    sed \
+        -e "s|@@BIN_PATH@@|${BIN_PATH}|g" \
+        -e "s|@@CODEX_PATH@@|${CODEX_PATH}|g" \
+        -e "s|@@PROJECT_DIR@@|${PROJECT_DIR}|g" \
+        -e "s|@@WEB_DATA_DIR@@|${WEB_DATA_DIR}|g" \
+        -e "s|@@VENV_DIR@@|${VENV_DIR}|g" \
+        -e "s|@@SCRIPT_DIR@@|${SCRIPT_DIR}|g" \
+        -e "s|@@PIPER_MODEL_DIR@@|${MODEL_DIR}|g" \
+        -e "s|@@LLM_SETUP_SCRIPT@@|${LLM_SETUP_SCRIPT}|g" \
+        -e "s|@@LLM_MODEL_DIR@@|${LLM_MODEL_DIR}|g" \
+        -e "s|@@STT_SETUP_SCRIPT@@|${STT_SETUP_SCRIPT}|g" \
+        "$src" >"$dst"
+}
+
 write_launchd_plists() {
-    local agent_dir
+    local staging_dir="$1"
+    local agent_dir template_dir
     agent_dir="${HOME}/Library/LaunchAgents"
+    template_dir="${staging_dir}/deploy/launchd"
 
     if [ "$DRY_RUN" = "1" ]; then
         log "[dry-run] write launchd plists under ${agent_dir}"
@@ -654,79 +678,16 @@ write_launchd_plists() {
 
     run_cmd mkdir -p "$agent_dir"
 
-    cat >"${agent_dir}/io.tabura.codex-app-server.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>io.tabura.codex-app-server</string>
-  <key>ProgramArguments</key><array>
-    <string>${CODEX_PATH}</string><string>app-server</string><string>--listen</string><string>ws://127.0.0.1:8787</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/tabura-codex-app-server.log</string>
-  <key>StandardErrorPath</key><string>/tmp/tabura-codex-app-server.log</string>
-</dict></plist>
-PLIST
+    [ -d "$template_dir" ] || fail "launchd templates not found in ${template_dir}"
 
-    cat >"${agent_dir}/io.tabura.piper-tts.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>io.tabura.piper-tts</string>
-  <key>ProgramArguments</key><array>
-    <string>${VENV_DIR}/bin/uvicorn</string><string>piper_tts_server:app</string><string>--app-dir</string><string>${SCRIPT_DIR}</string><string>--host</string><string>127.0.0.1</string><string>--port</string><string>8424</string>
-  </array>
-  <key>EnvironmentVariables</key><dict>
-    <key>PIPER_MODEL_DIR</key><string>${MODEL_DIR}</string>
-  </dict>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/tabura-piper-tts.log</string>
-  <key>StandardErrorPath</key><string>/tmp/tabura-piper-tts.log</string>
-</dict></plist>
-PLIST
+    substitute_launchd_template "${template_dir}/io.tabura.codex-app-server.plist" "${agent_dir}/io.tabura.codex-app-server.plist"
+    substitute_launchd_template "${template_dir}/io.tabura.piper-tts.plist" "${agent_dir}/io.tabura.piper-tts.plist"
 
     if [ -x "$LLM_SETUP_SCRIPT" ]; then
-        cat >"${agent_dir}/io.tabura.llm.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>io.tabura.llm</string>
-  <key>ProgramArguments</key><array>
-    <string>${LLM_SETUP_SCRIPT}</string>
-  </array>
-  <key>EnvironmentVariables</key><dict>
-    <key>TABURA_LLM_MODEL_DIR</key><string>${LLM_MODEL_DIR}</string>
-  </dict>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/tabura-llm.log</string>
-  <key>StandardErrorPath</key><string>/tmp/tabura-llm.log</string>
-</dict></plist>
-PLIST
+        substitute_launchd_template "${template_dir}/io.tabura.llm.plist" "${agent_dir}/io.tabura.llm.plist"
     fi
 
-    cat >"${agent_dir}/io.tabura.web.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>io.tabura.web</string>
-  <key>ProgramArguments</key><array>
-    <string>${BIN_PATH}</string><string>server</string><string>--project-dir</string><string>${PROJECT_DIR}</string><string>--data-dir</string><string>${WEB_DATA_DIR}</string><string>--web-host</string><string>127.0.0.1</string><string>--web-port</string><string>8420</string><string>--mcp-host</string><string>127.0.0.1</string><string>--mcp-port</string><string>9420</string><string>--app-server-url</string><string>ws://127.0.0.1:8787</string><string>--tts-url</string><string>http://127.0.0.1:8424</string>
-  </array>
-  <key>EnvironmentVariables</key><dict>
-    <key>TABURA_INTENT_LLM_URL</key><string>http://127.0.0.1:8426</string>
-    <key>TABURA_INTENT_LLM_MODEL</key><string>local</string>
-    <key>TABURA_INTENT_LLM_PROFILE</key><string>qwen3.5-9b</string>
-    <key>TABURA_INTENT_LLM_PROFILE_OPTIONS</key><string>qwen3.5-9b,qwen3.5-4b</string>
-  </dict>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/tabura-web.log</string>
-  <key>StandardErrorPath</key><string>/tmp/tabura-web.log</string>
-</dict></plist>
-PLIST
+    substitute_launchd_template "${template_dir}/io.tabura.web.plist" "${agent_dir}/io.tabura.web.plist"
 }
 
 load_launchd_service() {
@@ -736,9 +697,10 @@ load_launchd_service() {
 }
 
 install_services_macos() {
+    local staging_dir="$1"
     local agent_dir
     agent_dir="${HOME}/Library/LaunchAgents"
-    write_launchd_plists
+    write_launchd_plists "$staging_dir"
     load_launchd_service "${agent_dir}/io.tabura.codex-app-server.plist"
     load_launchd_service "${agent_dir}/io.tabura.piper-tts.plist"
     if [ -f "${agent_dir}/io.tabura.intent.plist" ]; then
@@ -853,7 +815,7 @@ install_flow() {
     setup_local_llm "$tmpdir"
     install_voxtype_stt
     if [ "$TABURA_OS" = "darwin" ]; then
-        install_services_macos
+        install_services_macos "$tmpdir"
     else
         install_services_linux
     fi

--- a/tests/deploy/launchd_test.go
+++ b/tests/deploy/launchd_test.go
@@ -1,0 +1,212 @@
+package deploy_test
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var repoRoot = filepath.Join("..", "..")
+
+var expectedPlists = []struct {
+	file   string
+	label  string
+	tokens []string
+}{
+	{
+		file:   "io.tabura.codex-app-server.plist",
+		label:  "io.tabura.codex-app-server",
+		tokens: []string{"@@CODEX_PATH@@"},
+	},
+	{
+		file:   "io.tabura.piper-tts.plist",
+		label:  "io.tabura.piper-tts",
+		tokens: []string{"@@VENV_DIR@@", "@@SCRIPT_DIR@@", "@@PIPER_MODEL_DIR@@"},
+	},
+	{
+		file:   "io.tabura.llm.plist",
+		label:  "io.tabura.llm",
+		tokens: []string{"@@LLM_SETUP_SCRIPT@@", "@@LLM_MODEL_DIR@@"},
+	},
+	{
+		file:   "io.tabura.stt.plist",
+		label:  "io.tabura.stt",
+		tokens: []string{"@@STT_SETUP_SCRIPT@@"},
+	},
+	{
+		file:   "io.tabura.web.plist",
+		label:  "io.tabura.web",
+		tokens: []string{"@@BIN_PATH@@", "@@PROJECT_DIR@@", "@@WEB_DATA_DIR@@"},
+	},
+}
+
+var shellVarPattern = regexp.MustCompile(`\$\{[A-Z_]+\}`)
+
+func TestLaunchdTemplatesExist(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	for _, tc := range expectedPlists {
+		path := filepath.Join(dir, tc.file)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("missing template: %s", path)
+		}
+	}
+}
+
+func TestLaunchdTemplatesValidXML(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if err := xml.Unmarshal(data, new(interface{})); err != nil {
+				t.Fatalf("invalid XML: %v", err)
+			}
+		})
+	}
+}
+
+func TestLaunchdTemplatesContainLabel(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			content := string(data)
+			if !strings.Contains(content, tc.label) {
+				t.Errorf("template missing Label %q", tc.label)
+			}
+		})
+	}
+}
+
+func TestLaunchdTemplatesContainTokens(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			content := string(data)
+			for _, tok := range tc.tokens {
+				if !strings.Contains(content, tok) {
+					t.Errorf("template missing token %s", tok)
+				}
+			}
+		})
+	}
+}
+
+func TestLaunchdTemplatesNoShellVars(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if m := shellVarPattern.FindString(string(data)); m != "" {
+				t.Errorf("template contains shell variable %s; use @@TOKEN@@ placeholders", m)
+			}
+		})
+	}
+}
+
+func TestLaunchdTemplatesHaveRequiredKeys(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	requiredKeys := []string{"Label", "ProgramArguments", "RunAtLoad", "KeepAlive", "StandardOutPath", "StandardErrorPath"}
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			content := string(data)
+			for _, key := range requiredKeys {
+				needle := "<key>" + key + "</key>"
+				if !strings.Contains(content, needle) {
+					t.Errorf("template missing required key %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestLaunchdTemplateTokenSubstitution(t *testing.T) {
+	dir := filepath.Join(repoRoot, "deploy", "launchd")
+	tokenValues := map[string]string{
+		"@@BIN_PATH@@":         "/usr/local/bin/tabura",
+		"@@CODEX_PATH@@":       "/usr/local/bin/codex",
+		"@@PROJECT_DIR@@":      "/tmp/project",
+		"@@WEB_DATA_DIR@@":     "/tmp/web-data",
+		"@@VENV_DIR@@":         "/tmp/venv",
+		"@@SCRIPT_DIR@@":       "/tmp/scripts",
+		"@@PIPER_MODEL_DIR@@":  "/tmp/models",
+		"@@LLM_SETUP_SCRIPT@@": "/tmp/setup-llm.sh",
+		"@@LLM_MODEL_DIR@@":    "/tmp/llm-models",
+		"@@STT_SETUP_SCRIPT@@": "/tmp/setup-stt.sh",
+	}
+
+	for _, tc := range expectedPlists {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, tc.file))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			content := string(data)
+			for tok, val := range tokenValues {
+				content = strings.ReplaceAll(content, tok, val)
+			}
+			if strings.Contains(content, "@@") {
+				t.Error("substituted plist still contains unresolved @@-tokens")
+			}
+			if err := xml.Unmarshal([]byte(content), new(interface{})); err != nil {
+				t.Errorf("substituted plist is invalid XML: %v", err)
+			}
+		})
+	}
+}
+
+func TestSystemdAndLaunchdServiceParity(t *testing.T) {
+	launchdDir := filepath.Join(repoRoot, "deploy", "launchd")
+	systemdDir := filepath.Join(repoRoot, "deploy", "systemd", "user")
+
+	launchdServices := map[string]bool{
+		"codex-app-server": false,
+		"piper-tts":        false,
+		"llm":              false,
+		"stt":              false,
+		"web":              false,
+	}
+
+	entries, err := os.ReadDir(launchdDir)
+	if err != nil {
+		t.Fatalf("read launchd dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".plist") {
+			continue
+		}
+		svc := strings.TrimPrefix(name, "io.tabura.")
+		svc = strings.TrimSuffix(svc, ".plist")
+		launchdServices[svc] = true
+	}
+
+	for svc, found := range launchdServices {
+		if !found {
+			t.Errorf("missing launchd template for service %q", svc)
+		}
+		systemdFile := filepath.Join(systemdDir, "tabura-"+svc+".service")
+		if _, err := os.Stat(systemdFile); os.IsNotExist(err) {
+			t.Errorf("launchd template for %q exists but systemd unit %s is missing", svc, systemdFile)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `deploy/launchd/` directory with 5 template plist files using `@@TOKEN@@` placeholders: codex-app-server, piper-tts, llm, stt, web
- Refactor `install.sh` `write_launchd_plists` to use `sed`-based template substitution instead of inline heredocs
- Bundle templates in release archives via `.goreleaser.yaml`
- Add Go tests validating template structure, XML validity, token presence, shell-var absence, and systemd/launchd service parity

## Verification

### Requirement: reviewable/diffable plist templates in repo
Templates exist under `deploy/launchd/` as standalone files, visible in this PR diff.

### Requirement: placeholder tokens (same scheme as #576)
```
$ grep -c '@@' deploy/launchd/*.plist
deploy/launchd/io.tabura.codex-app-server.plist:1
deploy/launchd/io.tabura.llm.plist:2
deploy/launchd/io.tabura.piper-tts.plist:3
deploy/launchd/io.tabura.stt.plist:1
deploy/launchd/io.tabura.web.plist:3
```

### Requirement: install.sh uses templates instead of inline generation
`write_launchd_plists` now calls `substitute_launchd_template` which reads from `deploy/launchd/` templates. All inline PLIST heredocs removed (see diff: -74 lines of heredoc, +16 lines of sed substitution).

### Requirement: STT plist template (currently missing, see #580)
`deploy/launchd/io.tabura.stt.plist` created with `@@STT_SETUP_SCRIPT@@` token. Not yet wired into `install_services_macos` (that is #580 scope).

### Tests pass
```
$ go test ./tests/deploy/ -v
=== RUN   TestLaunchdTemplatesExist
--- PASS: TestLaunchdTemplatesExist (0.00s)
=== RUN   TestLaunchdTemplatesValidXML
--- PASS: TestLaunchdTemplatesValidXML (0.00s)
=== RUN   TestLaunchdTemplatesContainLabel
--- PASS: TestLaunchdTemplatesContainLabel (0.00s)
=== RUN   TestLaunchdTemplatesContainTokens
--- PASS: TestLaunchdTemplatesContainTokens (0.00s)
=== RUN   TestLaunchdTemplatesNoShellVars
--- PASS: TestLaunchdTemplatesNoShellVars (0.00s)
=== RUN   TestLaunchdTemplatesHaveRequiredKeys
--- PASS: TestLaunchdTemplatesHaveRequiredKeys (0.00s)
=== RUN   TestLaunchdTemplateTokenSubstitution
--- PASS: TestLaunchdTemplateTokenSubstitution (0.00s)
=== RUN   TestSystemdAndLaunchdServiceParity
--- PASS: TestSystemdAndLaunchdServiceParity (0.00s)
PASS
ok      github.com/krystophny/tabura/tests/deploy       0.152s
```

### Installer dry-run still passes
```
$ bash tests/installers/installers_test.sh
installer tests passed
```

### Full test suite passes
```
$ go test ./...
ok      github.com/krystophny/tabura/tests/deploy       0.152s
ok      github.com/krystophny/tabura/internal/web        17.518s
[all packages pass]
```

## Test plan
- [x] Template validation tests (XML, tokens, labels, plist keys, parity)
- [x] Installer dry-run test
- [x] Full `go test ./...`