### PR TITLE
fix: Unplugged mode: fully local LLM backend replacing Codex app-serv (fixes #652)

### DIFF
--- a/internal/web/chat_assistant_local.go
+++ b/internal/web/chat_assistant_local.go
@@ -1,0 +1,260 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const (
+	assistantModeAuto            = "auto"
+	assistantModeLocal           = "local"
+	assistantModeCodex           = "codex"
+	DefaultAssistantMode         = assistantModeAuto
+	assistantLLMRequestTimeout   = 20 * time.Second
+	assistantLLMResponseLimit    = 256 * 1024
+	assistantLLMMaxTokens        = 2048
+	localAssistantDialoguePrompt = "You are Tabura's local assistant. Reply in plain text only. Do not emit JSON, code fences, or tool calls. The request has already passed through local command routing, so answer conversationally and concisely."
+)
+
+func normalizeAssistantMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case assistantModeLocal:
+		return assistantModeLocal
+	case assistantModeCodex:
+		return assistantModeCodex
+	default:
+		return assistantModeAuto
+	}
+}
+
+func (a *App) assistantRoutingMode() string {
+	if a == nil {
+		return DefaultAssistantMode
+	}
+	return normalizeAssistantMode(a.assistantMode)
+}
+
+func (a *App) assistantTurnMode(localOnly bool) string {
+	if localOnly {
+		return assistantModeLocal
+	}
+	switch a.assistantRoutingMode() {
+	case assistantModeLocal:
+		return assistantModeLocal
+	case assistantModeCodex:
+		return assistantModeCodex
+	default:
+		if a == nil || a.appServerClient == nil {
+			return assistantModeLocal
+		}
+		return assistantModeCodex
+	}
+}
+
+func (a *App) assistantLLMBaseURL() string {
+	if a == nil {
+		return ""
+	}
+	baseURL := strings.TrimSpace(a.assistantLLMURL)
+	if baseURL == "" {
+		baseURL = strings.TrimSpace(a.intentLLMURL)
+	}
+	return strings.TrimRight(baseURL, "/")
+}
+
+func (a *App) localAssistantLLMModel() string {
+	if a == nil {
+		return DefaultIntentLLMModel
+	}
+	if model := strings.TrimSpace(a.assistantLLMModel); model != "" {
+		return model
+	}
+	return a.localIntentLLMModel()
+}
+
+func (a *App) requestLocalAssistantMessage(ctx context.Context, prompt string) (string, error) {
+	baseURL := a.assistantLLMBaseURL()
+	if baseURL == "" {
+		return "", errors.New("local assistant is not configured")
+	}
+	requestBody, _ := json.Marshal(map[string]any{
+		"model":       a.localAssistantLLMModel(),
+		"temperature": 0,
+		"max_tokens":  assistantLLMMaxTokens,
+		"chat_template_kwargs": map[string]any{
+			"enable_thinking": false,
+		},
+		"messages": []map[string]string{
+			{"role": "system", "content": localAssistantDialoguePrompt},
+			{"role": "user", "content": prompt},
+		},
+	})
+	requestCtx, cancel := context.WithTimeout(ctx, assistantLLMRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		requestCtx,
+		http.MethodPost,
+		baseURL+"/v1/chat/completions",
+		bytes.NewReader(requestBody),
+	)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, assistantLLMResponseLimit))
+		return "", fmt.Errorf("assistant llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload localIntentLLMChatCompletionResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, assistantLLMResponseLimit)).Decode(&payload); err != nil {
+		return "", err
+	}
+	if len(payload.Choices) == 0 {
+		return "", errors.New("assistant llm returned no choices")
+	}
+	content := strings.TrimSpace(stripCodeFence(payload.Choices[0].Message.Content))
+	if content == "" {
+		return "", errors.New("assistant llm returned empty content")
+	}
+	if classification, err := parseIntentPlanClassification(content); err == nil && classification.LocalAnswer != nil {
+		if text := strings.TrimSpace(classification.LocalAnswer.Text); text != "" {
+			return text, nil
+		}
+	}
+	return content, nil
+}
+
+func (a *App) buildLocalAssistantPrompt(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string) (string, error) {
+	canvasCtx := a.resolveCanvasContext(session.WorkspacePath)
+	companionCtx := a.loadCompanionPromptContext(session.WorkspacePath)
+	prompt := buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, outputMode, "")
+	prompt = appendChatCursorPrompt(prompt, cursorCtx)
+	prompt = appendCanvasInkPrompt(prompt, inkCtx)
+	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
+	if strings.TrimSpace(prompt) == "" {
+		return "", errors.New("empty prompt")
+	}
+	prompt = a.applyWorkspacePromptContext(session.WorkspacePath, prompt)
+	prompt, err := a.applyPreAssistantPromptHook(context.Background(), sessionID, session.WorkspacePath, outputMode, session.Mode, prompt)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return "", errors.New("empty prompt")
+	}
+	return prompt, nil
+}
+
+func (a *App) runLocalAssistantTurn(sessionID string, session store.ChatSession, messages []store.ChatMessage, userText string, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, captureMode string, outputMode string) {
+	turnStartedAt := time.Now()
+	actionMessage, actionPayloads, handled := a.classifyAndExecuteSystemActionForTurn(context.Background(), sessionID, session, userText, cursorCtx, captureMode)
+	if handled {
+		if suppressLocalAssistantResponse(actionPayloads) {
+			a.finishCompanionPendingTurn(sessionID, "assistant_turn_suppressed")
+			return
+		}
+		runID := randomToken()
+		a.broadcastChatEvent(sessionID, map[string]interface{}{
+			"type":    "turn_started",
+			"turn_id": runID,
+		})
+		assistantText := strings.TrimSpace(actionMessage)
+		if assistantText == "" {
+			assistantText = "Done."
+		}
+		for _, actionPayload := range actionPayloads {
+			if actionPayload == nil {
+				continue
+			}
+			a.broadcastSystemActionEvent(sessionID, actionPayload)
+		}
+		persistedAssistantID := int64(0)
+		persistedAssistantText := ""
+		a.finalizeAssistantResponseWithMetadata(
+			sessionID,
+			session.WorkspacePath,
+			assistantText,
+			&persistedAssistantID,
+			&persistedAssistantText,
+			"",
+			runID,
+			"",
+			outputMode,
+			newAssistantResponseMetadata(a.localAssistantProvider(), a.localAssistantModelLabel(), time.Since(turnStartedAt)),
+		)
+		return
+	}
+
+	prompt, err := a.buildLocalAssistantPrompt(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, outputMode)
+	if err != nil {
+		errText := err.Error()
+		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runID := randomToken()
+	a.registerActiveChatTurn(sessionID, runID, cancel)
+	defer func() {
+		cancel()
+		a.unregisterActiveChatTurn(sessionID, runID)
+	}()
+
+	go a.watchCanvasFile(ctx, session.WorkspacePath)
+	a.broadcastChatEvent(sessionID, map[string]interface{}{
+		"type":    "turn_started",
+		"turn_id": runID,
+	})
+
+	reply, err := a.requestLocalAssistantMessage(ctx, prompt)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			a.finishCompanionPendingTurn(sessionID, "assistant_turn_cancelled")
+			a.broadcastChatEvent(sessionID, map[string]interface{}{
+				"type":    "turn_cancelled",
+				"turn_id": runID,
+			})
+			return
+		}
+		errText := normalizeAssistantError(err)
+		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
+		return
+	}
+
+	assistantText := strings.TrimSpace(reply)
+	if assistantText == "" {
+		assistantText = "(assistant returned no content)"
+	}
+	persistedAssistantID := int64(0)
+	persistedAssistantText := ""
+	a.finalizeAssistantResponseWithMetadata(
+		sessionID,
+		session.WorkspacePath,
+		assistantText,
+		&persistedAssistantID,
+		&persistedAssistantText,
+		"",
+		runID,
+		"",
+		outputMode,
+		newAssistantResponseMetadata(a.localAssistantProvider(), a.localAssistantModelLabel(), time.Since(turnStartedAt)),
+	)
+}

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -507,6 +507,142 @@ func TestRunAssistantTurnKeepsPlainTextAssistantOutput(t *testing.T) {
 	}
 }
 
