### PR TITLE
fix: Black-screen dialogue mode (fixes #637)

### DIFF
--- a/internal/web/static/app-canvas-ui.ts
+++ b/internal/web/static/app-canvas-ui.ts
@@ -235,7 +235,7 @@ export function beginConversationVoiceCapture(triggerSource = 'hotword') {
 export function currentIndicatorMode() {
   const mode = state.voiceLifecycle;
   const companionVisible = shouldShowCompanionIdleSurface();
-  if (companionVisible) return '';
+  if (companionVisible && !document.body.classList.contains('black-screen')) return '';
   if (mode === VOICE_LIFECYCLE.RECORDING) return 'recording';
   if (mode === VOICE_LIFECYCLE.LISTENING) return 'listening';
   if (isStopCapableLifecycle(mode)) return 'play';

--- a/internal/web/static/app-init.ts
+++ b/internal/web/static/app-init.ts
@@ -139,7 +139,9 @@ export function bindUi() {
   let lastMouseX = Math.floor(window.innerWidth / 2);
   let lastMouseY = Math.floor(window.innerHeight / 2);
   let hasLastMousePosition = false;
+  const isBlackScreenMode = () => document.body.classList.contains('black-screen');
   const isInEdgeZone = (x, y) => {
+    if (isBlackScreenMode()) return false;
     const s = getEdgeTapSizePx();
     const top = getTopEdgeTapSizePx();
     return x < s || x > window.innerWidth - s || y < top || y > window.innerHeight - s;

--- a/internal/web/static/app-runtime-ui.ts
+++ b/internal/web/static/app-runtime-ui.ts
@@ -753,15 +753,15 @@ export function hasVisibleCanvasArtifact() {
 }
 
 export function shouldShowCompanionIdleSurface() {
-  const dialogueCompanionActive = state.liveSessionActive && state.liveSessionMode === 'dialogue';
+  const dialogueCompanionActive = state.liveSessionActive && state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE;
   if (!state.companionEnabled && !dialogueCompanionActive) return false;
   if (hasVisibleCanvasArtifact()) return false;
-  if (state.liveSessionActive && state.liveSessionMode !== 'dialogue') return false;
+  if (state.liveSessionActive && state.liveSessionMode !== LIVE_SESSION_MODE_DIALOGUE) return false;
   return true;
 }
 
 function dialogueCompanionState() {
-  if (!state.liveSessionActive || state.liveSessionMode !== 'dialogue') return '';
+  if (!state.liveSessionActive || state.liveSessionMode !== LIVE_SESSION_MODE_DIALOGUE) return '';
   const capture = state.chatVoiceCapture;
   if (capture && (capture.speechDetected === true || capture.stopping === true)) {
     return COMPANION_RUNTIME_STATES.LISTENING;
@@ -774,18 +774,27 @@ function dialogueCompanionState() {
   return COMPANION_RUNTIME_STATES.IDLE;
 }
 
+function shouldUseBlackScreenMode(idleSurface = normalizeCompanionIdleSurface(state.companionIdleSurface)) {
+  return shouldShowCompanionIdleSurface()
+    && idleSurface === COMPANION_IDLE_SURFACES.BLACK
+    && state.liveSessionActive
+    && state.liveSessionMode === LIVE_SESSION_MODE_DIALOGUE;
+}
+
 export function updateCompanionIdleSurface() {
   const surface = companionIdleSurfaceEl();
-  if (!(surface instanceof HTMLElement)) return;
   const visible = shouldShowCompanionIdleSurface();
   const dialogueState = dialogueCompanionState();
   const runtimeState = dialogueState || normalizeCompanionRuntimeState(state.companionRuntimeState);
   const idleSurface = normalizeCompanionIdleSurface(state.companionIdleSurface);
+  const blackScreenActive = shouldUseBlackScreenMode(idleSurface);
+  document.body.classList.toggle('black-screen', blackScreenActive);
+  if (!(surface instanceof HTMLElement)) return;
   const copy = companionStatusCopy(runtimeState);
   surface.dataset.state = runtimeState;
   surface.dataset.surface = idleSurface;
-  surface.setAttribute('aria-hidden', visible ? 'false' : 'true');
-  surface.style.display = visible ? 'block' : 'none';
+  surface.setAttribute('aria-hidden', visible && !blackScreenActive ? 'false' : 'true');
+  surface.style.display = visible && !blackScreenActive ? 'block' : 'none';
   const statusNode = surface.querySelector('.companion-idle-status');
   if (statusNode) statusNode.textContent = copy.label;
   const detailNode = surface.querySelector('.companion-idle-detail');

--- a/internal/web/static/companion.css
+++ b/internal/web/static/companion.css
@@ -178,6 +178,45 @@
   border-radius: 22px 22px 0 0;
 }
 
+body.black-screen {
+  background: #000000 !important;
+  color: #f7f7f7;
+}
+
+body.black-screen #view-main,
+body.black-screen #workspace,
+body.black-screen #canvas-column,
+body.black-screen #canvas-viewport {
+  background: #000000 !important;
+}
+
+body.black-screen #canvas-viewport {
+  touch-action: manipulation;
+  cursor: pointer;
+}
+
+body.black-screen #canvas-text,
+body.black-screen #canvas-image,
+body.black-screen #canvas-pdf,
+body.black-screen #ink-layer,
+body.black-screen #ink-controls,
+body.black-screen #pr-file-pane,
+body.black-screen #pr-file-drawer-backdrop,
+body.black-screen #edge-left-tap,
+body.black-screen #edge-right-tap,
+body.black-screen #edge-top-tap,
+body.black-screen #edge-top,
+body.black-screen #edge-right,
+body.black-screen #tool-palette,
+body.black-screen #surface-toggle,
+body.black-screen #floating-input,
+body.black-screen #overlay,
+body.black-screen #status-bar,
+body.black-screen #companion-idle-surface,
+body.black-screen .bug-report-button {
+  display: none !important;
+}
+
 @keyframes companion-idle-listen {
   0%, 100% {
     transform: translateX(-50%) scale(1);

--- a/tests/playwright/live-dialogue-companion.spec.ts
+++ b/tests/playwright/live-dialogue-companion.spec.ts
@@ -73,14 +73,14 @@ async function switchToTestProject(page: Page) {
   })).toBe('ready');
 }
 
-async function enableCompanion(page: Page) {
-  await page.evaluate(() => {
+async function enableCompanion(page: Page, idleSurface: 'robot' | 'black' = 'robot') {
+  await page.evaluate((nextIdleSurface) => {
     const app = (window as any)._taburaApp;
     const s = app?.getState?.();
     if (!s) throw new Error('app state unavailable');
     s.companionEnabled = true;
-    s.companionIdleSurface = 'robot';
-  });
+    s.companionIdleSurface = nextIdleSurface;
+  }, idleSurface);
 }
 
 async function setDialogueMode(page: Page, enabled: boolean) {
@@ -229,4 +229,39 @@ test('companion reaches thinking state during assistant turn', async ({ page }) 
     const st = surface?.dataset.state || '';
     return st === 'idle' || st === 'listening';
   }), { timeout: 5_000 }).toBe(true);
+});
+
+test('black idle surface turns dialogue into a full-screen black tap target', async ({ page }) => {
+  await setDialogueListenWindowMs(page, 3_000);
+  await setDialogueMode(page, true);
+  await enableCompanion(page, 'black');
+  await page.evaluate(() => {
+    (window as any)._taburaApp?.syncCompanionIdleSurface?.();
+  });
+  await clearLog(page);
+
+  await expect.poll(async () => page.evaluate(() => {
+    const surface = document.getElementById('companion-idle-surface');
+    const indicator = document.getElementById('indicator');
+    return {
+      bodyBlackScreen: document.body.classList.contains('black-screen'),
+      viewportBackground: window.getComputedStyle(document.getElementById('canvas-viewport') as HTMLElement).backgroundColor,
+      companionDisplay: window.getComputedStyle(surface as HTMLElement).display,
+      edgeLeftDisplay: window.getComputedStyle(document.getElementById('edge-left-tap') as HTMLElement).display,
+      indicatorListening: indicator?.classList.contains('is-listening') ?? false,
+    };
+  })).toEqual({
+    bodyBlackScreen: true,
+    viewportBackground: 'rgb(0, 0, 0)',
+    companionDisplay: 'none',
+    edgeLeftDisplay: 'none',
+    indicatorListening: true,
+  });
+
+  await page.mouse.click(640, 520);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some((entry) => entry.type === 'recorder' && entry.action === 'start');
+  }, { timeout: 5_000 }).toBe(true);
 });


### PR DESCRIPTION
## Summary
- derive a real `body.black-screen` mode from live dialogue plus the persisted `idle_surface:"black"` companion setting
- keep the listening/recording indicator visible in black-screen mode and stop treating hidden edge strips as off-limits so the whole screen is tappable
- add Playwright coverage for the black-screen dialogue path

## Verification
- Requirement: black background with minimal UI in dialogue mode
  Command: `npm run build:frontend`
  Evidence: `built 52 frontend modules`
  Test: `tests/playwright/live-dialogue-companion.spec.ts` asserts `body.black-screen === true`, `#canvas-viewport` resolves to `rgb(0, 0, 0)`, and companion/edge UI are hidden.
- Requirement: recording/listening indicator remains visible in black mode
  Command: `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/live-dialogue-companion.spec.ts`
  Evidence: `4 passed (4.3s)`
  Test: `black idle surface turns dialogue into a full-screen black tap target` asserts `indicatorListening: true`.
- Requirement: full-screen tap toggles voice capture
  Command: `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/live-dialogue-companion.spec.ts`
  Evidence: `4 passed (4.3s)`
  Test: the same Playwright spec clicks the black screen away from the centered indicator and waits for the harness `recorder start` event.
