### PR TITLE
fix: Finish unplugged mode for real: local backend must support shell (fixes #684)

### DIFF
--- a/internal/web/chat_assistant_backend.go
+++ b/internal/web/chat_assistant_backend.go
@@ -1,0 +1,161 @@
+package web
+
+import (
+	"context"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type assistantTurnRequest struct {
+	sessionID   string
+	session     store.ChatSession
+	messages    []store.ChatMessage
+	userText    string
+	cursorCtx   *chatCursorContext
+	inkCtx      []*chatCanvasInkEvent
+	positionCtx []*chatCanvasPositionEvent
+	captureMode string
+	outputMode  string
+	localOnly   bool
+	turnModel   string
+	baseProfile appServerModelProfile
+	turnProfile appServerModelProfile
+}
+
+type assistantTurnBackend interface {
+	mode() string
+	run(*assistantTurnRequest)
+}
+
+type localAssistantBackend struct {
+	app        *App
+	evaluation *localTurnEvaluation
+}
+
+func (b *localAssistantBackend) mode() string {
+	return assistantModeLocal
+}
+
+func (b *localAssistantBackend) run(req *assistantTurnRequest) {
+	if b == nil || b.app == nil || req == nil {
+		return
+	}
+	b.app.runLocalAssistantTurn(req, b.evaluation)
+}
+
+type codexAssistantBackend struct {
+	app *App
+}
+
+func (b *codexAssistantBackend) mode() string {
+	return assistantModeCodex
+}
+
+func (b *codexAssistantBackend) run(req *assistantTurnRequest) {
+	if b == nil || b.app == nil || req == nil {
+		return
+	}
+	b.app.runCodexAssistantTurn(req)
+}
+
+func (a *App) assistantBackendForTurn(req *assistantTurnRequest) assistantTurnBackend {
+	if a == nil {
+		return &localAssistantBackend{}
+	}
+	if req == nil {
+		return &localAssistantBackend{app: a}
+	}
+	if req.localOnly {
+		return &localAssistantBackend{app: a}
+	}
+	switch a.assistantRoutingMode() {
+	case assistantModeLocal:
+		return &localAssistantBackend{app: a}
+	case assistantModeCodex:
+		return &codexAssistantBackend{app: a}
+	default:
+		return a.assistantBackendForAutoMode(req)
+	}
+}
+
+func (a *App) assistantBackendForAutoMode(req *assistantTurnRequest) assistantTurnBackend {
+	if a == nil {
+		return &localAssistantBackend{}
+	}
+	if a.appServerClient == nil {
+		return &localAssistantBackend{app: a}
+	}
+	if req == nil {
+		return &codexAssistantBackend{app: a}
+	}
+	evaluation := a.evaluateLocalTurn(
+		context.Background(),
+		req.sessionID,
+		req.session,
+		req.userText,
+		req.cursorCtx,
+		req.captureMode,
+	)
+	if evaluation.handled || evaluation.isHighConfidenceLocalAnswer() {
+		return &localAssistantBackend{app: a, evaluation: &evaluation}
+	}
+	if a.localAssistantAvailable() && localAssistantAutoRouteCandidate(req.userText) {
+		return &localAssistantBackend{app: a}
+	}
+	return &codexAssistantBackend{app: a}
+}
+
+func (a *App) localAssistantAvailable() bool {
+	return strings.TrimSpace(a.assistantLLMBaseURL()) != ""
+}
+
+func localAssistantAutoRouteCandidate(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	if requestRequiresOpenCanvasAction(lower) {
+		return true
+	}
+	indicators := []string{
+		"shell",
+		"command",
+		"terminal",
+		"repo",
+		"repository",
+		"workspace",
+		"file",
+		"folder",
+		"directory",
+		"canvas",
+		"mcp",
+		"calendar",
+		"mail",
+		"email",
+		"todoist",
+		"evernote",
+		"zotero",
+		"github",
+		"issue",
+		"pull request",
+		"pr ",
+		"rg ",
+		"grep ",
+		"find ",
+		"ls ",
+		"pwd",
+		"cat ",
+		"open ",
+		"show ",
+		"display ",
+		"list ",
+		"inspect ",
+	}
+	for _, indicator := range indicators {
+		if strings.Contains(lower, indicator) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/chat_assistant_backend_test.go
+++ b/internal/web/chat_assistant_backend_test.go
@@ -1,0 +1,355 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAssistantBackendForTurnAutoRoutesBetweenLocalAndCodex(t *testing.T) {
+	wsServer := setupMockAppServerStatusServer(t, "codex")
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	app, err := New(t.TempDir(), "", "", wsURL, "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.assistantLLMURL = "http://127.0.0.1:8081"
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	localReq := &assistantTurnRequest{userText: "open the workspace README"}
+	if got := app.assistantBackendForTurn(localReq).mode(); got != assistantModeLocal {
+		t.Fatalf("auto backend for tool task = %q, want %q", got, assistantModeLocal)
+	}
+
+	codexReq := &assistantTurnRequest{userText: "help me think through the plasma analysis"}
+	if got := app.assistantBackendForTurn(codexReq).mode(); got != assistantModeCodex {
+		t.Fatalf("auto backend for general task = %q, want %q", got, assistantModeCodex)
+	}
+}
+
+func TestParseLocalAssistantDecisionParsesNativeToolCalls(t *testing.T) {
+	decision, err := parseLocalAssistantDecision(localIntentLLMMessage{
+		ToolCalls: []localAssistantLLMToolCall{{
+			ID:   "call-shell",
+			Type: "function",
+			Function: localAssistantLLMFunctionCall{
+				Name:      "shell",
+				Arguments: `{"command":"printf 'hi'"}`,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("parseLocalAssistantDecision() error: %v", err)
+	}
+	if len(decision.ToolCalls) != 1 {
+		t.Fatalf("tool call count = %d, want 1", len(decision.ToolCalls))
+	}
+	if got := decision.ToolCalls[0].Name; got != "shell" {
+		t.Fatalf("tool call name = %q, want shell", got)
+	}
+	if got := strings.TrimSpace(decision.ToolCalls[0].Arguments["command"].(string)); got != "printf 'hi'" {
+		t.Fatalf("tool call command = %q, want printf 'hi'", got)
+	}
+}
+
+func TestExecuteLocalAssistantShellToolTracksWorkingDirectory(t *testing.T) {
+	workspaceDir := t.TempDir()
+	subdir := workspaceDir + "/nested"
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	state := localAssistantTurnState{
+		workspaceDir: workspaceDir,
+		currentDir:   workspaceDir,
+	}
+
+	result := executeLocalAssistantShellTool(&state, localAssistantToolCall{
+		ID:   "call-shell",
+		Name: "shell",
+		Arguments: map[string]any{
+			"command": "cd nested && pwd",
+		},
+	})
+	if result.IsError {
+		t.Fatalf("shell tool returned error: %+v", result)
+	}
+	if got := strings.TrimSpace(result.Output); got != subdir {
+		t.Fatalf("shell output = %q, want %q", got, subdir)
+	}
+	if got := state.currentDir; got != subdir {
+		t.Fatalf("state currentDir = %q, want %q", got, subdir)
+	}
+}
+
+func TestExecuteLocalAssistantMCPToolUsesConfiguredEndpoint(t *testing.T) {
+	var calls atomic.Int32
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode mcp payload: %v", err)
+		}
+		params, _ := payload["params"].(map[string]any)
+		if got := strings.TrimSpace(strFromAny(params["name"])); got != "echo_status" {
+			t.Fatalf("tool name = %q, want echo_status", got)
+		}
+		args, _ := params["arguments"].(map[string]any)
+		if got := strings.TrimSpace(strFromAny(args["status"])); got != "ready" {
+			t.Fatalf("tool args status = %q, want ready", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"structuredContent": map[string]any{
+					"ok":     true,
+					"status": "ready",
+				},
+			},
+		})
+	}))
+	defer mcp.Close()
+
+	app := newAuthedTestApp(t)
+	state := localAssistantTurnState{
+		mcpURL: mcp.URL,
+	}
+	result, err := app.executeLocalAssistantMCPTool(context.Background(), &state, localAssistantToolCall{
+		ID:   "call-mcp",
+		Name: "mcp",
+		Arguments: map[string]any{
+			"name": "echo_status",
+			"arguments": map[string]any{
+				"status": "ready",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("executeLocalAssistantMCPTool() error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("mcp tool returned error: %+v", result)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("mcp call count = %d, want 1", calls.Load())
+	}
+	if got := strings.TrimSpace(strFromAny(result.StructuredContent["status"])); got != "ready" {
+		t.Fatalf("structured status = %q, want ready", got)
+	}
+}
+
+func TestRunAssistantTurnLocalAssistantCompletesMultiToolLoop(t *testing.T) {
+	var llmCalls atomic.Int32
+	mcpCalls := atomic.Int32{}
+
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpCalls.Add(1)
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode mcp payload: %v", err)
+		}
+		params, _ := payload["params"].(map[string]any)
+		if got := strings.TrimSpace(strFromAny(params["name"])); got != "echo_status" {
+			t.Fatalf("tool name = %q, want echo_status", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"structuredContent": map[string]any{
+					"ok":     true,
+					"status": "ready",
+				},
+			},
+		})
+	}))
+	defer mcp.Close()
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := llmCalls.Add(1)
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode llm payload: %v", err)
+		}
+		messages, _ := payload["messages"].([]any)
+		switch call {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"tool_calls": []map[string]any{{
+							"id":   "call-shell",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "shell",
+								"arguments": `{"command":"printf 'shell-step'"}`,
+							},
+						}},
+					},
+				}},
+			})
+		case 2:
+			last, _ := messages[len(messages)-1].(map[string]any)
+			if got := strings.TrimSpace(strFromAny(last["content"])); !strings.Contains(got, "shell-step") {
+				t.Fatalf("second llm call missing shell output: %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"tool_calls": []map[string]any{{
+							"id":   "call-mcp",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "mcp",
+								"arguments": `{"name":"echo_status","arguments":{"status":"ready"}}`,
+							},
+						}},
+					},
+				}},
+			})
+		default:
+			last, _ := messages[len(messages)-1].(map[string]any)
+			if got := strings.TrimSpace(strFromAny(last["content"])); !strings.Contains(got, `"status":"ready"`) {
+				t.Fatalf("final llm call missing mcp result: %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"content": "Local backend completed shell and MCP steps.",
+					},
+				}},
+			})
+		}
+	}))
+	defer llm.Close()
+
+	app, err := New(t.TempDir(), "", mcp.URL, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.assistantMode = assistantModeLocal
+	app.assistantLLMURL = llm.URL
+	app.intentLLMURL = ""
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensureDefaultWorkspace: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("chatSessionForWorkspace: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "inspect the workspace and use MCP", "inspect the workspace and use MCP", "text"); err != nil {
+		t.Fatalf("AddChatMessage: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Local backend completed shell and MCP steps." {
+		t.Fatalf("assistant message = %q", got)
+	}
+	if llmCalls.Load() != 3 {
+		t.Fatalf("llm call count = %d, want 3", llmCalls.Load())
+	}
+	if mcpCalls.Load() != 1 {
+		t.Fatalf("mcp call count = %d, want 1", mcpCalls.Load())
+	}
+}
+
+func TestRunAssistantTurnLocalAssistantRecoversMalformedToolCall(t *testing.T) {
+	var llmCalls atomic.Int32
+
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := llmCalls.Add(1)
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode llm payload: %v", err)
+		}
+		messages, _ := payload["messages"].([]any)
+		switch call {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"tool_calls": []map[string]any{{
+							"id":   "call-bad",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "shll",
+								"arguments": `{"command":"printf 'broken'"}`,
+							},
+						}},
+					},
+				}},
+			})
+		case 2:
+			last, _ := messages[len(messages)-1].(map[string]any)
+			if got := strings.TrimSpace(strFromAny(last["content"])); !strings.Contains(got, "could not be executed") {
+				t.Fatalf("repair prompt = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"tool_calls": []map[string]any{{
+							"id":   "call-shell",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "shell",
+								"arguments": `{"command":"printf 'recovered'"}`,
+							},
+						}},
+					},
+				}},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"content": "Recovered after repairing the malformed tool call.",
+					},
+				}},
+			})
+		}
+	}))
+	defer llm.Close()
+
+	app, err := New(t.TempDir(), "", "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("new app: %v", err)
+	}
+	app.assistantMode = assistantModeLocal
+	app.assistantLLMURL = llm.URL
+	app.intentLLMURL = ""
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensureDefaultWorkspace: %v", err)
+	}
+	session, err := app.chatSessionForWorkspace(project)
+	if err != nil {
+		t.Fatalf("chatSessionForWorkspace: %v", err)
+	}
+	if _, err := app.store.AddChatMessage(session.ID, "user", "run the local tool", "run the local tool", "text"); err != nil {
+		t.Fatalf("AddChatMessage: %v", err)
+	}
+
+	app.runAssistantTurn(session.ID, dequeuedTurn{outputMode: turnOutputModeSilent})
+
+	if got := latestAssistantMessage(t, app, session.ID); got != "Recovered after repairing the malformed tool call." {
+		t.Fatalf("assistant message = %q", got)
+	}
+	if llmCalls.Load() != 3 {
+		t.Fatalf("llm call count = %d, want 3", llmCalls.Load())
+	}
+}

