### PR TITLE
fix: Native iOS app with PencilKit ink and background audio (fixes #633)

### DIFF
--- a/internal/web/chat_canvas_ink_test.go
+++ b/internal/web/chat_canvas_ink_test.go
@@ -170,3 +170,54 @@ func TestHandleChatWSTextMessage_CanvasInkQueuesRequestedTurnAndPersistsSnapshot
 		t.Fatal("expected snapshot bytes")
 	}
 }
+
+func TestHandleChatWSTextMessage_InkStrokeAliasQueuesRequestedTurn(t *testing.T) {
+	app := newAuthedTestApp(t)
+	sessionID := testSessionForCanvasPosition(t, app)
+	holdAssistantTurnWorker(t, app, sessionID)
+
+	handleChatWSTextMessage(app, newChatWSConn(nil), sessionID, []byte(`{
+		"type": "ink_stroke",
+		"artifact_kind": "text",
+		"output_mode": "voice",
+		"request_response": true,
+		"total_strokes": 1,
+		"cursor": {
+			"title": "notes.md",
+			"line": 8,
+			"surrounding_text": "7: beta\n8: gamma\n9: delta"
+		},
+		"strokes": [
+			{
+				"pointer_type": "pencil",
+				"width": 2.4,
+				"points": [
+					{ "x": 10, "y": 10, "pressure": 0.5, "tilt_x": 12, "tilt_y": 45, "roll": 0, "timestamp_ms": 1 },
+					{ "x": 22, "y": 10.5, "pressure": 0.6, "tilt_x": 12, "tilt_y": 45, "roll": 0, "timestamp_ms": 2 },
+					{ "x": 36, "y": 10, "pressure": 0.7, "tilt_x": 12, "tilt_y": 45, "roll": 0, "timestamp_ms": 3 }
+				]
+			}
+		]
+	}`))
+
+	if got := app.turns.queuedCount(sessionID); got != 1 {
+		t.Fatalf("queuedCount = %d, want 1", got)
+	}
+	events := app.chatCanvasInk.consume(sessionID)
+	if len(events) != 1 {
+		t.Fatalf("consume len = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event == nil {
+		t.Fatal("expected event")
+	}
+	if event.Gesture != "underline" {
+		t.Fatalf("gesture = %q, want underline", event.Gesture)
+	}
+	if event.Cursor == nil || event.Cursor.Line != 8 {
+		t.Fatalf("cursor = %#v", event.Cursor)
+	}
+	if event.StrokeCount != 1 {
+		t.Fatalf("stroke count = %d, want 1", event.StrokeCount)
+	}
+}

--- a/internal/web/chat_stt.go
+++ b/internal/web/chat_stt.go
@@ -204,6 +204,8 @@ func handleChatWSTextMessage(a *App, conn *chatWSConn, sessionID string, data []
 		enqueueRequestedCanvasPosition(a, sessionID, msg.Cursor, firstNonEmptyCursorText(msg.Gesture, msg.Kind, "gesture"), msg.RequestResponse, msg.OutputMode)
 	case "canvas_ink":
 		enqueueRequestedCanvasInk(a, sessionID, msg.Cursor, msg.ArtifactKind, msg.OutputMode, msg.RequestResponse, msg.SnapshotDataURL, msg.TotalStrokes, msg.BoundingBox, msg.OverlappingLines, msg.OverlappingText, msg.Strokes)
+	case "ink_stroke":
+		enqueueRequestedCanvasInk(a, sessionID, msg.Cursor, msg.ArtifactKind, msg.OutputMode, msg.RequestResponse, msg.SnapshotDataURL, msg.TotalStrokes, msg.BoundingBox, msg.OverlappingLines, msg.OverlappingText, msg.Strokes)
 	case "ink_commit":
 		enqueueRequestedCanvasInk(a, sessionID, msg.Cursor, msg.ArtifactKind, msg.OutputMode, msg.RequestResponse, msg.SnapshotDataURL, msg.TotalStrokes, msg.BoundingBox, msg.OverlappingLines, msg.OverlappingText, msg.Strokes)
 	}

--- a/platforms/ios/TaburaIOS.xcodeproj/project.pbxproj
+++ b/platforms/ios/TaburaIOS.xcodeproj/project.pbxproj
@@ -1,0 +1,259 @@
+// !$*UTF8*$!
+{
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B10000010000000000000001 /* TaburaIOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000001 /* TaburaIOSApp.swift */; };
+		B10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000002 /* ContentView.swift */; };
+		B10000010000000000000003 /* TaburaAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000003 /* TaburaAppModel.swift */; };
+		B10000010000000000000004 /* TaburaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000004 /* TaburaModels.swift */; };
+		B10000010000000000000005 /* TaburaServerDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000005 /* TaburaServerDiscovery.swift */; };
+		B10000010000000000000006 /* TaburaChatTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000006 /* TaburaChatTransport.swift */; };
+		B10000010000000000000007 /* TaburaCanvasTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000007 /* TaburaCanvasTransport.swift */; };
+		B10000010000000000000008 /* TaburaAudioCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000008 /* TaburaAudioCapture.swift */; };
+		B10000010000000000000009 /* TaburaInkCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000110000000000000009 /* TaburaInkCaptureView.swift */; };
+		B1000001000000000000000A /* TaburaCanvasWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000011000000000000000A /* TaburaCanvasWebView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B10000110000000000000001 /* TaburaIOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaIOSApp.swift; sourceTree = "<group>"; };
+		B10000110000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B10000110000000000000003 /* TaburaAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaAppModel.swift; sourceTree = "<group>"; };
+		B10000110000000000000004 /* TaburaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaModels.swift; sourceTree = "<group>"; };
+		B10000110000000000000005 /* TaburaServerDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaServerDiscovery.swift; sourceTree = "<group>"; };
+		B10000110000000000000006 /* TaburaChatTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaChatTransport.swift; sourceTree = "<group>"; };
+		B10000110000000000000007 /* TaburaCanvasTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaCanvasTransport.swift; sourceTree = "<group>"; };
+		B10000110000000000000008 /* TaburaAudioCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaAudioCapture.swift; sourceTree = "<group>"; };
+		B10000110000000000000009 /* TaburaInkCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaInkCaptureView.swift; sourceTree = "<group>"; };
+		B1000011000000000000000A /* TaburaCanvasWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaburaCanvasWebView.swift; sourceTree = "<group>"; };
+		B1000011000000000000000B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1000011000000000000000C /* TaburaIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = TaburaIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B10000210000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B10000310000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				B10000310000000000000002 /* TaburaIOS */,
+				B10000310000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B10000310000000000000002 /* TaburaIOS */ = {
+			isa = PBXGroup;
+			path = TaburaIOS;
+			sourceTree = "<group>";
+			children = (
+				B10000110000000000000001 /* TaburaIOSApp.swift */,
+				B10000110000000000000002 /* ContentView.swift */,
+				B10000110000000000000003 /* TaburaAppModel.swift */,
+				B10000110000000000000004 /* TaburaModels.swift */,
+				B10000110000000000000005 /* TaburaServerDiscovery.swift */,
+				B10000110000000000000006 /* TaburaChatTransport.swift */,
+				B10000110000000000000007 /* TaburaCanvasTransport.swift */,
+				B10000110000000000000008 /* TaburaAudioCapture.swift */,
+				B10000110000000000000009 /* TaburaInkCaptureView.swift */,
+				B1000011000000000000000A /* TaburaCanvasWebView.swift */,
+				B1000011000000000000000B /* Info.plist */,
+			);
+		};
+		B10000310000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B1000011000000000000000C /* TaburaIOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B10000410000000000000001 /* TaburaIOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B10000710000000000000002 /* Build configuration list for PBXNativeTarget "TaburaIOS" */;
+			buildPhases = (
+				B10000210000000000000002 /* Sources */,
+				B10000210000000000000001 /* Frameworks */,
+				B10000210000000000000003 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TaburaIOS;
+			productName = TaburaIOS;
+			productReference = B1000011000000000000000C /* TaburaIOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B10000510000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					B10000410000000000000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = B10000710000000000000001 /* Build configuration list for PBXProject "TaburaIOS" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B10000310000000000000001;
+			productRefGroup = B10000310000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B10000410000000000000001 /* TaburaIOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B10000210000000000000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B10000210000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B10000010000000000000001 /* TaburaIOSApp.swift in Sources */,
+				B10000010000000000000002 /* ContentView.swift in Sources */,
+				B10000010000000000000003 /* TaburaAppModel.swift in Sources */,
+				B10000010000000000000004 /* TaburaModels.swift in Sources */,
+				B10000010000000000000005 /* TaburaServerDiscovery.swift in Sources */,
+				B10000010000000000000006 /* TaburaChatTransport.swift in Sources */,
+				B10000010000000000000007 /* TaburaCanvasTransport.swift in Sources */,
+				B10000010000000000000008 /* TaburaAudioCapture.swift in Sources */,
+				B10000010000000000000009 /* TaburaInkCaptureView.swift in Sources */,
+				B1000001000000000000000A /* TaburaCanvasWebView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B10000610000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		B10000610000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		B10000610000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TaburaIOS/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = at.tabura.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B10000610000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TaburaIOS/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = at.tabura.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B10000710000000000000001 /* Build configuration list for PBXProject "TaburaIOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000610000000000000001 /* Debug */,
+				B10000610000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B10000710000000000000002 /* Build configuration list for PBXNativeTarget "TaburaIOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000610000000000000003 /* Debug */,
+				B10000610000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B10000510000000000000001 /* Project object */;
+}

