### PR TITLE
fix: Onyx Boox e-ink support with TouchHelper RawDrawing (fixes #635)

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0")
     implementation("androidx.webkit:webkit:1.13.0")
+    implementation("com.onyx.android.sdk:onyxsdk-device:1.1.11")
+    implementation("com.onyx.android.sdk:onyxsdk-pen:1.2.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/MainActivity.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -160,6 +161,11 @@ private fun TaburaAndroidApp(
     onInkCommit: (List<TaburaInkStroke>) -> Unit,
     onInkRequestsResponseChanged: (Boolean) -> Unit,
 ) {
+    val context = LocalContext.current
+    val displayProfile = remember(context) {
+        detectTaburaDisplayProfile(context)
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -204,6 +210,9 @@ private fun TaburaAndroidApp(
                 }
                 Text(state.statusText, style = MaterialTheme.typography.bodySmall)
             }
+            if (displayProfile.isBoox) {
+                Text("Boox E-Ink mode active", style = MaterialTheme.typography.bodySmall)
+            }
             if (state.lastError.isNotBlank()) {
                 Text(state.lastError, color = MaterialTheme.colorScheme.error)
             }
@@ -243,17 +252,27 @@ private fun TaburaAndroidApp(
             TaburaCanvasWebView(
                 html = state.canvas.html,
                 baseUrl = state.serverUrl,
+                isEinkDisplay = displayProfile.isBoox,
                 modifier = Modifier.fillMaxSize(),
             )
             AndroidView(
                 modifier = Modifier.fillMaxSize(),
                 factory = { context ->
-                    TaburaInkSurfaceView(context).apply {
-                        setOnCommit(onInkCommit)
+                    if (displayProfile.isBoox) {
+                        TaburaBooxInkSurfaceView(context).apply {
+                            setOnCommit(onInkCommit)
+                        }
+                    } else {
+                        TaburaInkSurfaceView(context).apply {
+                            setOnCommit(onInkCommit)
+                        }
                     }
                 },
                 update = { view ->
-                    view.setOnCommit(onInkCommit)
+                    when (view) {
+                        is TaburaBooxInkSurfaceView -> view.setOnCommit(onInkCommit)
+                        is TaburaInkSurfaceView -> view.setOnCommit(onInkCommit)
+                    }
                 },
             )
         }
@@ -304,7 +323,6 @@ private fun TaburaAndroidApp(
             Button(onClick = onSendComposer) {
                 Text("Send")
             }
-            val context = LocalContext.current
             Text(
                 text = context.packageName,
                 style = MaterialTheme.typography.bodySmall,

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxDevice.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxDevice.kt
@@ -1,0 +1,119 @@
+package com.tabura.android
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.view.View
+import android.webkit.WebView
+
+data class TaburaDisplayProfile(
+    val isBoox: Boolean,
+)
+
+fun detectTaburaDisplayProfile(context: Context): TaburaDisplayProfile {
+    return TaburaDisplayProfile(isBoox = isBooxDevice(context))
+}
+
+private fun isBooxDevice(context: Context): Boolean {
+    if (Build.MANUFACTURER.lowercase() == "onyx") {
+        return true
+    }
+    return hasOnyxSdkPackage(context) || hasClass("com.onyx.android.sdk.pen.TouchHelper")
+}
+
+private fun hasOnyxSdkPackage(context: Context): Boolean {
+    val packageManager = context.packageManager
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        runCatching {
+            packageManager.getPackageInfo(
+                "com.onyx.android.sdk",
+                PackageManager.PackageInfoFlags.of(0),
+            )
+            true
+        }.getOrDefault(false)
+    } else {
+        @Suppress("DEPRECATION")
+        runCatching {
+            packageManager.getPackageInfo("com.onyx.android.sdk", 0)
+            true
+        }.getOrDefault(false)
+    }
+}
+
+private fun hasClass(name: String): Boolean {
+    return runCatching {
+        Class.forName(name)
+        true
+    }.getOrDefault(false)
+}
+
+object TaburaBooxEinkController {
+    fun configureInkView(view: View) {
+        setViewDefaultUpdateMode(view, "DU")
+    }
+
+    fun configureContentView(view: View) {
+        setViewDefaultUpdateMode(view, "GC16", "GC")
+    }
+
+    fun refreshContentView(view: View) {
+        if (invokeController("applyGCOnce", arrayOf(View::class.java), arrayOf(view))) {
+            return
+        }
+        if (invokeController("applyGCOnce", emptyArray<Class<*>>(), emptyArray<Any>())) {
+            return
+        }
+        invalidate(view, "GC16", "GC")
+    }
+
+    fun setWebViewContrastOptimize(view: WebView, enabled: Boolean) {
+        invokeController(
+            "setWebViewContrastOptimize",
+            arrayOf(WebView::class.java, Boolean::class.javaPrimitiveType ?: Boolean::class.java),
+            arrayOf(view, enabled),
+        )
+    }
+
+    private fun setViewDefaultUpdateMode(view: View, vararg modeNames: String) {
+        val mode = resolveUpdateMode(*modeNames) ?: return
+        invokeController(
+            "setViewDefaultUpdateMode",
+            arrayOf(View::class.java, mode.javaClass),
+            arrayOf(view, mode),
+        )
+    }
+
+    private fun invalidate(view: View, vararg modeNames: String) {
+        val mode = resolveUpdateMode(*modeNames) ?: return
+        invokeController(
+            "invalidate",
+            arrayOf(View::class.java, mode.javaClass),
+            arrayOf(view, mode),
+        )
+    }
+
+    private fun resolveUpdateMode(vararg modeNames: String): Any? {
+        val enumClass = runCatching {
+            Class.forName("com.onyx.android.sdk.api.device.epd.EpdController\$UpdateMode")
+        }.getOrNull() ?: return null
+        val constants = enumClass.enumConstants ?: return null
+        for (modeName in modeNames) {
+            constants.firstOrNull { (it as Enum<*>).name == modeName }?.let { return it }
+        }
+        return null
+    }
+
+    private fun invokeController(
+        methodName: String,
+        parameterTypes: Array<Class<*>>,
+        args: Array<Any>,
+    ): Boolean {
+        val controllerClass = runCatching {
+            Class.forName("com.onyx.android.sdk.api.device.epd.EpdController")
+        }.getOrNull() ?: return false
+        return runCatching {
+            controllerClass.getMethod(methodName, *parameterTypes).invoke(null, *args)
+            true
+        }.getOrDefault(false)
+    }
+}

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxInkSurfaceView.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxInkSurfaceView.kt
@@ -1,0 +1,207 @@
+package com.tabura.android
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.View
+import com.onyx.android.sdk.data.note.TouchPoint
+import com.onyx.android.sdk.pen.RawInputCallback
+import com.onyx.android.sdk.pen.TouchHelper
+import com.onyx.android.sdk.pen.data.TouchPointList
+
+class TaburaBooxInkSurfaceView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : View(context, attrs) {
+    private var touchHelper: TouchHelper? = null
+    private val rawPoints = mutableListOf<TaburaInkPoint>()
+    private var onCommit: (List<TaburaInkStroke>) -> Unit = {}
+
+    private val callback = object : RawInputCallback {
+        override fun onBeginRawDrawing(active: Boolean, touchPoint: TouchPoint) {
+            rawPoints.clear()
+            rawPoints += touchPoint.toInkPoint()
+            TaburaBooxEinkController.configureInkView(this@TaburaBooxInkSurfaceView)
+        }
+
+        override fun onEndRawDrawing(active: Boolean, touchPoint: TouchPoint) {
+            rawPoints += touchPoint.toInkPoint()
+            emitStroke()
+        }
+
+        override fun onRawDrawingTouchPointMoveReceived(touchPoint: TouchPoint) {
+            rawPoints += touchPoint.toInkPoint()
+        }
+
+        override fun onRawDrawingTouchPointListReceived(touchPointList: TouchPointList) {
+            rawPoints += touchPointList.toInkPoints()
+        }
+
+        override fun onBeginRawErasing(active: Boolean, touchPoint: TouchPoint) {
+        }
+
+        override fun onEndRawErasing(active: Boolean, touchPoint: TouchPoint) {
+        }
+
+        override fun onRawErasingTouchPointMoveReceived(touchPoint: TouchPoint) {
+        }
+
+        override fun onRawErasingTouchPointListReceived(touchPointList: TouchPointList) {
+        }
+    }
+
+    init {
+        setBackgroundColor(Color.TRANSPARENT)
+        isClickable = true
+        isFocusable = true
+        addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+            if (right - left != oldRight - oldLeft || bottom - top != oldBottom - oldTop) {
+                restartRawDrawing()
+            }
+        }
+    }
+
+    fun setOnCommit(listener: (List<TaburaInkStroke>) -> Unit) {
+        onCommit = listener
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        post { ensureTouchHelper() }
+    }
+
+    override fun onDetachedFromWindow() {
+        shutdownTouchHelper()
+        super.onDetachedFromWindow()
+    }
+
+    override fun onWindowVisibilityChanged(visibility: Int) {
+        super.onWindowVisibilityChanged(visibility)
+        touchHelper?.setRawDrawingEnabled(visibility == VISIBLE)
+    }
+
+    private fun restartRawDrawing() {
+        if (!isAttachedToWindow) {
+            return
+        }
+        shutdownTouchHelper()
+        post { ensureTouchHelper() }
+    }
+
+    private fun ensureTouchHelper() {
+        if (touchHelper != null || width == 0 || height == 0) {
+            return
+        }
+        val limit = Rect()
+        getLocalVisibleRect(limit)
+        val helper = TouchHelper.create(this, callback)
+        helper.setStrokeWidth(DEFAULT_STROKE_WIDTH)
+        helper.setUseRawInput(true)
+        helper.setLimitRect(limit, emptyList<Rect>())
+        helper.openRawDrawing()
+        helper.setRawDrawingEnabled(true)
+        if (windowVisibility != VISIBLE) {
+            helper.setRawDrawingEnabled(false)
+        }
+        touchHelper = helper
+        TaburaBooxEinkController.configureInkView(this)
+    }
+
+    private fun shutdownTouchHelper() {
+        val helper = touchHelper ?: return
+        runCatching { helper.setRawDrawingEnabled(false) }
+        runCatching { helper.closeRawDrawing() }
+        touchHelper = null
+    }
+
+    private fun emitStroke() {
+        val points = rawPoints
+            .distinctBy { listOf(it.x, it.y, it.timestampMs) }
+            .toList()
+        rawPoints.clear()
+        if (points.isEmpty()) {
+            return
+        }
+        onCommit(
+            listOf(
+                TaburaInkStroke(
+                    pointerType = "stylus",
+                    width = points.maxOf { it.pressure.coerceAtLeast(1f) } * 2.4f,
+                    points = points,
+                )
+            )
+        )
+    }
+
+    private fun TouchPointList.toInkPoints(): List<TaburaInkPoint> {
+        val points = readIterable(this, "getPoints", "points")
+        return points
+            ?.mapNotNull { point -> (point as? TouchPoint)?.toInkPoint() }
+            .orEmpty()
+    }
+
+    private fun TouchPoint.toInkPoint(): TaburaInkPoint {
+        val timestamp = readLong(this, "getTimestamp", "timestamp", "getEventTime", "eventTime")
+            ?: System.currentTimeMillis()
+        return TaburaInkPoint(
+            x = readFloat(this, "getX", "x") ?: 0f,
+            y = readFloat(this, "getY", "y") ?: 0f,
+            pressure = readFloat(this, "getPressure", "pressure") ?: 1f,
+            tiltX = readFloat(this, "getTiltX", "tiltX") ?: 0f,
+            tiltY = readFloat(this, "getTiltY", "tiltY") ?: 0f,
+            roll = readFloat(this, "getOrientation", "orientation") ?: 0f,
+            timestampMs = timestamp,
+        )
+    }
+
+    private fun readFloat(target: Any, vararg accessors: String): Float? {
+        return readNumber(target, *accessors)?.toFloat()
+    }
+
+    private fun readLong(target: Any, vararg accessors: String): Long? {
+        return readNumber(target, *accessors)?.toLong()
+    }
+
+    private fun readNumber(target: Any, vararg accessors: String): Number? {
+        for (accessor in accessors) {
+            runCatching {
+                target.javaClass.methods
+                    .firstOrNull { it.name == accessor && it.parameterCount == 0 }
+                    ?.invoke(target) as? Number
+            }.getOrNull()?.let { return it }
+            runCatching {
+                target.javaClass.getField(accessor).get(target) as? Number
+            }.getOrNull()?.let { return it }
+            runCatching {
+                target.javaClass.getDeclaredField(accessor).apply {
+                    isAccessible = true
+                }.get(target) as? Number
+            }.getOrNull()?.let { return it }
+        }
+        return null
+    }
+
+    private fun readIterable(target: Any, vararg accessors: String): Iterable<*>? {
+        for (accessor in accessors) {
+            runCatching {
+                target.javaClass.methods
+                    .firstOrNull { it.name == accessor && it.parameterCount == 0 }
+                    ?.invoke(target) as? Iterable<*>
+            }.getOrNull()?.let { return it }
+            runCatching {
+                target.javaClass.getField(accessor).get(target) as? Iterable<*>
+            }.getOrNull()?.let { return it }
+            runCatching {
+                target.javaClass.getDeclaredField(accessor).apply {
+                    isAccessible = true
+                }.get(target) as? Iterable<*>
+            }.getOrNull()?.let { return it }
+        }
+        return null
+    }
+
+    private companion object {
+        const val DEFAULT_STROKE_WIDTH = 3.0f
+    }
+}

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaCanvasWebView.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaCanvasWebView.kt
@@ -1,5 +1,6 @@
 package com.tabura.android
 
+import android.content.Context
 import android.graphics.Color
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -11,22 +12,143 @@ import androidx.compose.ui.viewinterop.AndroidView
 fun TaburaCanvasWebView(
     html: String,
     baseUrl: String,
+    isEinkDisplay: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
+    val renderedHtml = if (isEinkDisplay) {
+        applyEinkDisplayHtml(html)
+    } else {
+        html
+    }
     AndroidView(
         modifier = modifier,
         factory = { context ->
-            WebView(context).apply {
+            TaburaCanvasDisplayWebView(context).apply {
                 setBackgroundColor(Color.TRANSPARENT)
                 settings.javaScriptEnabled = false
                 settings.allowFileAccess = false
                 settings.allowContentAccess = false
                 settings.domStorageEnabled = false
-                webViewClient = WebViewClient()
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) {
+                        super.onPageFinished(view, url)
+                        (view as? TaburaCanvasDisplayWebView)?.onContentRendered()
+                    }
+                }
             }
         },
         update = { view ->
-            view.loadDataWithBaseURL(baseUrl, html, "text/html", "utf-8", null)
+            view.setEinkDisplay(isEinkDisplay)
+            view.loadDataWithBaseURL(baseUrl, renderedHtml, "text/html", "utf-8", null)
         },
     )
 }
+
+private class TaburaCanvasDisplayWebView(
+    context: Context,
+) : WebView(context) {
+    private var isEinkDisplay = false
+    private var pendingRefresh: Runnable? = null
+
+    fun setEinkDisplay(enabled: Boolean) {
+        isEinkDisplay = enabled
+        if (enabled) {
+            TaburaBooxEinkController.configureContentView(this)
+            TaburaBooxEinkController.setWebViewContrastOptimize(this, true)
+            return
+        }
+        pendingRefresh?.let(::removeCallbacks)
+        pendingRefresh = null
+        TaburaBooxEinkController.setWebViewContrastOptimize(this, false)
+    }
+
+    fun onContentRendered() {
+        if (!isEinkDisplay) {
+            return
+        }
+        TaburaBooxEinkController.configureContentView(this)
+        scheduleRefresh()
+    }
+
+    override fun onDetachedFromWindow() {
+        pendingRefresh?.let(::removeCallbacks)
+        pendingRefresh = null
+        super.onDetachedFromWindow()
+    }
+
+    private fun scheduleRefresh() {
+        pendingRefresh?.let(::removeCallbacks)
+        val refresh = Runnable {
+            TaburaBooxEinkController.refreshContentView(this)
+        }
+        pendingRefresh = refresh
+        postDelayed(refresh, 160L)
+    }
+}
+
+private fun applyEinkDisplayHtml(html: String): String {
+    val withBodyClass = when {
+        BODY_TAG.containsMatchIn(html) -> BODY_TAG.replaceFirst(html) { match ->
+            val attributes = match.groupValues[1]
+            if (BODY_CLASS_TAG.containsMatchIn(attributes)) {
+                "<body${BODY_CLASS_TAG.replaceFirst(attributes) { classMatch ->
+                    val classes = classMatch.groupValues[1]
+                        .split(Regex("\\s+"))
+                        .filter { it.isNotBlank() }
+                        .toMutableList()
+                    if (!classes.contains("eink-display")) {
+                        classes += "eink-display"
+                    }
+                    " class=\"${classes.joinToString(" ")}\""
+                }}>"
+            } else {
+                "<body$attributes class=\"eink-display\">"
+            }
+        }
+        else -> "<html><body class=\"eink-display\">$html</body></html>"
+    }
+    return if (HEAD_END_TAG.containsMatchIn(withBodyClass)) {
+        HEAD_END_TAG.replaceFirst(withBodyClass, "$EINK_STYLE</head>")
+    } else {
+        BODY_TAG.replaceFirst(withBodyClass, "<head>$EINK_STYLE</head>$0")
+    }
+}
+
+private val BODY_TAG = Regex("<body([^>]*)>", RegexOption.IGNORE_CASE)
+private val BODY_CLASS_TAG = Regex("class\\s*=\\s*\"([^\"]*)\"", RegexOption.IGNORE_CASE)
+private val HEAD_END_TAG = Regex("</head>", RegexOption.IGNORE_CASE)
+private val EINK_STYLE = """
+<style>
+html, body {
+  background: #fff !important;
+  color: #000 !important;
+}
+body.eink-display,
+body.eink-display * {
+  transition: none !important;
+  animation: none !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+  filter: none !important;
+  scroll-behavior: auto !important;
+}
+body.eink-display a,
+body.eink-display pre,
+body.eink-display code,
+body.eink-display table,
+body.eink-display th,
+body.eink-display td,
+body.eink-display blockquote,
+body.eink-display hr {
+  color: #000 !important;
+  border-color: #000 !important;
+}
+body.eink-display [style*="gradient"],
+body.eink-display [style*="opacity"],
+body.eink-display [style*="shadow"] {
+  background: #fff !important;
+  opacity: 1 !important;
+}
+</style>
+""".trimIndent()