--- a/internal/web/chat_assistant_local.go
+++ b/internal/web/chat_assistant_local.go
@@ -1,13 +1,8 @@
 package web
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"time"
 
@@ -22,7 +17,9 @@ const (
 	assistantLLMRequestTimeout   = 20 * time.Second
 	assistantLLMResponseLimit    = 256 * 1024
 	assistantLLMMaxTokens        = 4096
-	localAssistantDialoguePrompt = "You are Tabura's local assistant. Reply in plain text only. Do not emit JSON, code fences, or tool calls. The request has already passed through local command routing, so answer conversationally and concisely."
+	assistantLLMMaxToolRounds    = 6
+	assistantLLMMalformedRetries = 2
+	localAssistantDialoguePrompt = "You are Tabura's local assistant. Use tools when the task depends on workspace state, shell inspection, or MCP capabilities. Prefer native tool calls when the model supports them. If native tool calls are unavailable, respond with JSON only using either {\"tool_calls\":[...]} or {\"final\":\"...\"}. Available tools: shell with command and optional cwd, and mcp with name, arguments, and optional mcp_url. When a tool fails, recover with another tool call or explain the failure clearly. Do not emit markdown fences around JSON."
 )
 
 func normalizeAssistantMode(raw string) string {
@@ -81,63 +78,6 @@ func (a *App) localAssistantLLMModel() string {
 	return a.localIntentLLMModel()
 }
 
-func (a *App) requestLocalAssistantMessage(ctx context.Context, prompt string, visual *chatVisualAttachment) (string, error) {
-	baseURL := a.assistantLLMBaseURL()
-	if baseURL == "" {
-		return "", errors.New("local assistant is not configured")
-	}
-	requestBody, _ := json.Marshal(map[string]any{
-		"model":       a.localAssistantLLMModel(),
-		"temperature": 0,
-		"max_tokens":  assistantLLMMaxTokens,
-		"chat_template_kwargs": map[string]any{
-			"enable_thinking": false,
-		},
-		"messages": []map[string]any{
-			{"role": "system", "content": localAssistantDialoguePrompt},
-			{"role": "user", "content": buildLocalAssistantUserContent(prompt, visual)},
-		},
-	})
-	requestCtx, cancel := context.WithTimeout(ctx, assistantLLMRequestTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(
-		requestCtx,
-		http.MethodPost,
-		baseURL+"/v1/chat/completions",
-		bytes.NewReader(requestBody),
-	)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, assistantLLMResponseLimit))
-		return "", fmt.Errorf("assistant llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-	var payload localIntentLLMChatCompletionResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, assistantLLMResponseLimit)).Decode(&payload); err != nil {
-		return "", err
-	}
-	if len(payload.Choices) == 0 {
-		return "", errors.New("assistant llm returned no choices")
-	}
-	content := strings.TrimSpace(stripCodeFence(payload.Choices[0].Message.Content))
-	if content == "" {
-		return "", errors.New("assistant llm returned empty content")
-	}
-	if classification, err := parseIntentPlanClassification(content); err == nil && classification.LocalAnswer != nil {
-		if text := strings.TrimSpace(classification.LocalAnswer.Text); text != "" {
-			return text, nil
-		}
-	}
-	return content, nil
-}
-
 func (a *App) buildLocalAssistantPrompt(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string) (string, error) {
 	canvasCtx := a.resolveCanvasContext(session.WorkspacePath)
 	companionCtx := a.loadCompanionPromptContext(session.WorkspacePath)
@@ -159,89 +99,103 @@ func (a *App) buildLocalAssistantPrompt(sessionID string, session store.ChatSess
 	return prompt, nil
 }
 
-func (a *App) runLocalAssistantTurn(sessionID string, session store.ChatSession, messages []store.ChatMessage, userText string, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, captureMode string, outputMode string) {
+func (a *App) runLocalAssistantTurn(req *assistantTurnRequest, evaluation *localTurnEvaluation) {
+	if a == nil || req == nil {
+		return
+	}
 	turnStartedAt := time.Now()
-	actionMessage, actionPayloads, handled := a.classifyAndExecuteSystemActionForTurn(context.Background(), sessionID, session, userText, cursorCtx, captureMode)
-	if handled {
-		if suppressLocalAssistantResponse(actionPayloads) {
-			a.finishCompanionPendingTurn(sessionID, "assistant_turn_suppressed")
+	eval := evaluation
+	if eval == nil {
+		computed := a.evaluateLocalTurn(
+			context.Background(),
+			req.sessionID,
+			req.session,
+			req.userText,
+			req.cursorCtx,
+			req.captureMode,
+		)
+		eval = &computed
+	}
+	if eval != nil && eval.handled {
+		if suppressLocalAssistantResponse(eval.payloads) {
+			a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_suppressed")
 			return
 		}
 		runID := randomToken()
-		a.broadcastChatEvent(sessionID, map[string]interface{}{
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 			"type":    "turn_started",
 			"turn_id": runID,
 		})
-		assistantText := strings.TrimSpace(actionMessage)
+		assistantText := strings.TrimSpace(eval.text)
 		if assistantText == "" {
 			assistantText = "Done."
 		}
-		for _, actionPayload := range actionPayloads {
+		for _, actionPayload := range eval.payloads {
 			if actionPayload == nil {
 				continue
 			}
-			a.broadcastSystemActionEvent(sessionID, actionPayload)
+			a.broadcastSystemActionEvent(req.sessionID, actionPayload)
 		}
 		persistedAssistantID := int64(0)
 		persistedAssistantText := ""
 		a.finalizeAssistantResponseWithMetadata(
-			sessionID,
-			session.WorkspacePath,
+			req.sessionID,
+			req.session.WorkspacePath,
 			assistantText,
 			&persistedAssistantID,
 			&persistedAssistantText,
 			"",
 			runID,
 			"",
-			outputMode,
+			req.outputMode,
 			newAssistantResponseMetadata(a.localAssistantProvider(), a.localAssistantModelLabel(), time.Since(turnStartedAt)),
 		)
 		return
 	}
 
-	prompt, err := a.buildLocalAssistantPrompt(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, outputMode)
+	prompt, err := a.buildLocalAssistantPrompt(req.sessionID, req.session, req.messages, req.cursorCtx, req.inkCtx, req.positionCtx, req.outputMode)
 	if err != nil {
 		errText := err.Error()
-		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
-		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
+		_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
+		a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": errText})
 		return
 	}
 	if compactedPrompt, compacted := compactLocalAssistantPrompt(prompt); compacted {
 		prompt = compactedPrompt
-		a.broadcastChatEvent(sessionID, map[string]any{
+		a.broadcastChatEvent(req.sessionID, map[string]any{
 			"type": "context_compact",
 		})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runID := randomToken()
-	a.registerActiveChatTurn(sessionID, runID, cancel)
+	a.registerActiveChatTurn(req.sessionID, runID, cancel)
 	defer func() {
 		cancel()
-		a.unregisterActiveChatTurn(sessionID, runID)
+		a.unregisterActiveChatTurn(req.sessionID, runID)
 	}()
 
-	go a.watchCanvasFile(ctx, session.WorkspacePath)
-	a.broadcastChatEvent(sessionID, map[string]interface{}{
+	go a.watchCanvasFile(ctx, req.session.WorkspacePath)
+	a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 		"type":    "turn_started",
 		"turn_id": runID,
 	})
 
-	reply, err := a.requestLocalAssistantMessage(ctx, prompt, latestCanvasPositionVisualAttachment(positionCtx))
+	reply, err := a.runLocalAssistantToolLoop(ctx, req, prompt, latestCanvasPositionVisualAttachment(req.positionCtx))
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			a.finishCompanionPendingTurn(sessionID, "assistant_turn_cancelled")
-			a.broadcastChatEvent(sessionID, map[string]interface{}{
+			a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_cancelled")
+			a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 				"type":    "turn_cancelled",
 				"turn_id": runID,
 			})
 			return
 		}
 		errText := normalizeAssistantError(err)
-		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
-		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
+		_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
+		a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": errText})
 		return
 	}
 
@@ -252,15 +206,15 @@ func (a *App) runLocalAssistantTurn(sessionID string, session store.ChatSession,
 	persistedAssistantID := int64(0)
 	persistedAssistantText := ""
 	a.finalizeAssistantResponseWithMetadata(
-		sessionID,
-		session.WorkspacePath,
+		req.sessionID,
+		req.session.WorkspacePath,
 		assistantText,
 		&persistedAssistantID,
 		&persistedAssistantText,
 		"",
 		runID,
 		"",
-		outputMode,
+		req.outputMode,
 		newAssistantResponseMetadata(a.localAssistantProvider(), a.localAssistantModelLabel(), time.Since(turnStartedAt)),
 	)
 }

--- a/internal/web/chat_assistant_local_tools.go
+++ b/internal/web/chat_assistant_local_tools.go
@@ -1,0 +1,645 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/krystophny/tabura/internal/store"
+)
+
+type localAssistantLLMToolCall struct {
+	ID       string                        `json:"id,omitempty"`
+	Type     string                        `json:"type,omitempty"`
+	Function localAssistantLLMFunctionCall `json:"function"`
+}
+
+type localAssistantLLMFunctionCall struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+type localAssistantDecision struct {
+	FinalText string
+	ToolCalls []localAssistantToolCall
+}
+
+type localAssistantToolCall struct {
+	ID        string
+	Name      string
+	Arguments map[string]any
+}
+
+type localAssistantToolResult struct {
+	ToolCallID        string         `json:"tool_call_id,omitempty"`
+	Name              string         `json:"name,omitempty"`
+	Arguments         map[string]any `json:"arguments,omitempty"`
+	CWD               string         `json:"cwd,omitempty"`
+	Output            string         `json:"output,omitempty"`
+	ExitCode          int            `json:"exit_code,omitempty"`
+	TimedOut          bool           `json:"timed_out,omitempty"`
+	IsError           bool           `json:"is_error,omitempty"`
+	Error             string         `json:"error,omitempty"`
+	StructuredContent map[string]any `json:"structured_content,omitempty"`
+}
+
+type localAssistantTurnState struct {
+	workspace    store.Workspace
+	workspaceDir string
+	currentDir   string
+	mcpURL       string
+}
+
+func localAssistantToolDefinitions() []map[string]any {
+	return []map[string]any{
+		{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "shell",
+				"description": "Run a shell command inside the active workspace and inspect the result.",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"command": map[string]any{
+							"type":        "string",
+							"description": "Shell command to execute.",
+						},
+						"cwd": map[string]any{
+							"type":        "string",
+							"description": "Optional relative or absolute directory inside the workspace.",
+						},
+					},
+					"required": []string{"command"},
+				},
+			},
+		},
+		{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "mcp",
+				"description": "Call an MCP tool on the active workspace MCP endpoint or the local fallback endpoint.",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{
+							"type":        "string",
+							"description": "Tool name to call.",
+						},
+						"arguments": map[string]any{
+							"type":        "object",
+							"description": "Tool arguments.",
+						},
+						"mcp_url": map[string]any{
+							"type":        "string",
+							"description": "Optional MCP URL override.",
+						},
+					},
+					"required": []string{"name"},
+				},
+			},
+		},
+	}
+}
+
+func (a *App) requestLocalAssistantCompletion(ctx context.Context, messages []map[string]any) (localIntentLLMMessage, error) {
+	baseURL := a.assistantLLMBaseURL()
+	if baseURL == "" {
+		return localIntentLLMMessage{}, errors.New("local assistant is not configured")
+	}
+	requestBody, _ := json.Marshal(map[string]any{
+		"model":       a.localAssistantLLMModel(),
+		"temperature": 0,
+		"max_tokens":  assistantLLMMaxTokens,
+		"tool_choice": "auto",
+		"tools":       localAssistantToolDefinitions(),
+		"chat_template_kwargs": map[string]any{
+			"enable_thinking": false,
+		},
+		"messages": messages,
+	})
+	requestCtx, cancel := context.WithTimeout(ctx, assistantLLMRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		requestCtx,
+		http.MethodPost,
+		baseURL+"/v1/chat/completions",
+		bytes.NewReader(requestBody),
+	)
+	if err != nil {
+		return localIntentLLMMessage{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return localIntentLLMMessage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, assistantLLMResponseLimit))
+		return localIntentLLMMessage{}, fmt.Errorf("assistant llm HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload localIntentLLMChatCompletionResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, assistantLLMResponseLimit)).Decode(&payload); err != nil {
+		return localIntentLLMMessage{}, err
+	}
+	if len(payload.Choices) == 0 {
+		return localIntentLLMMessage{}, errors.New("assistant llm returned no choices")
+	}
+	return payload.Choices[0].Message, nil
+}
+
+func parseLocalAssistantDecision(message localIntentLLMMessage) (localAssistantDecision, error) {
+	if len(message.ToolCalls) > 0 {
+		calls, err := parseLocalAssistantToolCalls(message.ToolCalls)
+		if err != nil {
+			return localAssistantDecision{}, err
+		}
+		return localAssistantDecision{ToolCalls: calls}, nil
+	}
+	if message.FunctionCall != nil && strings.TrimSpace(message.FunctionCall.Name) != "" {
+		calls, err := parseLocalAssistantToolCalls([]localAssistantLLMToolCall{{
+			ID:       randomToken(),
+			Type:     "function",
+			Function: *message.FunctionCall,
+		}})
+		if err != nil {
+			return localAssistantDecision{}, err
+		}
+		return localAssistantDecision{ToolCalls: calls}, nil
+	}
+	content := strings.TrimSpace(stripCodeFence(message.Content))
+	if content == "" {
+		return localAssistantDecision{}, errors.New("assistant llm returned empty content")
+	}
+	if classification, err := parseIntentPlanClassification(content); err == nil && classification.LocalAnswer != nil {
+		if text := strings.TrimSpace(classification.LocalAnswer.Text); text != "" {
+			return localAssistantDecision{FinalText: text}, nil
+		}
+	}
+	if decoded, ok := decodeLocalAssistantEnvelope(content); ok {
+		switch typed := decoded.(type) {
+		case map[string]any:
+			if final := strings.TrimSpace(fmt.Sprint(typed["final"])); final != "" && final != "<nil>" {
+				return localAssistantDecision{FinalText: final}, nil
+			}
+			if text := strings.TrimSpace(fmt.Sprint(typed["text"])); text != "" && text != "<nil>" {
+				return localAssistantDecision{FinalText: text}, nil
+			}
+			if rawCalls, ok := typed["tool_calls"]; ok {
+				calls, err := parseLocalAssistantToolCallsAny(rawCalls)
+				if err != nil {
+					return localAssistantDecision{}, err
+				}
+				return localAssistantDecision{ToolCalls: calls}, nil
+			}
+		}
+	}
+	if looksLikeMalformedLocalAssistantToolResponse(content) {
+		return localAssistantDecision{}, errors.New("assistant emitted malformed tool JSON")
+	}
+	return localAssistantDecision{FinalText: content}, nil
+}
+
+func decodeLocalAssistantEnvelope(raw string) (any, bool) {
+	decoded, ok := decodeSystemActionCandidate(raw)
+	if ok {
+		return decoded, true
+	}
+	embedded := extractEmbeddedJSON(raw)
+	if embedded == "" {
+		return nil, false
+	}
+	return decodeSystemActionCandidate(embedded)
+}
+
+func looksLikeMalformedLocalAssistantToolResponse(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return true
+	}
+	lower := strings.ToLower(trimmed)
+	return strings.Contains(lower, "tool_calls") || strings.Contains(lower, "function_call") || strings.Contains(lower, "\"arguments\"")
+}
+
+func parseLocalAssistantToolCallsAny(raw any) ([]localAssistantToolCall, error) {
+	switch typed := raw.(type) {
+	case []any:
+		calls := make([]localAssistantToolCall, 0, len(typed))
+		for _, item := range typed {
+			obj, _ := item.(map[string]any)
+			if obj == nil {
+				return nil, errors.New("tool_calls entry must be an object")
+			}
+			call, err := parseLocalAssistantToolCallMap(obj)
+			if err != nil {
+				return nil, err
+			}
+			calls = append(calls, call)
+		}
+		return calls, nil
+	case map[string]any:
+		call, err := parseLocalAssistantToolCallMap(typed)
+		if err != nil {
+			return nil, err
+		}
+		return []localAssistantToolCall{call}, nil
+	default:
+		return nil, errors.New("tool_calls must be an object or array")
+	}
+}
+
+func parseLocalAssistantToolCalls(raw []localAssistantLLMToolCall) ([]localAssistantToolCall, error) {
+	calls := make([]localAssistantToolCall, 0, len(raw))
+	for _, item := range raw {
+		name := normalizeLocalAssistantToolName(item.Function.Name)
+		if name == "" {
+			return nil, errors.New("tool call is missing a supported name")
+		}
+		args, err := parseLocalAssistantToolArguments(item.Function.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		callID := strings.TrimSpace(item.ID)
+		if callID == "" {
+			callID = randomToken()
+		}
+		calls = append(calls, localAssistantToolCall{
+			ID:        callID,
+			Name:      name,
+			Arguments: args,
+		})
+	}
+	return calls, nil
+}
+
+func parseLocalAssistantToolCallMap(obj map[string]any) (localAssistantToolCall, error) {
+	name := normalizeLocalAssistantToolName(fmt.Sprint(obj["name"]))
+	argsValue := obj["arguments"]
+	if function, ok := obj["function"].(map[string]any); ok {
+		if name == "" {
+			name = normalizeLocalAssistantToolName(fmt.Sprint(function["name"]))
+		}
+		if argsValue == nil {
+			argsValue = function["arguments"]
+		}
+	}
+	if name == "" {
+		return localAssistantToolCall{}, errors.New("tool call is missing a supported name")
+	}
+	args, err := parseLocalAssistantToolArguments(argsValue)
+	if err != nil {
+		return localAssistantToolCall{}, err
+	}
+	callID := strings.TrimSpace(fmt.Sprint(obj["id"]))
+	if callID == "" || callID == "<nil>" {
+		callID = randomToken()
+	}
+	return localAssistantToolCall{
+		ID:        callID,
+		Name:      name,
+		Arguments: args,
+	}, nil
+}
+
+func parseLocalAssistantToolArguments(raw any) (map[string]any, error) {
+	switch typed := raw.(type) {
+	case nil:
+		return map[string]any{}, nil
+	case map[string]any:
+		return typed, nil
+	case string:
+		clean := strings.TrimSpace(typed)
+		if clean == "" {
+			return map[string]any{}, nil
+		}
+		decoded, ok := decodeLocalAssistantEnvelope(clean)
+		if !ok {
+			return nil, fmt.Errorf("tool arguments are not valid JSON: %s", clean)
+		}
+		obj, ok := decoded.(map[string]any)
+		if !ok {
+			return nil, errors.New("tool arguments must decode to an object")
+		}
+		return obj, nil
+	default:
+		return nil, fmt.Errorf("tool arguments have unsupported type %T", raw)
+	}
+}
+
+func normalizeLocalAssistantToolName(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "shell":
+		return "shell"
+	case "mcp", "mcp_tool", "mcp_call":
+		return "mcp"
+	default:
+		return ""
+	}
+}
+
+func localAssistantAssistantMessage(message localIntentLLMMessage) map[string]any {
+	payload := map[string]any{
+		"role":    "assistant",
+		"content": strings.TrimSpace(message.Content),
+	}
+	if len(message.ToolCalls) > 0 {
+		payload["tool_calls"] = message.ToolCalls
+	}
+	if message.FunctionCall != nil && strings.TrimSpace(message.FunctionCall.Name) != "" {
+		payload["function_call"] = message.FunctionCall
+	}
+	return payload
+}
+
+func localAssistantRepairPrompt(err error) string {
+	return fmt.Sprintf(
+		"Your last tool response could not be executed: %s. Return a valid tool call or a valid {\"final\":\"...\"} object now.",
+		strings.TrimSpace(err.Error()),
+	)
+}
+
+func (a *App) runLocalAssistantToolLoop(ctx context.Context, req *assistantTurnRequest, prompt string, visual *chatVisualAttachment) (string, error) {
+	if a == nil || req == nil {
+		return "", errors.New("assistant turn request is required")
+	}
+	state, err := a.newLocalAssistantTurnState(req)
+	if err != nil {
+		return "", err
+	}
+	conversation := []map[string]any{
+		{"role": "system", "content": localAssistantDialoguePrompt},
+		{"role": "user", "content": buildLocalAssistantUserContent(prompt, visual)},
+	}
+	malformedRetries := 0
+	for round := 0; round < assistantLLMMaxToolRounds; round++ {
+		message, err := a.requestLocalAssistantCompletion(ctx, conversation)
+		if err != nil {
+			return "", err
+		}
+		decision, err := parseLocalAssistantDecision(message)
+		if err != nil {
+			if malformedRetries >= assistantLLMMalformedRetries {
+				return "", fmt.Errorf("local assistant emitted malformed tool output: %w", err)
+			}
+			malformedRetries++
+			conversation = append(conversation, localAssistantAssistantMessage(message))
+			conversation = append(conversation, map[string]any{
+				"role":    "user",
+				"content": localAssistantRepairPrompt(err),
+			})
+			continue
+		}
+		if text := strings.TrimSpace(decision.FinalText); text != "" {
+			return text, nil
+		}
+		if len(decision.ToolCalls) == 0 {
+			return "", errors.New("assistant returned neither tool calls nor a final response")
+		}
+		malformedRetries = 0
+		conversation = append(conversation, localAssistantAssistantMessage(message))
+		for _, call := range decision.ToolCalls {
+			result, execErr := a.executeLocalAssistantToolCall(ctx, &state, call)
+			if execErr != nil {
+				return "", execErr
+			}
+			if resultPayload := localAssistantToolPayload(result, state.workspace.ID); resultPayload != nil {
+				a.broadcastSystemActionEvent(req.sessionID, resultPayload)
+			}
+			conversation = append(conversation, map[string]any{
+				"role":         "tool",
+				"tool_call_id": call.ID,
+				"content":      result.content(),
+			})
+		}
+	}
+	return "", fmt.Errorf("local assistant exceeded %d tool rounds", assistantLLMMaxToolRounds)
+}
+
+func (a *App) newLocalAssistantTurnState(req *assistantTurnRequest) (localAssistantTurnState, error) {
+	workspace, err := a.effectiveWorkspaceForChatSession(req.session)
+	if err != nil {
+		return localAssistantTurnState{}, err
+	}
+	workspaceDir := strings.TrimSpace(workspace.DirPath)
+	if workspaceDir == "" {
+		return localAssistantTurnState{}, errors.New("workspace path is required")
+	}
+	mcpURL := strings.TrimSpace(workspace.MCPURL)
+	if mcpURL == "" {
+		mcpURL = strings.TrimSpace(a.localMCPURL)
+	}
+	return localAssistantTurnState{
+		workspace:    workspace,
+		workspaceDir: workspaceDir,
+		currentDir:   workspaceDir,
+		mcpURL:       mcpURL,
+	}, nil
+}
+
+func (a *App) executeLocalAssistantToolCall(ctx context.Context, state *localAssistantTurnState, call localAssistantToolCall) (localAssistantToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return localAssistantToolResult{}, err
+	}
+	switch call.Name {
+	case "shell":
+		return executeLocalAssistantShellTool(state, call), nil
+	case "mcp":
+		return a.executeLocalAssistantMCPTool(ctx, state, call)
+	default:
+		return localAssistantToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Arguments:  call.Arguments,
+			IsError:    true,
+			Error:      "unsupported local assistant tool",
+		}, nil
+	}
+}
+
+func executeLocalAssistantShellTool(state *localAssistantTurnState, call localAssistantToolCall) localAssistantToolResult {
+	result := localAssistantToolResult{
+		ToolCallID: call.ID,
+		Name:       call.Name,
+		Arguments:  call.Arguments,
+	}
+	command := strings.TrimSpace(fmt.Sprint(call.Arguments["command"]))
+	if command == "" || command == "<nil>" {
+		result.IsError = true
+		result.Error = "shell command is required"
+		return result
+	}
+	cwd, err := resolveLocalAssistantToolCWD(state.workspaceDir, state.currentDir, fmt.Sprint(call.Arguments["cwd"]))
+	if err != nil {
+		result.IsError = true
+		result.Error = err.Error()
+		return result
+	}
+	result.CWD = cwd
+	execResult := executeShellCommand(command, cwd)
+	result.Output = execResult.Output
+	result.ExitCode = execResult.ExitCode
+	result.TimedOut = execResult.TimedOut
+	if execResult.TimedOut {
+		result.IsError = true
+		result.Error = fmt.Sprintf("shell command timed out after %s", systemActionShellTimeout)
+		return result
+	}
+	if execResult.RunErr != nil && execResult.ExitCode == 0 {
+		result.IsError = true
+		result.Error = execResult.RunErr.Error()
+		return result
+	}
+	if execResult.ExitCode != 0 {
+		result.IsError = true
+		result.Error = fmt.Sprintf("shell command failed with exit %d", execResult.ExitCode)
+	}
+	if nextDir := localAssistantNextWorkingDir(command, state.workspaceDir, cwd); nextDir != "" {
+		state.currentDir = nextDir
+		result.CWD = nextDir
+	} else {
+		state.currentDir = cwd
+	}
+	return result
+}
+
+func (a *App) executeLocalAssistantMCPTool(ctx context.Context, state *localAssistantTurnState, call localAssistantToolCall) (localAssistantToolResult, error) {
+	result := localAssistantToolResult{
+		ToolCallID: call.ID,
+		Name:       call.Name,
+		Arguments:  call.Arguments,
+	}
+	mcpURL := strings.TrimSpace(fmt.Sprint(call.Arguments["mcp_url"]))
+	if mcpURL == "" || mcpURL == "<nil>" {
+		mcpURL = state.mcpURL
+	}
+	if mcpURL == "" {
+		result.IsError = true
+		result.Error = "MCP URL is not configured"
+		return result, nil
+	}
+	toolName := strings.TrimSpace(fmt.Sprint(call.Arguments["name"]))
+	if toolName == "" || toolName == "<nil>" {
+		result.IsError = true
+		result.Error = "MCP tool name is required"
+		return result, nil
+	}
+	toolArgs, err := parseLocalAssistantToolArguments(call.Arguments["arguments"])
+	if err != nil {
+		result.IsError = true
+		result.Error = err.Error()
+		return result, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return localAssistantToolResult{}, err
+	}
+	structuredContent, err := mcpToolsCallURL(mcpURL, toolName, toolArgs)
+	if err != nil {
+		result.IsError = true
+		result.Error = err.Error()
+		return result, nil
+	}
+	result.StructuredContent = structuredContent
+	return result, nil
+}
+
+func localAssistantToolPayload(result localAssistantToolResult, workspaceID int64) map[string]any {
+	if strings.TrimSpace(result.Name) == "" {
+		return nil
+	}
+	switch result.Name {
+	case "shell":
+		return map[string]any{
+			"type":         "shell",
+			"command":      strings.TrimSpace(fmt.Sprint(result.Arguments["command"])),
+			"cwd":          result.CWD,
+			"exit_code":    result.ExitCode,
+			"timed_out":    result.TimedOut,
+			"output":       result.Output,
+			"is_error":     result.IsError,
+			"error":        result.Error,
+			"workspace_id": workspaceID,
+		}
+	case "mcp":
+		return map[string]any{
+			"type":         "mcp_tool",
+			"name":         strings.TrimSpace(fmt.Sprint(result.Arguments["name"])),
+			"arguments":    result.Arguments["arguments"],
+			"result":       result.StructuredContent,
+			"is_error":     result.IsError,
+			"error":        result.Error,
+			"workspace_id": workspaceID,
+		}
+	default:
+		return nil
+	}
+}
+
+func (r localAssistantToolResult) content() string {
+	body, _ := json.Marshal(r)
+	return string(body)
+}
+
+func resolveLocalAssistantToolCWD(workspaceDir, currentDir, raw string) (string, error) {
+	base := strings.TrimSpace(currentDir)
+	if base == "" {
+		base = strings.TrimSpace(workspaceDir)
+	}
+	target := strings.TrimSpace(raw)
+	if target == "" || target == "<nil>" {
+		target = base
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(base, target)
+	}
+	target = filepath.Clean(target)
+	root := filepath.Clean(strings.TrimSpace(workspaceDir))
+	if root != "" {
+		rel, err := filepath.Rel(root, target)
+		if err != nil {
+			return "", err
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("cwd %q escapes the workspace", raw)
+		}
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("cwd %q is not a directory", raw)
+	}
+	return target, nil
+}
+
+func localAssistantNextWorkingDir(command string, workspaceDir string, currentDir string) string {
+	trimmed := strings.TrimSpace(command)
+	if !strings.HasPrefix(trimmed, "cd ") {
+		return ""
+	}
+	next := strings.TrimSpace(strings.TrimPrefix(trimmed, "cd"))
+	for _, separator := range []string{"&&", ";", "\n"} {
+		if idx := strings.Index(next, separator); idx >= 0 {
+			next = strings.TrimSpace(next[:idx])
+		}
+	}
+	next = strings.Trim(next, `"'`)
+	if next == "" {
+		return ""
+	}
+	resolved, err := resolveLocalAssistantToolCWD(workspaceDir, currentDir, next)
+	if err != nil {
+		return ""
+	}
+	return resolved
+}

