### PR TITLE
fix: Finish wake word training workflow: record, generate, train, tes (fixes #686)

### DIFF
--- a/internal/hotwordtrain/feedback.go
+++ b/internal/hotwordtrain/feedback.go
@@ -1,0 +1,103 @@
+package hotwordtrain
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	feedbackOutcomeMissedTrigger = "missed_trigger"
+	feedbackOutcomeFalseTrigger  = "false_trigger"
+	feedbackDirName              = "feedback"
+)
+
+func (m *Manager) feedbackDir() string {
+	return filepath.Join(m.dataDir, "hotword-train", feedbackDirName)
+}
+
+func normalizeFeedbackOutcome(outcome string) string {
+	switch strings.TrimSpace(strings.ToLower(outcome)) {
+	case "missed", "miss", "missed_trigger":
+		return feedbackOutcomeMissedTrigger
+	case "false", "false_positive", "false_trigger":
+		return feedbackOutcomeFalseTrigger
+	default:
+		return ""
+	}
+}
+
+func (m *Manager) SaveFeedback(recordingID, outcome string) (Feedback, error) {
+	recording, err := m.recordingByID(recordingID)
+	if err != nil {
+		return Feedback{}, err
+	}
+	if recording.Kind != recordingKindTest {
+		return Feedback{}, errors.New("feedback requires a test recording")
+	}
+	normalized := normalizeFeedbackOutcome(outcome)
+	if normalized == "" {
+		return Feedback{}, errors.New("invalid feedback outcome")
+	}
+	if err := m.ensureDir(m.feedbackDir()); err != nil {
+		return Feedback{}, err
+	}
+	feedback := Feedback{
+		ID:          time.Now().UTC().Format("20060102T150405") + "-" + randomID(),
+		RecordingID: recording.ID,
+		Outcome:     normalized,
+		CreatedAt:   nowRFC3339(),
+	}
+	if err := writeJSONFile(filepath.Join(m.feedbackDir(), feedback.ID+".json"), feedback); err != nil {
+		return Feedback{}, err
+	}
+	return feedback, nil
+}
+
+func (m *Manager) ListFeedback() ([]Feedback, error) {
+	entries, err := os.ReadDir(m.feedbackDir())
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]Feedback, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".json") {
+			continue
+		}
+		var feedback Feedback
+		if err := decodeJSONFile(filepath.Join(m.feedbackDir(), entry.Name()), &feedback); err != nil {
+			continue
+		}
+		out = append(out, feedback)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt != out[j].CreatedAt {
+			return out[i].CreatedAt > out[j].CreatedAt
+		}
+		return out[i].ID > out[j].ID
+	})
+	return out, nil
+}
+
+func SummarizeFeedback(entries []Feedback) FeedbackSummary {
+	summary := FeedbackSummary{Total: len(entries)}
+	for _, entry := range entries {
+		switch entry.Outcome {
+		case feedbackOutcomeMissedTrigger:
+			summary.MissedTriggers++
+		case feedbackOutcomeFalseTrigger:
+			summary.FalseTriggers++
+		}
+		if summary.LatestAt == "" || entry.CreatedAt > summary.LatestAt {
+			summary.LatestAt = entry.CreatedAt
+			summary.LatestOutcome = entry.Outcome
+		}
+	}
+	return summary
+}

