### PR TITLE
fix: Bug report: interaction failed in default (fixes #656)

### DIFF
--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -555,6 +555,28 @@ func TestBugReportIssueTitleUsesStructuredFallbackWithoutFreeText(t *testing.T) 
 	}
 }
 
+func TestBugReportIssueTitleUsesActiveModeFallbackForDefaultWorkspace(t *testing.T) {
+	bundle := bugReportBundle{
+		ActiveMode:      "pen",
+		ActiveWorkspace: "default",
+	}
+
+	title := bugReportIssueTitle(bundle)
+	if title != "Bug report: pen interaction failed in default" {
+		t.Fatalf("bugReportIssueTitle() = %q", title)
+	}
+	body := bugReportIssueBody(bundle, ".tabura/artifacts/bugs/20260321-183934-48759867/bundle.json")
+	for _, needle := range []string{
+		"## Summary\n\npen interaction failed in default",
+		"- Active mode: `pen`",
+		"- Workspace: `default`",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("bugReportIssueBody() missing %q:\n%s", needle, body)
+		}
+	}
+}
+
 func TestBugReportIssueTitleUsesCanvasStateFallbackForDefaultWorkspace(t *testing.T) {
 	canvasState, err := json.Marshal(map[string]any{
 		"interaction_surface":    "canvas",

--- a/internal/web/static/app-bug-report.ts
+++ b/internal/web/static/app-bug-report.ts
@@ -48,6 +48,35 @@ function safeText(value) {
   return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
 }
 
+function normalizeBugReportInputMode(value) {
+  const clean = safeText(value).toLowerCase();
+  switch (clean) {
+    case 'pen':
+    case 'voice':
+    case 'keyboard':
+      return clean;
+    case 'text':
+      return 'keyboard';
+    default:
+      return '';
+  }
+}
+
+function hasKeyboardBugReportEvidence(events) {
+  if (!Array.isArray(events)) return false;
+  return events.some((entry) => /^key\b/i.test(safeText(entry).replace(/^\S+\s+/, '')));
+}
+
+function resolveBugReportInputMode(trigger, events) {
+  const origin = normalizeBugReportInputMode(state.lastInputOrigin);
+  if (origin === 'voice' || origin === 'pen') return origin;
+  if (origin === 'keyboard' && hasKeyboardBugReportEvidence(events)) return 'keyboard';
+  const cleanTrigger = safeText(trigger).toLowerCase();
+  if (cleanTrigger === 'voice') return 'voice';
+  if (cleanTrigger === 'shortcut') return 'keyboard';
+  return '';
+}
+
 function bugReportTestEnv() {
   return window.__taburaBugReportTestEnv || {};
 }
@@ -265,7 +294,7 @@ function clearBugReportInk() {
   redrawBugReportInk();
 }
 
-function buildCanvasState() {
+function buildCanvasState(inputMode = '') {
   const uiState = getUiState();
   return {
     has_artifact: Boolean(state.hasArtifact),
@@ -282,7 +311,7 @@ function buildCanvasState() {
     active_workspace_id: safeText(state.activeWorkspaceId),
     item_sidebar_view: safeText(state.itemSidebarView),
     workspace_browser_path: safeText(state.workspaceBrowserPath),
-    last_input_origin: safeText(state.lastInputOrigin),
+    last_input_origin: normalizeBugReportInputMode(inputMode),
     last_input_x: Number.isFinite(uiState?.lastInputX) ? Math.round(uiState.lastInputX) : null,
     last_input_y: Number.isFinite(uiState?.lastInputY) ? Math.round(uiState.lastInputY) : null,
   };
@@ -702,6 +731,8 @@ async function snapshotBugReportContext(trigger, runtime) {
     ? app.getDialogueDiagnostics()
     : null;
   const meetingDiagnostics = await captureMeetingBugReportDiagnostics();
+  const recent = recentEvents.slice();
+  const inputMode = resolveBugReportInputMode(trigger, recent);
   return {
     trigger,
     timestamp: formatNow(),
@@ -709,9 +740,9 @@ async function snapshotBugReportContext(trigger, runtime) {
     version: safeText(runtime?.version),
     bootID: safeText(runtime?.boot_id),
     startedAt: safeText(runtime?.started_at),
-    activeMode: safeText(state.interaction?.tool),
-    canvasState: buildCanvasState(),
-    recentEvents: recentEvents.slice(),
+    activeMode: inputMode,
+    canvasState: buildCanvasState(inputMode),
+    recentEvents: recent,
     browserLogs: browserLogs.slice(),
     device: await buildDeviceState(),
     dialogueDiagnostics,

--- a/internal/web/static/app-init.ts
+++ b/internal/web/static/app-init.ts
@@ -346,6 +346,7 @@ export function bindUi() {
       if (ev.target instanceof Element && ev.target.closest('.edge-panel,#pr-file-pane,#pr-file-drawer-backdrop')) return;
       setInteractionToolLocal('ink');
       if (beginInkStroke(ev)) {
+        state.lastInputOrigin = 'pen';
         try { window.getSelection()?.removeAllRanges(); } catch (_) {}
         setPenInkingState(true);
         ev.preventDefault();

--- a/tests/playwright/bug-report.spec.ts
+++ b/tests/playwright/bug-report.spec.ts
@@ -14,6 +14,27 @@ async function waitReady(page: Page) {
   await waitWsReady(page);
 }
 
+async function dispatchPenStroke(page: Page, points: Array<{ x: number; y: number; pressure?: number }>) {
+  await page.evaluate((rawPoints) => {
+    const viewport = document.getElementById('canvas-viewport');
+    if (!(viewport instanceof HTMLElement) || !Array.isArray(rawPoints) || rawPoints.length === 0) return;
+    const mk = (type: string, point: any) => new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 41,
+      pointerType: 'pen',
+      pressure: Number(point.pressure ?? 0.6),
+      clientX: Number(point.x),
+      clientY: Number(point.y),
+    });
+    viewport.dispatchEvent(mk('pointerdown', rawPoints[0]));
+    for (let i = 1; i < rawPoints.length; i += 1) {
+      viewport.dispatchEvent(mk('pointermove', rawPoints[i]));
+    }
+    viewport.dispatchEvent(mk('pointerup', rawPoints[rawPoints.length - 1]));
+  }, points);
+}
+
 test.describe('bug report flow', () => {
   test('floating button captures a bundle with notes and annotations', async ({ page }) => {
     await waitReady(page);
@@ -56,6 +77,27 @@ test.describe('bug report flow', () => {
     await expect(page.locator('#bug-report-sheet')).toBeHidden();
     await expect(page.locator('#canvas-text')).toContainText('Bug report filed');
     await expect(page.locator('#canvas-text')).toContainText('#77');
+  });
+
+  test('pen interaction reports pen mode instead of the active tool id', async ({ page }) => {
+    await waitReady(page);
+
+    await dispatchPenStroke(page, [
+      { x: 90, y: 90, pressure: 0.6 },
+      { x: 150, y: 140, pressure: 0.7 },
+    ]);
+
+    await page.locator('#bug-report-button').click();
+    await page.locator('#bug-report-note').fill('Pen-origin repro.');
+    await page.locator('#bug-report-save').click();
+
+    await expect.poll(async () => {
+      return page.evaluate(() => (window as any).__bugReportRequests.length);
+    }).toBe(1);
+
+    const request = await page.evaluate(() => (window as any).__bugReportRequests[0]);
+    expect(request.active_mode).toBe('pen');
+    expect(request.canvas_state?.last_input_origin).toBe('pen');
   });
 
   test('filed bug reports appear in inbox immediately', async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve bug-report input mode context by using normalized pen/voice/keyboard modes instead of interaction tool ids
- record pen-origin canvas input so default-workspace reports keep actionable summaries
- add regression coverage for default-workspace summary fallback and pen-origin UI capture

## Verification
- Requirement: default-workspace bug reports must keep actionable interaction context instead of the generic title. Evidence: `go test ./internal/web -run 'TestBugReportIssueTitleUses(ActiveModeFallbackForDefaultWorkspace|CanvasStateFallbackForDefaultWorkspace|StructuredFallbackWithoutFreeText)$' 2>&1 | tee /tmp/tabura-issue-656-go.log`
  Output: `ok   github.com/krystophny/tabura/internal/web 0.004s`
  Test coverage: `TestBugReportIssueTitleUsesActiveModeFallbackForDefaultWorkspace` asserts the generated issue title/body include `pen interaction failed in default`.
- Requirement: pen-origin reports must send the input mode instead of the active tool id. Evidence: `npx playwright test tests/playwright/bug-report.spec.ts --grep 'pen interaction reports pen mode instead of the active tool id' 2>&1 | tee /tmp/tabura-issue-656-playwright.log`
  Output: `1 passed (1.6s)`
  Artifact verification: the Playwright assertion checks the captured bug-report request payload for `active_mode=pen` and `canvas_state.last_input_origin=pen`.
- Frontend verification: `npm run build:frontend` -> `built 52 frontend modules`; `npm run typecheck:frontend` -> success.
