### PR TITLE
fix: Bug report: interaction failed in default (fixes #665)

### DIFF
--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -181,15 +181,19 @@ func (a *App) handleBugReportCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	issueTitle := bugReportIssueTitle(bundle)
-	issue, itemID, issueErr := a.createGitHubIssueFromBugReport(workspace, bundlePath, bundle)
-	if issueErr != nil {
-		bundle.GitHubIssueError = strings.TrimSpace(issueErr.Error())
+	if issueSkipReason := bugReportAutoFileSkipReason(bundle); issueSkipReason != "" {
+		bundle.GitHubIssueError = issueSkipReason
 	} else {
-		bundle.GitHubIssueURL = strings.TrimSpace(issue.URL)
-		bundle.GitHubIssueNo = issue.Number
-		bundle.ItemID = itemID
-		bundle.IssueLabels = []string{"bug", "p0"}
-		issueTitle = strings.TrimSpace(issue.Title)
+		issue, itemID, issueErr := a.createGitHubIssueFromBugReport(workspace, bundlePath, bundle)
+		if issueErr != nil {
+			bundle.GitHubIssueError = strings.TrimSpace(issueErr.Error())
+		} else {
+			bundle.GitHubIssueURL = strings.TrimSpace(issue.URL)
+			bundle.GitHubIssueNo = issue.Number
+			bundle.ItemID = itemID
+			bundle.IssueLabels = []string{"bug", "p0"}
+			issueTitle = strings.TrimSpace(issue.Title)
+		}
 	}
 	if err := writeBugReportBundle(bundlePath, bundle); err != nil {
 		http.Error(w, "update bundle failed", http.StatusInternalServerError)
@@ -496,6 +500,29 @@ func bugReportSummary(bundle bugReportBundle) string {
 		return clean
 	}
 	return ""
+}
+
+func bugReportAutoFileSkipReason(bundle bugReportBundle) string {
+	if bugReportHasActionableSummary(bundle) {
+		return ""
+	}
+	return "auto-filing skipped: add a short note or capture clearer interaction context"
+}
+
+func bugReportHasActionableSummary(bundle bugReportBundle) bool {
+	for _, candidate := range []string{
+		firstSentence(bundle.Note),
+		firstSentence(bundle.VoiceTranscript),
+		bugReportLogSummary(bundle.BrowserLogs),
+		bugReportRecentEventSummary(bundle.RecentEvents),
+		bugReportCanvasArtifactTitle(bundle.CanvasState),
+		bugReportStructuredInteraction(bundle.CanvasState),
+	} {
+		if strings.TrimSpace(candidate) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func bugReportLogSummary(lines []string) string {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -329,6 +329,52 @@ func TestHandleBugReportCreateUsesDefaultWorkspace(t *testing.T) {
 	}
 }
 
+func TestHandleBugReportCreateSkipsIssueAutofilingForLowSignalBundle(t *testing.T) {
+	app := newAuthedTestApp(t)
+	workspaceDir := t.TempDir()
+	workspace, err := app.store.CreateWorkspace("default", workspaceDir, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(workspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace() error: %v", err)
+	}
+	app.ghCommandRunner = func(_ context.Context, _ string, args ...string) (string, error) {
+		t.Fatalf("unexpected gh invocation: %v", args)
+		return "", nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), "POST", "/api/bugs/report", map[string]any{
+		"screenshot_data_url": testPNGDataURL,
+	})
+	if rr.Code != 200 {
+		t.Fatalf("POST /api/bugs/report status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONResponse(t, rr)
+	if got := intFromAny(payload["issue_number"], 0); got != 0 {
+		t.Fatalf("issue_number = %d, want 0", got)
+	}
+	if got := strFromAny(payload["issue_error"]); got != "auto-filing skipped: add a short note or capture clearer interaction context" {
+		t.Fatalf("issue_error = %q", got)
+	}
+	bundlePath := strFromAny(payload["bundle_path"])
+	bundleBytes, err := os.ReadFile(filepath.Join(workspaceDir, filepath.FromSlash(bundlePath)))
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	var bundle map[string]any
+	if err := json.Unmarshal(bundleBytes, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	if got := strFromAny(bundle["github_issue_error"]); got != "auto-filing skipped: add a short note or capture clearer interaction context" {
+		t.Fatalf("bundle github_issue_error = %q", got)
+	}
+	if got := intFromAny(bundle["github_issue_number"], 0); got != 0 {
+		t.Fatalf("bundle github_issue_number = %d, want 0", got)
+	}
+}
+
 func TestHandleBugReportCreateUsesLocalProjectFallback(t *testing.T) {
 	dataDir := t.TempDir()
 	localProjectDir := t.TempDir()
@@ -586,6 +632,35 @@ func TestBugReportIssueTitleUsesStructuredFallbackWithoutFreeText(t *testing.T) 
 	body := bugReportIssueBody(bundle, ".tabura/artifacts/bugs/20260311-110721-568aa357/bundle.json")
 	if !strings.Contains(body, "## Summary\n\npen interaction failed in 2026/03/11") {
 		t.Fatalf("bugReportIssueBody() missing structured summary:\n%s", body)
+	}
+}
+
+func TestBugReportAutoFileSkipReasonRequiresActionableContext(t *testing.T) {
+	if got := bugReportAutoFileSkipReason(bugReportBundle{
+		ActiveMode:      "pen",
+		ActiveWorkspace: "default",
+	}); got != "auto-filing skipped: add a short note or capture clearer interaction context" {
+		t.Fatalf("bugReportAutoFileSkipReason() = %q", got)
+	}
+
+	canvasState, err := json.Marshal(map[string]any{
+		"text_input_visible": true,
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	if got := bugReportAutoFileSkipReason(bugReportBundle{
+		ActiveWorkspace: "default",
+		CanvasState:     canvasState,
+	}); got != "" {
+		t.Fatalf("bugReportAutoFileSkipReason() with structured interaction = %q, want empty", got)
+	}
+
+	if got := bugReportAutoFileSkipReason(bugReportBundle{
+		ActiveWorkspace: "default",
+		Note:            "The floating input stopped accepting Enter.",
+	}); got != "" {
+		t.Fatalf("bugReportAutoFileSkipReason() with note = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Skip GitHub auto-filing for bug bundles that only contain low-signal fallback context such as workspace/mode with no note, transcript, logs, recent event, artifact, or structured interaction.
- Preserve auto-filing for actionable bug reports by allowing notes and structured interaction context to continue through the existing issue-creation path.
- Persist the skip reason into the saved bundle so the UI can explain why only the bundle was saved.

## Verification
- Low-signal default-workspace repro no longer opens a GitHub issue: `go test ./internal/web -run 'TestHandleBugReportCreate|TestBugReport' 2>&1 | tee /tmp/test.log` ran `TestHandleBugReportCreateSkipsIssueAutofilingForLowSignalBundle`, which asserts no `gh` invocation, no `issue_number`, and the persisted `github_issue_error` reason.
- Actionable bug reports still auto-file: the same test run covers existing create-path tests plus `TestBugReportAutoFileSkipReasonRequiresActionableContext`, which accepts a note or structured interaction context and leaves auto-filing enabled.
- Captured test evidence: `/tmp/test.log` contains `ok   github.com/krystophny/tabura/internal/web  0.209s`; `rg -n "FAIL|panic:|--- FAIL|error:" /tmp/test.log` returned no matches.