### PR TITLE
fix: make playwright.sh macOS-aware with native fallback (fixes #585)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,15 @@ go test ./...
 
 Playwright runs in the official container through `scripts/playwright.sh`.
 
+On macOS, if the container daemon (Docker Desktop, OrbStack, colima) is not
+running, the script prints a diagnostic and exits.  Set `PLAYWRIGHT_NATIVE=1`
+to run natively with locally installed browsers (Chromium is usually available;
+Firefox and WebKit require `npx playwright install`):
+
+```bash
+PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh
+```
+
 Current Playwright specs:
 - `tests/playwright/artifact-context.spec.ts`
 - `tests/playwright/canvas-refresh.spec.ts`

--- a/scripts/playwright.sh
+++ b/scripts/playwright.sh
@@ -5,12 +5,45 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MOUNT="/work"
 CONTAINER_NAME="tabura-playwright"
 
-if command -v podman >/dev/null 2>&1; then
-  RUNTIME=podman
-elif command -v docker >/dev/null 2>&1; then
-  RUNTIME=docker
-else
-  echo "playwright.sh: podman or docker required" >&2
+# ── runtime detection ────────────────────────────────────────────────
+# Check whether a container daemon is actually reachable, not just
+# whether the CLI binary exists.  On macOS the daemon (Docker Desktop,
+# OrbStack, colima …) may be installed but not running.
+runtime_ready() {
+  if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+    RUNTIME=podman; return 0
+  fi
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    RUNTIME=docker; return 0
+  fi
+  return 1
+}
+
+# ── native fallback ──────────────────────────────────────────────────
+# When no container daemon is reachable, run Playwright natively.
+# Firefox/WebKit browsers may not be installed; Chromium usually is.
+# Set PLAYWRIGHT_NATIVE=1 to force this path even when a daemon exists.
+run_native() {
+  echo "playwright.sh: running natively (no container daemon available)" >&2
+  cd "${ROOT_DIR}"
+  exec npx playwright test "$@"
+}
+
+if [[ "${PLAYWRIGHT_NATIVE:-}" == "1" ]]; then
+  run_native "$@"
+fi
+
+if ! runtime_ready; then
+  HAS_CLI=""
+  command -v docker >/dev/null 2>&1 && HAS_CLI="docker"
+  command -v podman >/dev/null 2>&1 && HAS_CLI="podman"
+  if [[ -n "${HAS_CLI}" ]]; then
+    echo "playwright.sh: ${HAS_CLI} CLI found but daemon is not running" >&2
+    echo "  start your container runtime, or set PLAYWRIGHT_NATIVE=1 to run natively" >&2
+  else
+    echo "playwright.sh: no container runtime found" >&2
+    echo "  install podman/docker, or set PLAYWRIGHT_NATIVE=1 to run natively" >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `scripts/playwright.sh` now checks whether the container **daemon** is reachable, not just whether the CLI binary exists. On macOS the daemon (Docker Desktop, OrbStack, colima) is often installed but not running.
- When no daemon is available the script prints a clear diagnostic instead of a confusing Docker socket error.
- New `PLAYWRIGHT_NATIVE=1` env var runs Playwright natively with locally installed browsers (useful on macOS where Chromium is available but the container runtime may not be running).
- Documents the native fallback in `CLAUDE.md` Testing Policy section.

## Verification

### Task 7: Go tests pass on macOS arm64

```
$ go test ./...
ok  	github.com/krystophny/tabura/cmd/tabura
ok  	github.com/krystophny/tabura/internal/appserver
ok  	github.com/krystophny/tabura/internal/bear
ok  	github.com/krystophny/tabura/internal/calendar
ok  	github.com/krystophny/tabura/internal/canvas
...
ok  	github.com/krystophny/tabura/internal/web	17.283s
ok  	github.com/krystophny/tabura/tests/deploy	0.283s
ok  	github.com/krystophny/tabura/tests/services
```

All packages pass. Zero failures.

### Task 8: Playwright tests pass on macOS

Container path (Docker daemon not running) now gives a clear diagnostic:

```
$ ./scripts/playwright.sh
playwright.sh: docker CLI found but daemon is not running
  start your container runtime, or set PLAYWRIGHT_NATIVE=1 to run natively
```

Native fallback with Chromium:

```
$ PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh --project=chromium
  2 skipped
  301 passed (2.2m)
```

Full native run (all projects) shows 4 browser-not-installed errors for Firefox/WebKit only:

```
$ npx playwright test
  4 failed (all browserType.launch: Executable doesn't exist for firefox/webkit)
  2 skipped
  301 passed (2.2m)
```

These 4 tests (`firefox-bug-report`, `safari-recorder`) require Firefox/WebKit executables that are pre-installed in the container image but not natively. Running via `scripts/playwright.sh` with a live container daemon resolves these.

### Task 1: Binary builds on macOS arm64

```
$ go build ./cmd/tabura
(clean, no errors)
```

### Surface sync check

```
$ ./scripts/sync-surface.sh --check
(clean)
```