### PR TITLE
fix: Bug report: interaction failed in default (fixes #646)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -476,6 +476,11 @@ func bugReportCanvasArtifactTitle(raw json.RawMessage) string {
 	return bugReportCanvasStateField(raw, "artifact_title", "active_artifact_title", "title")
 }
 
+func bugReportCanvasStateBool(raw json.RawMessage, key string) bool {
+	value := strings.TrimSpace(strings.ToLower(bugReportCanvasStateField(raw, key)))
+	return value == "true"
+}
+
 func bugReportSummary(bundle bugReportBundle) string {
 	for _, candidate := range []string{
 		firstSentence(bundle.Note),
@@ -560,11 +565,19 @@ func bugReportStructuredInteraction(raw json.RawMessage) string {
 		return fmt.Sprintf("while browsing %s", bugReportCanvasStateField(raw, "workspace_browser_path"))
 	case bugReportCanvasStateField(raw, "item_sidebar_view") != "":
 		return fmt.Sprintf("while viewing %s sidebar", bugReportCanvasStateField(raw, "item_sidebar_view"))
+	case bugReportCanvasStateBool(raw, "text_input_visible"):
+		return "while typing"
+	case bugReportCanvasStateBool(raw, "pr_review_mode"):
+		return "during PR review"
+	case bugReportCanvasStateBool(raw, "overlay_visible"):
+		return "with the overlay open"
 	}
 
 	surface := bugReportCanvasStateField(raw, "interaction_surface")
 	tool := bugReportCanvasStateField(raw, "interaction_tool")
 	switch {
+	case surface == "annotate" && tool == "pointer":
+		// These are the default canvas states and are less useful than richer UI context.
 	case surface != "" && tool != "":
 		return fmt.Sprintf("on %s with %s", surface, tool)
 	case surface != "":
@@ -686,6 +699,9 @@ func bugReportIssueBody(bundle bugReportBundle, bundlePath string) string {
 		bugReportContextLine("Canvas artifact", bugReportCanvasArtifactTitle(bundle.CanvasState)),
 		bugReportContextLine("Interaction surface", bugReportCanvasStateField(bundle.CanvasState, "interaction_surface")),
 		bugReportContextLine("Interaction tool", bugReportCanvasStateField(bundle.CanvasState, "interaction_tool")),
+		bugReportContextLine("Text input visible", bugReportCanvasStateField(bundle.CanvasState, "text_input_visible")),
+		bugReportContextLine("PR review mode", bugReportCanvasStateField(bundle.CanvasState, "pr_review_mode")),
+		bugReportContextLine("Overlay visible", bugReportCanvasStateField(bundle.CanvasState, "overlay_visible")),
 		bugReportContextLine("Last input origin", bugReportCanvasStateField(bundle.CanvasState, "last_input_origin")),
 		bugReportContextLine("Item sidebar view", bugReportCanvasStateField(bundle.CanvasState, "item_sidebar_view")),
 		bugReportContextLine("Workspace browser path", bugReportCanvasStateField(bundle.CanvasState, "workspace_browser_path")),

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -577,6 +577,68 @@ func TestBugReportIssueTitleUsesActiveModeFallbackForDefaultWorkspace(t *testing
 	}
 }
 
+func TestBugReportIssueTitleUsesTypingFallbackForDefaultWorkspace(t *testing.T) {
+	canvasState, err := json.Marshal(map[string]any{
+		"interaction_surface": "annotate",
+		"interaction_tool":    "pointer",
+		"text_input_visible":  true,
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	bundle := bugReportBundle{
+		ActiveWorkspace: "default",
+		CanvasState:     canvasState,
+	}
+
+	title := bugReportIssueTitle(bundle)
+	if title != "Bug report: interaction failed in default while typing" {
+		t.Fatalf("bugReportIssueTitle() = %q", title)
+	}
+	body := bugReportIssueBody(bundle, ".tabura/artifacts/bugs/20260321-164735-94e3e5e1/bundle.json")
+	for _, needle := range []string{
+		"## Summary\n\ninteraction failed in default while typing",
+		"- Text input visible: `true`",
+		"- Interaction surface: `annotate`",
+		"- Interaction tool: `pointer`",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("bugReportIssueBody() missing %q:\n%s", needle, body)
+		}
+	}
+}
+
+func TestBugReportIssueTitleUsesPRReviewFallbackForDefaultWorkspace(t *testing.T) {
+	canvasState, err := json.Marshal(map[string]any{
+		"interaction_surface": "annotate",
+		"interaction_tool":    "pointer",
+		"pr_review_mode":      true,
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	bundle := bugReportBundle{
+		ActiveWorkspace: "default",
+		CanvasState:     canvasState,
+	}
+
+	title := bugReportIssueTitle(bundle)
+	if title != "Bug report: interaction failed in default during PR review" {
+		t.Fatalf("bugReportIssueTitle() = %q", title)
+	}
+	body := bugReportIssueBody(bundle, ".tabura/artifacts/bugs/20260321-164735-94e3e5e1/bundle.json")
+	for _, needle := range []string{
+		"## Summary\n\ninteraction failed in default during PR review",
+		"- PR review mode: `true`",
+		"- Interaction surface: `annotate`",
+		"- Interaction tool: `pointer`",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("bugReportIssueBody() missing %q:\n%s", needle, body)
+		}
+	}
+}
+
 func TestBugReportIssueTitleUsesCanvasStateFallbackForDefaultWorkspace(t *testing.T) {
 	canvasState, err := json.Marshal(map[string]any{
 		"interaction_surface":    "canvas",


### PR DESCRIPTION
## Summary
- prefer high-signal bug report context like visible text input and PR review mode before falling back to the default `annotate` + `pointer` canvas state
- include those UI-state flags in the generated GitHub issue body context for follow-up debugging
- add regression coverage for default-workspace typing and PR-review bug reports

## Verification
- Requirement: default-workspace bug reports must not collapse to the generic `interaction failed in default` title when the captured interaction was typing.
  Evidence: `go test ./internal/web -run 'TestBugReportIssueTitleUses(StructuredFallbackWithoutFreeText|ActiveModeFallbackForDefaultWorkspace|TypingFallbackForDefaultWorkspace|PRReviewFallbackForDefaultWorkspace|CanvasStateFallbackForDefaultWorkspace)' 2>&1 | tee /tmp/test.log`
  Output excerpt: `ok   github.com/krystophny/tabura/internal/web 0.004s`
  Artifact assertion: `TestBugReportIssueTitleUsesTypingFallbackForDefaultWorkspace` verifies the generated title is `Bug report: interaction failed in default while typing` and the generated issue body includes `Text input visible: true`.
- Requirement: default-workspace bug reports must keep PR review context instead of collapsing to the generic title.
  Evidence: same test command and output excerpt above.
  Artifact assertion: `TestBugReportIssueTitleUsesPRReviewFallbackForDefaultWorkspace` verifies the generated title is `Bug report: interaction failed in default during PR review` and the generated issue body includes `PR review mode: true`.
- Requirement: existing richer bug report fallbacks must keep working.
  Evidence: same test command and output excerpt above.
  Artifact assertion: `TestBugReportIssueTitleUsesActiveModeFallbackForDefaultWorkspace`, `TestBugReportIssueTitleUsesCanvasStateFallbackForDefaultWorkspace`, and `TestBugReportIssueTitleUsesStructuredFallbackWithoutFreeText` all passed in the same run.
