### PR TITLE
fix: Conference mode: add speaker-targeted floor management (fixes #595)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -39,6 +39,7 @@ type bugReportRequest struct {
 	BrowserLogs         []string        `json:"browser_logs"`
 	Device              map[string]any  `json:"device"`
 	DialogueDiagnostics json.RawMessage `json:"dialogue_diagnostics"`
+	MeetingDiagnostics  json.RawMessage `json:"meeting_diagnostics"`
 	Note                string          `json:"note"`
 	VoiceTranscript     string          `json:"voice_transcript"`
 	ScreenshotData      string          `json:"screenshot_data_url"`
@@ -61,6 +62,7 @@ type bugReportBundle struct {
 	BrowserLogs         []string        `json:"browser_logs,omitempty"`
 	Device              map[string]any  `json:"device,omitempty"`
 	DialogueDiagnostics json.RawMessage `json:"dialogue_diagnostics,omitempty"`
+	MeetingDiagnostics  json.RawMessage `json:"meeting_diagnostics,omitempty"`
 	Note                string          `json:"note,omitempty"`
 	VoiceTranscript     string          `json:"voice_transcript,omitempty"`
 	ScreenshotPath      string          `json:"screenshot,omitempty"`
@@ -166,6 +168,7 @@ func (a *App) handleBugReportCreate(w http.ResponseWriter, r *http.Request) {
 		BrowserLogs:         cleanBugReportLines(req.BrowserLogs),
 		Device:              req.Device,
 		DialogueDiagnostics: normalizeBugReportRawJSON(req.DialogueDiagnostics),
+		MeetingDiagnostics:  normalizeBugReportRawJSON(req.MeetingDiagnostics),
 		Note:                strings.TrimSpace(req.Note),
 		VoiceTranscript:     strings.TrimSpace(req.VoiceTranscript),
 		ScreenshotPath:      toBugReportRelativePath(workspace.DirPath, screenshotPath),

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -73,6 +73,14 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 			"timezone":             "Europe/Vienna",
 			"hardware_concurrency": float64(8),
 		},
+		"meeting_diagnostics": map[string]any{
+			"live_policy":         "meeting",
+			"turn_policy_profile": "balanced",
+			"participant_status": map[string]any{
+				"directed_speech_gate": map[string]any{"decision": "target_speaker_follow_up"},
+				"interaction_policy":   map[string]any{"decision": "respond"},
+			},
+		},
 		"note":                "The indicator froze after the tap.",
 		"voice_transcript":    "it stops responding after the second tap",
 		"screenshot_data_url": testPNGDataURL,
@@ -125,6 +133,24 @@ func TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts(t *testing.T) 
 	}
 	if got := strFromAny(bundle["voice_transcript"]); got != "it stops responding after the second tap" {
 		t.Fatalf("voice_transcript = %q, want transcript to round-trip", got)
+	}
+	meetingDiagnostics, ok := bundle["meeting_diagnostics"].(map[string]any)
+	if !ok {
+		t.Fatalf("meeting_diagnostics = %#v, want object", bundle["meeting_diagnostics"])
+	}
+	if got := strFromAny(meetingDiagnostics["live_policy"]); got != "meeting" {
+		t.Fatalf("meeting_diagnostics.live_policy = %q, want meeting", got)
+	}
+	participantStatus, ok := meetingDiagnostics["participant_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("meeting_diagnostics.participant_status = %#v, want object", meetingDiagnostics["participant_status"])
+	}
+	directedSpeechGate, ok := participantStatus["directed_speech_gate"].(map[string]any)
+	if !ok {
+		t.Fatalf("participant_status.directed_speech_gate = %#v, want object", participantStatus["directed_speech_gate"])
+	}
+	if got := strFromAny(directedSpeechGate["decision"]); got != "target_speaker_follow_up" {
+		t.Fatalf("participant_status.directed_speech_gate.decision = %q, want target_speaker_follow_up", got)
 	}
 	device, ok := bundle["device"].(map[string]any)
 	if !ok {

--- a/internal/web/companion_gate.go
+++ b/internal/web/companion_gate.go
@@ -20,6 +20,10 @@ type companionDirectedSpeechGate struct {
 	Reason        string `json:"reason"`
 	SessionID     string `json:"session_id,omitempty"`
 	SegmentID     int64  `json:"segment_id,omitempty"`
+	Speaker       string `json:"speaker,omitempty"`
+	TargetSpeaker string `json:"target_speaker,omitempty"`
+	TargetSegment int64  `json:"target_segment_id,omitempty"`
+	SpeakerMatch  bool   `json:"speaker_matched,omitempty"`
 	EvaluatedText string `json:"evaluated_text,omitempty"`
 	EvaluatedAt   int64  `json:"evaluated_at,omitempty"`
 	LastEventType string `json:"last_event_type,omitempty"`
@@ -92,13 +96,21 @@ func evaluateCompanionDirectedSpeechGate(cfg companionConfig, session *store.Par
 		return gate
 	}
 	gate.SegmentID = latest.ID
+	gate.Speaker = normalizeCompanionSpeaker(latest.Speaker)
 	gate.EvaluatedText = strings.TrimSpace(latest.Text)
 	if latest.CommittedAt > 0 {
 		gate.EvaluatedAt = latest.CommittedAt
 	}
+	gate.TargetSpeaker, gate.TargetSegment = companionTargetSpeaker(segments, events)
+	gate.SpeakerMatch = companionSpeakersMatch(gate.Speaker, gate.TargetSpeaker)
 	if isCompanionDirectAddress(latest.Text) {
 		gate.Decision = companionGateDecisionDirect
 		gate.Reason = "assistant_name_mentioned"
+		return gate
+	}
+	if gate.SpeakerMatch && isCompanionRequestWithoutDirectAddress(latest.Text) {
+		gate.Decision = companionGateDecisionDirect
+		gate.Reason = "target_speaker_follow_up"
 		return gate
 	}
 	if isCompanionRequestWithoutDirectAddress(latest.Text) {
@@ -118,6 +130,56 @@ func latestMeaningfulParticipantSegment(segments []store.ParticipantSegment) *st
 		return &segments[i]
 	}
 	return nil
+}
+
+func latestDirectAddressedParticipantSegment(segments []store.ParticipantSegment) *store.ParticipantSegment {
+	for i := len(segments) - 1; i >= 0; i-- {
+		if strings.TrimSpace(segments[i].Text) == "" {
+			continue
+		}
+		if isCompanionDirectAddress(segments[i].Text) {
+			return &segments[i]
+		}
+	}
+	return nil
+}
+
+func participantSegmentByID(segments []store.ParticipantSegment, segmentID int64) *store.ParticipantSegment {
+	if segmentID == 0 {
+		return nil
+	}
+	for i := range segments {
+		if segments[i].ID == segmentID {
+			return &segments[i]
+		}
+	}
+	return nil
+}
+
+func companionTargetSpeaker(segments []store.ParticipantSegment, events []store.ParticipantEvent) (string, int64) {
+	if pendingSegmentID, _ := latestPendingCompanionSegment(events); pendingSegmentID != 0 {
+		if segment := participantSegmentByID(segments, pendingSegmentID); segment != nil {
+			if speaker := normalizeCompanionSpeaker(segment.Speaker); speaker != "" {
+				return speaker, segment.ID
+			}
+		}
+	}
+	if latest := latestDirectAddressedParticipantSegment(segments); latest != nil {
+		if speaker := normalizeCompanionSpeaker(latest.Speaker); speaker != "" {
+			return speaker, latest.ID
+		}
+	}
+	return "", 0
+}
+
+func normalizeCompanionSpeaker(raw string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+}
+
+func companionSpeakersMatch(a, b string) bool {
+	left := normalizeCompanionSpeaker(a)
+	right := normalizeCompanionSpeaker(b)
+	return left != "" && right != "" && strings.EqualFold(left, right)
 }
 
 func isCompanionDirectAddress(raw string) bool {

--- a/internal/web/companion_gate_test.go
+++ b/internal/web/companion_gate_test.go
@@ -49,6 +49,26 @@ func TestEvaluateCompanionDirectedSpeechGate(t *testing.T) {
 		}
 	})
 
+	t.Run("target speaker follow up", func(t *testing.T) {
+		segments := []store.ParticipantSegment{
+			{ID: 10, Speaker: "Alice", Text: "Tabura, summarize that.", CommittedAt: 120},
+			{ID: 11, Speaker: "Alice", Text: "Can you send it to the team?", CommittedAt: 130},
+		}
+		gate := evaluateCompanionDirectedSpeechGate(cfg, session, segments, events)
+		if gate.Decision != companionGateDecisionDirect {
+			t.Fatalf("decision = %q, want %q", gate.Decision, companionGateDecisionDirect)
+		}
+		if gate.Reason != "target_speaker_follow_up" {
+			t.Fatalf("reason = %q, want target_speaker_follow_up", gate.Reason)
+		}
+		if gate.TargetSpeaker != "Alice" {
+			t.Fatalf("target_speaker = %q, want Alice", gate.TargetSpeaker)
+		}
+		if !gate.SpeakerMatch {
+			t.Fatal("speaker_matched = false, want true")
+		}
+	})
+
 	t.Run("disabled", func(t *testing.T) {
 		disabled := cfg
 		disabled.DirectedSpeechGateEnabled = false

--- a/internal/web/companion_policy.go
+++ b/internal/web/companion_policy.go
@@ -26,9 +26,14 @@ type companionInteractionPolicyState struct {
 	Reason           string `json:"reason"`
 	SessionID        string `json:"session_id,omitempty"`
 	SegmentID        int64  `json:"segment_id,omitempty"`
+	Speaker          string `json:"speaker,omitempty"`
+	TargetSpeaker    string `json:"target_speaker,omitempty"`
+	TargetSegmentID  int64  `json:"target_segment_id,omitempty"`
+	SpeakerMatched   bool   `json:"speaker_matched,omitempty"`
 	EvaluatedText    string `json:"evaluated_text,omitempty"`
 	EvaluatedAt      int64  `json:"evaluated_at,omitempty"`
 	PendingSegmentID int64  `json:"pending_segment_id,omitempty"`
+	PendingSpeaker   string `json:"pending_speaker,omitempty"`
 	PendingSince     int64  `json:"pending_since,omitempty"`
 	CooldownUntil    int64  `json:"cooldown_until,omitempty"`
 }
@@ -136,23 +141,37 @@ func evaluateCompanionInteractionPolicy(cfg companionConfig, session *store.Part
 		return state
 	}
 	state.SegmentID = latest.ID
+	state.Speaker = normalizeCompanionSpeaker(latest.Speaker)
 	state.EvaluatedText = strings.TrimSpace(latest.Text)
 	state.EvaluatedAt = latest.CommittedAt
 	if state.EvaluatedAt == 0 {
 		state.EvaluatedAt = latest.EndTS
 	}
+	state.TargetSpeaker, state.TargetSegmentID = companionTargetSpeaker(segments, events)
+	state.SpeakerMatched = companionSpeakersMatch(state.Speaker, state.TargetSpeaker)
 	pendingSegmentID, pendingSince := latestPendingCompanionSegment(events)
 	state.PendingSegmentID = pendingSegmentID
 	state.PendingSince = pendingSince
+	if pendingSegment := participantSegmentByID(segments, pendingSegmentID); pendingSegment != nil {
+		state.PendingSpeaker = normalizeCompanionSpeaker(pendingSegment.Speaker)
+	}
 	cooldownUntil := latestCompanionCooldownUntil(events)
 	state.CooldownUntil = cooldownUntil
+	directAddress := isCompanionDirectAddress(latest.Text)
+	requestWithoutDirectAddress := isCompanionRequestWithoutDirectAddress(latest.Text)
+	targetSpeakerFollowUp := state.SpeakerMatched && requestWithoutDirectAddress
 
 	if participantSegmentAlreadyTriggered(events, latest.ID) {
 		state.Decision = companionInteractionDecisionAlreadyTriggered
 		state.Reason = "segment_already_triggered"
 		return state
 	}
-	if !isCompanionDirectAddress(latest.Text) {
+	if !directAddress && !targetSpeakerFollowUp {
+		if pendingSegmentID != 0 && pendingSegmentID != latest.ID && requestWithoutDirectAddress && state.PendingSpeaker != "" && state.Speaker != "" && !companionSpeakersMatch(state.PendingSpeaker, state.Speaker) {
+			state.Decision = companionInteractionDecisionSuppressed
+			state.Reason = "overlap_other_speaker"
+			return state
+		}
 		state.Decision = companionInteractionDecisionAwaitingAddress
 		state.Reason = "not_direct_address"
 		return state
@@ -163,8 +182,17 @@ func evaluateCompanionInteractionPolicy(cfg companionConfig, session *store.Part
 		return state
 	}
 	if pendingSegmentID != 0 && pendingSegmentID != latest.ID {
+		if state.PendingSpeaker != "" && state.Speaker != "" && !companionSpeakersMatch(state.PendingSpeaker, state.Speaker) && !directAddress {
+			state.Decision = companionInteractionDecisionSuppressed
+			state.Reason = "overlap_other_speaker"
+			return state
+		}
 		state.Decision = companionInteractionDecisionInterrupt
-		state.Reason = "response_pending"
+		if targetSpeakerFollowUp {
+			state.Reason = "target_speaker_overlap"
+		} else {
+			state.Reason = "response_pending"
+		}
 		return state
 	}
 	if cooldownUntil > 0 && state.EvaluatedAt > 0 && state.EvaluatedAt < cooldownUntil {
@@ -173,7 +201,11 @@ func evaluateCompanionInteractionPolicy(cfg companionConfig, session *store.Part
 		return state
 	}
 	state.Decision = companionInteractionDecisionRespond
-	state.Reason = "direct_address_ready"
+	if targetSpeakerFollowUp {
+		state.Reason = "target_speaker_follow_up_ready"
+	} else {
+		state.Reason = "direct_address_ready"
+	}
 	return state
 }
 

--- a/internal/web/companion_policy_test.go
+++ b/internal/web/companion_policy_test.go
@@ -89,3 +89,58 @@ func TestEvaluateCompanionInteractionPolicyInterruptsPendingResponse(t *testing.
 		t.Fatalf("pending_segment_id = %d, want 1", policy.PendingSegmentID)
 	}
 }
+
+func TestEvaluateCompanionInteractionPolicyAllowsTargetSpeakerFollowUp(t *testing.T) {
+	cfg := defaultCompanionConfig()
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = true
+
+	session := &store.ParticipantSession{ID: "psess-1", WorkspacePath: "proj"}
+	segments := []store.ParticipantSegment{
+		{ID: 1, SessionID: session.ID, Speaker: "Alice", Text: "Tabura, summarize that.", CommittedAt: 100},
+		{ID: 2, SessionID: session.ID, Speaker: "Alice", Text: "Can you include the budget appendix?", CommittedAt: 102},
+	}
+
+	policy := evaluateCompanionInteractionPolicy(cfg, session, segments, nil)
+	if policy.Decision != companionInteractionDecisionRespond {
+		t.Fatalf("decision = %q, want %q", policy.Decision, companionInteractionDecisionRespond)
+	}
+	if policy.Reason != "target_speaker_follow_up_ready" {
+		t.Fatalf("reason = %q, want target_speaker_follow_up_ready", policy.Reason)
+	}
+	if policy.TargetSpeaker != "Alice" {
+		t.Fatalf("target_speaker = %q, want Alice", policy.TargetSpeaker)
+	}
+	if !policy.SpeakerMatched {
+		t.Fatal("speaker_matched = false, want true")
+	}
+}
+
+func TestEvaluateCompanionInteractionPolicySuppressesDifferentSpeakerOverlap(t *testing.T) {
+	cfg := defaultCompanionConfig()
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = true
+
+	session := &store.ParticipantSession{ID: "psess-1", WorkspacePath: "proj"}
+	segments := []store.ParticipantSegment{
+		{ID: 1, SessionID: session.ID, Speaker: "Alice", Text: "Tabura, summarize that.", CommittedAt: 100},
+		{ID: 2, SessionID: session.ID, Speaker: "Bob", Text: "Can you include the budget appendix?", CommittedAt: 102},
+	}
+	events := []store.ParticipantEvent{
+		{SessionID: session.ID, SegmentID: 1, EventType: "assistant_triggered", CreatedAt: 101},
+	}
+
+	policy := evaluateCompanionInteractionPolicy(cfg, session, segments, events)
+	if policy.Decision != companionInteractionDecisionSuppressed {
+		t.Fatalf("decision = %q, want %q", policy.Decision, companionInteractionDecisionSuppressed)
+	}
+	if policy.Reason != "overlap_other_speaker" {
+		t.Fatalf("reason = %q, want overlap_other_speaker", policy.Reason)
+	}
+	if policy.PendingSpeaker != "Alice" {
+		t.Fatalf("pending_speaker = %q, want Alice", policy.PendingSpeaker)
+	}
+	if policy.Speaker != "Bob" {
+		t.Fatalf("speaker = %q, want Bob", policy.Speaker)
+	}
+}

--- a/internal/web/companion_response_trigger_test.go
+++ b/internal/web/companion_response_trigger_test.go
@@ -250,6 +250,81 @@ func TestCompanionResponseTriggerExecutesAssistantTurn(t *testing.T) {
 	}
 }
 
+func TestCompanionResponseTriggerExecutesTargetSpeakerFollowUp(t *testing.T) {
+	t.Setenv("TABURA_INTENT_LLM_URL", "off")
+	app := newAuthedTestApp(t)
+	app.appServerClient = newCompanionAppServerClient(t, "Companion reply.")
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	cfg := app.loadCompanionConfig(project)
+	cfg.CompanionEnabled = true
+	cfg.DirectedSpeechGateEnabled = true
+	if err := app.saveCompanionConfig(project.ID, cfg); err != nil {
+		t.Fatalf("save companion config: %v", err)
+	}
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	participantSession, err := app.store.AddParticipantSession(project.WorkspacePath, "{}")
+	if err != nil {
+		t.Fatalf("add participant session: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, 0, "session_started", "{}"); err != nil {
+		t.Fatalf("add participant event: %v", err)
+	}
+	first, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     100,
+		EndTS:       101,
+		Speaker:     "Alice",
+		Text:        "Tabura, summarize the budget changes.",
+		CommittedAt: 102,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add initial participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, first.ID, "segment_committed", `{"text":"Tabura, summarize the budget changes."}`); err != nil {
+		t.Fatalf("add initial committed event: %v", err)
+	}
+	followUp, err := app.store.AddParticipantSegment(store.ParticipantSegment{
+		SessionID:   participantSession.ID,
+		StartTS:     103,
+		EndTS:       104,
+		Speaker:     "Alice",
+		Text:        "Can you include the blocker owners too?",
+		CommittedAt: 105,
+		Status:      "final",
+	})
+	if err != nil {
+		t.Fatalf("add follow-up participant segment: %v", err)
+	}
+	if err := app.store.AddParticipantEvent(participantSession.ID, followUp.ID, "segment_committed", `{"text":"Can you include the blocker owners too?"}`); err != nil {
+		t.Fatalf("add follow-up committed event: %v", err)
+	}
+
+	app.maybeTriggerCompanionResponse(participantSession.ID, followUp)
+
+	chatSession, err := app.store.GetOrCreateChatSession(project.WorkspacePath)
+	if err != nil {
+		t.Fatalf("get chat session: %v", err)
+	}
+	waitForAssistantMessage(t, app, chatSession.ID, "Companion reply.")
+
+	messages, err := app.store.ListChatMessages(chatSession.ID, 10)
+	if err != nil {
+		t.Fatalf("list chat messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("chat message count = %d, want 2", len(messages))
+	}
+	if got := strings.TrimSpace(messages[0].ContentPlain); got != "Can you include the blocker owners too?" {
+		t.Fatalf("first message text = %q, want follow-up text", got)
+	}
+}
+
 func TestCompanionResponseTriggerSkipsWhenCompanionDisabled(t *testing.T) {
 	t.Setenv("TABURA_INTENT_LLM_URL", "off")
 	app := newAuthedTestApp(t)

--- a/internal/web/projects_companion_test.go
+++ b/internal/web/projects_companion_test.go
@@ -224,6 +224,7 @@ func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 		SessionID:   sess.ID,
 		StartTS:     100,
 		EndTS:       101,
+		Speaker:     "Alice",
 		Text:        "Tabura, open the meeting transcript.",
 		CommittedAt: 102,
 		Status:      "final",
@@ -261,10 +262,25 @@ func TestProjectCompanionStateExposesDirectedSpeechGateMetadata(t *testing.T) {
 	if state.DirectedSpeechGate.EvaluatedText != "Tabura, open the meeting transcript." {
 		t.Fatalf("directed_speech_gate.evaluated_text = %q", state.DirectedSpeechGate.EvaluatedText)
 	}
+	if state.DirectedSpeechGate.Speaker != "Alice" {
+		t.Fatalf("directed_speech_gate.speaker = %q, want Alice", state.DirectedSpeechGate.Speaker)
+	}
+	if state.DirectedSpeechGate.TargetSpeaker != "Alice" {
+		t.Fatalf("directed_speech_gate.target_speaker = %q, want Alice", state.DirectedSpeechGate.TargetSpeaker)
+	}
+	if !state.DirectedSpeechGate.SpeakerMatch {
+		t.Fatal("directed_speech_gate.speaker_matched = false, want true")
+	}
 	if state.InteractionPolicy.Decision != companionInteractionDecisionRespond {
 		t.Fatalf("interaction_policy.decision = %q, want %q", state.InteractionPolicy.Decision, companionInteractionDecisionRespond)
 	}
 	if state.InteractionPolicy.Reason != "direct_address_ready" {
 		t.Fatalf("interaction_policy.reason = %q, want direct_address_ready", state.InteractionPolicy.Reason)
+	}
+	if state.InteractionPolicy.Speaker != "Alice" {
+		t.Fatalf("interaction_policy.speaker = %q, want Alice", state.InteractionPolicy.Speaker)
+	}
+	if state.InteractionPolicy.TargetSpeaker != "Alice" {
+		t.Fatalf("interaction_policy.target_speaker = %q, want Alice", state.InteractionPolicy.TargetSpeaker)
 	}
 }

--- a/internal/web/static/app-bug-report.ts
+++ b/internal/web/static/app-bug-report.ts
@@ -701,6 +701,7 @@ async function snapshotBugReportContext(trigger, runtime) {
   const dialogueDiagnostics = typeof app?.getDialogueDiagnostics === 'function'
     ? app.getDialogueDiagnostics()
     : null;
+  const meetingDiagnostics = await captureMeetingBugReportDiagnostics();
   return {
     trigger,
     timestamp: formatNow(),
@@ -714,9 +715,29 @@ async function snapshotBugReportContext(trigger, runtime) {
     browserLogs: browserLogs.slice(),
     device: await buildDeviceState(),
     dialogueDiagnostics,
+    meetingDiagnostics,
     screenshotDataURL: '',
     strokes: [],
     voiceTranscript: '',
+  };
+}
+
+async function captureMeetingBugReportDiagnostics() {
+  if (safeText(state.livePolicy).toLowerCase() !== 'meeting') return null;
+  let participantStatus = null;
+  try {
+    const resp = await fetch(apiURL('participant/status'));
+    if (resp.ok) {
+      participantStatus = await resp.json();
+    }
+  } catch (_) {}
+  return {
+    live_policy: safeText(state.livePolicy),
+    live_session_mode: safeText(state.liveSessionMode),
+    companion_runtime_state: safeText(state.companionRuntimeState),
+    companion_runtime_reason: safeText(state.companionRuntimeReason),
+    turn_policy_profile: safeText(state.turnPolicyProfile),
+    participant_status: participantStatus,
   };
 }
 
@@ -775,6 +796,7 @@ async function saveBugReport() {
     browser_logs: pendingReport.browserLogs,
     device: pendingReport.device,
     dialogue_diagnostics: pendingReport.dialogueDiagnostics,
+    meeting_diagnostics: pendingReport.meetingDiagnostics,
     note: note instanceof HTMLTextAreaElement ? note.value.trim() : '',
     voice_transcript: pendingReport.voiceTranscript,
     screenshot_data_url: pendingReport.screenshotDataURL,

--- a/tests/playwright/bug-report.spec.ts
+++ b/tests/playwright/bug-report.spec.ts
@@ -212,4 +212,52 @@ test.describe('bug report flow', () => {
     expect(preview?.pixel?.[1]).not.toBe(255);
     expect(preview?.pixel?.[2]).not.toBe(255);
   });
+
+  test('meeting bug report includes participant diagnostics', async ({ page }) => {
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      const app = (window as any)._taburaApp;
+      const state = app?.getState?.();
+      if (state) {
+        state.livePolicy = 'meeting';
+        state.liveSessionMode = 'meeting';
+        state.companionRuntimeState = 'listening';
+        state.companionRuntimeReason = 'participant_started';
+        state.turnPolicyProfile = 'balanced';
+      }
+      (window as any).__participantStatus = {
+        ok: true,
+        active_sessions: 1,
+        active_session_id: 'psess-harness-001',
+        directed_speech_gate: {
+          decision: 'target_speaker_follow_up',
+          reason: 'target_speaker_follow_up',
+          speaker: 'Alice',
+          target_speaker: 'Alice',
+          speaker_matched: true,
+        },
+        interaction_policy: {
+          decision: 'interrupt',
+          reason: 'target_speaker_overlap',
+          speaker: 'Alice',
+          target_speaker: 'Alice',
+          pending_speaker: 'Alice',
+        },
+      };
+    });
+
+    await page.locator('#bug-report-button').click();
+    await page.locator('#bug-report-note').fill('Meeting overlap reproduced.');
+    await page.locator('#bug-report-save').click();
+
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as any).__bugReportRequests.length);
+    }).toBe(1);
+
+    const request = await page.evaluate(() => (window as any).__bugReportRequests[0]);
+    expect(request.meeting_diagnostics?.live_policy).toBe('meeting');
+    expect(request.meeting_diagnostics?.participant_status?.directed_speech_gate?.decision).toBe('target_speaker_follow_up');
+    expect(request.meeting_diagnostics?.participant_status?.interaction_policy?.reason).toBe('target_speaker_overlap');
+  });
 });

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -2456,7 +2456,12 @@
         return new Response(JSON.stringify(window.__participantConfig), { status: 200 });
       }
       if (u.includes('/api/participant/status')) {
-        return new Response(JSON.stringify({ ok: true, active_sessions: 0 }), { status: 200 });
+        return new Response(JSON.stringify(window.__participantStatus || {
+          ok: true,
+          active_sessions: 0,
+          directed_speech_gate: { decision: 'disabled', reason: 'harness' },
+          interaction_policy: { decision: 'disabled', reason: 'harness' },
+        }), { status: 200 });
       }
       if (u.includes('/api/participant/sessions') && u.includes('/transcript')) {
         return new Response(JSON.stringify({ ok: true, segments: [] }), { status: 200 });


### PR DESCRIPTION
## Summary
- Add speaker-targeted meeting gating so same-speaker follow-ups can continue the floor without repeating "Tabura", while overlapping follow-up requests from a different speaker stay suppressed.
- Expose meeting gate/policy diagnostics in the companion state and include meeting diagnostics in bug-report bundles.
- Cover the server behavior with focused Go tests and the UI bundle path with Playwright coverage.

## Verification
- Target-speaker / directed-speech gating: `go test ./internal/web ./internal/turn -run 'Test(EvaluateCompanionDirectedSpeechGate|EvaluateCompanionInteractionPolicy|ProjectCompanionStateExposesDirectedSpeechGateMetadata|HandleBugReportCreateWritesBundleUnderWorkspaceArtifacts|CompanionResponseTriggerExecutesAssistantTurn|CompanionResponseTriggerExecutesTargetSpeakerFollowUp)'`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.139s`
  Evidence: `TestEvaluateCompanionDirectedSpeechGate`, `TestEvaluateCompanionInteractionPolicyAllowsTargetSpeakerFollowUp`, and `TestCompanionResponseTriggerExecutesTargetSpeakerFollowUp` verify same-speaker follow-up routing without repeating the assistant name.
- Overlap-aware meeting control: same Go test command above.
  Evidence: `TestEvaluateCompanionInteractionPolicySuppressesDifferentSpeakerOverlap` verifies a different speaker's overlapping follow-up request is suppressed with `overlap_other_speaker`; `TestEvaluateCompanionInteractionPolicyInterruptsPendingResponse` still covers the explicit interrupt path.
- Diagnostics surfaced in the bug-report bundle path: `go test ./internal/web ./internal/turn -run 'Test(EvaluateCompanionDirectedSpeechGate|EvaluateCompanionInteractionPolicy|ProjectCompanionStateExposesDirectedSpeechGateMetadata|HandleBugReportCreateWritesBundleUnderWorkspaceArtifacts|CompanionResponseTriggerExecutesAssistantTurn|CompanionResponseTriggerExecutesTargetSpeakerFollowUp)'`
  Evidence: `TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts` now verifies `meeting_diagnostics` round-trips into `.tabura/artifacts/bugs/.../bundle.json`, including `participant_status.directed_speech_gate.decision=target_speaker_follow_up`.
- Frontend capture + UI coverage: `npm run build:frontend`
  Output excerpt: `built 52 frontend modules`
- Playwright meeting diagnostics path: `PLAYWRIGHT_NATIVE=1 npx playwright test tests/playwright/bug-report.spec.ts`
  Output excerpt: `8 passed (4.0s)` and `1 skipped`
  Evidence: `tests/playwright/bug-report.spec.ts` now covers `meeting bug report includes participant diagnostics`, asserting the request payload includes meeting gate/policy diagnostics.
