### PR TITLE
fix: CI: Test Reports workflow spends long tail time in report (fixes #692)

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Verify chat prompt contract
         run: ./scripts/check-chat-prompt-contract.sh
 
+      - name: Verify Test Reports workflow gating
+        run: npm run test:workflow-config
+
       - name: Run shared UI flow suite
         env:
           PLAYWRIGHT_GREP_INVERT: "@local-only"
@@ -53,6 +56,7 @@ jobs:
         run: npm run test:e2e:ci
 
       - name: Generate coverage + E2E reports
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           TABURA_COVERAGE_MIN_TOTAL: "50.0"
           TABURA_COVERAGE_MIN_PACKAGES: "github.com/krystophny/tabura/internal/web=52.0,github.com/krystophny/tabura/internal/serve=40.0,github.com/krystophny/tabura/cmd/tabura=35.0,github.com/krystophny/tabura/internal/store=70.0,github.com/krystophny/tabura/internal/protocol=70.0,github.com/krystophny/tabura/internal/surface=70.0"
@@ -60,7 +64,7 @@ jobs:
         run: ./scripts/test-reports.sh
 
       - name: Upload test reports
-        if: always()
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: tabura-test-reports

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:flows": "node ./tests/flows/validate.cjs && node ./tests/flows/coverage.cjs && npx playwright test tests/playwright/flow-runner.spec.ts",
     "test:playtest": "./scripts/playtest.sh",
     "test:reports": "./scripts/test-reports.sh",
+    "test:workflow-config": "node ./scripts/check-test-reports-workflow.mjs",
     "typecheck:frontend": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/scripts/check-test-reports-workflow.mjs
+++ b/scripts/check-test-reports-workflow.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+
+const workflowPath = path.join(process.cwd(), '.github', 'workflows', 'test-reports.yml');
+const workflow = YAML.parse(fs.readFileSync(workflowPath, 'utf8'));
+const errors = [];
+
+if (workflow?.name !== 'Test Reports') {
+  errors.push(`expected workflow name "Test Reports", got ${JSON.stringify(workflow?.name)}`);
+}
+
+const pullRequest = workflow?.on?.pull_request;
+const pushBranches = workflow?.on?.push?.branches;
+if (pullRequest === undefined) {
+  errors.push('expected pull_request trigger');
+}
+if (!Array.isArray(pushBranches) || !pushBranches.includes('main')) {
+  errors.push('expected push trigger for main');
+}
+
+const steps = workflow?.jobs?.reports?.steps;
+if (!Array.isArray(steps)) {
+  errors.push('expected jobs.reports.steps array');
+}
+
+function findStep(name) {
+  return steps.find((step) => step?.name === name);
+}
+
+const reportStep = findStep('Generate coverage + E2E reports');
+const uploadStep = findStep('Upload test reports');
+const expectedGate = "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}";
+const expectedUploadGate = "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && always() }}";
+
+if (reportStep?.if !== expectedGate) {
+  errors.push(`expected report step gate ${expectedGate}, got ${JSON.stringify(reportStep?.if)}`);
+}
+if (uploadStep?.if !== expectedUploadGate) {
+  errors.push(`expected upload step gate ${expectedUploadGate}, got ${JSON.stringify(uploadStep?.if)}`);
+}
+
+if (errors.length > 0) {
+  for (const err of errors) {
+    console.error(`[workflow-check] ${err}`);
+  }
+  process.exit(1);
+}
+
+console.log('[workflow-check] Test Reports gating is limited to push events on main.');


### PR DESCRIPTION
## Summary
- keep `Test Reports` as the required PR workflow, but stop the pull-request path after `Run CI-safe E2E`
- run `Generate coverage + E2E reports` and artifact upload only on `push` to `main`
- add `npm run test:workflow-config` and call it from the workflow to lock this gating behavior in place

## Verification
- Requirement: reduce the report-generation tail on pull requests so the required signal ends with test execution.
```bash
$ npm run test:workflow-config
> test:workflow-config
> node ./scripts/check-test-reports-workflow.mjs

[workflow-check] Test Reports gating is limited to push events on main.
```
- Requirement: keep slow report generation and upload available where appropriate.
  Evidence: `.github/workflows/test-reports.yml` now gates both `Generate coverage + E2E reports` and `Upload test reports` behind `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so the report path still runs on `main` without holding PR merge state open.
- Requirement: prevent this regression from returning.
  Evidence: the workflow now executes `npm run test:workflow-config` before the UI flow and E2E suites, so CI will fail if report steps move back onto the pull-request path.