+func TestRunAssistantTurnUsesLocalAssistantModeWhenConfigured(t *testing.T) {
+	const localReply = "Running fully unplugged."
+	const codexReply = "This should not be used."
+	const assistantModel = "qwen-local-assistant"
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if got := strings.TrimSpace(strFromAny(payload["model"])); got != assistantModel {
+			http.Error(w, "unexpected model "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": localReply,
+					},
+				},
+			},
+		})
+	}))
+	defer llm.Close()
+
+	wsServer := setupMockAppServerStatusServer(t, codexReply)
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	app, err := New(t.TempDir(), "", "", wsURL, "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.assistantMode = assistantModeLocal
+	app.assistantLLMURL = llm.URL
+	app.assistantLLMModel = assistantModel
+	app.intentLLMURL = ""
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "help me with the plasma analysis", "help me with the plasma analysis", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != localReply {
+		t.Fatalf("assistant message = %q, want %q", got, localReply)
+	}
+}
+
+func TestRunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer(t *testing.T) {
+	const assistantReply = "Local assistant fallback engaged."
+	const assistantModel = "qwen-auto-fallback"
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if got := strings.TrimSpace(strFromAny(payload["model"])); got != assistantModel {
+			http.Error(w, "unexpected model "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]interface{}{
+						"content": assistantReply,
+					},
+				},
+			},
+		})
+	}))
+	defer llm.Close()
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.assistantLLMURL = llm.URL
+	app.assistantLLMModel = assistantModel
+	app.intentLLMURL = ""
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("project session: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "summarize the workspace status for me", "summarize the workspace status for me", "text"); err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != assistantReply {
+		t.Fatalf("assistant message = %q, want %q", got, assistantReply)
+	}
+}
+
 func TestRunAssistantTurnExecutesHighConfidenceLocalIntent(t *testing.T) {
 	llm := setupMockIntentLLMServer(t, http.StatusOK, `{"action":"toggle_silent"}`)
 	defer llm.Close()

--- a/internal/web/chat_model_test.go
+++ b/internal/web/chat_model_test.go
@@ -69,3 +69,26 @@ func TestAppServerModelProfileForWorkspacePathFallsBackWhenProjectMissing(t *tes
 		t.Fatalf("profile.TurnParams[effort] = %#v, want %q", got, modelprofile.ReasoningLow)
 	}
 }