--- a/internal/web/chat_intent_llm.go
+++ b/internal/web/chat_intent_llm.go
@@ -24,7 +24,9 @@ type localIntentLLMChoice struct {
 }
 
 type localIntentLLMMessage struct {
-	Content string `json:"content"`
+	Content      string                         `json:"content"`
+	ToolCalls    []localAssistantLLMToolCall    `json:"tool_calls"`
+	FunctionCall *localAssistantLLMFunctionCall `json:"function_call"`
 }
 
 type intentLocalAnswer struct {

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -33,24 +33,6 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	if a.maybeRunSilentLiveEditTurn(sessionID, session, userText, cursorCtx, positionCtx, turn.captureMode) {
 		return
 	}
-	if a.assistantTurnMode(turn.localOnly) == assistantModeLocal {
-		a.runLocalAssistantTurn(sessionID, session, messages, userText, cursorCtx, inkCtx, positionCtx, turn.captureMode, turn.outputMode)
-		return
-	}
-	if a.appServerClient == nil {
-		errText := "app-server is not configured"
-		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
-		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
-		return
-	}
-
-	cwd, err := a.effectiveWorkspaceDirForChatSession(session)
-	if err != nil {
-		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
-		return
-	}
 	baseProfile := a.appServerModelProfileForWorkspacePath(session.WorkspacePath)
 	turnProfile := baseProfile
 	if strings.TrimSpace(userText) != "" {
@@ -62,53 +44,88 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	}
 	baseProfile = a.appServerProfileForChatSession(session, baseProfile)
 	turnProfile = a.appServerProfileForChatSession(session, turnProfile)
+	req := &assistantTurnRequest{
+		sessionID:   sessionID,
+		session:     session,
+		messages:    messages,
+		userText:    userText,
+		cursorCtx:   cursorCtx,
+		inkCtx:      inkCtx,
+		positionCtx: positionCtx,
+		captureMode: turn.captureMode,
+		outputMode:  turn.outputMode,
+		localOnly:   turn.localOnly,
+		turnModel:   requestedTurnAlias,
+		baseProfile: baseProfile,
+		turnProfile: turnProfile,
+	}
+	a.assistantBackendForTurn(req).run(req)
+}
+
+func (a *App) runCodexAssistantTurn(req *assistantTurnRequest) {
+	if a == nil || req == nil {
+		return
+	}
+	if a.appServerClient == nil {
+		errText := "app-server is not configured"
+		_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
+		a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": errText})
+		return
+	}
+	cwd, err := a.effectiveWorkspaceDirForChatSession(req.session)
+	if err != nil {
+		a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": err.Error()})
+		return
+	}
 	turnStartedAt := time.Now()
-	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(turnProfile), turnProfile.Model, 0)
-	appSess, bindingSessionID, resumed, sessErr := a.getOrCreateAppSession(sessionID, cwd, baseProfile)
+	responseMeta := newAssistantResponseMetadata(providerForAppServerProfile(req.turnProfile), req.turnProfile.Model, 0)
+	appSess, bindingSessionID, resumed, sessErr := a.getOrCreateAppSession(req.sessionID, cwd, req.baseProfile)
 	if sessErr != nil {
-		a.runAssistantTurnLegacy(sessionID, session, messages, cursorCtx, inkCtx, positionCtx, turn.outputMode, baseProfile, turnProfile)
+		a.runAssistantTurnLegacy(req.sessionID, req.session, req.messages, req.cursorCtx, req.inkCtx, req.positionCtx, req.outputMode, req.baseProfile, req.turnProfile)
 		return
 	}
 