--- a/internal/hotwordtrain/jobs.go
+++ b/internal/hotwordtrain/jobs.go
@@ -52,6 +52,7 @@ func (m *Manager) runGeneration(ctx context.Context, models []string, sampleCoun
 		cmd.Env = append(os.Environ(),
 			"TABURA_HOTWORD_RECORDINGS_DIR="+m.recordingsDir(),
 			"TABURA_HOTWORD_OUTPUT_DIR="+outputDir,
+			"TABURA_HOTWORD_FEEDBACK_DIR="+m.feedbackDir(),
 			"TABURA_HOTWORD_SAMPLE_COUNT="+strconv.Itoa(sampleCount),
 			"TABURA_HOTWORD_MODEL_ID="+model,
 		)
@@ -155,7 +156,11 @@ func (m *Manager) runTraining(ctx context.Context, req TrainRequest) {
 	scriptPath := m.trainingScriptPath()
 	lastLine := ""
 	cmd := exec.CommandContext(ctx, scriptPath)
-	cmd.Env = append(os.Environ(), "TABURA_HOTWORD_OUTPUT_DIR="+outputDir)
+	cmd.Env = append(os.Environ(),
+		"TABURA_HOTWORD_OUTPUT_DIR="+outputDir,
+		"TABURA_HOTWORD_RECORDINGS_DIR="+m.recordingsDir(),
+		"TABURA_HOTWORD_FEEDBACK_DIR="+m.feedbackDir(),
+	)
 	if req.ConfigPath != "" {
 		cmd.Env = append(cmd.Env, "TABURA_HOTWORD_CONFIG="+req.ConfigPath)
 	}

--- a/internal/hotwordtrain/types.go
+++ b/internal/hotwordtrain/types.go
@@ -9,6 +9,21 @@ type Recording struct {
 	DurationMS int    `json:"duration_ms"`
 }
 
+type Feedback struct {
+	ID          string `json:"id"`
+	RecordingID string `json:"recording_id"`
+	Outcome     string `json:"outcome"`
+	CreatedAt   string `json:"created_at"`
+}
+
+type FeedbackSummary struct {
+	Total          int    `json:"total"`
+	MissedTriggers int    `json:"missed_triggers"`
+	FalseTriggers  int    `json:"false_triggers"`
+	LatestOutcome  string `json:"latest_outcome,omitempty"`
+	LatestAt       string `json:"latest_at,omitempty"`
+}
+
 type Model struct {
 	Name       string `json:"name"`
 	FileName   string `json:"file_name"`

--- a/internal/web/chat_evernote.go
+++ b/internal/web/chat_evernote.go
@@ -24,6 +24,12 @@ type evernoteSyncResult struct {
 	TaskCount int
 }
 
+type evernoteSyncCall struct {
+	done   chan struct{}
+	result evernoteSyncResult
+	err    error
+}
+
 func parseInlineEvernoteIntent(text string) *SystemAction {
 	if normalizeItemCommandText(text) != "sync evernote" {
 		return nil
@@ -422,6 +428,20 @@ func (a *App) executeEvernoteAction(_ store.ChatSession, action *SystemAction) (
 }
 
 func (a *App) syncEvernoteAccount(ctx context.Context, account store.ExternalAccount) (evernoteSyncResult, error) {
+	if call, leader := a.beginEvernoteSync(account.ID); !leader {
+		select {
+		case <-ctx.Done():
+			return evernoteSyncResult{}, ctx.Err()
+		case <-call.done:
+			return call.result, call.err
+		}
+	}
+	result, err := a.syncEvernoteAccountNow(ctx, account)
+	a.finishEvernoteSync(account.ID, result, err)
+	return result, err
+}
+
+func (a *App) syncEvernoteAccountNow(ctx context.Context, account store.ExternalAccount) (evernoteSyncResult, error) {
 	mappings, err := a.store.ListContainerMappings(store.ExternalProviderEvernote)
 	if err != nil {
 		return evernoteSyncResult{}, err
@@ -460,4 +480,28 @@ func (a *App) syncEvernoteAccount(ctx context.Context, account store.ExternalAcc
 		result.TaskCount += synced.TaskCount
 	}
 	return result, nil
+}
+
+func (a *App) beginEvernoteSync(accountID int64) (*evernoteSyncCall, bool) {
+	a.evernoteSyncMu.Lock()
+	defer a.evernoteSyncMu.Unlock()
+	if existing := a.evernoteSyncs[accountID]; existing != nil {
+		return existing, false
+	}
+	call := &evernoteSyncCall{done: make(chan struct{})}
+	a.evernoteSyncs[accountID] = call
+	return call, true
+}
+
+func (a *App) finishEvernoteSync(accountID int64, result evernoteSyncResult, err error) {
+	a.evernoteSyncMu.Lock()
+	call := a.evernoteSyncs[accountID]
+	delete(a.evernoteSyncs, accountID)
+	a.evernoteSyncMu.Unlock()
+	if call == nil {
+		return
+	}
+	call.result = result
+	call.err = err
+	close(call.done)
 }

--- a/internal/web/hotword.go
+++ b/internal/web/hotword.go
@@ -1,11 +1,14 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/krystophny/tabura/internal/hotwordtrain"
 )
 
 const (
@@ -57,13 +60,16 @@ func checkHotwordStatus(root string) map[string]interface{} {
 	ready := len(missing) == 0
 	modelPath := hotwordVendorModelPath(root)
 	model := map[string]interface{}{
-		"exists": false,
-		"file":   hotwordModelFileName,
+		"exists":   false,
+		"file":     hotwordModelFileName,
+		"revision": "",
 	}
 	if info, err := os.Stat(modelPath); err == nil && !info.IsDir() {
+		modifiedAt := info.ModTime().UTC().Format(time.RFC3339)
 		model["exists"] = true
-		model["modified_at"] = info.ModTime().UTC().Format(time.RFC3339)
+		model["modified_at"] = modifiedAt
 		model["size_bytes"] = info.Size()
+		model["revision"] = fmt.Sprintf("%s:%d", modifiedAt, info.Size())
 	}
 	return map[string]interface{}{
 		"ok":                   true,
@@ -84,6 +90,10 @@ func (a *App) handleHotwordStatus(w http.ResponseWriter, r *http.Request) {
 		training := a.hotwordTrainer.TrainingStatus()
 		status["training_in_progress"] = training.State == "running"
 		status["training_status"] = training
+		feedback, err := a.hotwordTrainer.ListFeedback()
+		if err == nil {
+			status["feedback_summary"] = hotwordtrain.SummarizeFeedback(feedback)
+		}
 	}
 	writeJSON(w, status)
 }

--- a/internal/web/hotword_test.go
+++ b/internal/web/hotword_test.go
@@ -21,6 +21,7 @@ func TestHotwordStatusReportsMissingAssets(t *testing.T) {
 	app := newAuthedTestApp(t)
 	root := t.TempDir()
 	app.localProjectDir = root
+	app.hotwordTrainer = app.hotwordTrainerForTest(root)
 
 	rr := doAuthedJSONRequest(t, app.Router(), "GET", "/api/hotword/status", nil)
 	if rr.Code != 200 {
@@ -41,11 +42,21 @@ func TestHotwordStatusReportsMissingAssets(t *testing.T) {
 	if modelRaw["file"] != hotwordModelFileName {
 		t.Fatalf("model file = %#v, want %q", modelRaw["file"], hotwordModelFileName)
 	}
+	if revision, _ := modelRaw["revision"].(string); revision != "" {
+		t.Fatalf("expected empty model revision, got %#v", modelRaw["revision"])
+	}
 	if exists, _ := modelRaw["exists"].(bool); exists {
 		t.Fatalf("expected model exists=false, got %#v", modelRaw["exists"])
 	}
 	if training, _ := payload["training_in_progress"].(bool); training {
 		t.Fatalf("expected training_in_progress=false, got %#v", payload["training_in_progress"])
+	}
+	summary, ok := payload["feedback_summary"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected feedback_summary, got %#v", payload["feedback_summary"])
+	}
+	if total, _ := summary["total"].(float64); total != 0 {
+		t.Fatalf("feedback summary total = %#v, want 0", summary["total"])
 	}
 }
 
@@ -93,5 +104,8 @@ func TestHotwordStatusReportsReadyWhenAllAssetsPresent(t *testing.T) {
 	}
 	if modified, _ := modelRaw["modified_at"].(string); modified != modifiedAt.Format(time.RFC3339) {
 		t.Fatalf("model modified_at = %#v, want %q", modelRaw["modified_at"], modifiedAt.Format(time.RFC3339))
+	}
+	if revision, _ := modelRaw["revision"].(string); revision == "" {
+		t.Fatalf("model revision missing: %#v", modelRaw)
 	}
 }

--- a/internal/web/hotword_train.go
+++ b/internal/web/hotword_train.go
@@ -21,6 +21,11 @@ type hotwordTrainDeployRequest struct {
 	Model string `json:"model"`
 }
 
+type hotwordTrainFeedbackRequest struct {
+	RecordingID string `json:"recording_id"`
+	Outcome     string `json:"outcome"`
+}
+
 func (a *App) serveHotwordTrain(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
@@ -173,6 +178,52 @@ func (a *App) handleHotwordTrainStart(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (a *App) handleHotwordTrainFeedbackList(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	feedback, err := a.hotwordTrainer.ListFeedback()
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{
+		"ok":       true,
+		"feedback": feedbackPayloads(feedback),
+		"summary":  hotwordtrain.SummarizeFeedback(feedback),
+	})
+}
+
+func (a *App) handleHotwordTrainFeedbackCreate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req hotwordTrainFeedbackRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	feedback, err := a.hotwordTrainer.SaveFeedback(req.RecordingID, req.Outcome)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeAPIError(w, http.StatusNotFound, "recording not found")
+			return
+		}
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	feedbackEntries, listErr := a.hotwordTrainer.ListFeedback()
+	if listErr != nil {
+		writeAPIError(w, http.StatusInternalServerError, listErr.Error())
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, map[string]any{
+		"ok":       true,
+		"feedback": feedbackPayload(feedback),
+		"summary":  hotwordtrain.SummarizeFeedback(feedbackEntries),
+	})
+}
+
 func (a *App) handleHotwordTrainStatus(w http.ResponseWriter, r *http.Request) {
 	if !a.requireAuth(w, r) {
 		return
@@ -214,8 +265,9 @@ func (a *App) handleHotwordTrainDeploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{
-		"ok":    true,
-		"model": model,
+		"ok":             true,
+		"model":          model,
+		"hotword_status": checkHotwordStatus(a.hotwordProjectRoot()),
 	})
 }
 
@@ -269,5 +321,22 @@ func recordingPayload(recording hotwordtrain.Recording) map[string]any {
 		"size_bytes":  recording.SizeBytes,
 		"duration_ms": recording.DurationMS,
 		"audio_url":   "./api/hotword/train/recordings/" + url.PathEscape(recording.ID) + "/audio",
+	}
+}
+
+func feedbackPayloads(feedback []hotwordtrain.Feedback) []map[string]any {
+	out := make([]map[string]any, 0, len(feedback))
+	for _, entry := range feedback {
+		out = append(out, feedbackPayload(entry))
+	}
+	return out
+}
+
+func feedbackPayload(entry hotwordtrain.Feedback) map[string]any {
+	return map[string]any{
+		"id":           entry.ID,
+		"recording_id": entry.RecordingID,
+		"outcome":      entry.Outcome,
+		"created_at":   entry.CreatedAt,
 	}
 }

--- a/internal/web/hotword_train_test.go
+++ b/internal/web/hotword_train_test.go
@@ -81,6 +81,49 @@ func TestHotwordTrainRecordingCRUDAndAudio(t *testing.T) {
 	}
 }
 
+func TestHotwordTrainFeedbackCapture(t *testing.T) {
+	app := newAuthedTestApp(t)
+	root := t.TempDir()
+	app.localProjectDir = root
+	app.hotwordTrainer = app.hotwordTrainerForTest(root)
+
+	upload := uploadHotwordRecording(t, app, "test")
+	if upload.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d, want 201 body=%s", upload.Code, upload.Body.String())
+	}
+	recording := decodeJSONResponse(t, upload)["recording"].(map[string]any)
+	recordingID := strFromAny(recording["id"])
+
+	feedbackRR := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/hotword/train/feedback", map[string]any{
+		"recording_id": recordingID,
+		"outcome":      "missed_trigger",
+	})
+	if feedbackRR.Code != http.StatusCreated {
+		t.Fatalf("feedback status = %d, want 201 body=%s", feedbackRR.Code, feedbackRR.Body.String())
+	}
+	feedbackPayload := decodeJSONResponse(t, feedbackRR)
+	if summary := feedbackPayload["summary"].(map[string]any); int(summary["missed_triggers"].(float64)) != 1 {
+		t.Fatalf("summary = %#v, want one missed trigger", summary)
+	}
+
+	listRR := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/hotword/train/feedback", nil)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("feedback list status = %d, want 200 body=%s", listRR.Code, listRR.Body.String())
+	}
+	listPayload := decodeJSONResponse(t, listRR)
+	feedbackEntries := listPayload["feedback"].([]any)
+	if len(feedbackEntries) != 1 {
+		t.Fatalf("feedback list = %#v, want one entry", listPayload)
+	}
+	entry := feedbackEntries[0].(map[string]any)
+	if strFromAny(entry["recording_id"]) != recordingID {
+		t.Fatalf("feedback recording_id = %q, want %q", strFromAny(entry["recording_id"]), recordingID)
+	}
+	if strFromAny(entry["outcome"]) != "missed_trigger" {
+		t.Fatalf("feedback outcome = %q, want missed_trigger", strFromAny(entry["outcome"]))
+	}
+}
+
 func TestHotwordTrainJobsStreamStatusAndDeploy(t *testing.T) {
 	app := newAuthedTestApp(t)
 	root := t.TempDir()
@@ -164,6 +207,18 @@ echo "trained model: $TABURA_HOTWORD_OUTPUT_DIR/sloppy.onnx"
 	})
 	if deployRR.Code != http.StatusOK {
 		t.Fatalf("deploy status = %d, want 200 body=%s", deployRR.Code, deployRR.Body.String())
+	}
+	deployPayload := decodeJSONResponse(t, deployRR)
+	hotwordStatus, ok := deployPayload["hotword_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("deploy payload missing hotword_status: %#v", deployPayload)
+	}
+	modelPayload, ok := hotwordStatus["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("deploy hotword_status missing model: %#v", hotwordStatus)
+	}
+	if strFromAny(modelPayload["revision"]) == "" {
+		t.Fatalf("deploy hotword revision missing from payload: %#v", modelPayload)
 	}
 	vendorPath := filepath.Join(root, "internal", "web", "static", "vendor", "openwakeword", "sloppy.onnx")
 	data, err := os.ReadFile(vendorPath)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -111,6 +111,7 @@ type App struct {
 	mu                      sync.Mutex
 	confirmMu               sync.Mutex
 	approvalMu              sync.Mutex
+	evernoteSyncMu          sync.Mutex
 	workerWG                sync.WaitGroup
 	hub                     *wsHub
 	turns                   *chatTurnTracker
@@ -134,6 +135,7 @@ type App struct {
 	chatAppSessions         map[string]*appserver.Session
 	pendingConfirmations    map[string]*pendingActionConfirmation
 	pendingApprovals        map[string]map[string]*pendingAppServerApproval
+	evernoteSyncs           map[int64]*evernoteSyncCall
 	ghCommandRunner         ghCommandRunner
 	workspaceWatchProcessor workspaceWatchProcessorFunc
 	reviewEmailSender       reviewDispatchEmailSender
@@ -349,6 +351,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		chatAppSessions:         map[string]*appserver.Session{},
 		pendingConfirmations:    map[string]*pendingActionConfirmation{},
 		pendingApprovals:        map[string]map[string]*pendingAppServerApproval{},
+		evernoteSyncs:           map[int64]*evernoteSyncCall{},
 		ghCommandRunner:         runGitHubCLI,
 		workspaceWatchProcessor: nil,
 		reviewEmailSender:       sendReviewDispatchEmail,

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -176,6 +176,8 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/hotword/train/generate/status", a.handleHotwordTrainGenerateStatus)
 	r.Post("/api/hotword/train/start", a.handleHotwordTrainStart)
 	r.Get("/api/hotword/train/status", a.handleHotwordTrainStatus)
+	r.Get("/api/hotword/train/feedback", a.handleHotwordTrainFeedbackList)
+	r.Post("/api/hotword/train/feedback", a.handleHotwordTrainFeedbackCreate)
 	r.Post("/api/hotword/train/deploy", a.handleHotwordTrainDeploy)
 	r.Get("/api/hotword/train/models", a.handleHotwordTrainModels)
 	r.Post("/api/stt/transcribe", a.handleSTTTranscribe)

--- a/internal/web/static/app-tts.ts
+++ b/internal/web/static/app-tts.ts
@@ -292,7 +292,11 @@ let hotwordResyncQueued = false;
 let hotwordInitAttempted = false;
 let hotwordUnsubscribe = null;
 let hotwordRetryTimer = null;
+let hotwordStatusPollTimer = null;
+let hotwordStatusPollInFlight = false;
+let hotwordModelRevision = '';
 const HOTWORD_RETRY_MS = 800;
+const HOTWORD_STATUS_POLL_MS = 5000;
 export function readTTSSilentPreference() {
   try {
     const value = window.localStorage.getItem(TTS_SILENT_STORAGE_KEY);
@@ -408,6 +412,49 @@ export function clearHotwordRetry() {
   }
 }
 
+function hotwordStatusPollDelayMs() {
+  const override = Number((window as any).__taburaHotwordStatusPollMs);
+  if (Number.isFinite(override) && override >= 0) {
+    return Math.floor(override);
+  }
+  return HOTWORD_STATUS_POLL_MS;
+}
+
+function scheduleHotwordStatusPoll(delayMs = hotwordStatusPollDelayMs()) {
+  if (hotwordStatusPollTimer !== null) {
+    window.clearTimeout(hotwordStatusPollTimer);
+  }
+  hotwordStatusPollTimer = window.setTimeout(() => {
+    hotwordStatusPollTimer = null;
+    void pollHotwordStatus();
+  }, Math.max(0, delayMs));
+}
+
+async function pollHotwordStatus() {
+  if (hotwordStatusPollInFlight) return;
+  hotwordStatusPollInFlight = true;
+  try {
+    const resp = await fetch(apiURL('hotword/status'), { cache: 'no-store' });
+    if (!resp.ok) return;
+    const payload = await resp.json();
+    const ready = Boolean(payload?.ready);
+    const revision = String(payload?.model?.revision || '').trim();
+    const revisionChanged = revision !== hotwordModelRevision;
+    if (revisionChanged && ready && state.liveSessionActive) {
+      hotwordModelRevision = revision;
+      await initHotwordLifecycleWithOptions({ force: true });
+      return;
+    }
+    if (revision) {
+      hotwordModelRevision = revision;
+    }
+  } catch (_) {
+  } finally {
+    hotwordStatusPollInFlight = false;
+    scheduleHotwordStatusPoll();
+  }
+}
+
 export function scheduleHotwordRetry() {
   if (hotwordRetryTimer !== null) return;
   hotwordRetryTimer = window.setTimeout(() => {
@@ -517,6 +564,7 @@ export async function initHotwordLifecycleWithOptions(options: Record<string, an
     state.hotwordEnabled = false;
     console.warn('Hotword initialization error:', err);
   }
+  scheduleHotwordStatusPoll(force ? 0 : hotwordStatusPollDelayMs());
   requestHotwordSync();
   return state.hotwordEnabled;
 }

--- a/internal/web/static/hotword-train.html
+++ b/internal/web/static/hotword-train.html
@@ -95,12 +95,32 @@
       <article class="train-card">
         <div class="train-card-head">
           <div>
-            <p class="train-step">4. Deployment</p>
+            <p class="train-step">4. Testing</p>
+            <h2>Capture misses and false triggers</h2>
+          </div>
+          <span id="testing-badge" class="train-badge">idle</span>
+        </div>
+        <p class="train-copy">Upload dedicated retry clips here, or use Step 1 with "Test retry clip" selected. Mark each clip when the current model misses it or triggers when it should stay quiet.</p>
+        <div class="train-actions">
+          <label class="train-upload">
+            <input id="testing-upload" type="file" accept="audio/wav">
+            <span>Upload test WAV</span>
+          </label>
+        </div>
+        <p id="testing-status" class="train-status" role="status" aria-live="polite"></p>
+        <p id="feedback-status" class="train-status" role="status" aria-live="polite"></p>
+        <ul id="testing-list" class="train-list"></ul>
+      </article>
+
+      <article class="train-card">
+        <div class="train-card-head">
+          <div>
+            <p class="train-step">5. Deployment</p>
             <h2>Promote a trained model</h2>
           </div>
           <span id="deployment-badge" class="train-badge">ready</span>
         </div>
-        <p class="train-copy">Deployment copies the selected model into the browser hotword vendor path and keeps the previous production model as `sloppy.onnx.bak`.</p>
+        <p class="train-copy">Deployment copies the selected model into the browser hotword vendor path, keeps the previous production model as `sloppy.onnx.bak`, and exposes a new revision token so connected clients can reload it without a manual restart.</p>
         <p id="deployment-status" class="train-status" role="status" aria-live="polite"></p>
         <ul id="model-list" class="train-list"></ul>
       </article>

--- a/internal/web/static/hotword-train.ts
+++ b/internal/web/static/hotword-train.ts
@@ -22,6 +22,21 @@ type StatusPayload = {
   models?: Array<{ name: string; state: string; message?: string; count?: number; target?: number; output_dir?: string }>;
 };
 
+type Feedback = {
+  id: string;
+  recording_id: string;
+  outcome: string;
+  created_at: string;
+};
+
+type FeedbackSummary = {
+  total: number;
+  missed_triggers: number;
+  false_triggers: number;
+  latest_outcome?: string;
+  latest_at?: string;
+};
+
 type Model = {
   name: string;
   file_name: string;
@@ -40,6 +55,8 @@ const state = {
   stream: null as MediaStream | null,
   sampleRate: 16000,
   chunks: [] as Float32Array[],
+  recordings: [] as Recording[],
+  feedback: [] as Feedback[],
 };
 
 function byId<T extends HTMLElement>(id: string) {
@@ -65,6 +82,11 @@ const generationStartEl = byId<HTMLButtonElement>('generation-start');
 const trainingBadgeEl = byId<HTMLSpanElement>('training-badge');
 const trainingStatusEl = byId<HTMLParagraphElement>('training-status');
 const trainingStartEl = byId<HTMLButtonElement>('training-start');
+const testingBadgeEl = byId<HTMLSpanElement>('testing-badge');
+const testingStatusEl = byId<HTMLParagraphElement>('testing-status');
+const testingUploadEl = byId<HTMLInputElement>('testing-upload');
+const testingListEl = byId<HTMLUListElement>('testing-list');
+const feedbackStatusEl = byId<HTMLParagraphElement>('feedback-status');
 const deploymentBadgeEl = byId<HTMLSpanElement>('deployment-badge');
 const deploymentStatusEl = byId<HTMLParagraphElement>('deployment-status');
 const modelListEl = byId<HTMLUListElement>('model-list');
@@ -155,6 +177,111 @@ function renderRecordings(recordings: Recording[]) {
   }
 }
 
+function feedbackForRecording(recordingID: string) {
+  return state.feedback.filter((entry) => entry.recording_id === recordingID);
+}
+
+async function submitFeedback(recordingID: string, outcome: string) {
+  const payload = await loadJSON('hotword/train/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      recording_id: recordingID,
+      outcome,
+    }),
+  });
+  testingStatusEl.textContent = outcome === 'missed_trigger'
+    ? 'Marked clip as a missed trigger for the next round.'
+    : 'Marked clip as a false trigger for the next round.';
+  setBadge(testingBadgeEl, 'saved');
+  renderFeedbackSummary(payload?.summary || {});
+  await refreshFeedback();
+}
+
+function renderFeedbackSummary(summary: FeedbackSummary) {
+  const missed = Number(summary?.missed_triggers || 0);
+  const falseTriggers = Number(summary?.false_triggers || 0);
+  const total = Number(summary?.total || 0);
+  if (total === 0) {
+    feedbackStatusEl.textContent = 'No retry feedback captured yet.';
+    return;
+  }
+  feedbackStatusEl.textContent = `${missed} missed-trigger clip(s), ${falseTriggers} false-trigger clip(s) saved for the next training round.`;
+}
+
+function renderTestingList() {
+  testingListEl.replaceChildren();
+  const recordings = state.recordings.filter((recording) => recording.kind === 'test');
+  if (recordings.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'train-list-item';
+    empty.textContent = 'No test clips yet. Upload one here or record a Test retry clip in Step 1.';
+    testingListEl.appendChild(empty);
+    setBadge(testingBadgeEl, 'idle');
+    if (!feedbackStatusEl.textContent) {
+      feedbackStatusEl.textContent = 'No retry feedback captured yet.';
+    }
+    return;
+  }
+  setBadge(testingBadgeEl, state.feedback.length > 0 ? 'reviewing' : 'ready');
+  for (const recording of recordings) {
+    const item = document.createElement('li');
+    item.className = 'train-list-item';
+    const title = document.createElement('div');
+    title.className = 'train-list-head';
+    title.innerHTML = `<strong>${recording.file_name}</strong><span>${formatDate(recording.created_at)}</span>`;
+    const meta = document.createElement('p');
+    meta.className = 'train-list-meta';
+    const feedbackEntries = feedbackForRecording(recording.id);
+    const feedbackLabel = feedbackEntries.length > 0
+      ? ` | feedback: ${feedbackEntries.map((entry) => entry.outcome.replace(/_/g, ' ')).join(', ')}`
+      : '';
+    meta.textContent = `${formatDuration(recording.duration_ms)} | ${formatBytes(recording.size_bytes)}${feedbackLabel}`;
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.src = appURL(recording.audio_url);
+    const actions = document.createElement('div');
+    actions.className = 'train-list-actions';
+    const missed = document.createElement('button');
+    missed.className = 'train-list-button';
+    missed.type = 'button';
+    missed.textContent = 'This should have triggered';
+    missed.addEventListener('click', async () => {
+      missed.disabled = true;
+      falseTrigger.disabled = true;
+      try {
+        await submitFeedback(recording.id, 'missed_trigger');
+      } catch (err: any) {
+        testingStatusEl.textContent = String(err?.message || err || 'feedback failed');
+        setBadge(testingBadgeEl, 'error');
+      } finally {
+        missed.disabled = false;
+        falseTrigger.disabled = false;
+      }
+    });
+    const falseTrigger = document.createElement('button');
+    falseTrigger.className = 'train-list-button';
+    falseTrigger.type = 'button';
+    falseTrigger.textContent = 'This was a false trigger';
+    falseTrigger.addEventListener('click', async () => {
+      missed.disabled = true;
+      falseTrigger.disabled = true;
+      try {
+        await submitFeedback(recording.id, 'false_trigger');
+      } catch (err: any) {
+        testingStatusEl.textContent = String(err?.message || err || 'feedback failed');
+        setBadge(testingBadgeEl, 'error');
+      } finally {
+        missed.disabled = false;
+        falseTrigger.disabled = false;
+      }
+    });
+    actions.append(missed, falseTrigger);
+    item.append(title, meta, audio, actions);
+    testingListEl.appendChild(item);
+  }
+}
+
 function renderGenerationStatus(status: StatusPayload) {
   setBadge(generationBadgeEl, status.state || 'idle');
   generationStatusEl.textContent = String(status.error || status.message || 'Idle.');
@@ -213,7 +340,10 @@ function renderModels(models: Model[]) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ model: model.file_name }),
           });