--- a/platforms/android/project_files_test.go
+++ b/platforms/android/project_files_test.go
@@ -21,6 +21,8 @@ func TestTaburaAndroidProjectIncludesExpectedFiles(t *testing.T) {
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "MainActivity.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaAppModel.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaAudioCaptureService.kt"),
+		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaBooxDevice.kt"),
+		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaBooxInkSurfaceView.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaCanvasTransport.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaCanvasWebView.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaChatTransport.kt"),
@@ -82,12 +84,29 @@ func TestTaburaAndroidBuildIncludesRealtimeInkStack(t *testing.T) {
 		"androidx.graphics:graphics-core",
 		"androidx.input:input-motionprediction",
 		"androidx.webkit:webkit",
+		"com.onyx.android.sdk:onyxsdk-device:1.1.11",
+		"com.onyx.android.sdk:onyxsdk-pen:1.2.1",
 		"com.squareup.okhttp3:okhttp",
 	}
 	for _, snippet := range required {
 		if !strings.Contains(buildFile, snippet) {
 			t.Fatalf("app/build.gradle.kts missing %q", snippet)
 		}
+	}
+}
+
+func TestTaburaAndroidBuildIncludesBooxRepository(t *testing.T) {
+	projectRoot, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(projectRoot, "settings.gradle.kts"))
+	if err != nil {
+		t.Fatalf("ReadFile(settings.gradle.kts): %v", err)
+	}
+	settings := string(data)
+	if !strings.Contains(settings, "https://repo.boox.com/repository/maven-public/") {
+		t.Fatalf("settings.gradle.kts missing Boox Maven repository")
 	}
 }
 