+
+func TestAssistantTurnModeHonorsConfiguredRouting(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	app.assistantMode = assistantModeLocal
+	if got := app.assistantTurnMode(false); got != assistantModeLocal {
+		t.Fatalf("assistantTurnMode(local) = %q, want %q", got, assistantModeLocal)
+	}
+
+	app.assistantMode = assistantModeCodex
+	if got := app.assistantTurnMode(false); got != assistantModeCodex {
+		t.Fatalf("assistantTurnMode(codex) = %q, want %q", got, assistantModeCodex)
+	}
+
+	app.assistantMode = assistantModeAuto
+	app.appServerClient = nil
+	if got := app.assistantTurnMode(false); got != assistantModeLocal {
+		t.Fatalf("assistantTurnMode(auto, no app-server) = %q, want %q", got, assistantModeLocal)
+	}
+	if got := app.assistantTurnMode(true); got != assistantModeLocal {
+		t.Fatalf("assistantTurnMode(localOnly) = %q, want %q", got, assistantModeLocal)
+	}
+}

--- a/internal/web/chat_provider.go
+++ b/internal/web/chat_provider.go
@@ -148,6 +148,9 @@ func (a *App) localAssistantModelLabel() string {
 	if a == nil {
 		return DefaultIntentLLMProfile
 	}
+	if model := strings.TrimSpace(a.assistantLLMModel); model != "" && !strings.EqualFold(model, DefaultIntentLLMModel) {
+		return model
+	}
 	if profile := strings.TrimSpace(a.intentLLMProfile); profile != "" {
 		return profile
 	}

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -30,10 +30,9 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	cursorCtx := turn.cursor
 	userText := queuedUserMessage(messages, turn.messageID)
 	requestedTurnAlias := explicitTurnModelAlias(userText)
-	if turn.localOnly || a.appServerClient == nil {
-		if a.tryRunLocalSystemActionTurn(sessionID, session, userText, cursorCtx, turn.captureMode, turn.outputMode, turn.localOnly) {
-			return
-		}
+	if a.assistantTurnMode(turn.localOnly) == assistantModeLocal {
+		a.runLocalAssistantTurn(sessionID, session, messages, userText, cursorCtx, inkCtx, positionCtx, turn.captureMode, turn.outputMode)
+		return
 	}
 	if a.appServerClient == nil {
 		errText := "app-server is not configured"

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -66,6 +66,9 @@ type App struct {
 	appServerURL                  string
 	appServerModel                string
 	appServerSparkReasoningEffort string
+	assistantMode                 string
+	assistantLLMURL               string
+	assistantLLMModel             string
 	intentLLMURL                  string
 	intentLLMModel                string
 	intentLLMProfile              string
@@ -177,6 +180,15 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	if resolvedTTSURL == "" {
 		resolvedTTSURL = strings.TrimSpace(os.Getenv("TABURA_TTS_URL"))
 	}
+	resolvedAssistantMode := normalizeAssistantMode(os.Getenv("TABURA_ASSISTANT_MODE"))
+	resolvedAssistantLLMURL := strings.TrimSpace(os.Getenv("TABURA_ASSISTANT_LLM_URL"))
+	if strings.EqualFold(resolvedAssistantLLMURL, "off") {
+		resolvedAssistantLLMURL = ""
+	}
+	resolvedAssistantLLMModel := strings.TrimSpace(os.Getenv("TABURA_ASSISTANT_LLM_MODEL"))
+	if strings.EqualFold(resolvedAssistantLLMModel, "off") {
+		resolvedAssistantLLMModel = ""
+	}
 	resolvedIntentLLMURL := strings.TrimSpace(os.Getenv("TABURA_INTENT_LLM_URL"))
 	if strings.EqualFold(resolvedIntentLLMURL, "off") {
 		resolvedIntentLLMURL = ""
@@ -195,6 +207,12 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		resolvedIntentLLMProfileOptions = parseIntentLLMProfileOptions(DefaultIntentLLMProfileOptions)
 	}
 	resolvedIntentLLMProfileOptions = ensureIntentLLMProfileOption(resolvedIntentLLMProfileOptions, resolvedIntentLLMProfile)
+	if resolvedAssistantLLMURL == "" {
+		resolvedAssistantLLMURL = resolvedIntentLLMURL
+	}
+	if resolvedAssistantLLMModel == "" {
+		resolvedAssistantLLMModel = resolvedIntentLLMModel
+	}
 	resolvedSTTURL := strings.TrimSpace(os.Getenv("TABURA_STT_URL"))
 	if strings.EqualFold(resolvedSTTURL, "off") {
 		resolvedSTTURL = ""
@@ -275,6 +293,9 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		appServerURL:                  appServerURL,
 		appServerModel:                resolvedModel,
 		appServerSparkReasoningEffort: resolvedSparkReasoningEffort,
+		assistantMode:                 resolvedAssistantMode,
+		assistantLLMURL:               resolvedAssistantLLMURL,
+		assistantLLMModel:             resolvedAssistantLLMModel,
 		intentLLMURL:                  resolvedIntentLLMURL,
 		intentLLMModel:                resolvedIntentLLMModel,
 		intentLLMProfile:              resolvedIntentLLMProfile,
@@ -558,6 +579,9 @@ func (a *App) handleRuntime(w http.ResponseWriter, r *http.Request) {
 		"app_server_url":              a.appServerURL,
 		"app_server_model":            a.appServerModel,
 		"app_server_reasoning_effort": sparkReasoningEffort,
+		"assistant_mode":              a.assistantRoutingMode(),
+		"assistant_llm_url":           a.assistantLLMBaseURL(),
+		"assistant_llm_model":         a.localAssistantLLMModel(),
 		"intent_llm_url":              a.intentLLMURL,
 		"intent_llm_model":            a.localIntentLLMModel(),
 		"intent_llm_profile":          a.intentLLMProfile,


### PR DESCRIPTION
## Summary
- add `TABURA_ASSISTANT_MODE` plus assistant-specific LLM URL/model wiring
- route `runAssistantTurn` through a new local assistant path for `local`, `localOnly`, and `auto` when Codex is unavailable
- cover local-mode bypass, auto fallback, and adjacent existing turn paths with focused web tests

## Verification
- Assistant mode routing and unplugged fallback: `go test ./internal/web -run 'Test(AssistantTurnModeHonorsConfiguredRouting|RunAssistantTurnKeepsPlainTextAssistantOutput|RunAssistantTurnUsesLocalAssistantModeWhenConfigured|RunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer|RunAssistantTurnExecutesHighConfidenceLocalIntent|RunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable)$' 2>&1 | tee /tmp/test.log` -> `ok   github.com/krystophny/tabura/internal/web\t0.126s`; covered by `TestAssistantTurnModeHonorsConfiguredRouting`, `TestRunAssistantTurnUsesLocalAssistantModeWhenConfigured`, and `TestRunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer`.
- Separate assistant LLM config: same command/output; `TestRunAssistantTurnUsesLocalAssistantModeWhenConfigured` and `TestRunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer` assert that `runAssistantTurn` posts to `/v1/chat/completions` with the configured assistant model, exercising the new env-backed fields.
- Existing Codex/default and high-confidence local-intent flows still work: same command/output; `TestRunAssistantTurnKeepsPlainTextAssistantOutput`, `TestRunAssistantTurnExecutesHighConfidenceLocalIntent`, and `TestRunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable` remain green.