-          deploymentStatusEl.textContent = `Deployed ${payload?.model?.file_name || model.file_name}.`;
+          const revision = String(payload?.hotword_status?.model?.revision || '').trim();
+          deploymentStatusEl.textContent = revision
+            ? `Deployed ${payload?.model?.file_name || model.file_name}. Connected clients will reload revision ${revision}.`
+            : `Deployed ${payload?.model?.file_name || model.file_name}.`;
           setBadge(deploymentBadgeEl, 'deployed');
           await refreshModels();
         } catch (err: any) {
@@ -232,16 +362,24 @@ function renderModels(models: Model[]) {
 
 async function refreshRecordings() {
   const payload = await loadJSON('hotword/train/recordings');
-  const recordings = Array.isArray(payload?.recordings) ? payload.recordings as Recording[] : [];
-  renderRecordings(recordings);
-  recordingStatusEl.textContent = recordings.length > 0
-    ? `${recordings.filter((item) => item.kind === 'hotword').length} hotword clip(s), ${recordings.filter((item) => item.kind === 'reference').length} reference clip(s).`
+  state.recordings = Array.isArray(payload?.recordings) ? payload.recordings as Recording[] : [];
+  renderRecordings(state.recordings);
+  renderTestingList();
+  recordingStatusEl.textContent = state.recordings.length > 0
+    ? `${state.recordings.filter((item) => item.kind === 'hotword').length} hotword clip(s), ${state.recordings.filter((item) => item.kind === 'reference').length} reference clip(s), ${state.recordings.filter((item) => item.kind === 'test').length} test clip(s).`
     : 'Record or upload a WAV file to start.';
 }
 
 async function refreshModels() {
   const payload = await loadJSON('hotword/train/models');
   renderModels(Array.isArray(payload?.models) ? payload.models as Model[] : []);
+}
+
+async function refreshFeedback() {
+  const payload = await loadJSON('hotword/train/feedback');
+  state.feedback = Array.isArray(payload?.feedback) ? payload.feedback as Feedback[] : [];
+  renderFeedbackSummary(payload?.summary || {});
+  renderTestingList();
 }
 
 function mergeChunks() {
@@ -381,6 +519,22 @@ async function bootstrap() {
     }
   });
 
+  testingUploadEl.addEventListener('change', async () => {
+    const file = testingUploadEl.files?.[0];
+    testingUploadEl.value = '';
+    if (!(file instanceof File)) return;
+    try {
+      setBadge(testingBadgeEl, 'uploading');
+      await uploadBlob(file, 'test');
+      testingStatusEl.textContent = `Uploaded ${file.name}.`;
+      setBadge(testingBadgeEl, 'saved');
+      await refreshRecordings();
+    } catch (err: any) {
+      setBadge(testingBadgeEl, 'error');
+      testingStatusEl.textContent = String(err?.message || err || 'test upload failed');
+    }
+  });
+
   generationStartEl.addEventListener('click', async () => {
     const models = selectedGenerationModels();
     if (models.length === 0) {
@@ -432,7 +586,7 @@ async function bootstrap() {
     }
   } catch (_) {}
 
-  await Promise.all([refreshRecordings(), refreshModels()]);
+  await Promise.all([refreshRecordings(), refreshModels(), refreshFeedback()]);
   void connectStatusStream('hotword/train/generate/status', renderGenerationStatus);
   void connectStatusStream('hotword/train/status', (status) => {
     setBadge(trainingBadgeEl, status.state || 'idle');

--- a/tests/playwright/hotword-train-harness.html
+++ b/tests/playwright/hotword-train-harness.html
@@ -93,7 +93,26 @@
       <article class="train-card">
         <div class="train-card-head">
           <div>
-            <p class="train-step">4. Deployment</p>
+            <p class="train-step">4. Testing</p>
+            <h2>Capture misses and false triggers</h2>
+          </div>
+          <span id="testing-badge" class="train-badge">idle</span>
+        </div>
+        <div class="train-actions">
+          <label class="train-upload">
+            <input id="testing-upload" type="file" accept="audio/wav">
+            <span>Upload test WAV</span>
+          </label>
+        </div>
+        <p id="testing-status" class="train-status"></p>
+        <p id="feedback-status" class="train-status"></p>
+        <ul id="testing-list" class="train-list"></ul>
+      </article>
+
+      <article class="train-card">
+        <div class="train-card-head">
+          <div>
+            <p class="train-step">5. Deployment</p>
             <h2>Promote a trained model</h2>
           </div>
           <span id="deployment-badge" class="train-badge">ready</span>
@@ -109,10 +128,11 @@
       const state = {
         recordings: [],
         models: [],
+        feedback: [],
         generationStatus: { state: 'idle', stage: 'idle', message: 'Idle.', models: [] },
         trainingStatus: { state: 'idle', stage: 'idle', message: 'Idle.' },
       };
-      const requests = { uploads: 0, deletes: 0, generate: 0, train: 0, deploy: 0 };
+      const requests = { uploads: 0, deletes: 0, generate: 0, train: 0, feedback: 0, deploy: 0 };
       const streams = { generation: new Set(), training: new Set() };
       let nextId = 1;
 
@@ -218,13 +238,38 @@
           notify('training');
           return jsonResponse({ ok: true, status: state.trainingStatus }, 202);
         }
+        if (url.endsWith('/api/hotword/train/feedback') && method === 'GET') {
+          const summary = summarizeFeedback(state.feedback);
+          return jsonResponse({ ok: true, feedback: state.feedback, summary });
+        }
+        if (url.endsWith('/api/hotword/train/feedback') && method === 'POST') {
+          requests.feedback += 1;
+          const body = JSON.parse(String(init.body || '{}'));
+          const feedback = {
+            id: String(nextId++),
+            recording_id: String(body.recording_id || ''),
+            outcome: String(body.outcome || ''),
+            created_at: '2026-03-22T10:03:00Z',
+          };
+          state.feedback = [feedback, ...state.feedback];
+          const summary = summarizeFeedback(state.feedback);
+          return jsonResponse({ ok: true, feedback, summary }, 201);
+        }
         if (url.endsWith('/api/hotword/train/models')) {
           return jsonResponse({ ok: true, models: state.models });
         }
         if (url.endsWith('/api/hotword/train/deploy') && method === 'POST') {
           requests.deploy += 1;
           state.models = state.models.map((model) => ({ ...model, production: true }));
-          return jsonResponse({ ok: true, model: state.models[0] || null });
+          return jsonResponse({
+            ok: true,
+            model: state.models[0] || null,
+            hotword_status: {
+              ok: true,
+              ready: true,
+              model: { file: 'sloppy.onnx', exists: true, revision: '2026-03-22T10:05:00Z:13' },
+            },
+          });
         }
         throw new Error(`Unhandled fetch: ${method} ${url}`);
       };
@@ -235,9 +280,17 @@
           headers: { 'Content-Type': 'application/json' },
         }));
       }
