### PR TITLE
fix: Fix meeting mode hotword: integrate pre-roll buffer and support (fixes #650)

### DIFF
--- a/internal/web/chat_intent.go
+++ b/internal/web/chat_intent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -67,6 +68,8 @@ func (e localTurnEvaluation) fallbackText() string {
 
 const systemActionLastShellPathPlaceholder = "$last_shell_path"
 
+var hotwordIntentLeadPattern = regexp.MustCompile(`(?i)^\s*(?:(?:hey|hi|ok|okay)\b[\s,.:;!?-]*)*(?:alexa|sloppy)\b[\s,.:;!?-]*`)
+
 func extractEmbeddedJSON(raw string) string {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -93,6 +96,18 @@ func extractEmbeddedJSON(raw string) string {
 		}
 	}
 	return ""
+}
+
+func stripHotwordIntentPrefix(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	stripped := strings.TrimSpace(hotwordIntentLeadPattern.ReplaceAllString(trimmed, ""))
+	if stripped == trimmed {
+		return trimmed, false
+	}
+	return stripped, true
 }
 
 func repairMalformedCommandQuotes(raw string) string {
@@ -561,15 +576,25 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	if trimmedText == "" {
 		return localTurnEvaluation{}
 	}
-	intentText := trimmedText
+	intentText, hotwordAddressed := stripHotwordIntentPrefix(trimmedText)
+	if hotwordAddressed && intentText == "" {
+		return localTurnEvaluation{
+			handled: true,
+			payloads: []map[string]interface{}{{
+				"type":              "system_action_suppressed",
+				"reason":            "hotword_only",
+				"suppress_response": true,
+			}},
+		}
+	}
 	livePolicy := a.LivePolicy()
 	assumeAddressed := livePolicy.Config().AssumeAddressed
 	tryExecutePlan := func(actions []*SystemAction, ack string) localTurnEvaluation {
-		enforced := enforceRoutingPolicy(trimmedText, actions)
+		enforced := enforceRoutingPolicy(intentText, actions)
 		if len(enforced) == 0 {
 			return localTurnEvaluation{}
 		}
-		message, payloads, err := a.executeSystemActionPlan(sessionID, session, trimmedText, enforced)
+		message, payloads, err := a.executeSystemActionPlan(sessionID, session, intentText, enforced)
 		if err != nil {
 			return localTurnEvaluation{}
 		}
@@ -582,7 +607,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	}
 
 	if pending := a.popPendingActionConfirmation(sessionID); pending != nil {
-		if isExplicitDangerConfirm(trimmedText) {
+		if isExplicitDangerConfirm(intentText) {
 			message, payloads, err := a.executeSystemActionPlanUnsafe(sessionID, session, pending.UserText, pending.Actions)
 			if err != nil {
 				return localTurnEvaluation{
@@ -596,7 +621,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 				payloads: payloads,
 			}
 		}
-		if isExplicitDangerDecline(trimmedText) {
+		if isExplicitDangerDecline(intentText) {
 			return localTurnEvaluation{
 				handled:  true,
 				text:     pendingConfirmationCanceledMessage(pending.Kind),
@@ -611,7 +636,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 		now = a.calendarNow().UTC()
 	}
 	pendingAck := ""
-	if looksLikeWorkspaceBusyQuery(trimmedText) {
+	if looksLikeWorkspaceBusyQuery(intentText) {
 		message, err := a.workspaceBusyOverview()
 		if err == nil && strings.TrimSpace(message) != "" {
 			return localTurnEvaluation{
@@ -622,7 +647,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 		}
 	}
 	tryDeterministicPlan := func() (string, []map[string]interface{}, bool) {
-		match := tryDeterministicFastPath(trimmedText, deterministicFastPathContext{
+		match := tryDeterministicFastPath(intentText, deterministicFastPathContext{
 			Now:         now,
 			CaptureMode: captureMode,
 			Cursor:      cursor,
@@ -641,12 +666,12 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 			}
 		}
 	}
-	intentText = a.contextualizeClarificationReplyForSession(sessionID, trimmedText)
+	intentText = a.contextualizeClarificationReplyForSession(sessionID, intentText)
 	if strings.TrimSpace(a.intentLLMURL) != "" {
 		classification, llmErr := a.classifyIntentPlanWithLLMResultForTurn(ctx, sessionID, session, intentText)
 		if llmErr == nil {
 			pendingAck = classification.Ack
-			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed); known && !addressed {
+			if addressed, known := resolveIntentAddressedness(livePolicy, intentText, classification.Addressed, hotwordAddressed); known && !addressed {
 				return localTurnEvaluation{
 					handled: true,
 					payloads: []map[string]interface{}{{
@@ -689,7 +714,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 			}
 		}
 	}
-	if !assumeAddressed && isCompanionDirectAddress(intentText) {
+	if !assumeAddressed && (hotwordAddressed || isCompanionDirectAddress(intentText)) {
 		if message, payloads, handled := tryDeterministicPlan(); handled {
 			return localTurnEvaluation{
 				handled:  true,
@@ -699,7 +724,7 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 		}
 	}
 
-	if cursor != nil && cursor.hasPointedItem() && looksLikeStandaloneSystemRequest(trimmedText) {
+	if cursor != nil && cursor.hasPointedItem() && looksLikeStandaloneSystemRequest(intentText) {
 		if message, payloads, ok := a.suggestCanonicalActionsForCursorItem(cursor); ok {
 			return localTurnEvaluation{
 				handled:  true,
@@ -711,11 +736,11 @@ func (a *App) evaluateLocalTurn(ctx context.Context, sessionID string, session s
 	return localTurnEvaluation{ack: pendingAck}
 }
 
-func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool) (bool, bool) {
+func resolveIntentAddressedness(policy LivePolicy, text string, addressed *bool, hotwordAddressed bool) (bool, bool) {
 	if !policy.RequiresExplicitAddress() {
 		return true, true
 	}
-	if isCompanionDirectAddress(text) {
+	if hotwordAddressed || isCompanionDirectAddress(text) {
 		return true, true
 	}
 	if addressed == nil {

--- a/internal/web/chat_intent_addressed_test.go
+++ b/internal/web/chat_intent_addressed_test.go
@@ -282,3 +282,64 @@ func TestRunAssistantTurnDialogueIgnoresAddressedFlag(t *testing.T) {
 		t.Fatalf("payloads = %#v, want toggle_silent payload", payloads)
 	}
 }
+
+func TestClassifyAndExecuteSystemActionForTurnStripsHotwordPrefix(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "Hey Alexa, be quiet", nil, "")
+	if !handled {
+		t.Fatal("expected wake-word-prefixed command to be handled")
+	}
+	if message != "Toggled silent mode." {
+		t.Fatalf("message = %q, want %q", message, "Toggled silent mode.")
+	}
+	if len(payloads) != 1 || strFromAny(payloads[0]["type"]) != "toggle_silent" {
+		t.Fatalf("payloads = %#v, want toggle_silent payload", payloads)
+	}
+}
+
+func TestClassifyAndExecuteSystemActionForTurnSuppressesStandaloneHotword(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+	setLivePolicyForTest(t, app, LivePolicyMeeting)
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemActionForTurn(context.Background(), session.ID, session, "Alexa", nil, "")
+	if !handled {
+		t.Fatal("expected standalone wake word to be handled locally")
+	}
+	if message != "" {
+		t.Fatalf("message = %q, want empty suppression message", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payloads len = %d, want 1", len(payloads))
+	}
+	if strFromAny(payloads[0]["type"]) != "system_action_suppressed" {
+		t.Fatalf("payload type = %q, want system_action_suppressed", strFromAny(payloads[0]["type"]))
+	}
+	if strFromAny(payloads[0]["reason"]) != "hotword_only" {
+		t.Fatalf("payload reason = %q, want hotword_only", strFromAny(payloads[0]["reason"]))
+	}
+	if suppress, ok := parseOptionalBool(payloads[0]["suppress_response"]); !ok || !suppress {
+		t.Fatalf("payload suppress_response = %#v, want true", payloads[0]["suppress_response"])
+	}
+}

--- a/internal/web/static/app-voice.ts
+++ b/internal/web/static/app-voice.ts
@@ -249,6 +249,44 @@ function isFirefoxLinux() {
   return ua.includes('firefox') && ua.includes('linux') && !ua.includes('android');
 }
 
+function hasLiveAudioTrack(stream) {
+  if (!stream || typeof stream.getAudioTracks !== 'function') return false;
+  const tracks = stream.getAudioTracks();
+  if (!Array.isArray(tracks) || tracks.length === 0) return false;
+  return tracks.some((track) => String(track?.readyState || '').toLowerCase() === 'live');
+}
+
+function concatFloat32Arrays(head, tail) {
+  const first = head instanceof Float32Array ? head : new Float32Array(0);
+  const second = tail instanceof Float32Array ? tail : new Float32Array(0);
+  if (first.length === 0) return second;
+  if (second.length === 0) return first;
+  const out = new Float32Array(first.length + second.length);
+  out.set(first, 0);
+  out.set(second, first.length);
+  return out;
+}
+
+export function buildHotwordCaptureSamples(speechAudio, preRollAudio = getPreRollAudio()) {
+  return concatFloat32Arrays(preRollAudio, speechAudio);
+}
+
+function buildHotwordVADAudio(speechAudio, preRollAudio = getPreRollAudio()) {
+  const preRoll = preRollAudio instanceof Float32Array ? preRollAudio : new Float32Array(0);
+  const combined = buildHotwordCaptureSamples(speechAudio, preRoll);
+  if (!(combined instanceof Float32Array) || combined.length === 0) {
+    return null;
+  }
+  const normalized = buildNormalizedSpeechWav(combined, 16000);
+  return {
+    blob: normalized.blob,
+    normalization: normalized,
+    durationMs: Math.round((combined.length / 16000) * 1000),
+    preRollSamples: preRoll.length,
+    totalSamples: combined.length,
+  };
+}
+
 let _sttMimeType = '';
 let _sttParts = [];
 let _sttActive = false;
@@ -392,6 +430,24 @@ export function stopChatVoiceMedia(capture) {
 }
 
 function handleVADNoSpeechTimeout(capture) {
+  const triggerSource = normalizeVoiceTriggerSource(capture?.triggerSource);
+  if (triggerSource === VOICE_TRIGGER_SOURCE_HOTWORD) {
+    const hotwordAudio = buildHotwordVADAudio(new Float32Array(0));
+    if (hotwordAudio) {
+      emitDialogueServerDiagnostic('voice_capture_vad_no_speech', {
+        trigger_source: triggerSource,
+        pre_roll_samples: hotwordAudio.preRollSamples,
+        samples: hotwordAudio.totalSamples,
+      });
+      capture._vadAudioBlob = hotwordAudio.blob;
+      capture._vadAudioNormalization = hotwordAudio.normalization;
+      capture._vadAudioDurationMs = hotwordAudio.durationMs;
+      capture._vadAutoStopped = true;
+      stopVADMonitor(capture);
+      void stopVoiceCaptureAndSend();
+      return;
+    }
+  }
   stopVADMonitor(capture);
   state.indicatorSuppressedByCanvasUpdate = false;
   showStatus('no speech detected');
@@ -448,7 +504,7 @@ export async function startSileroVADMonitor(capture) {
       stream: vadStream,
       audioContext: capture._vadAudioContext || undefined,
       redemptionMs: isHotwordCapture ? 1400 : undefined,
-      minSpeechMs: isHotwordCapture ? 400 : undefined,
+      minSpeechMs: isHotwordCapture ? 200 : undefined,
       onSpeechStart() {
         if (!vadState.isRunning || vadState.committed) return;
         emitDialogueServerDiagnostic('voice_capture_vad_speech_start', {
@@ -467,11 +523,19 @@ export async function startSileroVADMonitor(capture) {
       onSpeechEnd(audio) {
         if (!vadState.isRunning || vadState.committed) return;
         vadState.committed = true;
+        const hotwordAudio = isHotwordCapture ? buildHotwordVADAudio(audio) : null;
         emitDialogueServerDiagnostic('voice_capture_vad_speech_end', {
           trigger_source: triggerSource,
           samples: audio instanceof Float32Array ? audio.length : 0,
+          pre_roll_samples: Number(hotwordAudio?.preRollSamples || 0),
+          combined_samples: Number(hotwordAudio?.totalSamples || 0),
         });
-        if (audio instanceof Float32Array && audio.length > 0) {
+        if (hotwordAudio) {
+          capture._vadAudioBlob = hotwordAudio.blob;
+          capture._vadAudioNormalization = hotwordAudio.normalization;
+          capture._vadAudioDurationMs = hotwordAudio.durationMs;
+          capture._vadAutoStopped = true;
+        } else if (audio instanceof Float32Array && audio.length > 0) {
           const normalized = buildNormalizedSpeechWav(audio, 16000);
           capture._vadAudioBlob = normalized.blob;
           capture._vadAudioNormalization = normalized;
@@ -640,7 +704,8 @@ export async function beginVoiceCapture(x, y, anchor, options: Record<string, an
     showStatus('recording...');
   }
   try {
-    const stream = await acquireMicStream();
+    const hotwordStream = triggerSource === VOICE_TRIGGER_SOURCE_HOTWORD ? getHotwordMicStream() : null;
+    const stream = hasLiveAudioTrack(hotwordStream) ? hotwordStream : await acquireMicStream();
     if (state.chatVoiceCapture !== capture) {
       if (vadAudioContext) { try { vadAudioContext.close(); } catch (_) {} }
       return;

--- a/internal/web/static/hotword.ts
+++ b/internal/web/static/hotword.ts
@@ -35,7 +35,7 @@ const HOTWORD_KEYWORD_FRAMES = 16;
 const HOTWORD_RAW_BUFFER_MAX = HOTWORD_TARGET_SAMPLE_RATE * 10;
 const HOTWORD_MEL_BUFFER_MAX = 10 * 97;
 const HOTWORD_FEATURE_BUFFER_MAX = 120;
-const HOTWORD_RING_BUFFER_SIZE = HOTWORD_TARGET_SAMPLE_RATE * 2;
+const HOTWORD_RING_BUFFER_SIZE = HOTWORD_TARGET_SAMPLE_RATE * 4;
 
 const listeners = new Set<() => void>();
 
@@ -569,6 +569,18 @@ export function getPreRollAudio() {
     out.set(ringBuffer.buffer.subarray(0, len - firstPart), firstPart);
   }
   return out;
+}
+
+export function hotwordRingBufferCapacitySamplesForTest() {
+  return HOTWORD_RING_BUFFER_SIZE;
+}
+
+export function setPreRollAudioForTest(samples) {
+  resetRingBuffer();
+  if (!(samples instanceof Float32Array) || samples.length === 0) {
+    return;
+  }
+  writeRingBuffer(samples);
 }
 
 export function getHotwordMicStream() {

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -165,6 +165,31 @@ test('hotword runtime pins explicit ONNX wasm asset URLs', async ({ page }) => {
   expect(new URL(paths.wasm).pathname).toContain('/static/vad/ort-wasm-simd-threaded.wasm');
 });
 
+test('hotword ring buffer retains four seconds of pre-roll audio', async ({ page }) => {
+  await waitReady(page);
+
+  const ringBuffer = await page.evaluate(async () => {
+    const mod = await import('/internal/web/static/hotword.js');
+    const samples = new Float32Array(70_000);
+    for (let i = 0; i < samples.length; i += 1) {
+      samples[i] = i;
+    }
+    mod.setPreRollAudioForTest(samples);
+    const preRoll = mod.getPreRollAudio();
+    return {
+      capacity: mod.hotwordRingBufferCapacitySamplesForTest(),
+      length: preRoll.length,
+      first: preRoll[0],
+      last: preRoll[preRoll.length - 1],
+    };
+  });
+
+  expect(ringBuffer.capacity).toBe(64_000);
+  expect(ringBuffer.length).toBe(64_000);
+  expect(ringBuffer.first).toBe(6_000);
+  expect(ringBuffer.last).toBe(69_999);
+});
+
 test('hotword plus speech starts recording', async ({ page }) => {
   await waitReady(page);
   await setMeetingMode(page);
@@ -184,6 +209,20 @@ test('hotword plus speech starts recording', async ({ page }) => {
     const log = await getLog(page);
     return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
   }, { timeout: 5_000 }).toBe(true);
+});
+
+test('hotword pre-roll samples are prepended before STT normalization', async ({ page }) => {
+  await waitReady(page);
+
+  const combined = await page.evaluate(async () => {
+    const mod = await import('/internal/web/static/app-voice.js');
+    return Array.from(mod.buildHotwordCaptureSamples(
+      new Float32Array([0.3, 0.4]),
+      new Float32Array([0.1, 0.2]),
+    )).map((value) => Number(value.toFixed(3)));
+  });
+
+  expect(combined).toEqual([0.1, 0.2, 0.3, 0.4]);
 });
 
 test('hotword capture tolerates initial pause before user speech', async ({ page }) => {
@@ -209,6 +248,27 @@ test('hotword capture tolerates initial pause before user speech', async ({ page
   await page.waitForTimeout(1_000);
   const log = await getLog(page);
   expect(log.some((entry) => entry.type === 'recorder' && entry.action === 'stop')).toBe(false);
+});
+
+test('standalone hotword falls back to pre-roll audio after silence', async ({ page }) => {
+  await waitReady(page);
+  await setMeetingMode(page);
+  await waitForHotwordStart(page);
+  await page.evaluate(async () => {
+    const mod = await import('/internal/web/static/hotword.js');
+    mod.setPreRollAudioForTest(Float32Array.from({ length: 16_000 }, () => 0.2));
+    (window as any).__setSTTTranscribeResponse({ text: 'Alexa' });
+    (window as any).__setVadDbFrames(Array.from({ length: 220 }, () => -80));
+  });
+  await clearLog(page);
+
+  await triggerHotword(page);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    const upload = log.find((entry) => entry.type === 'api_fetch' && entry.action === 'stt_transcribe');
+    return Number(upload?.bytes || 0);
+  }, { timeout: 10_000 }).toBeGreaterThan(32_000);
 });
 
 test('dialogue turn controller finalizes a buffered fragment on timeout', async ({ page }) => {


### PR DESCRIPTION
## Summary
- prepend hotword pre-roll audio into the hotword-triggered STT path and fall back to pre-roll-only uploads when VAD times out
- extend the hotword ring buffer to four seconds and lower hotword VAD `minSpeechMs` to 200ms for mid-sentence capture
- strip hotword prefixes in meeting-mode intent handling and suppress standalone hotword-only turns

## Verification
- `getPreRollAudio()` is called and prepended on hotword-triggered captures.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - `tests/playwright/hotword.spec.ts`: `hotword pre-roll samples are prepended before STT normalization`
- Ring buffer extended to 4 seconds.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - `tests/playwright/hotword.spec.ts`: `hotword ring buffer retains four seconds of pre-roll audio`
- VAD `minSpeechMs` lowered for hotword captures.
  - `internal/web/static/app-voice.ts`: hotword VAD now uses `minSpeechMs: 200`
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts` keeps `hotword capture tolerates initial pause before user speech` passing
- Intent layer strips hotword prefix from transcripts.
  - `go test ./internal/web -run 'TestClassifyAndExecuteSystemActionForTurn(StripsHotwordPrefix|SuppressesStandaloneHotword)|TestRunAssistantTurn(MeetingDirectAddressOverridesFalseAddressedClassification|DialogueIgnoresAddressedFlag)' 2>&1 | tee /tmp/issue650-go-test.log`
  - Output: `ok   github.com/krystophny/tabura/internal/web 0.075s`
- Playwright tests cover pre-roll integration.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - New coverage in `tests/playwright/hotword.spec.ts`: `hotword ring buffer retains four seconds of pre-roll audio`, `hotword pre-roll samples are prepended before STT normalization`, `standalone hotword falls back to pre-roll audio after silence`
- Full-sentence hotword detection works in meeting mode.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - Pre-roll is included ahead of STT normalization, preserving the hotword prefix and earlier words in the captured utterance
- Standalone hotword detection still works.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - `tests/playwright/hotword.spec.ts`: `standalone hotword falls back to pre-roll audio after silence`
- All existing hotword tests pass.
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts`
  - Output: `16 passed (17.2s)`
