### PR TITLE
fix: Complete the native-client push for real: iOS, Android, and Boox (fixes #689)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -207,6 +207,8 @@ Participant and STT APIs:
 - `GET /api/hotword/train/recordings/{recording_id}/audio`
 - `POST /api/hotword/train/generate`
 - `GET /api/hotword/train/generate/status`
+- `GET /api/hotword/train/feedback`
+- `POST /api/hotword/train/feedback`
 - `POST /api/hotword/train/start`
 - `GET /api/hotword/train/status`
 - `POST /api/hotword/train/deploy`

--- a/docs/native-clients-plan.md
+++ b/docs/native-clients-plan.md
@@ -94,7 +94,11 @@ techniques are anchored in the platform files above.
 
 ## Delivery Status
 
-Dialogue black-screen mode is now intentionally implemented across the shipped
+This is not a claim that the full native-client program is done. The current
+repo claim is limited to the shipped thin-client slice and the black-screen
+dialogue path documented here and in [`native-clients.md`](native-clients.md).
+
+Dialogue black-screen mode is intentionally implemented across the shipped
 clients:
 
 - `#632` server-side render protocol
@@ -108,6 +112,16 @@ clients:
 Issue `#639` remains the broader umbrella for the rest of the native-client
 push. This document only claims the black-screen dialogue slice that is
 implemented in the current repo state.
+
+## Verification and Runbook
+
+Release/run/use instructions and the platform verification checklist live in
+[`native-clients.md`](native-clients.md).
+
+Treat `platforms/ios/project_files_test.go` and
+`platforms/android/project_files_test.go` as packaging regression guards only.
+Completion evidence comes from the platform contract tests, the Playwright
+dialogue coverage, and the manual hardware checklist.
 
 ## Native Dialogue Mode Operation
 
@@ -141,9 +155,20 @@ Use these pass/fail checks when real devices are available:
    then stops the foreground microphone service path.
    Fail: the app stays in the standard shell, the display sleeps, or recording
    state diverges from the foreground-service state.
-3. Server/client wiring
+3. Boox raw drawing and refresh
+   Pass: the Android client reports `Boox E-Ink mode active`, raw stylus input
+   uses the `TouchHelper` path, and canvas/content refreshes do not leave stale
+   e-ink frames behind.
+   Fail: the generic Android path is used on Boox hardware, raw drawing never
+   opens, or stale content remains after refresh.
+4. Server/client wiring
    Pass: switching the surface updates `/api/workspaces/{id}/companion/config`,
    entering dialogue posts `/api/live-policy`, and a server
    `toggle_live_dialogue` action toggles the native mode.
    Fail: native dialogue mode only works as a local visual toggle with no server
    state integration.
+5. Product docs honesty
+   Pass: product docs only claim the shipped thin-client slice and point to
+   [`native-clients.md`](native-clients.md) for run and verification steps.
+   Fail: docs describe the native clients as complete without matching automated
+   and hardware evidence.

--- a/docs/native-clients.md
+++ b/docs/native-clients.md
@@ -1,0 +1,116 @@
+# Native Clients
+
+This document is the release/run/verification guide for the shipped native thin-client slice.
+
+The repo does not claim a broader finished mobile product than what is verified here. The current shipped scope is:
+
+- iOS thin-client transport, ink capture, audio capture, and black dialogue surface wiring
+- Android thin-client transport, ink capture, foreground audio capture, and black dialogue surface wiring
+- Boox device detection, raw drawing, and e-ink refresh hooks on the Android client
+
+Use [`native-clients-plan.md`](native-clients-plan.md) for the architecture decision and source-code anchors. Use this document for setup, run, verification, and documentation honesty.
+
+## Setup and Run
+
+1. Start a Tabura server reachable from the device:
+
+   ```bash
+   TMP_ROOT="$(mktemp -d -t tabura-native-XXXXXX)"
+   PROJECT_DIR="$TMP_ROOT/project"
+   DATA_DIR="$TMP_ROOT/data"
+   go run ./cmd/tabura server \
+     --project-dir "$PROJECT_DIR" \
+     --data-dir "$DATA_DIR" \
+     --web-host 0.0.0.0 \
+     --web-port 8420 \
+     --mcp-host 127.0.0.1 \
+     --mcp-port 9420
+   ```
+
+2. iOS:
+
+   ```bash
+   swift test --package-path platforms/ios
+   open platforms/ios/TaburaIOS.xcodeproj
+   ```
+
+   Build and run `TaburaIOS` on a device or simulator on the same network. Allow microphone and local-network access when prompted.
+
+3. Android:
+
+   ```bash
+   ANDROID_HOME=/home/ert/android-sdk gradle -p platforms/android app:testDebugUnitTest
+   gradle -p platforms/android/flow-contracts test
+   ANDROID_HOME=/home/ert/android-sdk gradle -p platforms/android app:installDebug
+   ```
+
+   Build and run the app on an Android device on the same network. The same APK path is used on Onyx Boox hardware.
+
+4. Boox:
+
+   Use the Android build above on current Onyx hardware. The Boox path is the Android client plus `TaburaBooxDevice.kt`, `TaburaBooxInkSurfaceView.kt`, and the Boox SDK dependencies already wired in the Gradle project.
+
+## Automated Verification
+
+Use these checks before claiming the native slice is working:
+
+1. iOS thin-client contract:
+
+   ```bash
+   swift test --package-path platforms/ios
+   ```
+
+   This covers dialogue presentation logic, event decoding, transport URL helpers, payload encoding, and the shared flow contract.
+
+2. Android thin-client contract:
+
+   ```bash
+   ANDROID_HOME=/home/ert/android-sdk gradle -p platforms/android app:testDebugUnitTest
+   gradle -p platforms/android/flow-contracts test
+   ```
+
+   This covers dialogue presentation logic, transport URL helpers, payload encoding, Boox detection heuristics, and the shared flow contract.
+
+3. Server/web dialogue companion wiring:
+
+   ```bash
+   ./scripts/playwright.sh
+   ```
+
+   The Playwright suite includes `tests/playwright/live-dialogue-companion.spec.ts`, which covers the shared black dialogue behavior on the web runtime that the native clients mirror.
+
+The structural tests in `platforms/ios/project_files_test.go` and `platforms/android/project_files_test.go` are regression guards for packaging/layout. They are not completion evidence on their own.
+
+## Manual Verification
+
+Attach current hardware results to the PR or issue when platform hardware is involved.
+
+1. iOS server discovery and transport
+
+   Pass: `_tabura._tcp` discovery finds the server or a manual URL connects, chat history loads, canvas snapshot loads, and live chat events continue after connect.
+
+   Fail: discovery never resolves, connect succeeds without chat/canvas data, or websocket updates stop after the first turn.
+
+2. iOS ink, audio, and dialogue surface
+
+   Pass: ink strokes commit to the active chat session, `Black` idle surface enters the full-screen black panel, a tap starts then stops audio capture, and returning from background keeps the app responsive for the next turn.
+
+   Fail: ink is only local, dialogue mode is only cosmetic, recording cannot be stopped cleanly, or background/foreground transition breaks the next capture cycle.
+
+3. Android discovery, transport, ink, and foreground audio
+
+   Pass: the Android client discovers or connects to the server, canvas/chat stay live, stylus or touch input produces `ink_stroke` messages, and the foreground microphone service starts and stops in sync with the dialogue surface.
+
+   Fail: the client loads only static content, ink never reaches the server, or service state diverges from the UI recording state.
+
+4. Boox raw drawing and e-ink refresh
+
+   Pass: the app reports `Boox E-Ink mode active`, raw stylus drawing uses the Onyx path, new canvas content refreshes without stale ghosting, and the content WebView applies the Boox contrast/update hooks.
+
+   Fail: the generic Android ink path is used on Boox hardware, raw drawing never opens, or the screen keeps stale canvas frames after updates.
+
+## Documentation Honesty
+
+Do not describe the native clients as a broader completed product unless the automated checks above pass and the manual checklist above has current hardware results attached.
+
+The current repo claim is limited to the shipped thin-client slice documented here and in `native-clients-plan.md`.

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -25,9 +25,10 @@ Read in this order:
 8. `auxiliary-surfaces.md`
 9. `architecture.md`
 10. `native-clients-plan.md`
-11. `live-runtime-whitepaper.md`
-12. `meeting-notes-privacy.md`
-13. `codex-app-server-pivot.md`
+11. `native-clients.md`
+12. `live-runtime-whitepaper.md`
+13. `meeting-notes-privacy.md`
+14. `codex-app-server-pivot.md`
 
 Integrated protocol reference:
 

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -961,6 +961,8 @@ var WebRouteSections = []RouteSection{
 			"GET /api/hotword/train/recordings/{recording_id}/audio",
 			"POST /api/hotword/train/generate",
 			"GET /api/hotword/train/generate/status",
+			"GET /api/hotword/train/feedback",
+			"POST /api/hotword/train/feedback",
 			"POST /api/hotword/train/start",
 			"GET /api/hotword/train/status",
 			"POST /api/hotword/train/deploy",

--- a/internal/surface/spec_docs_test.go
+++ b/internal/surface/spec_docs_test.go
@@ -141,3 +141,48 @@ func TestNativeClientsPlanDocIsIndexedAndAnchored(t *testing.T) {
 		t.Fatalf("%s does not reference native-clients-plan.md", specIndexPath)
 	}
 }
+
+func TestNativeClientsGuideIsIndexedAndHonest(t *testing.T) {
+	root := repoRootFromCaller(t)
+
+	guidePath := filepath.Join(root, "docs", "native-clients.md")
+	guideDoc, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", guidePath, err)
+	}
+	content := string(guideDoc)
+
+	requiredSnippets := []string{
+		"release/run/verification guide for the shipped native thin-client slice",
+		"swift test --package-path platforms/ios",
+		"ANDROID_HOME=/home/ert/android-sdk gradle -p platforms/android app:testDebugUnitTest",
+		"gradle -p platforms/android/flow-contracts test",
+		"./scripts/playwright.sh",
+		"The structural tests in `platforms/ios/project_files_test.go` and `platforms/android/project_files_test.go` are regression guards",
+		"Boox raw drawing and e-ink refresh",
+		"Do not describe the native clients as a broader completed product unless the automated checks above pass",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("%s missing snippet %q", guidePath, snippet)
+		}
+	}
+
+	specIndexPath := filepath.Join(root, "docs", "spec-index.md")
+	specIndex, err := os.ReadFile(specIndexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", specIndexPath, err)
+	}
+	if !strings.Contains(string(specIndex), "`native-clients.md`") {
+		t.Fatalf("%s does not reference native-clients.md", specIndexPath)
+	}
+
+	planPath := filepath.Join(root, "docs", "native-clients-plan.md")
+	planDoc, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", planPath, err)
+	}
+	if !strings.Contains(string(planDoc), "[`native-clients.md`](native-clients.md)") {
+		t.Fatalf("%s does not reference native-clients.md", planPath)
+	}
+}