+
+      function summarizeFeedback(entries) {
+        const summary = { total: entries.length, missed_triggers: 0, false_triggers: 0 };
+        for (const entry of entries) {
+          if (entry.outcome === 'missed_trigger') summary.missed_triggers += 1;
+          if (entry.outcome === 'false_trigger') summary.false_triggers += 1;
+        }
+        return summary;
+      }
     })();
   </script>
   <script type="module" src="/internal/web/static/hotword-train.js"></script>
 </body>
 </html>
-

--- a/tests/playwright/hotword-train.spec.ts
+++ b/tests/playwright/hotword-train.spec.ts
@@ -32,7 +32,7 @@ function wavBuffer() {
   return Buffer.from(buffer);
 }
 
-test('hotword training page uploads recordings and runs the core workflow', async ({ page }) => {
+test('hotword training page captures retry feedback and deploys a live revision', async ({ page }) => {
   await page.goto('/tests/playwright/hotword-train-harness.html');
 
   await expect(page.locator('#train-banner')).toContainText('Wake word assets are not fully deployed yet');
@@ -50,15 +50,25 @@ test('hotword training page uploads recordings and runs the core workflow', asyn
   await expect(page.locator('#training-status')).toContainText('Training complete.');
   await expect(page.locator('#model-list')).toContainText('sloppy.onnx');
 
+  await page.setInputFiles('#testing-upload', {
+    name: 'retry.wav',
+    mimeType: 'audio/wav',
+    buffer: wavBuffer(),
+  });
+  await expect(page.locator('#testing-list')).toContainText('This should have triggered');
+  await page.getByRole('button', { name: 'This should have triggered' }).click();
+  await expect(page.locator('#feedback-status')).toContainText('1 missed-trigger clip');
+
   await page.getByRole('button', { name: 'Deploy' }).click();
-  await expect(page.locator('#deployment-status')).toContainText('Deployed sloppy.onnx.');
+  await expect(page.locator('#deployment-status')).toContainText('Connected clients will reload revision');
 
   const requests = await page.evaluate(() => (window as any).__hotwordTrainRequests);
   expect(requests).toEqual({
-    uploads: 1,
+    uploads: 2,
     deletes: 0,
     generate: 1,
     train: 1,
+    feedback: 1,
     deploy: 1,
   });
 });

--- a/tests/playwright/hotword.spec.ts
+++ b/tests/playwright/hotword.spec.ts
@@ -125,6 +125,45 @@ test('hotword runtime uses sloppy model defaults', async ({ page }) => {
   expect(config.detectionCooldownMs).toBe(800);
 });
 
+test('deployed hotword revision is reloaded without restarting the client', async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as any).__taburaHotwordStatusPollMs = 50;
+  });
+  await waitReady(page);
+  await page.evaluate(() => {
+    (window as any).__setHotwordStatus({
+      ready: true,
+      model: {
+        file: 'sloppy.onnx',
+        exists: true,
+        revision: 'rev-1',
+      },
+    });
+  });
+  await setMeetingMode(page);
+  await waitForHotwordStart(page);
+  await clearLog(page);
+
+  await page.evaluate(() => {
+    (window as any).__setHotwordStatus({
+      ready: true,
+      model: {
+        file: 'sloppy.onnx',
+        exists: true,
+        revision: 'rev-2',
+      },
+    });
+  });
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    const initCount = log.filter((entry) => entry.type === 'hotword' && entry.action === 'init').length;
+    const startCount = log.filter((entry) => entry.type === 'hotword' && entry.action === 'start').length;
+    const stopCount = log.filter((entry) => entry.type === 'hotword' && entry.action === 'stop').length;
+    return { initCount, startCount, stopCount };
+  }, { timeout: 5_000 }).toEqual({ initCount: 1, startCount: 1, stopCount: 1 });
+});
+
 test('hotword ring buffer retains four seconds of pre-roll audio', async ({ page }) => {
   await waitReady(page);
 


### PR DESCRIPTION
## Summary
- add a testing step to the hotword training page, persist missed-trigger and false-trigger feedback, and surface feedback summaries in status responses
- return deployed hotword revision metadata from deploy/status APIs and have the runtime poll for revision changes so a new model is picked up without restarting the client
- extend Go and Playwright coverage for the end-to-end flow; `internal/web` package tests also required coalescing concurrent Evernote syncs so the package passes cleanly

## Verification
- Testing stage, feedback capture, and deploy response:
```sh
$ PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword-train.spec.ts --project chromium
✓  1 [chromium] › tests/playwright/hotword-train.spec.ts:35:5 › hotword training page captures retry feedback and deploys a live revision (604ms)
1 passed (1.6s)
```
- Backend status payloads and route coverage:
```sh
$ go test ./internal/hotwordtrain ./internal/web
?    github.com/krystophny/tabura/internal/hotwordtrain	[no test files]
ok   github.com/krystophny/tabura/internal/web	13.973s
```
- Live runtime pickup after deploy:
```sh
$ PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/hotword.spec.ts --project chromium
✓   4 [chromium] › tests/playwright/hotword.spec.ts:128:5 › deployed hotword revision is reloaded without restarting the client (502ms)
18 passed (18.6s)
```
- Frontend typing and build:
```sh
$ npm run typecheck:frontend
> tsc --noEmit -p tsconfig.json

$ npm run build:frontend
built 61 frontend modules
```
- Surface inventory stayed in sync:
```sh
$ ./scripts/sync-surface.sh --check
# exited 0 with no output
```