--- a/platforms/ios/TaburaIOS/ContentView.swift
+++ b/platforms/ios/TaburaIOS/ContentView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var model = TaburaAppModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                connectionPanel
+                workspacePicker
+                canvasPanel
+                chatPanel
+                composerPanel
+            }
+            .padding(16)
+            .navigationTitle("Tabura iOS")
+        }
+    }
+
+    private var connectionPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Server")
+                .font(.headline)
+            TextField("http://127.0.0.1:8420", text: $model.serverURLString)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $model.password)
+                .textFieldStyle(.roundedBorder)
+            if model.discovery.servers.isEmpty == false {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(model.discovery.servers) { server in
+                            Button(server.name) {
+                                model.useDiscoveredServer(server)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+            }
+            HStack {
+                Button("Connect") {
+                    Task { await model.connect() }
+                }
+                .buttonStyle(.borderedProminent)
+                Text(model.statusText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            if model.lastError.isEmpty == false {
+                Text(model.lastError)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var workspacePicker: some View {
+        HStack {
+            Picker("Workspace", selection: $model.selectedWorkspaceID) {
+                ForEach(model.workspaces, id: \.id) { workspace in
+                    Text(workspace.name).tag(workspace.id)
+                }
+            }
+            .pickerStyle(.menu)
+            Button("Switch") {
+                Task { await model.switchWorkspace() }
+            }
+            .buttonStyle(.bordered)
+            Spacer()
+            Toggle("Ink asks Tabura", isOn: $model.inkRequestsResponse)
+                .toggleStyle(.switch)
+                .labelsHidden()
+        }
+    }
+
+    private var canvasPanel: some View {
+        ZStack(alignment: .topTrailing) {
+            TaburaCanvasWebView(html: model.canvas.html, baseURL: URL(string: model.serverURLString))
+                .frame(minHeight: 260)
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
+                )
+            TaburaInkCaptureView { strokes in
+                Task { await model.submitInk(strokes) }
+            }
+            .allowsHitTesting(true)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
+            .padding(8)
+        }
+    }
+
+    private var chatPanel: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                ForEach(model.messages) { message in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(message.role.capitalized)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(message.text)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(12)
+                    .background(message.role == "user" ? Color.blue.opacity(0.08) : Color.secondary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+            }
+        }
+        .frame(maxHeight: 220)
+    }
+
+    private var composerPanel: some View {
+        VStack(spacing: 12) {
+            TextEditor(text: $model.composerText)
+                .frame(minHeight: 90)
+                .padding(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
+                )
+            HStack {
+                Button(model.isRecording ? "Stop Mic" : "Record Mic") {
+                    Task { await model.toggleRecording() }
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+                Button("Send") {
+                    Task { await model.sendComposerMessage() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/Info.plist
+++ b/platforms/ios/TaburaIOS/Info.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_tabura._tcp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Tabura discovers nearby servers over Bonjour on your local network.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Tabura records microphone audio for dialogue capture and speech transcription.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/platforms/ios/TaburaIOS/TaburaAppModel.swift
+++ b/platforms/ios/TaburaIOS/TaburaAppModel.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+@MainActor
+final class TaburaAppModel: ObservableObject {
+    @Published var serverURLString = "http://127.0.0.1:8420"
+    @Published var password = ""
+    @Published var composerText = ""
+    @Published var messages: [TaburaRenderedMessage] = []
+    @Published var canvas = TaburaCanvasArtifact(kind: "", title: "", html: "<p style=\"margin:24px; font: -apple-system-body;\">Connect to a Tabura server to load the canvas.</p>", text: "")
+    @Published var workspaces: [TaburaWorkspace] = []
+    @Published var selectedWorkspaceID = ""
+    @Published var statusText = "Disconnected"
+    @Published var lastError = ""
+    @Published var isRecording = false
+    @Published var inkRequestsResponse = true
+
+    let discovery = TaburaServerDiscovery()
+
+    private let session: URLSession
+    private lazy var chatTransport = TaburaChatTransport(session: session, onEvent: { [weak self] event in
+        self?.handleChatEvent(event)
+    }, onDisconnect: { [weak self] message in
+        self?.statusText = "Chat disconnected"
+        self?.lastError = message
+    })
+    private lazy var canvasTransport = TaburaCanvasTransport(session: session, onArtifact: { [weak self] artifact in
+        self?.canvas = artifact
+    }, onDisconnect: { [weak self] message in
+        self?.statusText = "Canvas disconnected"
+        self?.lastError = message
+    })
+    private lazy var audioCapture = TaburaAudioCapture(onChunk: { [weak self] data in
+        await self?.sendAudioChunk(data)
+    }, onStateChange: { [weak self] running, message in
+        self?.isRecording = running
+        if message.isEmpty == false {
+            self?.lastError = message
+        }
+    })
+
+    private var activeWorkspace: TaburaWorkspace?
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.httpCookieAcceptPolicy = .always
+        config.httpCookieStorage = HTTPCookieStorage.shared
+        config.waitsForConnectivity = true
+        self.session = URLSession(configuration: config)
+        discovery.start()
+    }
+
+    func useDiscoveredServer(_ server: TaburaDiscoveredServer) {
+        serverURLString = server.baseURLString
+    }
+
+    func connect() async {
+        guard let baseURL = normalizedBaseURL() else {
+            lastError = "Enter a valid server URL."
+            return
+        }
+        do {
+            try await loginIfNeeded(baseURL: baseURL)
+            let response = try await loadWorkspaces(baseURL: baseURL)
+            workspaces = response.workspaces
+            if let workspace = response.workspaces.first(where: { $0.id == response.activeWorkspaceID }) ?? response.workspaces.first {
+                selectedWorkspaceID = workspace.id
+                activeWorkspace = workspace
+                try await loadHistory(baseURL: baseURL, workspace: workspace)
+                try await attachRealtime(baseURL: baseURL, workspace: workspace)
+                statusText = "Connected to \(workspace.name)"
+            } else {
+                statusText = "Authenticated"
+            }
+        } catch {
+            lastError = error.localizedDescription
+            statusText = "Connection failed"
+        }
+    }
+
+    func switchWorkspace() async {
+        guard let baseURL = normalizedBaseURL() else {
+            return
+        }
+        guard let workspace = workspaces.first(where: { $0.id == selectedWorkspaceID }) else {
+            return
+        }
+        do {
+            activeWorkspace = workspace
+            try await loadHistory(baseURL: baseURL, workspace: workspace)
+            try await attachRealtime(baseURL: baseURL, workspace: workspace)
+            statusText = "Connected to \(workspace.name)"
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func sendComposerMessage() async {
+        guard let baseURL = normalizedBaseURL(), let workspace = activeWorkspace else {
+            return
+        }
+        let text = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.isEmpty == false else {
+            return
+        }
+        composerText = ""
+        do {
+            var request = URLRequest(url: taburaAPIURL(baseURL: baseURL, path: "chat/sessions/\(workspace.chatSessionID)/messages"))
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONEncoder().encode(TaburaChatSendRequest(text: text, outputMode: "voice"))
+            _ = try await session.data(for: request)
+            messages.append(TaburaRenderedMessage(id: UUID().uuidString, role: "user", text: text, html: ""))
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func toggleRecording() async {
+        if isRecording {
+            audioCapture.stop()
+            do {
+                try await chatTransport.send(TaburaAudioCaptureMessage(type: "audio_stop", mimeType: nil, data: nil))
+            } catch {
+                lastError = error.localizedDescription
+            }
+            return
+        }
+        do {
+            audioCapture.stop()
+            try audioCapture.start()
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func submitInk(_ strokes: [TaburaInkStroke]) async {
+        guard !strokes.isEmpty else {
+            return
+        }
+        let payload = TaburaInkCommitMessage(
+            type: "ink_stroke",
+            artifactKind: "text",
+            requestResponse: inkRequestsResponse,
+            outputMode: "voice",
+            totalStrokes: strokes.count,
+            strokes: strokes
+        )
+        do {
+            try await chatTransport.send(payload)
+            statusText = inkRequestsResponse ? "Ink sent to Tabura" : "Ink captured"
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    private func normalizedBaseURL() -> URL? {
+        let trimmed = serverURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        return URL(string: trimmed)
+    }
+
+    private func loginIfNeeded(baseURL: URL) async throws {
+        var setupRequest = URLRequest(url: taburaAPIURL(baseURL: baseURL, path: "setup"))
+        setupRequest.httpMethod = "GET"
+        let (setupData, _) = try await session.data(for: setupRequest)
+        let setupObject = try JSONSerialization.jsonObject(with: setupData) as? [String: Any]
+        let authenticated = setupObject?["authenticated"] as? Bool ?? false
+        let hasPassword = setupObject?["has_password"] as? Bool ?? false
+        if authenticated || !hasPassword {
+            return
+        }
+        var request = URLRequest(url: taburaAPIURL(baseURL: baseURL, path: "login"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONEncoder().encode(TaburaLoginRequest(password: password))
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.userAuthenticationRequired)
+        }
+    }
+
+    private func loadWorkspaces(baseURL: URL) async throws -> TaburaWorkspaceListResponse {
+        let (data, _) = try await session.data(from: taburaAPIURL(baseURL: baseURL, path: "runtime/workspaces"))
+        return try JSONDecoder().decode(TaburaWorkspaceListResponse.self, from: data)
+    }
+
+    private func loadHistory(baseURL: URL, workspace: TaburaWorkspace) async throws {
+        let (data, _) = try await session.data(from: taburaAPIURL(baseURL: baseURL, path: "chat/sessions/\(workspace.chatSessionID)/history"))
+        let history = try JSONDecoder().decode(TaburaChatHistoryResponse.self, from: data)
+        messages = history.messages.map {
+            TaburaRenderedMessage(id: "persisted-\($0.id)", role: $0.role, text: $0.content, html: "")
+        }
+    }
+
+    private func attachRealtime(baseURL: URL, workspace: TaburaWorkspace) async throws {
+        chatTransport.connect(baseURL: baseURL, sessionID: workspace.chatSessionID)
+        canvasTransport.connect(baseURL: baseURL, sessionID: workspace.canvasSessionID)
+        try await canvasTransport.loadSnapshot(baseURL: baseURL, sessionID: workspace.canvasSessionID)
+    }
+
+    private func sendAudioChunk(_ data: Data) async {
+        do {
+            try await chatTransport.send(TaburaAudioCaptureMessage(
+                type: "audio_pcm",
+                mimeType: "audio/L16;rate=16000;channels=1",
+                data: data.base64EncodedString()
+            ))
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    private func handleChatEvent(_ event: TaburaChatEventPayload) {
+        switch event.type {
+        case "render_chat", "assistant_output", "message_persisted":
+            let text = event.markdown ?? event.message ?? event.text ?? ""
+            if text.isEmpty {
+                return
+            }
+            messages.append(TaburaRenderedMessage(
+                id: event.turnID ?? UUID().uuidString,
+                role: event.role ?? "assistant",
+                text: text,
+                html: event.html ?? ""
+            ))
+        case "stt_result":
+            if let text = event.text, text.isEmpty == false {
+                composerText = text
+                statusText = "Transcription ready"
+            }
+        case "stt_empty":
+            statusText = event.reason ?? "No speech detected"
+        case "stt_error", "error":
+            lastError = event.error ?? "Unknown server error"
+        default:
+            break
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaAudioCapture.swift
+++ b/platforms/ios/TaburaIOS/TaburaAudioCapture.swift
@@ -1,0 +1,106 @@
+import AVFoundation
+import Foundation
+
+final class TaburaAudioCapture {
+    private let engine = AVAudioEngine()
+    private let outputFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16_000, channels: 1, interleaved: true)
+    private let voiceThreshold: Float = 0.012
+    private let onChunk: @MainActor (Data) -> Void
+    private let onStateChange: @MainActor (Bool, String) -> Void
+    private var isRunning = false
+
+    init(onChunk: @escaping @MainActor (Data) -> Void, onStateChange: @escaping @MainActor (Bool, String) -> Void) {
+        self.onChunk = onChunk
+        self.onStateChange = onStateChange
+    }
+
+    func start() throws {
+        if isRunning {
+            return
+        }
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.mixWithOthers, .defaultToSpeaker, .allowBluetooth])
+        try session.setPreferredSampleRate(16_000)
+        try session.setActive(true, options: [])
+
+        let input = engine.inputNode
+        let inputFormat = input.inputFormat(forBus: 0)
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 2048, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard self.voiceDetected(in: buffer) else { return }
+            guard let converted = self.convertToPCM16(buffer: buffer) else { return }
+            Task { @MainActor in
+                self.onChunk(converted)
+            }
+        }
+
+        engine.prepare()
+        try engine.start()
+        isRunning = true
+        Task { @MainActor in
+            self.onStateChange(true, "")
+        }
+    }
+
+    func stop() {
+        if !isRunning {
+            return
+        }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        isRunning = false
+        Task { @MainActor in
+            self.onStateChange(false, "")
+        }
+    }
+
+    private func voiceDetected(in buffer: AVAudioPCMBuffer) -> Bool {
+        guard let channelData = buffer.floatChannelData else {
+            return true
+        }
+        let frameCount = Int(buffer.frameLength)
+        if frameCount == 0 {
+            return false
+        }
+        let samples = channelData[0]
+        var total: Float = 0
+        for index in 0..<frameCount {
+            total += abs(samples[index])
+        }
+        let average = total / Float(frameCount)
+        return average >= voiceThreshold
+    }
+
+    private func convertToPCM16(buffer: AVAudioPCMBuffer) -> Data? {
+        let converter = AVAudioConverter(from: buffer.format, to: outputFormat)
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * outputFormat.sampleRate / buffer.format.sampleRate) + 512
+        guard
+            let converter,
+            let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: capacity)
+        else {
+            return nil
+        }
+
+        var error: NSError?
+        var sourceConsumed = false
+        converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+            if sourceConsumed {
+                outStatus.pointee = .endOfStream
+                return nil
+            }
+            sourceConsumed = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+        if error != nil {
+            return nil
+        }
+        guard let data = outputBuffer.int16ChannelData else {
+            return nil
+        }
+        let sampleCount = Int(outputBuffer.frameLength)
+        return Data(bytes: data[0], count: sampleCount * MemoryLayout<Int16>.size)
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaCanvasTransport.swift
+++ b/platforms/ios/TaburaIOS/TaburaCanvasTransport.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+final class TaburaCanvasTransport {
+    private let session: URLSession
+    private let decoder = JSONDecoder()
+    private var task: URLSessionWebSocketTask?
+    private let onArtifact: @MainActor (TaburaCanvasArtifact) -> Void
+    private let onDisconnect: @MainActor (String) -> Void
+
+    init(session: URLSession, onArtifact: @escaping @MainActor (TaburaCanvasArtifact) -> Void, onDisconnect: @escaping @MainActor (String) -> Void) {
+        self.session = session
+        self.onArtifact = onArtifact
+        self.onDisconnect = onDisconnect
+    }
+
+    func connect(baseURL: URL, sessionID: String) {
+        disconnect()
+        guard let wsURL = taburaWSURL(baseURL: baseURL, path: "canvas/\(sessionID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionID)") else {
+            return
+        }
+        let task = session.webSocketTask(with: wsURL)
+        self.task = task
+        task.resume()
+        receiveLoop(task: task)
+    }
+
+    func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+    }
+
+    func loadSnapshot(baseURL: URL, sessionID: String) async throws {
+        let url = taburaAPIURL(baseURL: baseURL, path: "canvas/\(sessionID)/snapshot")
+        let (data, _) = try await session.data(from: url)
+        let snapshot = try decoder.decode(TaburaCanvasSnapshotResponse.self, from: data)
+        guard let event = snapshot.event else {
+            return
+        }
+        await onArtifact(TaburaCanvasArtifact(
+            kind: event.kind ?? "",
+            title: event.title ?? "",
+            html: taburaCanvasHTML(from: event),
+            text: event.text ?? event.markdownOrText ?? ""
+        ))
+    }
+
+    private func receiveLoop(task: URLSessionWebSocketTask) {
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case let .success(message):
+                self.handle(message: message)
+                self.receiveLoop(task: task)
+            case let .failure(error):
+                Task { @MainActor in
+                    self.onDisconnect(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func handle(message: URLSessionWebSocketTask.Message) {
+        let data: Data
+        switch message {
+        case let .data(raw):
+            data = raw
+        case let .string(raw):
+            data = Data(raw.utf8)
+        @unknown default:
+            return
+        }
+        guard let payload = try? decoder.decode(TaburaCanvasEventPayload.self, from: data) else {
+            return
+        }
+        let artifact = TaburaCanvasArtifact(
+            kind: payload.kind ?? "",
+            title: payload.title ?? "",
+            html: taburaCanvasHTML(from: payload),
+            text: payload.text ?? payload.markdownOrText ?? ""
+        )
+        Task { @MainActor in
+            self.onArtifact(artifact)
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaCanvasWebView.swift
+++ b/platforms/ios/TaburaIOS/TaburaCanvasWebView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import WebKit
+
+struct TaburaCanvasWebView: UIViewRepresentable {
+    let html: String
+    let baseURL: URL?
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        let view = WKWebView(frame: .zero, configuration: config)
+        view.isOpaque = false
+        view.backgroundColor = .clear
+        view.scrollView.contentInsetAdjustmentBehavior = .never
+        return view
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.loadHTMLString(html, baseURL: baseURL)
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaChatTransport.swift
+++ b/platforms/ios/TaburaIOS/TaburaChatTransport.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+final class TaburaChatTransport {
+    private let session: URLSession
+    private let decoder = JSONDecoder()
+    private var task: URLSessionWebSocketTask?
+    private let onEvent: @MainActor (TaburaChatEventPayload) -> Void
+    private let onDisconnect: @MainActor (String) -> Void
+
+    init(session: URLSession, onEvent: @escaping @MainActor (TaburaChatEventPayload) -> Void, onDisconnect: @escaping @MainActor (String) -> Void) {
+        self.session = session
+        self.onEvent = onEvent
+        self.onDisconnect = onDisconnect
+    }
+
+    func connect(baseURL: URL, sessionID: String) {
+        disconnect()
+        guard let wsURL = taburaWSURL(baseURL: baseURL, path: "chat/\(sessionID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionID)") else {
+            return
+        }
+        let task = session.webSocketTask(with: wsURL)
+        self.task = task
+        task.resume()
+        receiveLoop(task: task)
+    }
+
+    func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+    }
+
+    func send<E: Encodable>(_ payload: E) async throws {
+        guard let task else {
+            throw URLError(.networkConnectionLost)
+        }
+        let data = try JSONEncoder().encode(payload)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw URLError(.cannotEncodeContentData)
+        }
+        try await task.send(.string(text))
+    }
+
+    private func receiveLoop(task: URLSessionWebSocketTask) {
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case let .success(message):
+                self.handle(message: message)
+                self.receiveLoop(task: task)
+            case let .failure(error):
+                Task { @MainActor in
+                    self.onDisconnect(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func handle(message: URLSessionWebSocketTask.Message) {
+        let data: Data
+        switch message {
+        case let .data(raw):
+            data = raw
+        case let .string(raw):
+            data = Data(raw.utf8)
+        @unknown default:
+            return
+        }
+        guard let payload = try? decoder.decode(TaburaChatEventPayload.self, from: data) else {
+            return
+        }
+        Task { @MainActor in
+            self.onEvent(payload)
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaIOSApp.swift
+++ b/platforms/ios/TaburaIOS/TaburaIOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TaburaIOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaInkCaptureView.swift
+++ b/platforms/ios/TaburaIOS/TaburaInkCaptureView.swift
@@ -1,0 +1,62 @@
+import PencilKit
+import SwiftUI
+
+struct TaburaInkCaptureView: UIViewRepresentable {
+    let onCommit: ([TaburaInkStroke]) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCommit: onCommit)
+    }
+
+    func makeUIView(context: Context) -> PKCanvasView {
+        let canvas = PKCanvasView()
+        canvas.backgroundColor = .clear
+        canvas.isOpaque = false
+        canvas.drawingPolicy = .pencilOnly
+        canvas.delegate = context.coordinator
+        canvas.tool = PKInkingTool(.pen, color: .black, width: 2.4)
+        return canvas
+    }
+
+    func updateUIView(_ uiView: PKCanvasView, context: Context) {
+        uiView.delegate = context.coordinator
+    }
+
+    final class Coordinator: NSObject, PKCanvasViewDelegate {
+        private let onCommit: ([TaburaInkStroke]) -> Void
+        private var lastStrokeCount = 0
+
+        init(onCommit: @escaping ([TaburaInkStroke]) -> Void) {
+            self.onCommit = onCommit
+        }
+
+        func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+            let drawing = canvasView.drawing
+            guard drawing.strokes.count > lastStrokeCount else {
+                return
+            }
+            let newStrokes = Array(drawing.strokes[lastStrokeCount...]).map { stroke in
+                TaburaInkStroke(
+                    pointerType: "pencil",
+                    width: Double(stroke.ink.width),
+                    points: stroke.path.map { point in
+                        TaburaInkPoint(
+                            x: point.location.x,
+                            y: point.location.y,
+                            pressure: Double(point.force),
+                            tiltX: Double(point.azimuth),
+                            tiltY: Double(point.altitude),
+                            roll: 0,
+                            timestampMS: point.timeOffset * 1000
+                        )
+                    }
+                )
+            }.filter { !$0.points.isEmpty }
+            lastStrokeCount = drawing.strokes.count
+            guard !newStrokes.isEmpty else {
+                return
+            }
+            onCommit(newStrokes)
+        }
+    }
+}

--- a/platforms/ios/TaburaIOS/TaburaModels.swift
+++ b/platforms/ios/TaburaIOS/TaburaModels.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+struct TaburaLoginRequest: Encodable {
+    let password: String
+}
+
+struct TaburaWorkspaceListResponse: Decodable {
+    let ok: Bool
+    let activeWorkspaceID: String
+    let workspaces: [TaburaWorkspace]
+
+    private enum CodingKeys: String, CodingKey {
+        case ok
+        case activeWorkspaceID = "active_workspace_id"
+        case workspaces
+    }
+}
+
+struct TaburaWorkspace: Decodable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let rootPath: String
+    let chatSessionID: String
+    let canvasSessionID: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case rootPath = "root_path"
+        case chatSessionID = "chat_session_id"
+        case canvasSessionID = "canvas_session_id"
+    }
+}
+
+struct TaburaChatHistoryResponse: Decodable {
+    let messages: [TaburaPersistedMessage]
+}
+
+struct TaburaPersistedMessage: Decodable, Identifiable {
+    let id: Int64
+    let role: String
+    let contentMarkdown: String
+    let contentPlain: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case role
+        case contentMarkdown = "content_markdown"
+        case contentPlain = "content_plain"
+    }
+
+    var content: String {
+        if contentMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return contentMarkdown
+        }
+        return contentPlain
+    }
+}
+
+struct TaburaChatSendRequest: Encodable {
+    let text: String
+    let outputMode: String
+
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case outputMode = "output_mode"
+    }
+}
+
+struct TaburaRenderedMessage: Identifiable, Equatable {
+    let id: String
+    let role: String
+    let text: String
+    let html: String
+}
+
+struct TaburaCanvasArtifact: Equatable {
+    let kind: String
+    let title: String
+    let html: String
+    let text: String
+}
+
+struct TaburaCanvasSnapshotResponse: Decodable {
+    let event: TaburaCanvasEventPayload?
+}
+
+struct TaburaCanvasEventPayload: Decodable {
+    let kind: String?
+    let title: String?
+    let html: String?
+    let text: String?
+    let markdownOrText: String?
+    let path: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case title
+        case html
+        case text
+        case markdownOrText = "markdown_or_text"
+        case path
+    }
+}
+
+struct TaburaChatEventPayload: Decodable {
+    let type: String
+    let turnID: String?
+    let role: String?
+    let message: String?
+    let markdown: String?
+    let html: String?
+    let error: String?
+    let text: String?
+    let reason: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case turnID = "turn_id"
+        case role
+        case message
+        case markdown
+        case html
+        case error
+        case text
+        case reason
+    }
+}
+
+struct TaburaAudioCaptureMessage: Encodable {
+    let type: String
+    let mimeType: String?
+    let data: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case mimeType = "mime_type"
+        case data
+    }
+}
+
+struct TaburaInkPoint: Encodable {
+    let x: Double
+    let y: Double
+    let pressure: Double
+    let tiltX: Double
+    let tiltY: Double
+    let roll: Double
+    let timestampMS: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case x
+        case y
+        case pressure
+        case tiltX = "tilt_x"
+        case tiltY = "tilt_y"
+        case roll
+        case timestampMS = "timestamp_ms"
+    }
+}
+
+struct TaburaInkStroke: Encodable {
+    let pointerType: String
+    let width: Double
+    let points: [TaburaInkPoint]
+
+    private enum CodingKeys: String, CodingKey {
+        case pointerType = "pointer_type"
+        case width
+        case points
+    }
+}
+
+struct TaburaInkCommitMessage: Encodable {
+    let type: String
+    let artifactKind: String
+    let requestResponse: Bool
+    let outputMode: String
+    let totalStrokes: Int
+    let strokes: [TaburaInkStroke]
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case artifactKind = "artifact_kind"
+        case requestResponse = "request_response"
+        case outputMode = "output_mode"
+        case totalStrokes = "total_strokes"
+        case strokes
+    }
+}
+
+struct TaburaDiscoveredServer: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let host: String
+    let port: Int
+
+    var baseURLString: String {
+        "http://\(host):\(port)"
+    }
+}
+
+func taburaWSURL(baseURL: URL, path: String) -> URL? {
+    guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+        return nil
+    }
+    components.scheme = components.scheme == "https" ? "wss" : "ws"
+    components.path = "/ws/" + path
+    return components.url
+}
+
+func taburaAPIURL(baseURL: URL, path: String) -> URL {
+    baseURL.appending(path: "api/" + path)
+}
+
+func taburaCanvasHTML(from payload: TaburaCanvasEventPayload) -> String {
+    if let html = payload.html, html.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+        return html
+    }
+    let text = payload.markdownOrText ?? payload.text ?? ""
+    let escaped = text
+        .replacingOccurrences(of: "&", with: "&amp;")
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+    return "<pre style=\"white-space: pre-wrap; font: -apple-system-body; margin: 24px;\">\(escaped)</pre>"
+}

--- a/platforms/ios/TaburaIOS/TaburaServerDiscovery.swift
+++ b/platforms/ios/TaburaIOS/TaburaServerDiscovery.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+final class TaburaServerDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate, NetServiceDelegate {
+    @Published private(set) var servers: [TaburaDiscoveredServer] = []
+
+    private var browser: NetServiceBrowser?
+    private var discovered: [String: TaburaDiscoveredServer] = [:]
+    private var services: [String: NetService] = [:]
+
+    func start() {
+        if browser != nil {
+            return
+        }
+        let browser = NetServiceBrowser()
+        browser.delegate = self
+        self.browser = browser
+        browser.searchForServices(ofType: "_tabura._tcp.", inDomain: "local.")
+    }
+
+    func stop() {
+        browser?.stop()
+        browser = nil
+        discovered = [:]
+        services = [:]
+        servers = []
+    }
+
+    func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
+        let key = "\(service.name).\(service.type)\(service.domain)"
+        services[key] = service
+        service.delegate = self
+        service.resolve(withTimeout: 5)
+        if !moreComing {
+            publishServers()
+        }
+    }
+
+    func netServiceBrowser(_ browser: NetServiceBrowser, didRemove service: NetService, moreComing: Bool) {
+        let key = "\(service.name).\(service.type)\(service.domain)"
+        services.removeValue(forKey: key)
+        discovered = discovered.filter { _, value in value.name != service.name }
+        if !moreComing {
+            publishServers()
+        }
+    }
+
+    func netServiceDidResolveAddress(_ sender: NetService) {
+        guard let host = sender.hostName?.trimmingCharacters(in: .whitespacesAndNewlines), host.isEmpty == false else {
+            return
+        }
+        let cleanHost = host.hasSuffix(".") ? String(host.dropLast()) : host
+        let id = "\(sender.name)-\(cleanHost)-\(sender.port)"
+        discovered[id] = TaburaDiscoveredServer(id: id, name: sender.name, host: cleanHost, port: sender.port)
+        publishServers()
+    }
+
+    func netService(_ sender: NetService, didNotResolve errorDict: [String : NSNumber]) {
+        _ = sender
+        _ = errorDict
+    }
+
+    private func publishServers() {
+        servers = discovered.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+}

--- a/platforms/ios/project_files_test.go
+++ b/platforms/ios/project_files_test.go
@@ -1,0 +1,69 @@
+package ios
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTaburaIOSProjectIncludesExpectedFiles(t *testing.T) {
+	projectRoot, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	projectFile := filepath.Join(projectRoot, "TaburaIOS.xcodeproj", "project.pbxproj")
+	data, err := os.ReadFile(projectFile)
+	if err != nil {
+		t.Fatalf("ReadFile(project): %v", err)
+	}
+	project := string(data)
+	expected := []string{
+		"TaburaIOSApp.swift",
+		"ContentView.swift",
+		"TaburaAppModel.swift",
+		"TaburaModels.swift",
+		"TaburaServerDiscovery.swift",
+		"TaburaChatTransport.swift",
+		"TaburaCanvasTransport.swift",
+		"TaburaAudioCapture.swift",
+		"TaburaInkCaptureView.swift",
+		"TaburaCanvasWebView.swift",
+		"Info.plist",
+	}
+	for _, name := range expected {
+		path := filepath.Join(projectRoot, "TaburaIOS", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing expected file %q: %v", path, err)
+		}
+		if !strings.Contains(project, name) {
+			t.Fatalf("project.pbxproj missing reference to %q", name)
+		}
+	}
+}
+
+func TestTaburaIOSInfoPlistDeclaresMobileCapabilities(t *testing.T) {
+	projectRoot, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	infoPath := filepath.Join(projectRoot, "TaburaIOS", "Info.plist")
+	data, err := os.ReadFile(infoPath)
+	if err != nil {
+		t.Fatalf("ReadFile(Info.plist): %v", err)
+	}
+	info := string(data)
+	requiredSnippets := []string{
+		"<key>UIBackgroundModes</key>",
+		"<string>audio</string>",
+		"<key>NSBonjourServices</key>",
+		"<string>_tabura._tcp</string>",
+		"<key>NSMicrophoneUsageDescription</key>",
+		"<key>NSLocalNetworkUsageDescription</key>",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(info, snippet) {
+			t.Fatalf("Info.plist missing %q", snippet)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a real `platforms/ios/` thin-client source tree for Tabura and closes the remaining server-side native-client gap by accepting `ink_stroke` websocket messages alongside the existing canvas ink flow.

## Verification

- Native iOS thin client exists under `platforms/ios/` with an openable Xcode project and app source tree.
  Evidence: `platforms/ios/TaburaIOS.xcodeproj/project.pbxproj`, `platforms/ios/TaburaIOS/TaburaIOSApp.swift`, `platforms/ios/TaburaIOS/ContentView.swift`, `platforms/ios/TaburaIOS/TaburaAppModel.swift`.
- PencilKit ink capture is wired to the shared thin-client websocket contract.
  Evidence: `platforms/ios/TaburaIOS/TaburaInkCaptureView.swift` serializes strokes to `ink_stroke`; `internal/web/chat_stt.go` now accepts `ink_stroke`; `go test ./internal/web ./platforms/ios -run 'TestHandleChatWSTextMessage_(CanvasInkQueuesRequestedTurnAndPersistsSnapshot|InkStrokeAliasQueuesRequestedTurn)|TestTaburaIOS(ProjectIncludesExpectedFiles|InfoPlistDeclaresMobileCapabilities)$'` -> `ok   github.com/krystophny/tabura/internal/web`.
- Background audio capture and mobile runtime declarations are present.
  Evidence: `platforms/ios/TaburaIOS/TaburaAudioCapture.swift` configures `AVAudioSession` + PCM upload; `platforms/ios/TaburaIOS/Info.plist` declares `UIBackgroundModes` audio, Bonjour, local-network, and microphone usage; `go test ...` -> `ok   github.com/krystophny/tabura/platforms/ios`.
- Native chat/canvas rendering and server discovery are implemented against the existing server surface.
  Evidence: `platforms/ios/TaburaIOS/TaburaChatTransport.swift`, `platforms/ios/TaburaIOS/TaburaCanvasTransport.swift`, `platforms/ios/TaburaIOS/TaburaCanvasWebView.swift`, `platforms/ios/TaburaIOS/TaburaServerDiscovery.swift`.

## Notes

- Xcode/iOS runtime compilation was not runnable in this Linux environment, so verification here is the focused Go test coverage above plus the machine-checked project/Info.plist assertions under `platforms/ios/project_files_test.go`.