-	canvasCtx := a.resolveCanvasContext(session.WorkspacePath)
-	companionCtx := a.loadCompanionPromptContext(session.WorkspacePath)
+	canvasCtx := a.resolveCanvasContext(req.session.WorkspacePath)
+	companionCtx := a.loadCompanionPromptContext(req.session.WorkspacePath)
 	var prompt string
 	if resumed {
-		prompt = buildTurnPromptForSessionWithCompanion(sessionID, messages, canvasCtx, companionCtx, turn.outputMode, turnProfile.Alias)
+		prompt = buildTurnPromptForSessionWithCompanion(req.sessionID, req.messages, canvasCtx, companionCtx, req.outputMode, req.turnProfile.Alias)
 	} else {
-		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(session.Mode, a.yoloModeEnabled(), sessionID, messages, canvasCtx, companionCtx, turn.outputMode, turnProfile.Alias)
+		prompt = buildPromptFromHistoryForSessionWithCompanionPolicy(req.session.Mode, a.yoloModeEnabled(), req.sessionID, req.messages, canvasCtx, companionCtx, req.outputMode, req.turnProfile.Alias)
 		_ = a.store.UpdateChatSessionThread(bindingSessionID, appSess.ThreadID())
 	}
-	prompt = appendChatCursorPrompt(prompt, cursorCtx)
-	prompt = appendCanvasInkPrompt(prompt, inkCtx)
-	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
+	prompt = appendChatCursorPrompt(prompt, req.cursorCtx)
+	prompt = appendCanvasInkPrompt(prompt, req.inkCtx)
+	prompt = appendCanvasPositionPrompt(prompt, req.positionCtx)
 	if strings.TrimSpace(prompt) == "" {
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
 	}
