### PR TITLE
fix: Add Gmail defer/snooze support (fixes #629)

### DIFF
--- a/internal/mcp/server_mail.go
+++ b/internal/mcp/server_mail.go
@@ -176,6 +176,10 @@ func (s *Server) mailAction(args map[string]interface{}) (map[string]interface{}
 	if action == "" {
 		return nil, fmt.Errorf("action is required")
 	}
+	untilAt, untilRaw, err := parseMailActionUntil(args, action)
+	if err != nil {
+		return nil, err
+	}
 	query := strings.TrimSpace(strArg(args, "query"))
 	messageIDs, err := resolveMailActionMessageIDs(context.Background(), provider, args)
 	if err != nil {
@@ -189,9 +193,9 @@ func (s *Server) mailAction(args map[string]interface{}) (map[string]interface{}
 	}
 	byID := mailMessagesByID(context.Background(), provider, messageIDs)
 	targetFolder := mcpMailActionTargetFolder(account, action, folder, label)
-	requestPayload := mailActionRequestPayload(args, action, messageIDs, folder, label, query, archive)
+	requestPayload := mailActionRequestPayload(args, action, messageIDs, folder, label, query, archive, untilRaw)
 	if len(messageIDs) == 0 {
-		return mailActionResult(account, action, nil, 0), nil
+		return mailActionResult(account, action, nil, 0, untilAt), nil
 	}
 	logs := make([]store.MailActionLog, 0, len(messageIDs))
 	for _, messageID := range messageIDs {
@@ -213,7 +217,7 @@ func (s *Server) mailAction(args map[string]interface{}) (map[string]interface{}
 		}
 		logs = append(logs, logEntry)
 	}
-	applied, err := applyMailActionGeneric(context.Background(), account, provider, action, messageIDs, folder, label, archive)
+	applied, err := applyMailActionGeneric(context.Background(), account, provider, action, messageIDs, folder, label, archive, untilAt)
 	if err != nil {
 		for _, logEntry := range logs {
 			_ = st.UpdateMailActionLogResult(logEntry.ID, store.MailActionLogFailed, "", err.Error())
@@ -233,7 +237,7 @@ func (s *Server) mailAction(args map[string]interface{}) (map[string]interface{}
 	for _, logEntry := range logs {
 		_ = st.UpdateMailActionLogResult(logEntry.ID, store.MailActionLogApplied, resolvedByMessageID[strings.TrimSpace(logEntry.MessageID)], "")
 	}
-	return mailActionResult(account, action, messageIDs, applied.Count), nil
+	return mailActionResult(account, action, messageIDs, applied.Count, untilAt), nil
 }
 
 func resolveMailActionMessageIDs(ctx context.Context, provider email.EmailProvider, args map[string]interface{}) ([]string, error) {
@@ -277,7 +281,7 @@ func mailMessagesByID(ctx context.Context, provider email.EmailProvider, message
 	return byID
 }
 
-func mailActionRequestPayload(args map[string]interface{}, action string, messageIDs []string, folder, label, query string, archive *bool) map[string]any {
+func mailActionRequestPayload(args map[string]interface{}, action string, messageIDs []string, folder, label, query string, archive *bool, untilRaw string) map[string]any {
 	requestPayload := map[string]any{
 		"action":      action,
 		"message_ids": append([]string(nil), messageIDs...),
@@ -293,16 +297,23 @@ func mailActionRequestPayload(args map[string]interface{}, action string, messag
 	if archive != nil {
 		requestPayload["archive"] = *archive
 	}
+	if untilRaw != "" {
+		requestPayload["until"] = untilRaw
+	}
 	return requestPayload
 }
 
-func mailActionResult(account store.ExternalAccount, action string, messageIDs []string, succeeded int) map[string]interface{} {
-	return map[string]interface{}{
+func mailActionResult(account store.ExternalAccount, action string, messageIDs []string, succeeded int, untilAt time.Time) map[string]interface{} {
+	result := map[string]interface{}{
 		"account":     account,
 		"action":      action,
 		"message_ids": append([]string(nil), messageIDs...),
 		"succeeded":   succeeded,
 	}
+	if action == "defer" && !untilAt.IsZero() {
+		result["until"] = untilAt.UTC().Format(time.RFC3339)
+	}
+	return result
 }
 
 func (s *Server) mailServerFilterList(args map[string]interface{}) (map[string]interface{}, error) {
@@ -641,7 +652,7 @@ type mcpMailActionApplyResult struct {
 	Resolutions []email.ActionResolution
 }
 
-func applyMailActionGeneric(ctx context.Context, account store.ExternalAccount, provider email.EmailProvider, action string, messageIDs []string, folder, label string, archive *bool) (mcpMailActionApplyResult, error) {
+func applyMailActionGeneric(ctx context.Context, account store.ExternalAccount, provider email.EmailProvider, action string, messageIDs []string, folder, label string, archive *bool, untilAt time.Time) (mcpMailActionApplyResult, error) {
 	switch action {
 	case "mark_read":
 		count, err := provider.MarkRead(ctx, messageIDs)
@@ -673,6 +684,19 @@ func applyMailActionGeneric(ctx context.Context, account store.ExternalAccount, 
 	case "delete":
 		count, err := provider.Delete(ctx, messageIDs)
 		return mcpMailActionApplyResult{Count: count}, err
+	case "defer":
+		actionProvider, ok := provider.(email.MessageActionProvider)
+		if !ok || !actionProvider.SupportsNativeDefer() {
+			return mcpMailActionApplyResult{}, fmt.Errorf("defer is not supported for provider %s", account.Provider)
+		}
+		count := 0
+		for _, messageID := range messageIDs {
+			if _, err := actionProvider.Defer(ctx, messageID, untilAt); err != nil {
+				return mcpMailActionApplyResult{}, err
+			}
+			count++
+		}
+		return mcpMailActionApplyResult{Count: count}, nil
 	case "move_to_folder":
 		folderProvider, ok := provider.(email.NamedFolderProvider)
 		if !ok {
@@ -781,6 +805,8 @@ func mcpMailActionTargetFolder(account store.ExternalAccount, action, folder, la
 			return "Archive"
 		}
 		return "archive"
+	case "defer":
+		return "snoozed"
 	case "move_to_folder":
 		return folder
 	case "archive_label":
@@ -793,6 +819,17 @@ func mcpMailActionTargetFolder(account store.ExternalAccount, action, folder, la
 	default:
 		return ""
 	}
+}
+
+func parseMailActionUntil(args map[string]interface{}, action string) (time.Time, string, error) {
+	if action != "defer" {
+		return time.Time{}, "", nil
+	}
+	untilAt, untilRaw, err := parseCalendarToolTimeArg(args, "until")
+	if err != nil {
+		return time.Time{}, untilRaw, err
+	}
+	return untilAt, untilRaw, nil
 }
 
 func mcpMailActionMessageFolder(message *providerdata.EmailMessage) string {

--- a/internal/mcp/server_mail_test.go
+++ b/internal/mcp/server_mail_test.go
@@ -14,19 +14,21 @@ import (
 )
 
 type fakeMailProvider struct {
-	labels      []providerdata.Label
-	listIDs     []string
-	pageIDs     []string
-	nextPage    string
-	messages    map[string]*providerdata.EmailMessage
-	attachment  *providerdata.AttachmentData
-	filters     []email.ServerFilter
-	resolvedIDs map[string]string
-	lastOpts    email.SearchOptions
-	lastAction  string
-	lastIDs     []string
-	lastFolder  string
-	lastLabel   string
+	labels        []providerdata.Label
+	listIDs       []string
+	pageIDs       []string
+	nextPage      string
+	messages      map[string]*providerdata.EmailMessage
+	attachment    *providerdata.AttachmentData
+	filters       []email.ServerFilter
+	resolvedIDs   map[string]string
+	lastOpts      email.SearchOptions
+	lastAction    string
+	lastIDs       []string
+	lastFolder    string
+	lastLabel     string
+	lastUntil     time.Time
+	supportsDefer bool
 }
 
 func (p *fakeMailProvider) ListLabels(_ context.Context) ([]providerdata.Label, error) {
@@ -93,8 +95,21 @@ func (p *fakeMailProvider) TrashResolved(_ context.Context, ids []string) ([]ema
 func (p *fakeMailProvider) Delete(_ context.Context, ids []string) (int, error) {
 	return p.record("delete", ids), nil
 }
-func (p *fakeMailProvider) ProviderName() string { return "fake" }
-func (p *fakeMailProvider) Close() error         { return nil }
+func (p *fakeMailProvider) Defer(_ context.Context, messageID string, untilAt time.Time) (email.MessageActionResult, error) {
+	p.record("defer", []string{messageID})
+	p.lastUntil = untilAt
+	return email.MessageActionResult{
+		Provider:              p.ProviderName(),
+		Action:                "defer",
+		MessageID:             messageID,
+		Status:                "ok",
+		EffectiveProviderMode: "native",
+		DeferredUntilAt:       untilAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+func (p *fakeMailProvider) SupportsNativeDefer() bool { return p.supportsDefer }
+func (p *fakeMailProvider) ProviderName() string      { return "fake" }
+func (p *fakeMailProvider) Close() error              { return nil }
 func (p *fakeMailProvider) MoveToFolder(_ context.Context, ids []string, folder string) (int, error) {
 	p.record("move_to_folder", ids)
 	p.lastFolder = folder
@@ -353,6 +368,73 @@ func TestMailActionResolvesTargetsFromQuery(t *testing.T) {
 	}
 }
 
+func TestMailActionDeferResolvesTargetsFromQuery(t *testing.T) {
+	s, st, _ := newDomainServerForTest(t)
+	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount: %v", err)
+	}
+	now := time.Date(2026, time.March, 19, 9, 0, 0, 0, time.UTC)
+	untilAt := time.Date(2030, time.March, 20, 15, 4, 5, 0, time.UTC)
+	provider := &fakeMailProvider{
+		listIDs:       []string{"m1", "m2"},
+		supportsDefer: true,
+		messages: map[string]*providerdata.EmailMessage{
+			"m1": {ID: "m1", Subject: "Weekly digest", Sender: "newsletter@example.com", Date: now},
+			"m2": {ID: "m2", Subject: "Second digest", Sender: "newsletter@example.com", Date: now.Add(-time.Hour)},
+		},
+	}
+	s.newEmailProvider = func(context.Context, store.ExternalAccount) (email.EmailProvider, error) {
+		return provider, nil
+	}
+
+	acted, err := s.callTool("mail_action", map[string]interface{}{
+		"account_id": account.ID,
+		"action":     "defer",
+		"query":      "from:newsletter@example.com newer_than:7d",
+		"limit":      2,
+		"until":      untilAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("mail_action failed: %v", err)
+	}
+	if provider.lastAction != "defer" {
+		t.Fatalf("lastAction = %q", provider.lastAction)
+	}
+	if len(provider.lastIDs) != 1 || provider.lastIDs[0] != "m2" {
+		t.Fatalf("lastIDs = %#v", provider.lastIDs)
+	}
+	if !provider.lastUntil.Equal(untilAt) {
+		t.Fatalf("lastUntil = %s, want %s", provider.lastUntil.Format(time.RFC3339), untilAt.Format(time.RFC3339))
+	}
+	if got := provider.lastOpts.Text; got != "from:newsletter@example.com newer_than:7d" {
+		t.Fatalf("lastOpts.Text = %q", got)
+	}
+	if got := provider.lastOpts.MaxResults; got != 2 {
+		t.Fatalf("lastOpts.MaxResults = %d", got)
+	}
+	if succeeded, _ := acted["succeeded"].(int); succeeded != 2 {
+		t.Fatalf("succeeded = %#v", acted["succeeded"])
+	}
+	if got := strings.TrimSpace(strFromAny(acted["until"])); got != untilAt.Format(time.RFC3339) {
+		t.Fatalf("until = %q", got)
+	}
+	logs, err := st.ListMailActionLogs(account.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMailActionLogs: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("logs len = %d", len(logs))
+	}
+	request := map[string]any{}
+	if err := json.Unmarshal([]byte(logs[0].RequestJSON), &request); err != nil {
+		t.Fatalf("Unmarshal(request_json): %v", err)
+	}
+	if got := strings.TrimSpace(strFromAny(request["until"])); got != untilAt.Format(time.RFC3339) {
+		t.Fatalf("request until = %q", got)
+	}
+}
+
 func TestMailActionRejectsMissingIDsAndQuery(t *testing.T) {
 	s, st, _ := newDomainServerForTest(t)
 	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", map[string]any{})
@@ -372,6 +454,66 @@ func TestMailActionRejectsMissingIDsAndQuery(t *testing.T) {
 	}
 	if got := err.Error(); got != "message_ids or query are required" {
 		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestMailActionDeferRequiresUntil(t *testing.T) {
+	s, st, _ := newDomainServerForTest(t)
+	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount: %v", err)
+	}
+	s.newEmailProvider = func(context.Context, store.ExternalAccount) (email.EmailProvider, error) {
+		return &fakeMailProvider{supportsDefer: true}, nil
+	}
+
+	_, err = s.callTool("mail_action", map[string]interface{}{
+		"account_id":  account.ID,
+		"action":      "defer",
+		"message_ids": []interface{}{"m1"},
+	})
+	if err == nil {
+		t.Fatal("mail_action error = nil, want missing until error")
+	}
+	if got := err.Error(); got != "until is required" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestMailActionDeferRejectsUnsupportedProvider(t *testing.T) {
+	s, st, _ := newDomainServerForTest(t)
+	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderIMAP, "Work IMAP", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount: %v", err)
+	}
+	s.newEmailProvider = func(context.Context, store.ExternalAccount) (email.EmailProvider, error) {
+		return &fakeMailProvider{}, nil
+	}
+
+	_, err = s.callTool("mail_action", map[string]interface{}{
+		"account_id":  account.ID,
+		"action":      "defer",
+		"message_ids": []interface{}{"m1"},
+		"until":       "2030-03-20T15:04:05Z",
+	})
+	if err == nil {
+		t.Fatal("mail_action error = nil, want unsupported defer error")
+	}
+	if got := err.Error(); got != "defer is not supported for provider imap" {
+		t.Fatalf("error = %q", got)
+	}
+	logs, err := st.ListMailActionLogs(account.ID, 10)
+	if err != nil {
+		t.Fatalf("ListMailActionLogs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("logs len = %d", len(logs))
+	}
+	if logs[0].Status != store.MailActionLogFailed {
+		t.Fatalf("log status = %q", logs[0].Status)
+	}
+	if logs[0].ErrorText != "defer is not supported for provider imap" {
+		t.Fatalf("log error = %q", logs[0].ErrorText)
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -145,6 +145,7 @@ func TestToolDefinitionsEmitsProperties(t *testing.T) {
 	var tempRemoveDef map[string]interface{}
 	var calendarEventsDef map[string]interface{}
 	var calendarCreateDef map[string]interface{}
+	var mailActionDef map[string]interface{}
 	for _, d := range defs {
 		switch d["name"] {
 		case "temp_file_create":
@@ -155,6 +156,8 @@ func TestToolDefinitionsEmitsProperties(t *testing.T) {
 			calendarEventsDef = d
 		case "calendar_event_create":
 			calendarCreateDef = d
+		case "mail_action":
+			mailActionDef = d
 		}
 	}
 	if tempCreateDef == nil {
@@ -168,6 +171,9 @@ func TestToolDefinitionsEmitsProperties(t *testing.T) {
 	}
 	if calendarCreateDef == nil {
 		t.Fatal("calendar_event_create not found in tool definitions")
+	}
+	if mailActionDef == nil {
+		t.Fatal("mail_action not found in tool definitions")
 	}
 	tempCreateSchema, _ := tempCreateDef["inputSchema"].(map[string]interface{})
 	tempCreateProps, _ := tempCreateSchema["properties"].(map[string]interface{})
@@ -188,6 +194,32 @@ func TestToolDefinitionsEmitsProperties(t *testing.T) {
 	calendarCreateProps, _ := calendarCreateSchema["properties"].(map[string]interface{})
 	if calendarCreateProps["summary"] == nil || calendarCreateProps["start"] == nil || calendarCreateProps["duration_minutes"] == nil || calendarCreateProps["all_day"] == nil {
 		t.Fatalf("calendar_event_create missing expected properties: %#v", calendarCreateProps)
+	}
+	mailActionSchema, _ := mailActionDef["inputSchema"].(map[string]interface{})
+	mailActionProps, _ := mailActionSchema["properties"].(map[string]interface{})
+	if mailActionProps["until"] == nil {
+		t.Fatalf("mail_action missing until property: %#v", mailActionProps)
+	}
+	actionProp, _ := mailActionProps["action"].(map[string]interface{})
+	actionEnum, _ := actionProp["enum"].([]string)
+	if len(actionEnum) == 0 {
+		rawEnum, _ := actionProp["enum"].([]interface{})
+		actionEnum = make([]string, 0, len(rawEnum))
+		for _, value := range rawEnum {
+			if text, ok := value.(string); ok {
+				actionEnum = append(actionEnum, text)
+			}
+		}
+	}
+	foundDefer := false
+	for _, value := range actionEnum {
+		if value == "defer" {
+			foundDefer = true
+			break
+		}
+	}
+	if !foundDefer {
+		t.Fatalf("mail_action enum missing defer: %#v", actionProp["enum"])
 	}
 }
 

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -595,7 +595,7 @@ var MCPTools = []Tool{
 			"action": {
 				Type:        "string",
 				Description: "Mailbox action.",
-				Enum:        []string{"mark_read", "mark_unread", "archive", "move_to_inbox", "trash", "delete", "move_to_folder", "apply_label", "archive_label"},
+				Enum:        []string{"mark_read", "mark_unread", "archive", "move_to_inbox", "trash", "delete", "defer", "move_to_folder", "apply_label", "archive_label"},
 			},
 			"message_id": {
 				Type:        "string",
@@ -624,6 +624,10 @@ var MCPTools = []Tool{
 			"archive": {
 				Type:        "boolean",
 				Description: "Optional archive hint for apply_label.",
+			},
+			"until": {
+				Type:        "string",
+				Description: "Required for defer. Accepts RFC3339, YYYY-MM-DDTHH:MM, YYYY-MM-DD HH:MM, or YYYY-MM-DD.",
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- expose `defer` on `mail_action`, require an `until` timestamp, and return the normalized `until` value in the tool result
- route `mail_action defer` through provider-native defer support and fail fast with a clear provider-specific error when native defer is unavailable
- extend MCP tests to cover the tool schema, Gmail-account defer dispatch, missing `until`, and unsupported-provider failures

## Verification
- Requirement 1: `mail_action` accepts `defer` with an `until` timestamp.
  - Evidence: `internal/surface/definitions.go` now publishes `defer` in the `action` enum and an `until` property.
  - Test coverage: `TestToolDefinitionsEmitsProperties`, `TestMailActionDeferRequiresUntil`.
- Requirement 2: Gmail accounts can invoke native defer through `mail_action`.
  - Test coverage: `TestMailActionDeferResolvesTargetsFromQuery` creates a Gmail account, resolves messages from `query`, applies `action=defer`, and asserts `succeeded=2`, the canonical `until` response, and stored `request_json.until`.
- Requirement 3: unsupported providers return a clear native-defer error.
  - Test coverage: `TestMailActionDeferRejectsUnsupportedProvider` asserts the exact error `defer is not supported for provider imap` and a failed mail-action log entry.
- Command: `{ ./scripts/sync-surface.sh --check && go test ./internal/mcp ./internal/email; } 2>&1 | tee /tmp/issue-629-verify.log`
  - Output excerpt:
    - `ok   github.com/krystophny/tabura/internal/mcp	0.167s`
    - `ok   github.com/krystophny/tabura/internal/email	(cached)`