### PR TITLE
fix: Add real producer-side email handoff protocol support (fixes #688)

### DIFF
--- a/docs/handoff-protocol/README.md
+++ b/docs/handoff-protocol/README.md
@@ -12,12 +12,14 @@ Primary goals:
 Read in this order:
 1. `spec/overview.md`
 2. `spec/lifecycle.md`
-3. `spec/security.md`
-4. `security/threat-model.md`
+3. `spec/mail.md`
+4. `spec/security.md`
+5. `security/threat-model.md`
 
 Schemas:
 - `schemas/envelope-v1.json`
 - `schemas/kind-file-v1.json`
+- `schemas/kind-mail-v1.json`
 - `schemas/error-v1.json`
 
 Conformance examples:

--- a/docs/handoff-protocol/conformance/examples/mail-envelope.json
+++ b/docs/handoff-protocol/conformance/examples/mail-envelope.json
@@ -1,0 +1,58 @@
+{
+  "spec_version": "handoff.v1",
+  "handoff_id": "mail-abc123",
+  "kind": "mail",
+  "created_at": "2026-03-22T12:00:00Z",
+  "meta": {
+    "account": {
+      "id": 42,
+      "name": "Work Mail",
+      "provider": "exchange_ews",
+      "sphere": "work"
+    },
+    "message_count": 1,
+    "message_ids": ["m1"],
+    "subjects": ["Quarterly review"],
+    "senders": ["Ada <ada@example.com>"],
+    "recipients": ["team@example.com", "ops@example.com"],
+    "dates": ["2026-03-20T09:30:00Z"],
+    "internet_message_ids": ["<m1@example.test>"],
+    "thread_ids": ["thread-1"],
+    "attachment_count": 1,
+    "contains_rich_content": true
+  },
+  "payload": {
+    "messages": [
+      {
+        "message_id": "m1",
+        "thread_id": "thread-1",
+        "internet_message_id": "<m1@example.test>",
+        "subject": "Quarterly review",
+        "sender": "Ada <ada@example.com>",
+        "recipients": ["team@example.com", "ops@example.com"],
+        "date": "2026-03-20T09:30:00Z",
+        "snippet": "Summary",
+        "labels": ["Inbox", "Important"],
+        "is_read": true,
+        "is_flagged": true,
+        "body_text": "Plain text summary",
+        "body_html": "<p>Plain text summary</p>",
+        "has_body_text": true,
+        "has_body_html": true,
+        "attachment_count": 1,
+        "recipient_count": 2,
+        "label_count": 2,
+        "contains_attachments": true,
+        "attachments": [
+          {
+            "id": "att-1",
+            "filename": "report.pdf",
+            "mime_type": "application/pdf",
+            "size": 128,
+            "is_inline": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/handoff-protocol/schemas/kind-mail-v1.json
+++ b/docs/handoff-protocol/schemas/kind-mail-v1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/handoff-protocol/schemas/kind-mail-v1.json",
+  "title": "Mail Handoff Payload",
+  "type": "object",
+  "required": ["kind", "meta", "payload"],
+  "properties": {
+    "kind": { "type": "string", "const": "mail" },
+    "meta": {
+      "type": "object",
+      "required": ["account", "message_count", "message_ids", "subjects", "senders", "recipients", "dates"],
+      "properties": {
+        "account": {
+          "type": "object",
+          "required": ["id", "name", "provider", "sphere"],
+          "properties": {
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "provider": { "type": "string" },
+            "sphere": { "type": "string" }
+          }
+        },
+        "message_count": { "type": "integer", "minimum": 1 },
+        "message_ids": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+        "subjects": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "senders": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "recipients": { "type": "array", "items": { "type": "string" } },
+        "dates": { "type": "array", "items": { "type": "string", "format": "date-time" }, "minItems": 1 },
+        "internet_message_ids": { "type": "array", "items": { "type": "string" } },
+        "thread_ids": { "type": "array", "items": { "type": "string" } },
+        "attachment_count": { "type": "integer", "minimum": 0 },
+        "contains_rich_content": { "type": "boolean" }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": ["messages"],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["message_id", "subject", "sender", "recipients", "attachments"],
+            "properties": {
+              "message_id": { "type": "string", "minLength": 1 },
+              "thread_id": { "type": "string" },
+              "internet_message_id": { "type": "string" },
+              "subject": { "type": "string" },
+              "sender": { "type": "string" },
+              "recipients": { "type": "array", "items": { "type": "string" } },
+              "date": { "type": "string", "format": "date-time" },
+              "snippet": { "type": "string" },
+              "labels": { "type": "array", "items": { "type": "string" } },
+              "is_read": { "type": "boolean" },
+              "is_flagged": { "type": "boolean" },
+              "body_text": { "type": "string" },
+              "body_html": { "type": "string" },
+              "has_body_text": { "type": "boolean" },
+              "has_body_html": { "type": "boolean" },
+              "attachment_count": { "type": "integer", "minimum": 0 },
+              "recipient_count": { "type": "integer", "minimum": 0 },
+              "label_count": { "type": "integer", "minimum": 0 },
+              "contains_attachments": { "type": "boolean" },
+              "attachments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "filename", "mime_type", "size", "is_inline"],
+                  "properties": {
+                    "id": { "type": "string" },
+                    "filename": { "type": "string" },
+                    "mime_type": { "type": "string" },
+                    "size": { "type": "integer", "minimum": 0 },
+                    "is_inline": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/handoff-protocol/spec/lifecycle.md
+++ b/docs/handoff-protocol/spec/lifecycle.md
@@ -5,8 +5,9 @@
 ## handoff.create
 
 Input:
-- `kind`: `file`
+- `kind`: producer kind such as `file` or `mail`
 - `selector`: kind-specific source selection
+  - `mail`: `account_id` plus `message_id` or `message_ids`
 - `policy` (optional): `ttl_seconds`, `expires_at`, `max_consumes`
 
 Output:

--- a/docs/handoff-protocol/spec/mail.md
+++ b/docs/handoff-protocol/spec/mail.md
@@ -1,0 +1,53 @@
+# Mail Handoff Kind
+
+> **Legal notice:** Tabura is provided "as is" and "as available" without warranties, and to the maximum extent permitted by applicable law the authors/contributors accept no liability for damages, data loss, or misuse. You are solely responsible for backups, verification, and safe operation. See [`DISCLAIMER.md`](/DISCLAIMER.md).
+
+## Producer selector
+
+Create a mail handoff with:
+- `kind: mail`
+- `selector.account_id`
+- `selector.message_id` or `selector.message_ids`
+
+Tabura resolves those message IDs through the configured mail provider and builds one envelope from normalized message metadata.
+
+## Envelope shape
+
+`meta` fields:
+- `account.id`
+- `account.name`
+- `account.provider`
+- `account.sphere`
+- `message_count`
+- `message_ids`
+- `subjects`
+- `senders`
+- `recipients`
+- `dates`
+- `internet_message_ids`
+- `thread_ids`
+- `attachment_count`
+- `contains_rich_content`
+
+`payload.messages[]` fields:
+- `message_id`
+- `thread_id`
+- `internet_message_id`
+- `subject`
+- `sender`
+- `recipients`
+- `date`
+- `snippet`
+- `labels`
+- `is_read`
+- `is_flagged`
+- `body_text` when present
+- `body_html` when present
+- `attachments[]` with `id`, `filename`, `mime_type`, `size`, `is_inline`
+
+## Downstream usage
+
+Intended consumers can:
+- inspect `meta` during routing without pulling full message bodies into unrelated flows
+- consume `payload.messages` to render mail summaries, start triage flows, or bridge into another mail-aware MCP service
+- rely on the generic lifecycle counters and revocation state exposed by `handoff.peek`, `handoff.consume`, `handoff.revoke`, and `handoff.status`

--- a/docs/handoff-protocol/spec/overview.md
+++ b/docs/handoff-protocol/spec/overview.md
@@ -21,6 +21,11 @@
 - `handoff.revoke`
 - `handoff.status`
 
+## Kind notes
+
+- `file` carries file metadata plus encoded content bytes.
+- `mail` carries normalized email metadata and message body fields for downstream mail-aware consumers.
+
 ## Required envelope fields
 
 - `spec_version` (example: `handoff.v1`)

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -219,6 +219,11 @@ Defined in `internal/surface/definitions.go` and used by `internal/mcp/server.go
 - `canvas_artifact_show`
 - `canvas_status`
 - `canvas_import_handoff`
+- `handoff.create`
+- `handoff.peek`
+- `handoff.consume`
+- `handoff.revoke`
+- `handoff.status`
 - `temp_file_create`
 - `temp_file_remove`
 - `workspace_list`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -26,6 +26,7 @@ const (
 	LatestProtocolVersion = "2025-03-26"
 	defaultProducerMCPURL = "http://127.0.0.1:8090/mcp"
 	handoffKindFile       = "file"
+	handoffKindMail       = "mail"
 	tempArtifactsDirRel   = ".tabura/artifacts/tmp"
 )
 
@@ -42,6 +43,7 @@ type RPCError struct {
 type Server struct {
 	adapter                 *canvas.Adapter
 	appServerClient         *appserver.Client
+	handoffs                *handoffRegistry
 	store                   *store.Store
 	newGoogleCalendarReader func(context.Context) (googleCalendarReader, error)
 	newEmailProvider        func(context.Context, store.ExternalAccount) (email.EmailProvider, error)
@@ -74,6 +76,7 @@ func NewServerWithStore(adapter *canvas.Adapter, st *store.Store, appServerClien
 	return &Server{
 		adapter:         adapter,
 		appServerClient: client,
+		handoffs:        newHandoffRegistry(),
 		store:           st,
 		newGoogleCalendarReader: func(ctx context.Context) (googleCalendarReader, error) {
 			return tabcalendar.New(ctx)
@@ -204,6 +207,16 @@ func (s *Server) callTool(name string, args map[string]interface{}) (map[string]
 		return s.adapter.CanvasHistory(sid, intArg(args, "limit", 20)), nil
 	case "canvas_import_handoff":
 		return s.canvasImportHandoff(sid, args)
+	case "handoff.create":
+		return s.handoffCreate(args)
+	case "handoff.peek":
+		return s.handoffPeek(args)
+	case "handoff.consume":
+		return s.handoffConsume(args)
+	case "handoff.revoke":
+		return s.handoffRevoke(args)
+	case "handoff.status":
+		return s.handoffStatus(args)
 	case "temp_file_create":
 		return s.tempFileCreate(args)
 	case "temp_file_remove":

--- a/internal/mcp/server_handoff.go
+++ b/internal/mcp/server_handoff.go
@@ -1,0 +1,446 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/krystophny/tabura/internal/email"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+const defaultHandoffMaxConsumes = 1
+
+type handoffRegistry struct {
+	mu       sync.Mutex
+	handoffs map[string]*storedHandoff
+}
+
+type storedHandoff struct {
+	envelope      handoffEnvelope
+	expiresAt     time.Time
+	maxConsumes   int
+	consumedCount int
+	revoked       bool
+}
+
+func newHandoffRegistry() *handoffRegistry {
+	return &handoffRegistry{handoffs: map[string]*storedHandoff{}}
+}
+
+func (s *Server) handoffCreate(args map[string]interface{}) (map[string]interface{}, error) {
+	kind := strings.TrimSpace(strArg(args, "kind"))
+	if kind == "" {
+		return nil, errors.New("kind is required")
+	}
+	selector, _ := args["selector"].(map[string]interface{})
+	if selector == nil {
+		return nil, errors.New("selector is required")
+	}
+	policy, _ := args["policy"].(map[string]interface{})
+	switch kind {
+	case handoffKindMail:
+		return s.mailHandoffCreate(selector, policy)
+	default:
+		return nil, fmt.Errorf("unsupported handoff kind: %s", kind)
+	}
+}
+
+func (s *Server) handoffPeek(args map[string]interface{}) (map[string]interface{}, error) {
+	record, err := s.lookupHandoff(args)
+	if err != nil {
+		return nil, err
+	}
+	return handoffSummary(record), nil
+}
+
+func (s *Server) handoffConsume(args map[string]interface{}) (map[string]interface{}, error) {
+	record, err := s.lookupHandoff(args)
+	if err != nil {
+		return nil, err
+	}
+	return s.handoffs.consume(record.envelope.HandoffID)
+}
+
+func (s *Server) handoffRevoke(args map[string]interface{}) (map[string]interface{}, error) {
+	record, err := s.lookupHandoff(args)
+	if err != nil {
+		return nil, err
+	}
+	return s.handoffs.revoke(record.envelope.HandoffID)
+}
+
+func (s *Server) handoffStatus(args map[string]interface{}) (map[string]interface{}, error) {
+	record, err := s.lookupHandoff(args)
+	if err != nil {
+		return nil, err
+	}
+	return handoffStatus(record), nil
+}
+
+func (s *Server) lookupHandoff(args map[string]interface{}) (*storedHandoff, error) {
+	handoffID := strings.TrimSpace(strArg(args, "handoff_id"))
+	if handoffID == "" {
+		return nil, errors.New("handoff_id is required")
+	}
+	return s.handoffs.lookup(handoffID)
+}
+
+func (s *Server) mailHandoffCreate(selector, policy map[string]interface{}) (map[string]interface{}, error) {
+	account, provider, messageIDs, err := s.mailHandoffSelection(selector)
+	if err != nil {
+		return nil, err
+	}
+	defer provider.Close()
+
+	messages, err := provider.GetMessages(context.Background(), messageIDs, "full")
+	if err != nil {
+		return nil, err
+	}
+	orderedMessages, err := orderedMailMessages(messageIDs, messages)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	handoffID, err := newHandoffID(handoffKindMail)
+	if err != nil {
+		return nil, err
+	}
+	policyState, err := parseHandoffPolicy(policy, now)
+	if err != nil {
+		return nil, err
+	}
+	envelope := handoffEnvelope{
+		SpecVersion: "handoff.v1",
+		HandoffID:   handoffID,
+		Kind:        handoffKindMail,
+		CreatedAt:   now.Format(time.RFC3339),
+		Meta:        mailHandoffMeta(account, orderedMessages),
+		Payload: map[string]interface{}{
+			"messages": mailHandoffMessages(orderedMessages),
+		},
+	}
+	record := &storedHandoff{
+		envelope:    envelope,
+		expiresAt:   policyState.expiresAt,
+		maxConsumes: policyState.maxConsumes,
+	}
+	s.handoffs.store(record)
+	return handoffSummary(record), nil
+}
+
+func (s *Server) mailHandoffSelection(selector map[string]interface{}) (store.ExternalAccount, email.EmailProvider, []string, error) {
+	accountID, err := int64Arg(selector, "account_id")
+	if err != nil {
+		return store.ExternalAccount{}, nil, nil, err
+	}
+	messageIDs := mailMessageIDsArg(selector)
+	if len(messageIDs) == 0 {
+		return store.ExternalAccount{}, nil, nil, errors.New("message_id or message_ids is required")
+	}
+	account, provider, err := s.mailProviderForTool(map[string]interface{}{"account_id": accountID})
+	if err != nil {
+		return store.ExternalAccount{}, nil, nil, err
+	}
+	return account, provider, messageIDs, nil
+}
+
+func orderedMailMessages(messageIDs []string, messages []*providerdata.EmailMessage) ([]*providerdata.EmailMessage, error) {
+	byID := make(map[string]*providerdata.EmailMessage, len(messages))
+	for _, message := range messages {
+		if message == nil {
+			continue
+		}
+		byID[strings.TrimSpace(message.ID)] = message
+	}
+	out := make([]*providerdata.EmailMessage, 0, len(messageIDs))
+	for _, messageID := range messageIDs {
+		message := byID[strings.TrimSpace(messageID)]
+		if message == nil {
+			return nil, fmt.Errorf("message not found: %s", messageID)
+		}
+		out = append(out, message)
+	}
+	return out, nil
+}
+
+type handoffPolicyState struct {
+	expiresAt   time.Time
+	maxConsumes int
+}
+
+func parseHandoffPolicy(policy map[string]interface{}, now time.Time) (handoffPolicyState, error) {
+	out := handoffPolicyState{maxConsumes: defaultHandoffMaxConsumes}
+	if policy == nil {
+		return out, nil
+	}
+	if value, ok, err := optionalIntArg(policy, "max_consumes"); err != nil {
+		return handoffPolicyState{}, err
+	} else if ok {
+		if value <= 0 {
+			return handoffPolicyState{}, errors.New("max_consumes must be positive")
+		}
+		out.maxConsumes = value
+	}
+	if expiresAtRaw := strings.TrimSpace(strArg(policy, "expires_at")); expiresAtRaw != "" {
+		expiresAt, err := time.Parse(time.RFC3339, expiresAtRaw)
+		if err != nil {
+			return handoffPolicyState{}, errors.New("expires_at must be RFC3339")
+		}
+		out.expiresAt = expiresAt.UTC()
+	}
+	if value, ok, err := optionalIntArg(policy, "ttl_seconds"); err != nil {
+		return handoffPolicyState{}, err
+	} else if ok {
+		if value <= 0 {
+			return handoffPolicyState{}, errors.New("ttl_seconds must be positive")
+		}
+		ttlExpiry := now.Add(time.Duration(value) * time.Second).UTC()
+		if out.expiresAt.IsZero() || ttlExpiry.Before(out.expiresAt) {
+			out.expiresAt = ttlExpiry
+		}
+	}
+	return out, nil
+}
+
+func optionalIntArg(args map[string]interface{}, key string) (int, bool, error) {
+	value, ok := args[key]
+	if !ok {
+		return 0, false, nil
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed, true, nil
+	case int64:
+		return int(typed), true, nil
+	case float64:
+		return int(typed), true, nil
+	default:
+		return 0, false, fmt.Errorf("%s must be an integer", key)
+	}
+}
+
+func newHandoffID(kind string) (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return kind + "-" + hex.EncodeToString(buf), nil
+}
+
+func (r *handoffRegistry) store(record *storedHandoff) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handoffs[record.envelope.HandoffID] = record
+}
+
+func (r *handoffRegistry) lookup(handoffID string) (*storedHandoff, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record := r.handoffs[strings.TrimSpace(handoffID)]
+	if record == nil {
+		return nil, errors.New("handoff not found")
+	}
+	copyValue := *record
+	return &copyValue, nil
+}
+
+func (r *handoffRegistry) consume(handoffID string) (map[string]interface{}, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record := r.handoffs[strings.TrimSpace(handoffID)]
+	if record == nil {
+		return nil, errors.New("handoff not found")
+	}
+	if record.revoked {
+		return nil, errors.New("handoff is revoked")
+	}
+	if record.expired(time.Now().UTC()) {
+		return nil, errors.New("handoff is expired")
+	}
+	if record.maxConsumes > 0 && record.consumedCount >= record.maxConsumes {
+		return nil, errors.New("handoff has no remaining consumes")
+	}
+	record.consumedCount++
+	return handoffEnvelopePayload(record), nil
+}
+
+func (r *handoffRegistry) revoke(handoffID string) (map[string]interface{}, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record := r.handoffs[strings.TrimSpace(handoffID)]
+	if record == nil {
+		return nil, errors.New("handoff not found")
+	}
+	record.revoked = true
+	out := handoffSummary(record)
+	out["revoked"] = true
+	return out, nil
+}
+
+func (h *storedHandoff) expired(now time.Time) bool {
+	return !h.expiresAt.IsZero() && !now.Before(h.expiresAt)
+}
+
+func handoffSummary(record *storedHandoff) map[string]interface{} {
+	return map[string]interface{}{
+		"spec_version":   record.envelope.SpecVersion,
+		"handoff_id":     record.envelope.HandoffID,
+		"kind":           record.envelope.Kind,
+		"created_at":     record.envelope.CreatedAt,
+		"meta":           record.envelope.Meta,
+		"policy_summary": handoffPolicySummary(record),
+	}
+}
+
+func handoffStatus(record *storedHandoff) map[string]interface{} {
+	out := handoffSummary(record)
+	out["revoked"] = record.revoked
+	out["expired"] = record.expired(time.Now().UTC())
+	return out
+}
+
+func handoffEnvelopePayload(record *storedHandoff) map[string]interface{} {
+	return map[string]interface{}{
+		"spec_version": record.envelope.SpecVersion,
+		"handoff_id":   record.envelope.HandoffID,
+		"kind":         record.envelope.Kind,
+		"created_at":   record.envelope.CreatedAt,
+		"meta":         record.envelope.Meta,
+		"payload":      record.envelope.Payload,
+		"policy":       handoffPolicySummary(record),
+	}
+}
+
+func handoffPolicySummary(record *storedHandoff) map[string]interface{} {
+	remaining := 0
+	if record.maxConsumes > 0 {
+		remaining = max(record.maxConsumes-record.consumedCount, 0)
+	}
+	out := map[string]interface{}{
+		"max_consumes":       record.maxConsumes,
+		"consumed_count":     record.consumedCount,
+		"remaining_consumes": remaining,
+		"revoked":            record.revoked,
+		"expired":            record.expired(time.Now().UTC()),
+	}
+	if !record.expiresAt.IsZero() {
+		out["expires_at"] = record.expiresAt.Format(time.RFC3339)
+	}
+	return out
+}
+
+func mailHandoffMeta(account store.ExternalAccount, messages []*providerdata.EmailMessage) map[string]interface{} {
+	messageIDs := make([]string, 0, len(messages))
+	subjects := make([]string, 0, len(messages))
+	senders := make([]string, 0, len(messages))
+	recipients := make([]string, 0, len(messages))
+	dates := make([]string, 0, len(messages))
+	internetMessageIDs := make([]string, 0, len(messages))
+	threadIDs := make([]string, 0, len(messages))
+	for _, message := range messages {
+		messageIDs = append(messageIDs, strings.TrimSpace(message.ID))
+		subjects = append(subjects, strings.TrimSpace(message.Subject))
+		senders = append(senders, strings.TrimSpace(message.Sender))
+		recipients = append(recipients, message.Recipients...)
+		if !message.Date.IsZero() {
+			dates = append(dates, message.Date.UTC().Format(time.RFC3339))
+		}
+		if value := strings.TrimSpace(message.InternetMessageID); value != "" {
+			internetMessageIDs = append(internetMessageIDs, value)
+		}
+		if value := strings.TrimSpace(message.ThreadID); value != "" {
+			threadIDs = append(threadIDs, value)
+		}
+	}
+	return map[string]interface{}{
+		"account": map[string]interface{}{
+			"id":       account.ID,
+			"name":     account.AccountName,
+			"provider": account.Provider,
+			"sphere":   account.Sphere,
+		},
+		"message_count":         len(messages),
+		"message_ids":           messageIDs,
+		"subjects":              subjects,
+		"senders":               compactStringList(senders),
+		"recipients":            compactStringList(recipients),
+		"dates":                 dates,
+		"internet_message_ids":  compactStringList(internetMessageIDs),
+		"thread_ids":            compactStringList(threadIDs),
+		"attachment_count":      mailAttachmentCount(messages),
+		"contains_rich_content": mailContainsRichContent(messages),
+	}
+}
+
+func mailHandoffMessages(messages []*providerdata.EmailMessage) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(messages))
+	for _, message := range messages {
+		entry := map[string]interface{}{
+			"message_id":           strings.TrimSpace(message.ID),
+			"thread_id":            strings.TrimSpace(message.ThreadID),
+			"internet_message_id":  strings.TrimSpace(message.InternetMessageID),
+			"subject":              strings.TrimSpace(message.Subject),
+			"sender":               strings.TrimSpace(message.Sender),
+			"recipients":           append([]string(nil), message.Recipients...),
+			"snippet":              strings.TrimSpace(message.Snippet),
+			"labels":               append([]string(nil), message.Labels...),
+			"is_read":              message.IsRead,
+			"is_flagged":           message.IsFlagged,
+			"attachments":          mailHandoffAttachments(message.Attachments),
+			"has_body_text":        message.BodyText != nil,
+			"has_body_html":        message.BodyHTML != nil,
+			"attachment_count":     len(message.Attachments),
+			"recipient_count":      len(message.Recipients),
+			"label_count":          len(message.Labels),
+			"contains_attachments": len(message.Attachments) > 0,
+		}
+		if !message.Date.IsZero() {
+			entry["date"] = message.Date.UTC().Format(time.RFC3339)
+		}
+		if message.BodyText != nil {
+			entry["body_text"] = *message.BodyText
+		}
+		if message.BodyHTML != nil {
+			entry["body_html"] = *message.BodyHTML
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func mailHandoffAttachments(attachments []providerdata.Attachment) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(attachments))
+	for _, attachment := range attachments {
+		out = append(out, map[string]interface{}{
+			"id":        strings.TrimSpace(attachment.ID),
+			"filename":  strings.TrimSpace(attachment.Filename),
+			"mime_type": strings.TrimSpace(attachment.MimeType),
+			"size":      attachment.Size,
+			"is_inline": attachment.IsInline,
+		})
+	}
+	return out
+}
+
+func mailAttachmentCount(messages []*providerdata.EmailMessage) int {
+	count := 0
+	for _, message := range messages {
+		count += len(message.Attachments)
+	}
+	return count
+}
+
+func mailContainsRichContent(messages []*providerdata.EmailMessage) bool {
+	return slices.ContainsFunc(messages, func(message *providerdata.EmailMessage) bool {
+		return message != nil && (message.BodyText != nil || message.BodyHTML != nil)
+	})
+}

--- a/internal/mcp/server_handoff_test.go
+++ b/internal/mcp/server_handoff_test.go
@@ -1,0 +1,311 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/krystophny/tabura/internal/email"
+	"github.com/krystophny/tabura/internal/providerdata"
+	"github.com/krystophny/tabura/internal/store"
+)
+
+func TestMailHandoffLifecycle(t *testing.T) {
+	s, st, _ := newDomainServerForTest(t)
+	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderExchangeEWS, "TU Graz", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount: %v", err)
+	}
+	bodyText := "Plain text summary"
+	bodyHTML := "<p>Plain text summary</p>"
+	firstDate := time.Date(2026, time.March, 20, 9, 30, 0, 0, time.UTC)
+	secondDate := firstDate.Add(2 * time.Hour)
+	provider := &fakeMailProvider{
+		messages: map[string]*providerdata.EmailMessage{
+			"m1": {
+				ID:                "m1",
+				ThreadID:          "thread-1",
+				InternetMessageID: "<m1@example.test>",
+				Subject:           "Quarterly review",
+				Sender:            "Ada <ada@example.com>",
+				Recipients:        []string{"team@example.com", "ops@example.com"},
+				Date:              firstDate,
+				Snippet:           "Summary",
+				Labels:            []string{"Inbox", "Important"},
+				IsRead:            true,
+				IsFlagged:         true,
+				BodyText:          &bodyText,
+				BodyHTML:          &bodyHTML,
+				Attachments: []providerdata.Attachment{{
+					ID:       "att-1",
+					Filename: "report.pdf",
+					MimeType: "application/pdf",
+					Size:     128,
+				}},
+			},
+			"m2": {
+				ID:                "m2",
+				ThreadID:          "thread-2",
+				InternetMessageID: "<m2@example.test>",
+				Subject:           "Follow-up",
+				Sender:            "Grace <grace@example.com>",
+				Recipients:        []string{"team@example.com"},
+				Date:              secondDate,
+				Snippet:           "Next steps",
+			},
+		},
+	}
+	s.newEmailProvider = func(context.Context, store.ExternalAccount) (email.EmailProvider, error) {
+		return provider, nil
+	}
+
+	created, err := s.callTool("handoff.create", map[string]interface{}{
+		"kind": "mail",
+		"selector": map[string]interface{}{
+			"account_id":  account.ID,
+			"message_ids": []interface{}{"m1", "m2"},
+		},
+		"policy": map[string]interface{}{
+			"max_consumes": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("handoff.create failed: %v", err)
+	}
+	createdMap := normalizeMap(t, created)
+	handoffID := stringValue(t, createdMap["handoff_id"])
+	if handoffID == "" {
+		t.Fatal("handoff_id = empty")
+	}
+	if got := stringValue(t, createdMap["kind"]); got != handoffKindMail {
+		t.Fatalf("kind = %q", got)
+	}
+	meta := mapValue(t, createdMap["meta"])
+	if got := intValue(t, meta["message_count"]); got != 2 {
+		t.Fatalf("message_count = %d", got)
+	}
+	if got := stringSliceValue(t, meta["message_ids"]); len(got) != 2 || got[0] != "m1" || got[1] != "m2" {
+		t.Fatalf("message_ids = %#v", got)
+	}
+	if got := stringSliceValue(t, meta["subjects"]); len(got) != 2 || got[0] != "Quarterly review" || got[1] != "Follow-up" {
+		t.Fatalf("subjects = %#v", got)
+	}
+	if got := stringSliceValue(t, meta["senders"]); len(got) != 2 || got[0] != "Ada <ada@example.com>" || got[1] != "Grace <grace@example.com>" {
+		t.Fatalf("senders = %#v", got)
+	}
+	policySummary := mapValue(t, createdMap["policy_summary"])
+	if got := intValue(t, policySummary["remaining_consumes"]); got != 2 {
+		t.Fatalf("remaining_consumes = %d", got)
+	}
+
+	peeked, err := s.callTool("handoff.peek", map[string]interface{}{"handoff_id": handoffID})
+	if err != nil {
+		t.Fatalf("handoff.peek failed: %v", err)
+	}
+	peekMap := normalizeMap(t, peeked)
+	if _, ok := peekMap["payload"]; ok {
+		t.Fatalf("handoff.peek payload = %#v, want none", peekMap["payload"])
+	}
+
+	consumed, err := s.callTool("handoff.consume", map[string]interface{}{"handoff_id": handoffID})
+	if err != nil {
+		t.Fatalf("handoff.consume failed: %v", err)
+	}
+	consumeMap := normalizeMap(t, consumed)
+	payload := mapValue(t, consumeMap["payload"])
+	messages := sliceValue(t, payload["messages"])
+	if len(messages) != 2 {
+		t.Fatalf("payload.messages len = %d", len(messages))
+	}
+	firstMessage := mapValue(t, messages[0])
+	if got := stringValue(t, firstMessage["message_id"]); got != "m1" {
+		t.Fatalf("message_id = %q", got)
+	}
+	if got := stringValue(t, firstMessage["subject"]); got != "Quarterly review" {
+		t.Fatalf("subject = %q", got)
+	}
+	if got := stringValue(t, firstMessage["sender"]); got != "Ada <ada@example.com>" {
+		t.Fatalf("sender = %q", got)
+	}
+	if got := stringSliceValue(t, firstMessage["recipients"]); len(got) != 2 || got[0] != "team@example.com" || got[1] != "ops@example.com" {
+		t.Fatalf("recipients = %#v", got)
+	}
+	if got := stringValue(t, firstMessage["date"]); got != firstDate.Format(time.RFC3339) {
+		t.Fatalf("date = %q", got)
+	}
+	if got := stringValue(t, firstMessage["body_text"]); got != bodyText {
+		t.Fatalf("body_text = %q", got)
+	}
+	attachments := sliceValue(t, firstMessage["attachments"])
+	if len(attachments) != 1 {
+		t.Fatalf("attachments len = %d", len(attachments))
+	}
+	policyState := mapValue(t, consumeMap["policy"])
+	if got := intValue(t, policyState["consumed_count"]); got != 1 {
+		t.Fatalf("consumed_count = %d", got)
+	}
+	if got := intValue(t, policyState["remaining_consumes"]); got != 1 {
+		t.Fatalf("remaining_consumes = %d", got)
+	}
+
+	status, err := s.callTool("handoff.status", map[string]interface{}{"handoff_id": handoffID})
+	if err != nil {
+		t.Fatalf("handoff.status failed: %v", err)
+	}
+	statusMap := normalizeMap(t, status)
+	statusPolicy := mapValue(t, statusMap["policy_summary"])
+	if got := intValue(t, statusPolicy["consumed_count"]); got != 1 {
+		t.Fatalf("status consumed_count = %d", got)
+	}
+
+	revoked, err := s.callTool("handoff.revoke", map[string]interface{}{"handoff_id": handoffID})
+	if err != nil {
+		t.Fatalf("handoff.revoke failed: %v", err)
+	}
+	revokedMap := normalizeMap(t, revoked)
+	if !boolValue(t, revokedMap["revoked"]) {
+		t.Fatalf("revoked = %#v", revokedMap["revoked"])
+	}
+	if _, err := s.callTool("handoff.consume", map[string]interface{}{"handoff_id": handoffID}); err == nil {
+		t.Fatal("handoff.consume after revoke error = nil")
+	}
+}
+
+func TestMailHandoffConsumeLimit(t *testing.T) {
+	s, st, _ := newDomainServerForTest(t)
+	account, err := st.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Work Gmail", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount: %v", err)
+	}
+	provider := &fakeMailProvider{
+		messages: map[string]*providerdata.EmailMessage{
+			"m1": {
+				ID:      "m1",
+				Subject: "Only once",
+				Sender:  "ada@example.com",
+				Date:    time.Date(2026, time.March, 21, 10, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	s.newEmailProvider = func(context.Context, store.ExternalAccount) (email.EmailProvider, error) {
+		return provider, nil
+	}
+
+	created, err := s.callTool("handoff.create", map[string]interface{}{
+		"kind": "mail",
+		"selector": map[string]interface{}{
+			"account_id": account.ID,
+			"message_id": "m1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("handoff.create failed: %v", err)
+	}
+	handoffID := stringValue(t, normalizeMap(t, created)["handoff_id"])
+	if _, err := s.callTool("handoff.consume", map[string]interface{}{"handoff_id": handoffID}); err != nil {
+		t.Fatalf("first handoff.consume failed: %v", err)
+	}
+	_, err = s.callTool("handoff.consume", map[string]interface{}{"handoff_id": handoffID})
+	if err == nil {
+		t.Fatal("second handoff.consume error = nil")
+	}
+	if got := err.Error(); got != "handoff has no remaining consumes" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestHandoffToolDefinitions(t *testing.T) {
+	defs := toolDefinitions()
+	names := map[string]map[string]interface{}{}
+	for _, def := range defs {
+		name, _ := def["name"].(string)
+		names[name] = def
+	}
+	for _, name := range []string{"handoff.create", "handoff.peek", "handoff.consume", "handoff.revoke", "handoff.status"} {
+		if names[name] == nil {
+			t.Fatalf("%s missing from tool definitions", name)
+		}
+	}
+	schema, _ := names["handoff.create"]["inputSchema"].(map[string]interface{})
+	props, _ := schema["properties"].(map[string]interface{})
+	if props["selector"] == nil || props["policy"] == nil {
+		t.Fatalf("handoff.create properties = %#v", props)
+	}
+}
+
+func normalizeMap(t *testing.T, value interface{}) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	return out
+}
+
+func mapValue(t *testing.T, value interface{}) map[string]interface{} {
+	t.Helper()
+	typed, ok := value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("value = %#v, want map", value)
+	}
+	return typed
+}
+
+func sliceValue(t *testing.T, value interface{}) []interface{} {
+	t.Helper()
+	typed, ok := value.([]interface{})
+	if !ok {
+		t.Fatalf("value = %#v, want slice", value)
+	}
+	return typed
+}
+
+func stringValue(t *testing.T, value interface{}) string {
+	t.Helper()
+	typed, ok := value.(string)
+	if !ok {
+		t.Fatalf("value = %#v, want string", value)
+	}
+	return typed
+}
+
+func stringSliceValue(t *testing.T, value interface{}) []string {
+	t.Helper()
+	items := sliceValue(t, value)
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			t.Fatalf("item = %#v, want string", item)
+		}
+		out = append(out, text)
+	}
+	return out
+}
+
+func intValue(t *testing.T, value interface{}) int {
+	t.Helper()
+	switch typed := value.(type) {
+	case float64:
+		return int(typed)
+	case int:
+		return typed
+	default:
+		t.Fatalf("value = %#v, want number", value)
+		return 0
+	}
+}
+
+func boolValue(t *testing.T, value interface{}) bool {
+	t.Helper()
+	typed, ok := value.(bool)
+	if !ok {
+		t.Fatalf("value = %#v, want bool", value)
+	}
+	return typed
+}

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -42,6 +42,70 @@ var MCPTools = []Tool{
 		Required:    []string{"session_id", "handoff_id"},
 	},
 	{
+		Name:        "handoff.create",
+		Description: "Create a producer handoff. Tabura currently supports kind=mail with selector.account_id plus message_id or message_ids.",
+		Required:    []string{"kind", "selector"},
+		Properties: map[string]ToolProperty{
+			"kind": {
+				Type:        "string",
+				Description: "Handoff kind. Tabura currently supports mail.",
+				Enum:        []string{"mail"},
+			},
+			"selector": {
+				Type:        "object",
+				Description: "Kind-specific source selection. For mail, provide account_id and message_id or message_ids.",
+			},
+			"policy": {
+				Type:        "object",
+				Description: "Optional lifecycle policy with ttl_seconds, expires_at, and max_consumes.",
+			},
+		},
+	},
+	{
+		Name:        "handoff.peek",
+		Description: "Read producer handoff metadata without payload bytes.",
+		Required:    []string{"handoff_id"},
+		Properties: map[string]ToolProperty{
+			"handoff_id": {
+				Type:        "string",
+				Description: "Producer handoff identifier.",
+			},
+		},
+	},
+	{
+		Name:        "handoff.consume",
+		Description: "Consume one producer handoff payload and advance policy counters.",
+		Required:    []string{"handoff_id"},
+		Properties: map[string]ToolProperty{
+			"handoff_id": {
+				Type:        "string",
+				Description: "Producer handoff identifier.",
+			},
+		},
+	},
+	{
+		Name:        "handoff.revoke",
+		Description: "Revoke one producer handoff so future consumes are rejected.",
+		Required:    []string{"handoff_id"},
+		Properties: map[string]ToolProperty{
+			"handoff_id": {
+				Type:        "string",
+				Description: "Producer handoff identifier.",
+			},
+		},
+	},
+	{
+		Name:        "handoff.status",
+		Description: "Show producer handoff metadata plus lifecycle counters and revocation state.",
+		Required:    []string{"handoff_id"},
+		Properties: map[string]ToolProperty{
+			"handoff_id": {
+				Type:        "string",
+				Description: "Producer handoff identifier.",
+			},
+		},
+	},
+	{
 		Name:        "temp_file_create",
 		Description: "Create a temporary file under .tabura/artifacts/tmp for file-backed canvas usage.",
 		Properties: map[string]ToolProperty{


### PR DESCRIPTION
## Summary
- add producer-side MCP handoff lifecycle tools for `mail`
- build normalized mail envelopes from real provider message metadata
- document the envelope shape and sync the published MCP interface inventory

## Verification
- Producer-side mail handoff creation:
  - `go test ./internal/mcp -run 'TestMailHandoffLifecycle|TestMailHandoffConsumeLimit|TestHandoffToolDefinitions'`
  - `ok   github.com/krystophny/tabura/internal/mcp	0.024s`
  - `TestMailHandoffLifecycle` asserts `handoff.create` emits `message_ids`, `subjects`, `senders`, `recipients`, `dates`, bodies, and attachment metadata from provider-backed messages.
- Lifecycle support:
  - `go test ./internal/mcp -run 'TestMailHandoffLifecycle|TestMailHandoffConsumeLimit|TestHandoffToolDefinitions'`
  - `ok   github.com/krystophny/tabura/internal/mcp	0.024s`
  - `TestMailHandoffLifecycle` and `TestMailHandoffConsumeLimit` cover `handoff.peek`, `handoff.consume`, `handoff.status`, `handoff.revoke`, and consume-limit enforcement.
- Envelope format documented and surfaced:
  - `./scripts/sync-surface.sh --check`
  - exit status `0`
  - artifacts: `docs/handoff-protocol/spec/mail.md`, `docs/handoff-protocol/schemas/kind-mail-v1.json`, `docs/handoff-protocol/conformance/examples/mail-envelope.json`, `docs/interfaces.md`
- Interoperability and regression coverage:
  - `go test ./...`
  - `ok   github.com/krystophny/tabura/internal/mcp	0.245s`
  - `ok   github.com/krystophny/tabura/internal/web	14.185s`
  - `ok   github.com/krystophny/tabura/tests/services	(cached)`
- UI regression pass:
  - `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh`
  - `368 passed (2.9m)`
  - `40 skipped`