@@ -126,7 +145,28 @@ func TestTaburaAndroidSourcesCoverThinClientResponsibilities(t *testing.T) {
 		},
 		{
 			relative: filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaCanvasWebView.kt"),
-			snippets: []string{"WebView", "loadDataWithBaseURL"},
+			snippets: []string{"WebView", "loadDataWithBaseURL", "body.eink-display", "scroll-behavior: auto !important"},
+		},
+		{
+			relative: filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaBooxDevice.kt"),
+			snippets: []string{
+				"Build.MANUFACTURER.lowercase() == \"onyx\"",
+				"setViewDefaultUpdateMode",
+				"applyGCOnce",
+				"setWebViewContrastOptimize",
+			},
+		},
+		{
+			relative: filepath.Join("app", "src", "main", "kotlin", "com", "tabura", "android", "TaburaBooxInkSurfaceView.kt"),
+			snippets: []string{
+				"TouchHelper.create",
+				"setUseRawInput(true)",
+				"openRawDrawing",
+				"setRawDrawingEnabled(true)",
+				"closeRawDrawing",
+				"onRawDrawingTouchPointListReceived",
+				"TaburaInkStroke",
+			},
 		},
 	}
 	for _, check := range checks {

--- a/platforms/android/settings.gradle.kts
+++ b/platforms/android/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://repo.boox.com/repository/maven-public/")
     }
 }
 