-	prompt = a.applyWorkspacePromptContext(session.WorkspacePath, prompt)
-	prompt, err = a.applyPreAssistantPromptHook(context.Background(), sessionID, session.WorkspacePath, turn.outputMode, session.Mode, prompt)
+	prompt = a.applyWorkspacePromptContext(req.session.WorkspacePath, prompt)
+	prompt, err = a.applyPreAssistantPromptHook(context.Background(), req.sessionID, req.session.WorkspacePath, req.outputMode, req.session.Mode, prompt)
 	if err != nil {
 		errText := err.Error()
-		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": errText})
+		_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": errText})
 		return
 	}
 	if strings.TrimSpace(prompt) == "" {
-		a.broadcastChatEvent(sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
+		a.broadcastChatEvent(req.sessionID, map[string]interface{}{"type": "error", "error": "empty prompt"})
 		return
 	}
-	turnInput := buildAppServerTurnInput(prompt, latestCanvasPositionVisualAttachment(positionCtx))
+	turnInput := buildAppServerTurnInput(prompt, latestCanvasPositionVisualAttachment(req.positionCtx))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runID := randomToken()
-	a.registerActiveChatTurn(sessionID, runID, cancel)
+	a.registerActiveChatTurn(req.sessionID, runID, cancel)
 	defer func() {
 		cancel()
-		a.unregisterActiveChatTurn(sessionID, runID)
+		a.unregisterActiveChatTurn(req.sessionID, runID)
 	}()
 
-	go a.watchCanvasFile(ctx, session.WorkspacePath)
+	go a.watchCanvasFile(ctx, req.session.WorkspacePath)
 
 	latestMessage := ""
 	latestTurnID := ""
@@ -129,11 +146,11 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			return
 		}
 		if persistedAssistantID == 0 {
-			storedAssistant, storeErr := a.store.AddChatMessage(sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...)
+			storedAssistant, storeErr := a.store.AddChatMessage(req.sessionID, "assistant", candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...)
 			if storeErr != nil {
 				if !persistWriteFailed {
 					persistWriteFailed = true
-					a.broadcastChatEvent(sessionID, map[string]interface{}{
+					a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 						"type":  "error",
 						"error": storeErr.Error(),
 					})
@@ -154,7 +171,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		if storeErr := a.store.UpdateChatMessageContent(persistedAssistantID, candidateMarkdown, candidatePlain, candidateFormat, snapshotOpts()...); storeErr != nil {
 			if !persistWriteFailed {
 				persistWriteFailed = true
-				a.broadcastChatEvent(sessionID, map[string]interface{}{
+				a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 					"type":  "error",
 					"error": storeErr.Error(),
 				})
@@ -166,12 +183,12 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		persistedAssistantFormat = candidateFormat
 	}
 
-	appResp, err := appSess.SendTurnInputWithParams(ctx, turnInput, turnProfile.Model, turnProfile.TurnParams, func(ev appserver.StreamEvent) {
+	appResp, err := appSess.SendTurnInputWithParams(ctx, turnInput, req.turnProfile.Model, req.turnProfile.TurnParams, func(ev appserver.StreamEvent) {
 		payload := map[string]interface{}{
 			"type":        ev.Type,
 			"thread_id":   ev.ThreadID,
 			"turn_id":     ev.TurnID,
-			"output_mode": turn.outputMode,
+			"output_mode": req.outputMode,
 		}
 		shouldBroadcast := true
 		var renderCommand map[string]interface{}
@@ -182,15 +199,15 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			if strings.TrimSpace(ev.TurnID) != "" {
 				latestTurnID = ev.TurnID
 			}
-			a.markCompanionThinking(sessionID, session.WorkspacePath, latestTurnID, turn.outputMode, "assistant_turn_started")
+			a.markCompanionThinking(req.sessionID, req.session.WorkspacePath, latestTurnID, req.outputMode, "assistant_turn_started")
 		case "assistant_message":
 			latestMessage = ev.Message
 			latestTurnID = ev.TurnID
-			renderPlan := assistantRenderPlanForMode(ev.Message, turn.outputMode)
+			renderPlan := assistantRenderPlanForMode(ev.Message, req.outputMode)
 			persistAssistantSnapshot(ev.Message, renderPlan.RenderOnCanvas, renderPlan.AutoCanvas)
 			payload["message"] = ev.Message
 			payload["delta"] = ev.Delta
-			renderCommand = assistantRenderChatCommand(latestTurnID, turn.outputMode, ev.Message)
+			renderCommand = assistantRenderChatCommand(latestTurnID, req.outputMode, ev.Message)
 			if renderPlan.RenderOnCanvas {
 				payload["render_on_canvas"] = true
 			}
@@ -202,10 +219,10 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 				latestMessage = ev.Message
 			}
 			latestTurnID = ev.TurnID
-			renderPlan := assistantRenderPlanForMode(latestMessage, turn.outputMode)
+			renderPlan := assistantRenderPlanForMode(latestMessage, req.outputMode)
 			persistAssistantSnapshot(latestMessage, renderPlan.RenderOnCanvas, renderPlan.AutoCanvas)
 			payload["message"] = latestMessage
-			renderCommand = assistantRenderChatCommand(latestTurnID, turn.outputMode, latestMessage)
+			renderCommand = assistantRenderChatCommand(latestTurnID, req.outputMode, latestMessage)
 			if renderPlan.RenderOnCanvas {
 				payload["render_on_canvas"] = true
 			}
@@ -223,7 +240,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		case "context_compact":
 			// pass through to frontend
 		case "approval_request":
-			decision, decisionErr := a.requestAppServerApproval(ctx, sessionID, ev)
+			decision, decisionErr := a.requestAppServerApproval(ctx, req.sessionID, ev)
 			if decisionErr != nil {
 				if ev.Respond != nil {
 					_ = ev.Respond("cancel")
@@ -246,26 +263,26 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			shouldBroadcast = false
 		}
 		if shouldBroadcast {
-			a.broadcastChatEvent(sessionID, payload)
+			a.broadcastChatEvent(req.sessionID, payload)
 			if renderCommand != nil {
-				a.broadcastChatEvent(sessionID, renderCommand)
+				a.broadcastChatEvent(req.sessionID, renderCommand)
 			}
 		}
 	})
 	if err != nil {
-		a.closeAppSession(sessionID)
+		a.closeAppSession(req.sessionID)
 		if errors.Is(err, context.Canceled) {
-			a.finishCompanionPendingTurn(sessionID, "assistant_turn_cancelled")
-			a.broadcastChatEvent(sessionID, map[string]interface{}{
+			a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_cancelled")
+			a.broadcastChatEvent(req.sessionID, map[string]interface{}{
 				"type":    "turn_cancelled",
 				"turn_id": latestTurnID,
 			})
 			return
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+			a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
 			errText := "assistant request timed out"
-			_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+			_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
 			payload := map[string]interface{}{
 				"type":  "error",
 				"error": errText,
@@ -273,12 +290,12 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 			if strings.TrimSpace(latestTurnID) != "" {
 				payload["turn_id"] = latestTurnID
 			}
-			a.broadcastChatEvent(sessionID, payload)
+			a.broadcastChatEvent(req.sessionID, payload)
 			return
 		}
-		a.finishCompanionPendingTurn(sessionID, "assistant_turn_failed")
+		a.finishCompanionPendingTurn(req.sessionID, "assistant_turn_failed")
 		errText := normalizeAssistantError(err)
-		_, _ = a.store.AddChatMessage(sessionID, "system", errText, errText, "text")
+		_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")
 		payload := map[string]interface{}{
 			"type":  "error",
 			"error": errText,
@@ -286,7 +303,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		if strings.TrimSpace(latestTurnID) != "" {
 			payload["turn_id"] = latestTurnID
 		}
-		a.broadcastChatEvent(sessionID, payload)
+		a.broadcastChatEvent(req.sessionID, payload)
 		return
 	}
 
@@ -299,15 +316,15 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	}
 
 	assistantText = a.finalizeAssistantResponseWithMetadata(
-		sessionID,
-		session.WorkspacePath,
+		req.sessionID,
+		req.session.WorkspacePath,
 		assistantText,
 		&persistedAssistantID,
 		&persistedAssistantText,
 		appResp.TurnID,
 		latestTurnID,
 		appResp.ThreadID,
-		turn.outputMode,
+		req.outputMode,
 		newAssistantResponseMetadata(responseMeta.Provider, responseMeta.ProviderModel, time.Since(turnStartedAt)),
 	)
 	_ = assistantText


### PR DESCRIPTION
## Summary
- add a real assistant backend abstraction so local and Codex turns share one server-side entry point
- replace the local plain-text fallback with a multi-round local tool loop that supports `shell` and generic `mcp` calls, preserves turn-local working directory state, and retries malformed tool output
- cover local, codex, and auto routing plus local shell/MCP execution and malformed-call recovery with focused tests

## Verification
- Backend abstraction and Codex path regression: `TestAssistantBackendForTurnAutoRoutesBetweenLocalAndCodex`, `TestRunAssistantTurnKeepsPlainTextAssistantOutput`, `TestRunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable`
- Local shell execution and turn-local working directory persistence: `TestExecuteLocalAssistantShellToolTracksWorkingDirectory`
- Local MCP forwarding: `TestExecuteLocalAssistantMCPToolUsesConfiguredEndpoint`
- Multi-round local replacement with shell plus MCP: `TestRunAssistantTurnLocalAssistantCompletesMultiToolLoop`
- Malformed tool-call recovery: `TestRunAssistantTurnLocalAssistantRecoversMalformedToolCall`
- Explicit local mode: `TestRunAssistantTurnUsesLocalAssistantModeWhenConfigured`
- Auto mode without app-server: `TestRunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer`

Command:
```bash
go test ./internal/web -run 'TestAssistantBackendForTurnAutoRoutesBetweenLocalAndCodex|TestParseLocalAssistantDecisionParsesNativeToolCalls|TestExecuteLocalAssistantShellToolTracksWorkingDirectory|TestExecuteLocalAssistantMCPToolUsesConfiguredEndpoint|TestRunAssistantTurnLocalAssistantCompletesMultiToolLoop|TestRunAssistantTurnLocalAssistantRecoversMalformedToolCall|TestRunAssistantTurnKeepsPlainTextAssistantOutput|TestRunAssistantTurnUsesLocalAssistantModeWhenConfigured|TestRunAssistantTurnUsesAssistantLLMFallbackInAutoModeWithoutAppServer|TestRunAssistantTurnFallsBackToAppServerWhenIntentLLMUnavailable' 2>&1 | tee /tmp/issue684-test.log
```

Output:
```text
ok  	github.com/krystophny/tabura/internal/web	2.101s
```
