### PR TITLE
fix: make piper-tts setup compatible with macOS (fixes #579)

### DIFF
--- a/scripts/setup-tabura-piper-tts.sh
+++ b/scripts/setup-tabura-piper-tts.sh
@@ -17,16 +17,6 @@ SERVER_SCRIPT="$(cd "$(dirname "$0")" && pwd)/piper_tts_server.py"
 
 HF_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main"
 
-declare -A MODELS=(
-    ["en_GB-alan-medium"]="en/en_GB/alan/medium"
-    ["de_DE-karlsson-low"]="de/de_DE/karlsson/low"
-)
-
-declare -A MODEL_LICENSE_NOTES=(
-    ["en_GB-alan-medium"]="Model card indicates MIT-compatible terms."
-    ["de_DE-karlsson-low"]="Per-model terms must be checked in model card."
-)
-
 confirm_default_yes() {
     local prompt="$1"
     if [ "${TABURA_ASSUME_YES:-0}" = "1" ]; then
@@ -40,6 +30,30 @@ confirm_default_yes() {
         "" | [Yy] | [Yy][Ee][Ss]) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+download_model() {
+    local model="$1" subpath="$2" note="$3"
+    local onnx="${MODEL_DIR}/${model}.onnx"
+    local json="${MODEL_DIR}/${model}.onnx.json"
+
+    if [ -f "$onnx" ] && [ -f "$json" ]; then
+        echo "Model already exists: $model"
+        return
+    fi
+
+    echo "Model license notice: ${model}"
+    echo "  ${note}"
+    echo "  Model card: ${HF_BASE}/${subpath}/MODEL_CARD"
+    if ! confirm_default_yes "Download ${model}?"; then
+        echo "Skipping model download: ${model}"
+        return
+    fi
+
+    echo "Downloading model: $model ..."
+    curl -fsSL -o "$onnx" "${HF_BASE}/${subpath}/${model}.onnx"
+    curl -fsSL -o "$json" "${HF_BASE}/${subpath}/${model}.onnx.json"
+    echo "  $(du -h "$onnx" | cut -f1) $onnx"
 }
 
 mkdir -p "$MODEL_DIR"
@@ -59,29 +73,10 @@ fi
 
 # --- Step 1: Download voice models ---
 
-for model in "${!MODELS[@]}"; do
-    subpath="${MODELS[$model]}"
-    onnx="${MODEL_DIR}/${model}.onnx"
-    json="${MODEL_DIR}/${model}.onnx.json"
-
-    if [ -f "$onnx" ] && [ -f "$json" ]; then
-        echo "Model already exists: $model"
-        continue
-    fi
-
-    echo "Model license notice: ${model}"
-    echo "  ${MODEL_LICENSE_NOTES[$model]}"
-    echo "  Model card: ${HF_BASE}/${subpath}/MODEL_CARD"
-    if ! confirm_default_yes "Download ${model}?"; then
-        echo "Skipping model download: ${model}"
-        continue
-    fi
-
-    echo "Downloading model: $model ..."
-    curl -fsSL -o "$onnx" "${HF_BASE}/${subpath}/${model}.onnx"
-    curl -fsSL -o "$json" "${HF_BASE}/${subpath}/${model}.onnx.json"
-    echo "  $(du -h "$onnx" | cut -f1) $onnx"
-done
+download_model "en_GB-alan-medium" "en/en_GB/alan/medium" \
+    "Model card indicates MIT-compatible terms."
+download_model "de_DE-karlsson-low" "de/de_DE/karlsson/low" \
+    "Per-model terms must be checked in model card."
 
 # --- Step 2: Python venv + dependencies ---
 
@@ -111,9 +106,17 @@ echo "  Server:      $SERVER_SCRIPT"
 echo ""
 echo "Next steps:"
 echo "  1. Run: scripts/install-tabura-user-units.sh"
-echo "  2. systemctl --user start tabura-piper-tts.service"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "  2. launchctl load ~/Library/LaunchAgents/io.tabura.piper-tts.plist"
+else
+    echo "  2. systemctl --user start tabura-piper-tts.service"
+fi
 echo "  3. Test:"
 echo "     curl -X POST http://127.0.0.1:8424/v1/audio/speech \\"
 echo "       -H 'Content-Type: application/json' \\"
 echo "       -d '{\"input\":\"Hello world\",\"voice\":\"en\"}' > /tmp/test.wav"
-echo "     aplay /tmp/test.wav"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "     afplay /tmp/test.wav"
+else
+    echo "     aplay /tmp/test.wav"
+fi

--- a/tests/installers/installers_test.sh
+++ b/tests/installers/installers_test.sh
@@ -37,6 +37,14 @@ run_install_sh_dry_run() {
     make_fake_cmd "$fakebin" systemctl
     make_fake_cmd "$fakebin" launchctl
 
+    # Stub curl that always fails so detect_llama_server cannot find
+    # services running on the host and the test stays deterministic.
+    cat >"${fakebin}/curl" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "${fakebin}/curl"
+
     # Need a real python3 >= 3.10 for the version check.
     # Prefer the system-wide python3 if adequate, otherwise try common paths.
     local real_python3=""


### PR DESCRIPTION
## Summary

- Replace `declare -A` (bash 4+ only) in `setup-tabura-piper-tts.sh` with a `download_model` function using positional arguments, making the script compatible with macOS stock bash 3.2.57
- Add platform-aware "Next steps" output: `launchctl`/`afplay` on macOS instead of `systemctl`/`aplay`
- Fix installer test: stub `curl` in fakebin so `detect_llama_server` cannot find services running on the host, making the test deterministic

## Verification

### Task 1: pip install piper-tts works on macOS arm64

```
$ python3 -m venv /tmp/piper-test-venv && source /tmp/piper-test-venv/bin/activate && pip install piper-tts
Collecting piper-tts
  Downloading piper_tts-1.4.1-cp39-abi3-macosx_11_0_arm64.whl.metadata (2.3 kB)
...
Successfully installed flatbuffers-25.12.19 mpmath-1.3.0 numpy-2.4.3 onnxruntime-1.24.3 packaging-26.0 piper-tts-1.4.1 protobuf-7.34.0 sympy-1.14.0
```

Pre-built macOS arm64 wheel exists; no build-from-source needed.

### Task 2: declare -A fails on macOS stock bash 3.2

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ /bin/bash -c 'declare -A X=(["a"]="b")'
/bin/bash: line 0: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

### Task 3: fixed script passes bash 3.2 syntax check

```
$ /bin/bash -n scripts/setup-tabura-piper-tts.sh
(exit 0, no errors)
```

### Task 4: download_model function works on bash 3.2

```
$ /bin/bash -c '
download_model() {
    local model="$1" subpath="$2" note="$3"
    echo "model=$model subpath=$subpath note=$note"
}
download_model "en_GB-alan-medium" "en/en_GB/alan/medium" "MIT-compatible"
download_model "de_DE-karlsson-low" "de/de_DE/karlsson/low" "check model card"
'
model=en_GB-alan-medium subpath=en/en_GB/alan/medium note=MIT-compatible
model=de_DE-karlsson-low subpath=de/de_DE/karlsson/low note=check model card
```

### Task 5: all tests pass

```
$ go test ./...
ok   github.com/krystophny/tabura/cmd/tabura
ok   github.com/krystophny/tabura/internal/appserver
... (all packages ok)
ok   github.com/krystophny/tabura/tests/deploy
ok   github.com/krystophny/tabura/tests/services

$ bash tests/installers/installers_test.sh
distribution artifact tests passed
installer tests passed
```