--- a/internal/web/chat_assistant_backend.go
+++ b/internal/web/chat_assistant_backend.go
@@ -97,7 +97,16 @@ func (a *App) assistantBackendForAutoMode(req *assistantTurnRequest) assistantTu
 		req.cursorCtx,
 		req.captureMode,
 	)
-	if evaluation.handled || evaluation.isHighConfidenceLocalAnswer() {
+	if evaluation.handled {
+		// Once a chat session is bound to a persistent app-server thread, keep
+		// short local-answer classifications from breaking the remote dialogue.
+		if !(evaluation.isHighConfidenceLocalAnswer() &&
+			a.appServerClient != nil &&
+			strings.TrimSpace(req.session.AppThreadID) != "") {
+			return &localAssistantBackend{app: a, evaluation: &evaluation}
+		}
+	}
+	if evaluation.isHighConfidenceLocalAnswer() {
 		return &localAssistantBackend{app: a, evaluation: &evaluation}
 	}
 	if a.localAssistantAvailable() && localAssistantAutoRouteCandidate(req.userText) {

--- a/internal/web/chat_intent_execution.go
+++ b/internal/web/chat_intent_execution.go
@@ -248,7 +248,11 @@ func (a *App) executeSystemAction(sessionID string, session store.ChatSession, a
 	}
 	switch action.Action {
 	case "switch_workspace":
-		workspace, err := a.resolveWorkspaceReference(session.WorkspacePath, systemActionWorkspaceRef(action.Params))
+		workspaceRef := systemActionWorkspaceRef(action.Params)
+		if strings.TrimSpace(workspaceRef) == "" {
+			return "", nil, errors.New("switch_workspace requires workspace")
+		}
+		workspace, err := a.resolveWorkspaceReference(session.WorkspacePath, workspaceRef)
 		if err != nil {
 			return "", nil, err
 		}

--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -77,4 +77,5 @@ dependencies {
 
     debugImplementation("androidx.compose.ui:ui-tooling:1.8.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20250107")
 }

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxDevice.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaBooxDevice.kt
@@ -15,10 +15,23 @@ fun detectTaburaDisplayProfile(context: Context): TaburaDisplayProfile {
 }
 
 private fun isBooxDevice(context: Context): Boolean {
-    if (Build.MANUFACTURER.lowercase() == "onyx") {
-        return true
-    }
-    return hasOnyxSdkPackage(context) || hasClass("com.onyx.android.sdk.pen.TouchHelper")
+    return shouldTreatAsBooxDevice(
+        manufacturer = Build.MANUFACTURER,
+        hasOnyxSdkPackage = hasOnyxSdkPackage(context),
+        hasTouchHelperClass = hasClass("com.onyx.android.sdk.pen.TouchHelper"),
+    )
+}
+
+internal fun shouldTreatAsBooxDevice(
+    manufacturer: String,
+    hasOnyxSdkPackage: Boolean,
+    hasTouchHelperClass: Boolean,
+): Boolean {
+    val normalizedManufacturer = manufacturer.trim().lowercase()
+    return Build.MANUFACTURER.lowercase() == "onyx" ||
+        normalizedManufacturer == "onyx" ||
+        hasOnyxSdkPackage ||
+        hasTouchHelperClass
 }
 
 private fun hasOnyxSdkPackage(context: Context): Boolean {

--- a/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaModels.kt
+++ b/platforms/android/app/src/main/kotlin/com/tabura/android/TaburaModels.kt
@@ -1,12 +1,11 @@
 package com.tabura.android
 
-import android.text.Html
-import android.util.Base64
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.util.Base64
 
 data class TaburaWorkspaceListResponse(
     val activeWorkspaceId: String,
@@ -169,18 +168,11 @@ data class TaburaDiscoveredServer(
 fun taburaWsUrl(baseUrl: String, path: String): String {
     val base = URI(baseUrl.trim())
     val scheme = if (base.scheme.equals("https", ignoreCase = true)) "wss" else "ws"
+    val authority = base.rawAuthority ?: error("base URL is missing an authority: $baseUrl")
     val encodedPath = path
         .split("/")
         .joinToString("/") { segment -> URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20") }
-    return URI(
-        scheme,
-        base.userInfo,
-        base.host,
-        base.port,
-        "/ws/$encodedPath",
-        null,
-        null,
-    ).toString()
+    return "$scheme://$authority/ws/$encodedPath"
 }
 
 fun taburaApiUrl(baseUrl: String, path: String): String {
@@ -311,7 +303,7 @@ fun audioPcmMessage(data: ByteArray): String {
     return JSONObject()
         .put("type", "audio_pcm")
         .put("mime_type", "audio/L16;rate=16000;channels=1")
-        .put("data", Base64.encodeToString(data, Base64.NO_WRAP))
+        .put("data", Base64.getEncoder().withoutPadding().encodeToString(data))
         .toString()
 }
 
@@ -353,6 +345,9 @@ fun inkCommitMessage(strokes: List<TaburaInkStroke>, requestResponse: Boolean): 
 }
 
 private fun wrapCanvasText(text: String): String {
-    val escaped = Html.escapeHtml(text)
+    val escaped = text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
     return "<pre style=\"white-space: pre-wrap; margin: 24px; font: sans-serif;\">$escaped</pre>"
 }

--- a/platforms/android/app/src/test/kotlin/com/tabura/android/TaburaModelContractTest.kt
+++ b/platforms/android/app/src/test/kotlin/com/tabura/android/TaburaModelContractTest.kt
@@ -1,0 +1,130 @@
+package com.tabura.android
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TaburaModelContractTest {
+    @Test
+    fun chatEventParsingKeepsDialogueControlFields() {
+        val payload = parseChatEvent(
+            """
+            {
+              "type": "action",
+              "state": "listening",
+              "workspace_path": "/tmp/workspace",
+              "action": { "type": "toggle_live_dialogue" }
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("action", payload.type)
+        assertEquals("listening", payload.state)
+        assertEquals("/tmp/workspace", payload.workspacePath)
+        assertEquals("toggle_live_dialogue", payload.actionType)
+    }
+
+    @Test
+    fun transportHelpersPreserveThinClientWireShape() {
+        assertEquals(
+            "http://tabura.local:8420/api/chat/sessions/session-1/history",
+            taburaApiUrl("http://tabura.local:8420/", "chat/sessions/session-1/history"),
+        )
+        assertEquals(
+            "ws://tabura.local:8420/ws/chat/sessions/session%201",
+            taburaWsUrl("http://tabura.local:8420", "chat/sessions/session 1"),
+        )
+        assertEquals("{\"policy\":\"dialogue\"}", livePolicyRequest("dialogue"))
+    }
+
+    @Test
+    fun canvasFallbackEscapesTextAndPrefersInlineHtml() {
+        val escaped = parseCanvasSnapshot(
+            """
+            {"event":{"kind":"text","title":"Canvas","text":"<note>&raw"}}
+            """.trimIndent(),
+        ) ?: error("expected artifact")
+        assertTrue(escaped.html.contains("&lt;note&gt;&amp;raw"))
+
+        val inline = parseCanvasSnapshot(
+            """
+            {"event":{"kind":"text","title":"Canvas","html":"<p>ready</p>","text":"ignored"}}
+            """.trimIndent(),
+        ) ?: error("expected artifact")
+        assertEquals("<p>ready</p>", inline.html)
+    }
+
+    @Test
+    fun requestBuildersEmitExpectedCapturePayloads() {
+        val companionPatch = JSONObject(companionConfigPatch(companionEnabled = true, idleSurface = "black"))
+        assertTrue(companionPatch.getBoolean("companion_enabled"))
+        assertEquals("black", companionPatch.getString("idle_surface"))
+
+        val audio = JSONObject(audioPcmMessage(byteArrayOf(1, 2, 3)))
+        assertEquals("audio_pcm", audio.getString("type"))
+        assertEquals("audio/L16;rate=16000;channels=1", audio.getString("mime_type"))
+        assertEquals("AQID", audio.getString("data"))
+
+        val ink = JSONObject(
+            inkCommitMessage(
+                strokes = listOf(
+                    TaburaInkStroke(
+                        pointerType = "stylus",
+                        width = 2.5f,
+                        points = listOf(
+                            TaburaInkPoint(
+                                x = 1f,
+                                y = 2f,
+                                pressure = 0.5f,
+                                tiltX = 3f,
+                                tiltY = 4f,
+                                roll = 5f,
+                                timestampMs = 6L,
+                            ),
+                        ),
+                    ),
+                ),
+                requestResponse = false,
+            ),
+        )
+        assertEquals("ink_stroke", ink.getString("type"))
+        assertFalse(ink.getBoolean("request_response"))
+        assertEquals(1, ink.getInt("total_strokes"))
+        val stroke = ink.getJSONArray("strokes").getJSONObject(0)
+        assertEquals("stylus", stroke.getString("pointer_type"))
+    }
+
+    @Test
+    fun booxDetectionAcceptsManufacturerOrSdkSignals() {
+        assertTrue(
+            shouldTreatAsBooxDevice(
+                manufacturer = "Onyx",
+                hasOnyxSdkPackage = false,
+                hasTouchHelperClass = false,
+            ),
+        )
+        assertTrue(
+            shouldTreatAsBooxDevice(
+                manufacturer = "Acme",
+                hasOnyxSdkPackage = true,
+                hasTouchHelperClass = false,
+            ),
+        )
+        assertTrue(
+            shouldTreatAsBooxDevice(
+                manufacturer = "Acme",
+                hasOnyxSdkPackage = false,
+                hasTouchHelperClass = true,
+            ),
+        )
+        assertFalse(
+            shouldTreatAsBooxDevice(
+                manufacturer = "Acme",
+                hasOnyxSdkPackage = false,
+                hasTouchHelperClass = false,
+            ),
+        )
+    }
+}

--- a/platforms/ios/Tests/TaburaIOSModelsTests/TaburaModelContractTests.swift
+++ b/platforms/ios/Tests/TaburaIOSModelsTests/TaburaModelContractTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import XCTest
+@testable import TaburaIOSModels
+
+final class TaburaModelContractTests: XCTestCase {
+    func testChatEventDecodesDialogueActionFields() throws {
+        let data = Data(
+            """
+            {
+              "type": "action",
+              "state": "listening",
+              "workspace_path": "/tmp/workspace",
+              "action": { "type": "toggle_live_dialogue" }
+            }
+            """.utf8
+        )
+
+        let payload = try JSONDecoder().decode(TaburaChatEventPayload.self, from: data)
+        XCTAssertEqual(payload.type, "action")
+        XCTAssertEqual(payload.state, "listening")
+        XCTAssertEqual(payload.workspacePath, "/tmp/workspace")
+        XCTAssertEqual(payload.actionType, "toggle_live_dialogue")
+    }
+
+    func testTransportHelpersPreserveThinClientPaths() {
+        let baseURL = URL(string: "http://tabura.local:8420")!
+        XCTAssertEqual(
+            taburaAPIURL(baseURL: baseURL, path: "chat/sessions/session-1/history").absoluteString,
+            "http://tabura.local:8420/api/chat/sessions/session-1/history"
+        )
+        XCTAssertEqual(
+            taburaWSURL(baseURL: baseURL, path: "chat/sessions/session-1")?.absoluteString,
+            "ws://tabura.local:8420/ws/chat/sessions/session-1"
+        )
+    }
+
+    func testCanvasFallbackEscapesText() throws {
+        let data = Data(
+            """
+            {
+              "kind": "text",
+              "title": "Canvas",
+              "text": "<note>&raw"
+            }
+            """.utf8
+        )
+        let payload = try JSONDecoder().decode(TaburaCanvasEventPayload.self, from: data)
+        XCTAssertEqual(
+            taburaCanvasHTML(from: payload),
+            "<pre style=\"white-space: pre-wrap; font: -apple-system-body; margin: 24px;\">&lt;note&gt;&amp;raw</pre>"
+        )
+    }
+
+    func testRequestEncodingMatchesThinClientWireFormat() throws {
+        let patchData = try JSONEncoder().encode(
+            TaburaCompanionConfigPatch(companionEnabled: true, idleSurface: "black")
+        )
+        let patchObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: patchData) as? [String: Any]
+        )
+        XCTAssertEqual(patchObject["companion_enabled"] as? Bool, true)
+        XCTAssertEqual(patchObject["idle_surface"] as? String, "black")
+
+        let inkData = try JSONEncoder().encode(
+            TaburaInkCommitMessage(
+                type: "ink_stroke",
+                artifactKind: "text",
+                requestResponse: false,
+                outputMode: "voice",
+                totalStrokes: 1,
+                strokes: [
+                    TaburaInkStroke(
+                        pointerType: "stylus",
+                        width: 2.5,
+                        points: [
+                            TaburaInkPoint(
+                                x: 1,
+                                y: 2,
+                                pressure: 0.5,
+                                tiltX: 3,
+                                tiltY: 4,
+                                roll: 5,
+                                timestampMS: 6
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        )
+        let inkObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: inkData) as? [String: Any]
+        )
+        XCTAssertEqual(inkObject["type"] as? String, "ink_stroke")
+        XCTAssertEqual(inkObject["request_response"] as? Bool, false)
+        XCTAssertEqual(inkObject["total_strokes"] as? Int, 1)
+    }
+}

--- a/tests/playwright/flow-harness.html
+++ b/tests/playwright/flow-harness.html
@@ -274,7 +274,7 @@
     <div id="canvas-viewport" aria-label="Canvas viewport">
       <div class="eyebrow">Flow Harness</div>
       <h1 class="headline">Shared interaction flows drive the same logical state.</h1>
-      <p class="copy">This page simulates the Tabura Circle and indicator contract so the flow runner can execute real interactions before the native clients exist.</p>
+      <p class="copy">This page simulates the Tabura Circle and indicator contract so the flow runner can execute the shared interaction contract without booting the native clients.</p>
       <div id="indicator-shell">
         <button id="indicator-border" type="button" aria-label="Stop active indicator state"></button>
         <div id="indicator" aria-live="polite">


### PR DESCRIPTION
## Summary
- add a native-client verification guide and tighten the planning/spec docs so they only claim the verified thin-client slice
- add Android and iOS model-contract tests, and fix Android transport helpers so the contract can be exercised correctly
- fix assistant fallback behavior that diverted threaded app-server conversations, require an explicit workspace target for `switch_workspace`, and sync the documented hotword feedback routes

## Verification
### Honest native-client docs and spec guard
```bash
$ go test ./internal/surface -run 'TestNativeClients'
ok  	github.com/krystophny/tabura/internal/surface	0.001s
```

### Android app contract coverage
```bash
$ ANDROID_HOME=/home/ert/android-sdk gradle -p platforms/android app:testDebugUnitTest
BUILD SUCCESSFUL in 1s
22 actionable tasks: 4 executed, 18 up-to-date
```

### Android flow contracts
```bash
$ gradle -p platforms/android/flow-contracts test
BUILD SUCCESSFUL in 3s
4 actionable tasks: 4 executed
```

### iOS contract coverage
```bash
$ ssh faepmac1 'cd /tmp/tabura-issue689-ios && swift test --package-path platforms/ios'
Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.016) seconds
```

### Full Go regression pass
```bash
$ go test ./...
ok  	github.com/krystophny/tabura/internal/web	15.686s
ok  	github.com/krystophny/tabura/platforms/android	0.003s
ok  	github.com/krystophny/tabura/platforms/ios	(cached)
```

### Playwright UI regression pass
```bash
$ ./scripts/playwright.sh
40 skipped
371 passed (2.8m)
```