### PR DESCRIPTION
## Summary
- add the Onyx Boox Maven repository and SDK dependencies to the Android thin client project
- detect Boox hardware, route ink capture through `TouchHelper` raw drawing, and keep stroke commits in Tabura's existing `ink_stroke` payload shape
- inject an e-ink WebView mode that disables motion-heavy styling and triggers Boox refresh handling for server-rendered canvas content
- extend the Android project coverage tests so the Boox path is enforced in CI-visible source checks

## Verification
- Boox SDK wiring: `go test ./platforms/android 2>&1 | tee /tmp/issue-635-tabura-android.log` passed with `ok   github.com/krystophny/tabura/platforms/android  0.002s`; this covers `TestTaburaAndroidBuildIncludesRealtimeInkStack` and `TestTaburaAndroidBuildIncludesBooxRepository`, which assert the `repo.boox.com` repository plus `onyxsdk-device:1.1.11` and `onyxsdk-pen:1.2.1`.
- Device detection: the same test run covers `TestTaburaAndroidSourcesCoverThinClientResponsibilities`, which asserts `Build.MANUFACTURER.lowercase() == "onyx"` plus Onyx SDK availability checks in `platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxDevice.kt`.
- Raw drawing ink path: the same test run covers `TestTaburaAndroidSourcesCoverThinClientResponsibilities`, which asserts `TouchHelper.create`, `setUseRawInput(true)`, `openRawDrawing`, `setRawDrawingEnabled(true)`, `closeRawDrawing`, and `TaburaInkStroke` emission in `platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxInkSurfaceView.kt`.
- E-ink canvas rendering: the same test run covers `TestTaburaAndroidSourcesCoverThinClientResponsibilities`, which asserts `body.eink-display`, `scroll-behavior: auto !important`, and WebView render loading in `platforms/android/app/src/main/kotlin/com/tabura/android/TaburaCanvasWebView.kt`.
- Test log artifact: `/tmp/issue-635-tabura-android.log`
