### PR TITLE
Add slsh terminal chat client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,11 @@ Environment toggles:
 - `SLOPSHELL_INTENT_LLM_PROFILE` selects the active local routing profile (default `qwen3.5-9b`)
 - `SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS` exposes selectable local routing profiles (default `qwen3.5-9b,qwen3.5-4b`)
 - `SLOPSHELL_STT_URL=off` disables STT sidecar usage
+- `SLOPSHELL_WEB_MCP_URL` points at a supplementary MCP endpoint that
+  exposes `web_search` / `web_fetch` (for example a local helpy server at
+  `http://127.0.0.1:8090/mcp`). When set, search-intent turns stay on the
+  local assistant and call those tools instead of routing to Codex/Spark.
+  Leave unset (or `off`) to keep the prior Codex fallback behavior.
 
 ## Local Dev Start
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,26 @@ systemctl --user restart sloptools.service slopshell-codex-app-server.service sl
 - Intent LLM base URL: `http://127.0.0.1:8081` (Slopshell calls `/v1/chat/completions`)
 - STT base URL: `http://127.0.0.1:8427` (`/v1/audio/transcriptions`)
 - Local canvas session: `local`
+- CLI login endpoint: `POST /api/cli/login` (loopback-only; consumes the token
+  written to `$XDG_RUNTIME_DIR/slopshell/cli-token` at server start)
+
+## Terminal client (`slsh`)
+
+Source in `cmd/slsh/`. Single binary, HTTP+WS client over the same API the
+browser uses. Build with `./scripts/build-slsh.sh` (or have the user-units
+installer place it in `$HOME/.local/bin/slsh`). One-shot with `-p`, interactive
+REPL otherwise. Routes to GPT by prefixing prompts that match the existing
+`parseTurnRoutingDirectives` in `internal/web/routing_policy.go`:
+
+- `slsh --gpt -p "…"` → "use gpt to …"
+- `slsh --think high -p "…"` → "think hard, …"
+
+E2E tests are gated with `//go:build e2e` in `cmd/slsh/e2e_test.go` and use
+mock LLM + mock MCP — never real EWS/TUGonline. Run with:
+
+```bash
+go test -tags=e2e ./cmd/slsh/...
+```
 
 Environment toggles:
 - `SLOPSHELL_TTS_URL` overrides the TTS base URL

--- a/README.md
+++ b/README.md
@@ -88,6 +88,53 @@ slopshell server --project-dir . --data-dir ~/.slopshell-web --local-mcp-url htt
 slopshell server --project-dir . --data-dir ~/.slopshell-web --local-mcp-url http://127.0.0.1:9420/mcp --web-host 0.0.0.0 --web-port 8443 --web-cert-file ~/.config/slopshell/certs/slopshell.pem --web-key-file ~/.config/slopshell/certs/slopshell-key.pem --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
 ```
 
+## Terminal client: `slsh`
+
+`slsh` is a minimal terminal chat client that talks to the running
+`slopshell server` over the same HTTP/WS API the browser uses. It reuses the
+existing tool surface (local LLM, shell tool, MCP mail/calendar/items) and the
+remote Codex app-server for GPT/Spark routing — no extra services required.
+
+Build and install to `$HOME/.local/bin/slsh` (or set `SLOPSHELL_BIN_DIR`):
+
+```bash
+./scripts/build-slsh.sh
+```
+
+`scripts/install-slopshell-user-units.sh` installs `slsh` automatically
+alongside the web server when you install the user units from source.
+
+Authentication is loopback-only: `web.New` writes a random 32-byte token to
+`$XDG_RUNTIME_DIR/slopshell/cli-token` (falling back to
+`~/.local/share/slopshell-web/cli-token`) with `0600` perms; `slsh` reads it
+and POSTs to `/api/cli/login`, which refuses non-loopback peers and ignores
+forwarded-for headers.
+
+Usage:
+
+```bash
+slsh -p "run echo hello from slsh"          # one-shot, local + shell tool
+slsh -p "list my email accounts briefly"    # routes through sloptools MCP
+slsh --gpt -p "solve this design question"  # routes to Codex app-server
+slsh --think high -p "explain this plan"    # raises reasoning effort
+slsh                                        # REPL; /clear, /resume, /exit, /model, /think
+slsh --resume <session-id>                  # reattach to a prior chat
+```
+
+Fresh sessions are the default: `slsh` creates the chat session for the
+current workspace and calls the existing `/compact` command so the next turn
+starts without old thread context. `/clear` inside the REPL wipes all chat
+state via the existing `clearAllAgentsAndContexts` handler. Session ids for
+each workspace are cached under `$XDG_STATE_HOME/slopshell/slsh-sessions.json`
+so `/sessions` can list them.
+
+Smoke the live stack with `scripts/slsh-smoke.sh`. Go e2e tests run against
+mock LLM and mock MCP (never real EWS/TUGonline) and are gated:
+
+```bash
+go test -tags=e2e ./cmd/slsh/...
+```
+
 ## Runtime Stack (Canonical)
 
 Slopshell runs with one web runtime plus a dedicated local MCP daemon:

--- a/cmd/slsh/client.go
+++ b/cmd/slsh/client.go
@@ -309,6 +309,7 @@ func (c *chatClient) consumeTurn(ctx context.Context, ws *websocket.Conn, render
 		for {
 			_, data, err := ws.ReadMessage()
 			if err != nil {
+				renderer.finishProgressLine()
 				if turnSeen && finalText != "" {
 					doneCh <- finalText
 					return
@@ -352,9 +353,11 @@ func (c *chatClient) consumeTurn(ctx context.Context, ws *websocket.Conn, render
 				renderer.onRenderChat(event)
 			case "error":
 				msg, _ := event["error"].(string)
+				renderer.finishProgressLine()
 				errCh <- fmt.Errorf("%w: %s", errAssistantError, strings.TrimSpace(msg))
 				return
 			case "turn_cancelled":
+				renderer.finishProgressLine()
 				errCh <- errors.New("turn cancelled")
 				return
 			case "chat_cleared":

--- a/cmd/slsh/client.go
+++ b/cmd/slsh/client.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	errAssistantError = errors.New("assistant error")
+)
+
+type clientConfig struct {
+	baseURL   string
+	tokenFile string
+	verbose   bool
+	stderr    io.Writer
+}
+
+type chatClient struct {
+	base    *url.URL
+	http    *http.Client
+	verbose bool
+	stderr  io.Writer
+}
+
+type chatSessionInfo struct {
+	ID              string `json:"session_id"`
+	WorkspaceID     int64  `json:"workspace_id"`
+	WorkspacePath   string `json:"workspace_path"`
+	Mode            string `json:"mode"`
+	CanvasSessionID string `json:"canvas_session_id"`
+}
+
+func newClient(ctx context.Context, cfg clientConfig) (*chatClient, error) {
+	base, err := url.Parse(strings.TrimSpace(cfg.baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("invalid base url: %w", err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return nil, fmt.Errorf("base url must include scheme and host: %q", cfg.baseURL)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("cookie jar: %w", err)
+	}
+	client := &chatClient{
+		base: base,
+		http: &http.Client{
+			Jar:     jar,
+			Timeout: 0,
+		},
+		verbose: cfg.verbose,
+		stderr:  cfg.stderr,
+	}
+	if err := client.cliLogin(ctx, cfg.tokenFile); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func (c *chatClient) cliLogin(ctx context.Context, tokenFile string) error {
+	token, err := readCLIToken(tokenFile)
+	if err != nil {
+		return fmt.Errorf("read cli token: %w (is the slopshell server running on this host?)", err)
+	}
+	payload, _ := json.Marshal(map[string]string{"token": token})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/cli/login"), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("cli login: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("cli login failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+func readCLIToken(path string) (string, error) {
+	clean := strings.TrimSpace(path)
+	if clean == "" {
+		return "", errors.New("cli token file path unresolved; set --token-file or SLOPSHELL_CLI_TOKEN_FILE")
+	}
+	body, err := os.ReadFile(clean)
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(body))
+	if token == "" {
+		return "", fmt.Errorf("cli token file %s is empty", clean)
+	}
+	return token, nil
+}
+
+func (c *chatClient) urlFor(path string) string {
+	u := *c.base
+	u.Path = strings.TrimRight(u.Path, "/") + path
+	return u.String()
+}
+
+func (c *chatClient) wsURLFor(path string) string {
+	u := *c.base
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + path
+	return u.String()
+}
+
+func (c *chatClient) startChatSession(ctx context.Context, projectDir, resumeID string) (*chatSessionInfo, error) {
+	if strings.TrimSpace(resumeID) != "" {
+		return c.attachSession(ctx, resumeID)
+	}
+	body := map[string]any{}
+	if strings.TrimSpace(projectDir) != "" {
+		body["workspace_path"] = projectDir
+	}
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/chat/sessions"), bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("create chat session: status %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var info chatSessionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decode session: %w", err)
+	}
+	if strings.TrimSpace(info.ID) == "" {
+		return nil, errors.New("server returned empty session id")
+	}
+	return &info, nil
+}
+
+func (c *chatClient) attachSession(ctx context.Context, sessionID string) (*chatSessionInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.urlFor("/api/chat/sessions/"+url.PathEscape(sessionID)+"/history"), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("attach session %s: status %d: %s", sessionID, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var wrapped struct {
+		Session struct {
+			ID            string `json:"id"`
+			WorkspaceID   int64  `json:"workspace_id"`
+			WorkspacePath string `json:"workspace_path"`
+			Mode          string `json:"mode"`
+		} `json:"session"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapped); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(wrapped.Session.ID) == "" {
+		return nil, fmt.Errorf("session %q not found", sessionID)
+	}
+	return &chatSessionInfo{
+		ID:            wrapped.Session.ID,
+		WorkspaceID:   wrapped.Session.WorkspaceID,
+		WorkspacePath: wrapped.Session.WorkspacePath,
+		Mode:          wrapped.Session.Mode,
+	}, nil
+}
+
+type historyMessage struct {
+	ID           string `json:"id"`
+	Role         string `json:"role"`
+	ContentPlain string `json:"content_plain"`
+	Content      string `json:"content"`
+	CreatedAt    string `json:"created_at"`
+}
+
+func (c *chatClient) printRecentHistory(ctx context.Context, sessionID string, renderer *renderer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.urlFor("/api/chat/sessions/"+url.PathEscape(sessionID)+"/history"), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("fetch history: status %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var wrapped struct {
+		Messages []historyMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapped); err != nil {
+		return err
+	}
+	keep := wrapped.Messages
+	if len(keep) > 12 {
+		keep = keep[len(keep)-12:]
+	}
+	for _, msg := range keep {
+		text := strings.TrimSpace(msg.ContentPlain)
+		if text == "" {
+			text = strings.TrimSpace(msg.Content)
+		}
+		if text == "" {
+			continue
+		}
+		renderer.renderHistoryMessage(msg.Role, text)
+	}
+	return nil
+}
+
+func (c *chatClient) sendCommand(ctx context.Context, sessionID, command string) (map[string]any, error) {
+	payload, _ := json.Marshal(map[string]string{"command": command})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/chat/sessions/"+url.PathEscape(sessionID)+"/commands"), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("command %s: status %d: %s", command, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	result, _ := body["result"].(map[string]any)
+	if result == nil {
+		result = map[string]any{}
+	}
+	return result, nil
+}
+
+func (c *chatClient) sendAndWaitForFinal(ctx context.Context, sessionID, prompt string, renderer *renderer) (string, error) {
+	ws, err := c.dialChatWS(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("ws dial: %w", err)
+	}
+	defer ws.Close()
+
+	// Send user message
+	payload, _ := json.Marshal(map[string]any{
+		"text":        prompt,
+		"output_mode": "silent",
+		"local_only":  false,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/chat/sessions/"+url.PathEscape(sessionID)+"/messages"), bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("send message: status %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	// Drain WS events until assistant_output or error or ctx done.
+	return c.consumeTurn(ctx, ws, renderer)
+}
+
+func (c *chatClient) consumeTurn(ctx context.Context, ws *websocket.Conn, renderer *renderer) (string, error) {
+	errCh := make(chan error, 1)
+	doneCh := make(chan string, 1)
+	go func() {
+		var finalText string
+		var turnSeen bool
+		for {
+			_, data, err := ws.ReadMessage()
+			if err != nil {
+				if turnSeen && finalText != "" {
+					doneCh <- finalText
+					return
+				}
+				errCh <- err
+				return
+			}
+			var event map[string]any
+			if err := json.Unmarshal(data, &event); err != nil {
+				continue
+			}
+			if c.verbose {
+				compact, _ := json.Marshal(event)
+				fmt.Fprintln(c.stderr, "ws:", string(compact))
+			}
+			kind, _ := event["type"].(string)
+			switch kind {
+			case "turn_started":
+				turnSeen = true
+				renderer.onTurnStarted(event)
+			case "assistant_message":
+				renderer.onAssistantDelta(event)
+			case "assistant_output":
+				if role, _ := event["role"].(string); role == "assistant" {
+					text, _ := event["message"].(string)
+					finalText = text
+					renderer.onAssistantFinal(event)
+					doneCh <- finalText
+					return
+				}
+			case "message_persisted":
+				if role, _ := event["role"].(string); role == "assistant" && finalText == "" {
+					text, _ := event["message"].(string)
+					if strings.TrimSpace(text) != "" {
+						finalText = text
+					}
+				}
+			case "system_action":
+				renderer.onSystemAction(event)
+			case "render_chat":
+				renderer.onRenderChat(event)
+			case "error":
+				msg, _ := event["error"].(string)
+				errCh <- fmt.Errorf("%w: %s", errAssistantError, strings.TrimSpace(msg))
+				return
+			case "turn_cancelled":
+				errCh <- errors.New("turn cancelled")
+				return
+			case "chat_cleared":
+				renderer.onChatCleared(event)
+			case "chat_compacted":
+				renderer.onChatCompacted(event)
+			default:
+				renderer.onOther(event)
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseGoingAway, "ctx"), time.Now().Add(500*time.Millisecond))
+		return "", ctx.Err()
+	case err := <-errCh:
+		return "", err
+	case text := <-doneCh:
+		return text, nil
+	}
+}
+
+func (c *chatClient) dialChatWS(ctx context.Context, sessionID string) (*websocket.Conn, error) {
+	dialer := *websocket.DefaultDialer
+	dialer.Jar = c.http.Jar
+	dialer.HandshakeTimeout = 10 * time.Second
+	ws, _, err := dialer.DialContext(ctx, c.wsURLFor("/ws/chat/"+url.PathEscape(sessionID)), nil)
+	if err != nil {
+		return nil, err
+	}
+	return ws, nil
+}

--- a/cmd/slsh/e2e_test.go
+++ b/cmd/slsh/e2e_test.go
@@ -1,0 +1,340 @@
+//go:build e2e
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sloppy-org/slopshell/internal/web"
+)
+
+// buildSlshBinary compiles cmd/slsh into a tempdir and returns the absolute path.
+func buildSlshBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "slsh-e2e")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/slsh")
+	cmd.Dir = projectRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build ./cmd/slsh: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(cwd, "..", ".."))
+}
+
+type fakeLLM struct {
+	server *httptest.Server
+	calls  atomic.Int32
+}
+
+// newFakeShellLLM returns a mock OpenAI-style /v1/chat/completions server
+// that first replies with a `shell` tool call, then answers with a final
+// message on the follow-up turn.
+func newFakeShellLLM(t *testing.T, command, finalReply string) *fakeLLM {
+	t.Helper()
+	llm := &fakeLLM{}
+	llm.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		call := llm.calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"content": "",
+						"tool_calls": []map[string]any{{
+							"id":   "call_shell_1",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "shell",
+								"arguments": fmt.Sprintf(`{"command":%q}`, command),
+							},
+						}},
+					},
+				}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{
+					"content": finalReply,
+				},
+			}},
+		})
+	}))
+	t.Cleanup(llm.server.Close)
+	return llm
+}
+
+// newFakeMailLLM returns a mock LLM that first emits an mcp__mail_account_list
+// tool call, then returns a human-readable summary after receiving the tool
+// result. The Mail family is activated by keywords in the user prompt.
+func newFakeMailLLM(t *testing.T, finalReply string) *fakeLLM {
+	t.Helper()
+	llm := &fakeLLM{}
+	llm.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(r.URL.Path) != "/v1/chat/completions" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		call := llm.calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]any{
+						"content": "",
+						"tool_calls": []map[string]any{{
+							"id":   "call_mail_1",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "mcp__mail_account_list",
+								"arguments": `{}`,
+							},
+						}},
+					},
+				}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{
+					"content": finalReply,
+				},
+			}},
+		})
+	}))
+	t.Cleanup(llm.server.Close)
+	return llm
+}
+
+// newFakeMCPMailServer mocks just enough of the MCP JSON-RPC surface for
+// the Mail family: tools/list advertises mail_account_list, and tools/call
+// returns a synthetic account. No real EWS/sloptools traffic.
+func newFakeMCPMailServer(t *testing.T, address string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		method, _ := payload["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		switch strings.TrimSpace(method) {
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{
+					"tools": []map[string]any{{
+						"name":        "mail_account_list",
+						"description": "List enabled email accounts available through Sloppy.",
+						"inputSchema": map[string]any{
+							"type":       "object",
+							"properties": map[string]any{},
+						},
+					}},
+				},
+			})
+		case "tools/call":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{
+					"structuredContent": map[string]any{
+						"ok": true,
+						"accounts": []map[string]any{{
+							"id":      42,
+							"address": address,
+							"enabled": true,
+						}},
+					},
+				},
+			})
+		default:
+			http.Error(w, "unexpected mcp method", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// setupE2EHarness spins up a slopshell web.App backed by the provided mock
+// LLM and MCP URLs, writes a CLI token file, and returns everything needed
+// to exercise the slsh binary against it.
+func setupE2EHarness(t *testing.T, llmURL, mcpURL string) (webBaseURL, tokenFile string) {
+	t.Helper()
+
+	workspaceDir := t.TempDir()
+	dataDir := t.TempDir()
+	t.Setenv("SLOPSHELL_BACKGROUND_SYNC", "off")
+
+	app, err := web.New(dataDir, workspaceDir, mcpURL, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("web.New: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	tokenPath := filepath.Join(dataDir, "cli-token")
+	token := "e2e-cli-token-" + randToken(t)
+	if err := os.WriteFile(tokenPath, []byte(token+"\n"), 0o600); err != nil {
+		t.Fatalf("write cli token: %v", err)
+	}
+	web.TestingOverrideCLIAuth(app, token, tokenPath)
+
+	web.TestingForceLocalAssistantLLM(app, llmURL)
+
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+	return srv.URL, tokenPath
+}
+
+// runSlsh invokes the prebuilt slsh binary and returns stdout+stderr.
+func runSlsh(t *testing.T, bin string, args ...string) (stdout, stderr string, exit int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append(os.Environ(),
+		// Ensure no ambient token file path leaks in; tests always pass --token-file.
+		"SLOPSHELL_CLI_TOKEN_FILE=",
+		"SLOPSHELL_CLI_STATE_FILE="+filepath.Join(t.TempDir(), "slsh-state.json"),
+	)
+	outBuf, errBuf := &strings.Builder{}, &strings.Builder{}
+	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
+	runErr := cmd.Run()
+	stdout = outBuf.String()
+	stderr = errBuf.String()
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exit = exitErr.ExitCode()
+			return stdout, stderr, exit
+		}
+		t.Fatalf("run slsh: %v\nstderr=%s", runErr, stderr)
+	}
+	return stdout, stderr, 0
+}
+
+func TestSlshOneShotShellToolProducesExpectedFinalText(t *testing.T) {
+	bin := buildSlshBinary(t)
+	llm := newFakeShellLLM(t, "printf e2e-shell-hello", "Shell tool printed: e2e-shell-hello")
+	// MCP server is never contacted for shell family, but the app requires a URL.
+	mcp := newFakeMCPMailServer(t, "never-used@example.test")
+	baseURL, tokenFile := setupE2EHarness(t, llm.server.URL, mcp.URL)
+
+	stdout, stderr, exit := runSlsh(t, bin,
+		"--base-url", baseURL,
+		"--token-file", tokenFile,
+		"--no-color",
+		"--timeout", "45s",
+		"-p", "Use shell to print e2e-shell-hello",
+	)
+	if exit != 0 {
+		t.Fatalf("slsh exit = %d\nstderr:\n%s\nstdout:\n%s", exit, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Shell tool printed: e2e-shell-hello") {
+		t.Fatalf("stdout missing final reply; got:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if llm.calls.Load() < 2 {
+		t.Fatalf("llm calls = %d, want >= 2", llm.calls.Load())
+	}
+}
+
+func TestSlshOneShotMailAccountListRoutesThroughMCP(t *testing.T) {
+	bin := buildSlshBinary(t)
+	llm := newFakeMailLLM(t, "Account fake@e2e.test is enabled.")
+	mcp := newFakeMCPMailServer(t, "fake@e2e.test")
+	baseURL, tokenFile := setupE2EHarness(t, llm.server.URL, mcp.URL)
+
+	stdout, stderr, exit := runSlsh(t, bin,
+		"--base-url", baseURL,
+		"--token-file", tokenFile,
+		"--no-color",
+		"--timeout", "45s",
+		"-p", "List my email accounts briefly",
+	)
+	if exit != 0 {
+		t.Fatalf("slsh exit = %d\nstderr:\n%s\nstdout:\n%s", exit, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Account fake@e2e.test is enabled.") {
+		t.Fatalf("stdout missing final reply; got:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if llm.calls.Load() < 2 {
+		t.Fatalf("llm calls = %d, want >= 2", llm.calls.Load())
+	}
+}
+
+func TestSlshOneShotJSONModeEmitsNDJSON(t *testing.T) {
+	bin := buildSlshBinary(t)
+	llm := newFakeShellLLM(t, "printf json-ok", "Done.")
+	mcp := newFakeMCPMailServer(t, "unused@example.test")
+	baseURL, tokenFile := setupE2EHarness(t, llm.server.URL, mcp.URL)
+
+	stdout, stderr, exit := runSlsh(t, bin,
+		"--base-url", baseURL,
+		"--token-file", tokenFile,
+		"--no-color",
+		"--json",
+		"--timeout", "45s",
+		"-p", "Use shell to print json-ok",
+	)
+	if exit != 0 {
+		t.Fatalf("slsh exit = %d\nstderr:\n%s\nstdout:\n%s", exit, stderr, stdout)
+	}
+	sawFinal := false
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &event); err != nil {
+			t.Fatalf("non-NDJSON line %q: %v", trimmed, err)
+		}
+		if event["type"] == "assistant_output" {
+			if role, _ := event["role"].(string); role == "assistant" {
+				sawFinal = true
+			}
+		}
+	}
+	if !sawFinal {
+		t.Fatalf("no assistant_output event in NDJSON stream:\n%s", stdout)
+	}
+}
+
+// --- test scaffolding -------------------------------------------------------
+
+func randToken(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}

--- a/cmd/slsh/e2e_test.go
+++ b/cmd/slsh/e2e_test.go
@@ -197,6 +197,9 @@ func setupE2EHarness(t *testing.T, llmURL, mcpURL string) (webBaseURL, tokenFile
 	workspaceDir := t.TempDir()
 	dataDir := t.TempDir()
 	t.Setenv("SLOPSHELL_BACKGROUND_SYNC", "off")
+	// Pin the CLI token path into the per-test tempdir so web.New does not
+	// overwrite a running system server's token at $XDG_RUNTIME_DIR/slopshell.
+	t.Setenv("SLOPSHELL_CLI_TOKEN_FILE", filepath.Join(dataDir, "cli-token"))
 
 	app, err := web.New(dataDir, workspaceDir, mcpURL, "", "", "", "", false)
 	if err != nil {

--- a/cmd/slsh/main.go
+++ b/cmd/slsh/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"flag"
@@ -12,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/chzyer/readline"
 )
 
 const (
@@ -296,21 +297,25 @@ func runREPL(ctx context.Context, client *chatClient, session *chatSessionInfo, 
 		}
 	}
 
-	scanner := bufio.NewScanner(stdin)
-	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-	promptStr := renderer.colorize(colorCyan, "› ")
+	rl, err := newReadline(stdin, stdout, stderr, renderer.colorize(colorCyan, "› "), opts.verbose)
+	if err != nil {
+		fmt.Fprintf(stderr, "slsh: input: %v\n", err)
+		return 1
+	}
+	defer rl.Close()
+
 	activeOpts := opts
 	for {
-		fmt.Fprint(stdout, promptStr)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
-				fmt.Fprintf(stderr, "slsh: input: %v\n", err)
-				return 1
+		line, readErr := rl.Readline()
+		if readErr != nil {
+			if errors.Is(readErr, readline.ErrInterrupt) || errors.Is(readErr, io.EOF) {
+				fmt.Fprintln(stdout)
+				return 0
 			}
-			fmt.Fprintln(stdout)
-			return 0
+			fmt.Fprintf(stderr, "slsh: input: %v\n", readErr)
+			return 1
 		}
-		line := strings.TrimSpace(scanner.Text())
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
@@ -337,6 +342,55 @@ func runREPL(ctx context.Context, client *chatClient, session *chatSessionInfo, 
 			continue
 		}
 	}
+}
+
+// newReadline builds a readline.Instance with persistent history, arrow-key
+// recall, Ctrl+R reverse search, and tab completion for slash commands.
+// readline handles non-tty stdin internally (used in tests and piped input).
+func newReadline(stdin io.Reader, stdout, stderr io.Writer, prompt string, verbose bool) (*readline.Instance, error) {
+	historyPath := historyFilePath()
+	if historyPath != "" {
+		if err := os.MkdirAll(filepath.Dir(historyPath), 0o700); err != nil && verbose {
+			fmt.Fprintf(stderr, "slsh: history dir: %v\n", err)
+		}
+	}
+	cfg := &readline.Config{
+		Prompt:            prompt,
+		HistoryFile:       historyPath,
+		HistoryLimit:      10000,
+		HistorySearchFold: true,
+		InterruptPrompt:   "^C",
+		EOFPrompt:         "exit",
+		AutoComplete: readline.NewPrefixCompleter(
+			readline.PcItem("/help"),
+			readline.PcItem("/exit"),
+			readline.PcItem("/quit"),
+			readline.PcItem("/clear"),
+			readline.PcItem("/new"),
+			readline.PcItem("/compact"),
+			readline.PcItem("/resume"),
+			readline.PcItem("/sessions"),
+			readline.PcItem("/model",
+				readline.PcItem("local"),
+				readline.PcItem("spark"),
+				readline.PcItem("gpt"),
+				readline.PcItem("mini"),
+			),
+			readline.PcItem("/think",
+				readline.PcItem("low"),
+				readline.PcItem("medium"),
+				readline.PcItem("high"),
+				readline.PcItem("off"),
+			),
+			readline.PcItem("/stop"),
+		),
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	if f, ok := stdin.(*os.File); ok {
+		cfg.Stdin = f
+	}
+	return readline.NewEx(cfg)
 }
 
 func handleReplCommand(ctx context.Context, client *chatClient, sessionPtr **chatSessionInfo, optsPtr *cliOptions, renderer *renderer, line string, stdout, stderr io.Writer) (bool, *cliOptions, error) {

--- a/cmd/slsh/main.go
+++ b/cmd/slsh/main.go
@@ -1,0 +1,476 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "http://127.0.0.1:8420"
+	defaultTimeout = 10 * time.Minute
+	envBaseURL     = "SLOPSHELL_BASE_URL"
+	envTokenFile   = "SLOPSHELL_CLI_TOKEN_FILE"
+)
+
+type cliOptions struct {
+	baseURL    string
+	projectDir string
+	resumeID   string
+	prompt     string
+	model      string
+	gpt        bool
+	think      string
+	timeout    time.Duration
+	tokenFile  string
+	jsonOut    bool
+	noColor    bool
+	verbose    bool
+	stdinPrompt bool
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	opts, tail, err := parseFlags(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	// Positional args after the flags are concatenated as an implicit prompt.
+	if opts.prompt == "" && len(tail) > 0 {
+		opts.prompt = strings.Join(tail, " ")
+	}
+
+	// Stdin pipe: if stdin is not a terminal and --prompt is empty, consume
+	// the whole input as the one-shot prompt.
+	if opts.prompt == "" && isPipedStdin(stdin) {
+		body, readErr := io.ReadAll(stdin)
+		if readErr != nil {
+			fmt.Fprintf(stderr, "slsh: reading stdin: %v\n", readErr)
+			return 1
+		}
+		trimmed := strings.TrimSpace(string(body))
+		if trimmed != "" {
+			opts.prompt = trimmed
+			opts.stdinPrompt = true
+		}
+	}
+
+	resolved := opts.resolveBaseURL()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := newClient(ctx, clientConfig{
+		baseURL:   resolved,
+		tokenFile: opts.effectiveTokenFile(),
+		verbose:   opts.verbose,
+		stderr:    stderr,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "slsh: %v\n", err)
+		return 1
+	}
+
+	session, err := client.startChatSession(ctx, opts.projectDir, opts.resumeID)
+	if err != nil {
+		fmt.Fprintf(stderr, "slsh: %v\n", err)
+		return 1
+	}
+	if err := persistSessionForWorkspace(session.WorkspacePath, session.ID); err != nil && opts.verbose {
+		fmt.Fprintf(stderr, "slsh: warning: persist session: %v\n", err)
+	}
+
+	renderer := newRenderer(stdout, opts.jsonOut, !opts.noColor && isTerminal(stdout))
+
+	if opts.prompt != "" {
+		return runOneShot(ctx, client, session, opts, renderer, stderr)
+	}
+	return runREPL(ctx, client, session, opts, renderer, stdin, stdout, stderr)
+}
+
+func parseFlags(args []string) (cliOptions, []string, error) {
+	fs := flag.NewFlagSet("slsh", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cwd, _ := os.Getwd()
+	opts := cliOptions{
+		baseURL:    os.Getenv(envBaseURL),
+		projectDir: cwd,
+		timeout:    defaultTimeout,
+		tokenFile:  os.Getenv(envTokenFile),
+	}
+	fs.StringVar(&opts.baseURL, "base-url", opts.baseURL, "slopshell server base URL")
+	fs.StringVar(&opts.projectDir, "project-dir", opts.projectDir, "workspace directory (defaults to cwd)")
+	fs.StringVar(&opts.resumeID, "resume", "", "resume a prior chat session by id instead of starting fresh")
+	fs.StringVar(&opts.prompt, "prompt", "", "one-shot prompt (also -p)")
+	fs.StringVar(&opts.prompt, "p", "", "one-shot prompt (shorthand for --prompt)")
+	fs.StringVar(&opts.model, "model", "", "model alias: local|spark|gpt|mini")
+	fs.BoolVar(&opts.gpt, "gpt", false, "shorthand for --model gpt")
+	fs.StringVar(&opts.think, "think", "", "reasoning-effort hint: low|medium|high")
+	fs.DurationVar(&opts.timeout, "timeout", opts.timeout, "per-turn timeout (e.g. 2m, 10m)")
+	fs.StringVar(&opts.tokenFile, "token-file", opts.tokenFile, "override CLI token file path")
+	fs.BoolVar(&opts.jsonOut, "json", false, "emit NDJSON events instead of pretty output")
+	fs.BoolVar(&opts.noColor, "no-color", false, "disable ANSI colors")
+	fs.BoolVar(&opts.verbose, "verbose", false, "log websocket events to stderr")
+	help := fs.Bool("help", false, "show usage")
+	fs.BoolVar(help, "h", false, "show usage")
+
+	if err := fs.Parse(args); err != nil {
+		return cliOptions{}, nil, err
+	}
+	if *help {
+		return cliOptions{}, nil, errHelp{Usage: usage()}
+	}
+	if opts.gpt {
+		opts.model = "gpt"
+	}
+	if strings.TrimSpace(opts.projectDir) == "" {
+		opts.projectDir = cwd
+	}
+	if abs, err := filepath.Abs(opts.projectDir); err == nil {
+		opts.projectDir = abs
+	}
+	model := strings.ToLower(strings.TrimSpace(opts.model))
+	if model != "" {
+		switch model {
+		case "local", "spark", "gpt", "mini", "codex":
+		default:
+			return cliOptions{}, nil, fmt.Errorf("unsupported --model %q (want local|spark|gpt|mini)", opts.model)
+		}
+		opts.model = model
+	}
+	think := strings.ToLower(strings.TrimSpace(opts.think))
+	if think != "" {
+		switch think {
+		case "low", "medium", "high":
+		default:
+			return cliOptions{}, nil, fmt.Errorf("unsupported --think %q (want low|medium|high)", opts.think)
+		}
+		opts.think = think
+	}
+	return opts, fs.Args(), nil
+}
+
+type errHelp struct{ Usage string }
+
+func (e errHelp) Error() string { return e.Usage }
+
+func usage() string {
+	return strings.TrimSpace(`
+slsh — SlopShell terminal chat client
+
+usage:
+  slsh [flags] [prompt words...]
+  echo "..." | slsh [flags]
+
+flags:
+  --base-url URL        slopshell server (default http://127.0.0.1:8420 or $SLOPSHELL_BASE_URL)
+  --project-dir DIR     workspace directory (default cwd)
+  --resume SESSION_ID   resume a prior chat session instead of starting fresh
+  -p, --prompt STRING   one-shot mode: send this prompt and exit
+  --model ALIAS         local|spark|gpt|mini (default local)
+  --gpt                 shorthand for --model gpt
+  --think LEVEL         low|medium|high reasoning-effort hint
+  --timeout DURATION    per-turn timeout (default 10m)
+  --token-file PATH     override CLI token file path
+  --json                emit NDJSON events instead of pretty output
+  --no-color            disable ANSI colors
+  --verbose             log websocket events to stderr
+  -h, --help            show this message
+
+REPL commands (type inside slsh):
+  /help                 show this help
+  /exit, /quit          leave
+  /clear                wipe all chat state on the server
+  /compact              drop just the app-server thread for this session
+  /new                  alias for /clear
+  /resume ID            reattach to a previous session id
+  /sessions             list session ids this CLI has seen per workspace
+  /model ALIAS          switch model for the next turn
+  /think LEVEL          set reasoning-effort hint for the next turn
+  /stop                 cancel the running assistant turn
+
+Anything that does not start with '/' is sent as a chat message.
+`)
+}
+
+func (o cliOptions) resolveBaseURL() string {
+	raw := strings.TrimSpace(o.baseURL)
+	if raw == "" {
+		return defaultBaseURL
+	}
+	return raw
+}
+
+func (o cliOptions) effectiveTokenFile() string {
+	if strings.TrimSpace(o.tokenFile) != "" {
+		return strings.TrimSpace(o.tokenFile)
+	}
+	if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
+		return filepath.Join(runtimeDir, "slopshell", "cli-token")
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".local", "share", "slopshell-web", "cli-token")
+	}
+	return ""
+}
+
+func buildPromptWithDirectives(raw string, opts cliOptions) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return ""
+	}
+	var prefix []string
+	switch opts.model {
+	case "gpt":
+		prefix = append(prefix, "use gpt")
+	case "spark", "codex":
+		prefix = append(prefix, "use spark")
+	case "mini":
+		prefix = append(prefix, "use mini")
+	}
+	switch opts.think {
+	case "low":
+		prefix = append(prefix, "think quickly")
+	case "medium":
+		prefix = append(prefix, "think a bit")
+	case "high":
+		prefix = append(prefix, "think hard")
+	}
+	if len(prefix) == 0 {
+		return text
+	}
+	return strings.Join(prefix, ", ") + " to " + text
+}
+
+func runOneShot(ctx context.Context, client *chatClient, session *chatSessionInfo, opts cliOptions, renderer *renderer, stderr io.Writer) int {
+	prompt := buildPromptWithDirectives(opts.prompt, opts)
+	if prompt == "" {
+		fmt.Fprintln(stderr, "slsh: empty prompt")
+		return 2
+	}
+	turnCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	final, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, renderer)
+	if err != nil {
+		if errors.Is(err, errAssistantError) {
+			fmt.Fprintf(stderr, "slsh: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stderr, "slsh: %v\n", err)
+		return 1
+	}
+	if !opts.jsonOut {
+		trimmed := strings.TrimSpace(final)
+		if trimmed != "" && !renderer.didEmitFinalText() {
+			fmt.Fprintln(renderer.out, trimmed)
+		}
+	}
+	return 0
+}
+
+func runREPL(ctx context.Context, client *chatClient, session *chatSessionInfo, opts cliOptions, renderer *renderer, stdin io.Reader, stdout, stderr io.Writer) int {
+	info := renderer.colorize(colorDim, fmt.Sprintf("slsh session %s @ %s", session.ID, session.WorkspacePath))
+	fmt.Fprintln(stdout, info)
+	fmt.Fprintln(stdout, renderer.colorize(colorDim, "type /help for commands, /exit to leave"))
+
+	if strings.TrimSpace(opts.resumeID) != "" {
+		if err := client.printRecentHistory(ctx, session.ID, renderer); err != nil && opts.verbose {
+			fmt.Fprintf(stderr, "slsh: history: %v\n", err)
+		}
+	} else {
+		// Fresh context: drop the app-server thread so the next turn starts clean.
+		if _, err := client.sendCommand(ctx, session.ID, "/compact"); err != nil && opts.verbose {
+			fmt.Fprintf(stderr, "slsh: compact: %v\n", err)
+		}
+	}
+
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	promptStr := renderer.colorize(colorCyan, "› ")
+	activeOpts := opts
+	for {
+		fmt.Fprint(stdout, promptStr)
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+				fmt.Fprintf(stderr, "slsh: input: %v\n", err)
+				return 1
+			}
+			fmt.Fprintln(stdout)
+			return 0
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "/") {
+			stop, newOpts, err := handleReplCommand(ctx, client, &session, &activeOpts, renderer, line, stdout, stderr)
+			if err != nil {
+				fmt.Fprintln(stderr, renderer.colorize(colorRed, fmt.Sprintf("error: %v", err)))
+				continue
+			}
+			if stop {
+				return 0
+			}
+			if newOpts != nil {
+				activeOpts = *newOpts
+			}
+			continue
+		}
+		prompt := buildPromptWithDirectives(line, activeOpts)
+		turnCtx, cancel := context.WithTimeout(ctx, activeOpts.timeout)
+		_, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, renderer)
+		cancel()
+		if err != nil {
+			fmt.Fprintln(stderr, renderer.colorize(colorRed, fmt.Sprintf("turn failed: %v", err)))
+			continue
+		}
+	}
+}
+
+func handleReplCommand(ctx context.Context, client *chatClient, sessionPtr **chatSessionInfo, optsPtr *cliOptions, renderer *renderer, line string, stdout, stderr io.Writer) (bool, *cliOptions, error) {
+	parts := strings.Fields(line)
+	name := strings.ToLower(strings.TrimPrefix(parts[0], "/"))
+	rest := parts[1:]
+	switch name {
+	case "help", "?":
+		fmt.Fprintln(stdout, usage())
+		return false, nil, nil
+	case "exit", "quit", "q":
+		return true, nil, nil
+	case "clear", "new", "reset":
+		if _, err := client.sendCommand(ctx, (*sessionPtr).ID, "/clear"); err != nil {
+			return false, nil, err
+		}
+		fmt.Fprintln(stdout, renderer.colorize(colorDim, "context cleared"))
+		return false, nil, nil
+	case "compact":
+		if _, err := client.sendCommand(ctx, (*sessionPtr).ID, "/compact"); err != nil {
+			return false, nil, err
+		}
+		fmt.Fprintln(stdout, renderer.colorize(colorDim, "thread compacted"))
+		return false, nil, nil
+	case "stop", "cancel":
+		if _, err := client.sendCommand(ctx, (*sessionPtr).ID, "/stop"); err != nil {
+			return false, nil, err
+		}
+		return false, nil, nil
+	case "resume":
+		if len(rest) == 0 {
+			return false, nil, errors.New("usage: /resume SESSION_ID")
+		}
+		next, err := client.attachSession(ctx, rest[0])
+		if err != nil {
+			return false, nil, err
+		}
+		*sessionPtr = next
+		fmt.Fprintln(stdout, renderer.colorize(colorDim, fmt.Sprintf("resumed %s @ %s", next.ID, next.WorkspacePath)))
+		_ = client.printRecentHistory(ctx, next.ID, renderer)
+		return false, nil, nil
+	case "sessions":
+		entries, err := listKnownSessions()
+		if err != nil {
+			return false, nil, err
+		}
+		if len(entries) == 0 {
+			fmt.Fprintln(stdout, renderer.colorize(colorDim, "(no saved sessions)"))
+			return false, nil, nil
+		}
+		for _, entry := range entries {
+			fmt.Fprintf(stdout, "  %s\t%s\t%s\n", entry.SessionID, entry.WorkspacePath, entry.UpdatedAt.Format(time.RFC3339))
+		}
+		return false, nil, nil
+	case "model":
+		if len(rest) == 0 {
+			fmt.Fprintf(stdout, "current model: %s\n", firstNonEmpty(optsPtr.model, "local"))
+			return false, nil, nil
+		}
+		newOpts := *optsPtr
+		newOpts.model = strings.ToLower(rest[0])
+		newOpts.gpt = newOpts.model == "gpt"
+		switch newOpts.model {
+		case "local", "spark", "gpt", "mini", "codex":
+		default:
+			return false, nil, fmt.Errorf("unsupported model %q", rest[0])
+		}
+		fmt.Fprintln(stdout, renderer.colorize(colorDim, "model set to "+newOpts.model))
+		return false, &newOpts, nil
+	case "think":
+		if len(rest) == 0 {
+			fmt.Fprintf(stdout, "current think level: %s\n", firstNonEmpty(optsPtr.think, "(default)"))
+			return false, nil, nil
+		}
+		level := strings.ToLower(rest[0])
+		switch level {
+		case "low", "medium", "high", "off", "none":
+		default:
+			return false, nil, fmt.Errorf("unsupported think level %q (want low|medium|high)", rest[0])
+		}
+		newOpts := *optsPtr
+		if level == "off" || level == "none" {
+			newOpts.think = ""
+		} else {
+			newOpts.think = level
+		}
+		fmt.Fprintln(stdout, renderer.colorize(colorDim, "think level set to "+firstNonEmpty(newOpts.think, "(default)")))
+		return false, &newOpts, nil
+	default:
+		// Unknown slash command — let the server decide. Some commands like
+		// /plan, /pr, /status are handled server-side.
+		result, err := client.sendCommand(ctx, (*sessionPtr).ID, line)
+		if err != nil {
+			return false, nil, err
+		}
+		if message, ok := result["message"].(string); ok && strings.TrimSpace(message) != "" {
+			fmt.Fprintln(stdout, message)
+		}
+		return false, nil, nil
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func isPipedStdin(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) == 0
+}
+
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/cmd/slsh/render.go
+++ b/cmd/slsh/render.go
@@ -18,16 +18,28 @@ const (
 )
 
 type renderer struct {
-	out       io.Writer
-	jsonMode  bool
-	colors    bool
-	lastTurn  string
-	lastDelta string
-	didFinal  bool
+	out         io.Writer
+	jsonMode    bool
+	colors      bool
+	lastTurn    string
+	lastPreview string
+	progressOn  bool
+	didFinal    bool
 }
 
 func newRenderer(out io.Writer, jsonMode, colors bool) *renderer {
 	return &renderer{out: out, jsonMode: jsonMode, colors: colors}
+}
+
+// finishProgressLine terminates any in-place progress preview so subsequent
+// output starts on a clean line.
+func (r *renderer) finishProgressLine() {
+	if !r.progressOn {
+		return
+	}
+	fmt.Fprintln(r.out)
+	r.progressOn = false
+	r.lastPreview = ""
 }
 
 func (r *renderer) colorize(color, text string) string {
@@ -52,12 +64,15 @@ func (r *renderer) writeEvent(event map[string]any) {
 
 func (r *renderer) onTurnStarted(event map[string]any) {
 	r.lastTurn, _ = event["turn_id"].(string)
-	r.lastDelta = ""
+	r.lastPreview = ""
 	if r.jsonMode {
 		r.writeEvent(event)
 		return
 	}
-	fmt.Fprintln(r.out, r.colorize(colorDim, "… thinking"))
+	r.finishProgressLine()
+	// Deliberately no visible marker here: the first assistant delta (or
+	// system_action / final) is the first thing the user should see. A
+	// "thinking" label is misleading when reasoning is disabled.
 }
 
 func (r *renderer) onAssistantDelta(event map[string]any) {
@@ -67,14 +82,24 @@ func (r *renderer) onAssistantDelta(event map[string]any) {
 	}
 	msg, _ := event["message"].(string)
 	trimmed := strings.TrimSpace(msg)
-	if trimmed == "" || trimmed == r.lastDelta {
+	if trimmed == "" {
 		return
 	}
-	r.lastDelta = trimmed
-	// Streaming deltas contain the running full message. Render as single
-	// carriage-return line so we don't spam output; for now keep it simple
-	// and just print a dim progress marker.
-	fmt.Fprintln(r.out, r.colorize(colorGray, "   "+previewLine(trimmed, 120)))
+	preview := previewLine(trimmed, 120)
+	if preview == r.lastPreview {
+		return
+	}
+	r.lastPreview = preview
+	line := "   " + preview
+	if r.colors {
+		// Overwrite the current progress line in place so streaming growth
+		// shows up as a single evolving preview instead of spamming the
+		// terminal with near-duplicate lines.
+		fmt.Fprint(r.out, "\r\x1b[2K"+r.colorize(colorGray, line))
+		r.progressOn = true
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorGray, line))
 }
 
 func (r *renderer) onAssistantFinal(event map[string]any) {
@@ -85,6 +110,7 @@ func (r *renderer) onAssistantFinal(event map[string]any) {
 		r.writeEvent(event)
 		return
 	}
+	r.finishProgressLine()
 	if trimmed == "" {
 		return
 	}
@@ -96,6 +122,7 @@ func (r *renderer) onSystemAction(event map[string]any) {
 		r.writeEvent(event)
 		return
 	}
+	r.finishProgressLine()
 	action, _ := event["action"].(map[string]any)
 	name := "(unknown)"
 	if action != nil {
@@ -122,7 +149,18 @@ func (r *renderer) onRenderChat(event map[string]any) {
 	if trimmed == "" {
 		return
 	}
-	fmt.Fprintln(r.out, r.colorize(colorGray, "   "+previewLine(trimmed, 120)))
+	preview := previewLine(trimmed, 120)
+	if preview == r.lastPreview {
+		return
+	}
+	r.lastPreview = preview
+	line := "   " + preview
+	if r.colors {
+		fmt.Fprint(r.out, "\r\x1b[2K"+r.colorize(colorGray, line))
+		r.progressOn = true
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorGray, line))
 }
 
 func (r *renderer) onChatCleared(event map[string]any) {
@@ -130,6 +168,7 @@ func (r *renderer) onChatCleared(event map[string]any) {
 		r.writeEvent(event)
 		return
 	}
+	r.finishProgressLine()
 	fmt.Fprintln(r.out, r.colorize(colorDim, "chat cleared"))
 }
 
@@ -138,6 +177,7 @@ func (r *renderer) onChatCompacted(event map[string]any) {
 		r.writeEvent(event)
 		return
 	}
+	r.finishProgressLine()
 	fmt.Fprintln(r.out, r.colorize(colorDim, "thread compacted"))
 }
 

--- a/cmd/slsh/render.go
+++ b/cmd/slsh/render.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	colorReset  = "\x1b[0m"
+	colorDim    = "\x1b[2m"
+	colorCyan   = "\x1b[36m"
+	colorGreen  = "\x1b[32m"
+	colorYellow = "\x1b[33m"
+	colorRed    = "\x1b[31m"
+	colorGray   = "\x1b[90m"
+)
+
+type renderer struct {
+	out       io.Writer
+	jsonMode  bool
+	colors    bool
+	lastTurn  string
+	lastDelta string
+	didFinal  bool
+}
+
+func newRenderer(out io.Writer, jsonMode, colors bool) *renderer {
+	return &renderer{out: out, jsonMode: jsonMode, colors: colors}
+}
+
+func (r *renderer) colorize(color, text string) string {
+	if !r.colors || color == "" {
+		return text
+	}
+	return color + text + colorReset
+}
+
+func (r *renderer) didEmitFinalText() bool { return r.didFinal }
+
+func (r *renderer) writeEvent(event map[string]any) {
+	if !r.jsonMode {
+		return
+	}
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(r.out, string(encoded))
+}
+
+func (r *renderer) onTurnStarted(event map[string]any) {
+	r.lastTurn, _ = event["turn_id"].(string)
+	r.lastDelta = ""
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorDim, "… thinking"))
+}
+
+func (r *renderer) onAssistantDelta(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	msg, _ := event["message"].(string)
+	trimmed := strings.TrimSpace(msg)
+	if trimmed == "" || trimmed == r.lastDelta {
+		return
+	}
+	r.lastDelta = trimmed
+	// Streaming deltas contain the running full message. Render as single
+	// carriage-return line so we don't spam output; for now keep it simple
+	// and just print a dim progress marker.
+	fmt.Fprintln(r.out, r.colorize(colorGray, "   "+previewLine(trimmed, 120)))
+}
+
+func (r *renderer) onAssistantFinal(event map[string]any) {
+	msg, _ := event["message"].(string)
+	trimmed := strings.TrimSpace(msg)
+	r.didFinal = true
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	if trimmed == "" {
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorGreen, "assistant: ")+trimmed)
+}
+
+func (r *renderer) onSystemAction(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	action, _ := event["action"].(map[string]any)
+	name := "(unknown)"
+	if action != nil {
+		name, _ = action["name"].(string)
+	}
+	summary, _ := event["summary"].(string)
+	if summary == "" && action != nil {
+		summary, _ = action["summary"].(string)
+	}
+	line := "tool: " + strings.TrimSpace(name)
+	if summary != "" {
+		line += " — " + summary
+	}
+	fmt.Fprintln(r.out, r.colorize(colorYellow, line))
+}
+
+func (r *renderer) onRenderChat(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	md, _ := event["markdown"].(string)
+	trimmed := strings.TrimSpace(md)
+	if trimmed == "" {
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorGray, "   "+previewLine(trimmed, 120)))
+}
+
+func (r *renderer) onChatCleared(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorDim, "chat cleared"))
+}
+
+func (r *renderer) onChatCompacted(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+		return
+	}
+	fmt.Fprintln(r.out, r.colorize(colorDim, "thread compacted"))
+}
+
+func (r *renderer) onOther(event map[string]any) {
+	if r.jsonMode {
+		r.writeEvent(event)
+	}
+}
+
+func (r *renderer) renderHistoryMessage(role, text string) {
+	if r.jsonMode {
+		r.writeEvent(map[string]any{"type": "history", "role": role, "message": text})
+		return
+	}
+	prefix := role
+	switch strings.ToLower(role) {
+	case "assistant":
+		prefix = r.colorize(colorGreen, "assistant: ")
+	case "user":
+		prefix = r.colorize(colorCyan, "you: ")
+	case "system":
+		prefix = r.colorize(colorDim, "system: ")
+	default:
+		prefix = role + ": "
+	}
+	fmt.Fprintln(r.out, prefix+text)
+}
+
+func previewLine(text string, max int) string {
+	oneline := strings.ReplaceAll(text, "\n", " ")
+	oneline = strings.Join(strings.Fields(oneline), " ")
+	if len([]rune(oneline)) <= max {
+		return oneline
+	}
+	runes := []rune(oneline)
+	return string(runes[:max-1]) + "…"
+}

--- a/cmd/slsh/render_test.go
+++ b/cmd/slsh/render_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRendererDedupesDeltaPreviews(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, false)
+
+	// Long running text — exceeds the 120-rune preview cap so each delta
+	// produces the same truncated preview. The renderer must collapse them.
+	full := strings.Repeat("I do not have access to external logs or the ability to diagnose why a previous call to GPT failed. ", 5)
+	for i := 1; i <= 10; i++ {
+		r.onAssistantDelta(map[string]any{"message": full[:len(full)-10+i%2]})
+	}
+
+	out := buf.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	nonEmpty := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty > 1 {
+		t.Fatalf("expected at most 1 preview line for identical previews, got %d:\n%s", nonEmpty, out)
+	}
+}
+
+func TestRendererStreamsDistinctPreviews(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, false)
+
+	r.onAssistantDelta(map[string]any{"message": "one small preview"})
+	r.onAssistantDelta(map[string]any{"message": "another different preview"})
+	r.onAssistantDelta(map[string]any{"message": "a third changed preview"})
+
+	out := buf.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	nonEmpty := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty != 3 {
+		t.Fatalf("expected 3 distinct preview lines, got %d:\n%s", nonEmpty, out)
+	}
+}
+
+func TestRendererFinalClosesInPlaceProgress(t *testing.T) {
+	var buf bytes.Buffer
+	// colors=true triggers in-place overwrite mode
+	r := newRenderer(&buf, false, true)
+
+	r.onAssistantDelta(map[string]any{"message": "progress one"})
+	r.onAssistantDelta(map[string]any{"message": "progress two"})
+	r.onAssistantFinal(map[string]any{"message": "final answer"})
+
+	out := buf.String()
+	if !strings.Contains(out, "final answer") {
+		t.Fatalf("final answer missing from output:\n%q", out)
+	}
+	// After the final line, the progressOn flag should be false.
+	if r.progressOn {
+		t.Fatalf("progressOn should be cleared after final; out=%q", out)
+	}
+}
+
+func TestRendererSystemActionClearsProgress(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, true)
+
+	r.onAssistantDelta(map[string]any{"message": "running thought"})
+	r.onSystemAction(map[string]any{
+		"action": map[string]any{"name": "shell"},
+	})
+	r.onAssistantFinal(map[string]any{"message": "done"})
+
+	out := buf.String()
+	if !strings.Contains(out, "tool:") {
+		t.Fatalf("expected tool line in output:\n%q", out)
+	}
+	if !strings.Contains(out, "done") {
+		t.Fatalf("expected final line in output:\n%q", out)
+	}
+}

--- a/cmd/slsh/session.go
+++ b/cmd/slsh/session.go
@@ -33,6 +33,19 @@ func sessionStorePath() string {
 	return ""
 }
 
+func historyFilePath() string {
+	if override := strings.TrimSpace(os.Getenv("SLOPSHELL_CLI_HISTORY_FILE")); override != "" {
+		return override
+	}
+	if state := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); state != "" {
+		return filepath.Join(state, "slopshell", "slsh-history")
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".local", "state", "slopshell", "slsh-history")
+	}
+	return ""
+}
+
 func loadSessionStore() (*sessionStore, string, error) {
 	path := sessionStorePath()
 	if path == "" {

--- a/cmd/slsh/session.go
+++ b/cmd/slsh/session.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type sessionEntry struct {
+	WorkspacePath string    `json:"workspace_path"`
+	SessionID     string    `json:"session_id"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type sessionStore struct {
+	Entries []sessionEntry `json:"entries"`
+}
+
+func sessionStorePath() string {
+	if override := strings.TrimSpace(os.Getenv("SLOPSHELL_CLI_STATE_FILE")); override != "" {
+		return override
+	}
+	if state := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); state != "" {
+		return filepath.Join(state, "slopshell", "slsh-sessions.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".local", "state", "slopshell", "slsh-sessions.json")
+	}
+	return ""
+}
+
+func loadSessionStore() (*sessionStore, string, error) {
+	path := sessionStorePath()
+	if path == "" {
+		return nil, "", errors.New("cannot resolve slsh state path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &sessionStore{}, path, nil
+		}
+		return nil, path, err
+	}
+	var s sessionStore
+	if err := json.Unmarshal(data, &s); err != nil {
+		return &sessionStore{}, path, nil
+	}
+	return &s, path, nil
+}
+
+func persistSessionForWorkspace(workspacePath, sessionID string) error {
+	workspacePath = strings.TrimSpace(workspacePath)
+	sessionID = strings.TrimSpace(sessionID)
+	if workspacePath == "" || sessionID == "" {
+		return nil
+	}
+	store, path, err := loadSessionStore()
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	updated := false
+	for i := range store.Entries {
+		if store.Entries[i].WorkspacePath == workspacePath {
+			store.Entries[i].SessionID = sessionID
+			store.Entries[i].UpdatedAt = now
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		store.Entries = append(store.Entries, sessionEntry{
+			WorkspacePath: workspacePath,
+			SessionID:     sessionID,
+			UpdatedAt:     now,
+		})
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o600)
+}
+
+func listKnownSessions() ([]sessionEntry, error) {
+	store, _, err := loadSessionStore()
+	if err != nil {
+		return nil, err
+	}
+	entries := append([]sessionEntry(nil), store.Entries...)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].UpdatedAt.After(entries[j].UpdatedAt)
+	})
+	return entries, nil
+}

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -26,6 +26,7 @@ Public pages:
 Auth and setup:
 - `GET /api/setup`
 - `POST /api/login`
+- `POST /api/cli/login`
 - `POST /api/logout`
 - `GET /api/google/auth`
 - `GET /api/google/callback`

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/Azure/go-ntlmssp v0.1.0
 	github.com/alecthomas/chroma/v2 v2.23.1
+	github.com/chzyer/readline v1.5.1
 	github.com/creack/pty v1.1.24
 	github.com/emersion/go-imap/v2 v2.0.0-beta.7
 	github.com/emersion/go-message v0.18.2
@@ -25,7 +26,6 @@ require (
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Azure/go-ntlmssp v0.1.0 h1:DjFo6YtWzNqNvQdrwEyr/e4nhU3vRiwenz5QX7sFz+A=
 github.com/Azure/go-ntlmssp v0.1.0/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.2.0/go.mod h1:vf4zrexSH54oEjJ7EdB65tGNHmH3pGZmVkgTP5RHvAs=
@@ -18,6 +16,12 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -150,6 +154,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -792,6 +792,7 @@ var WebRouteSections = []RouteSection{
 		Routes: []string{
 			"GET /api/setup",
 			"POST /api/login",
+			"POST /api/cli/login",
 			"POST /api/logout",
 			"GET /api/google/auth",
 			"GET /api/google/callback",

--- a/internal/web/chat.go
+++ b/internal/web/chat.go
@@ -23,54 +23,16 @@ const (
 	promptContractStateKey = "chat_prompt_contract_sha256"
 )
 
-const defaultVoiceHistoryPrompt = `You are Slopshell, an AI assistant.
-Chat text is always spoken via TTS.
-
-## Response Format
-
-Use exactly one response shape:
-
-1. Spoken chat must be one paragraph max.
-   If your response needs more than one paragraph, write that long content to a temp file and show it on canvas.
-2. Canvas content must appear only inside :::file blocks with a file path.
-   For temporary canvas files, create/remove paths via temp_file_create and temp_file_remove tools.
-   Do not use :::canvas blocks.
-
-If output needs more than one paragraph, put it in a temp file with temp_file_create and render on canvas.
-Do not return metadata-only chat.
-
-Write naturally for speech. Avoid raw paths, URLs, or code in prose.
-Use [lang:de] at the start of your answer when responding in German. Default is English.
-
-Voice mode is chat-first:
-- Do not emit :::file blocks unless the user explicitly asks to show/open/render content on canvas.
-- Do not emit :::canvas blocks.
-- Do not mirror ordinary chat output on canvas.
-- Keep spoken responses concise.
-
-When user asks to show/open an existing file, do NOT paste that file body into chat. Use canvas_artifact_show with a brief spoken confirmation.
-When user explicitly asks you to show/render content on canvas, you may emit :::file blocks for that file-backed canvas output.
-
-Line references: when the user mentions [Line N of "file"], apply changes at that location.
-
-When you need the user to tap or click a location, emit exactly [[request_position:Tap where you want it]] on its own line.
-
-## PR review fast path:
-When asked to review a PR, open PR view via gh CLI, read the diff, and respond with analysis.
-Publish exactly one file block at path .slopshell/artifacts/pr/pr-<number>.diff with the patch content.
+const defaultVoiceHistoryPrompt = `You are Slopshell, the assistant in this workspace.
+Tools available this turn are described in the tools parameter; call them when needed.
+For long or file-like output, emit a :::file{path="..."} block under .slopshell/artifacts/tmp (use temp_file_create / temp_file_remove). Do not use :::canvas blocks.
+Chat-first: otherwise answer in plain chat, one paragraph max. Do not mirror chat on canvas.
+When the user asks to show/open an existing file, do not paste the body into chat; use canvas_artifact_show with a brief confirmation.
+Use [lang:de] at the start of your answer when responding in German; default is English.
+To request a tap location from the user, emit exactly [[request_position:Tap where you want it]] on its own line.
 `
 
-const defaultVoiceTurnPrompt = `Voice mode is chat-first:
-- Reply with spoken chat text only.
-- Do not emit :::file blocks unless the user explicitly asks to show/open/render content on canvas.
-- Do not emit :::canvas blocks.
-- Do not mirror ordinary chat output on canvas.
-
-When user asks to show/open an existing file, do NOT paste file body into chat; use canvas_artifact_show and keep chat text brief.
-When user explicitly asks you to show/render content on canvas, you may emit :::file blocks for that file-backed canvas output.
-
-When you need the user to tap or click a location, emit exactly [[request_position:Tap where you want it]] on its own line.
-
+const defaultVoiceTurnPrompt = `Reply for the latest user turn. Chat-first; emit :::file{path="..."} only when the user explicitly asks to show, open, or render content on canvas.
 `
 
 type chatMessageRequest struct {

--- a/internal/web/chat_assistant_backend.go
+++ b/internal/web/chat_assistant_backend.go
@@ -23,7 +23,7 @@ type assistantTurnRequest struct {
 	fastMode        bool
 	messageID       int64
 	turnModel       string
-	searchTurn      bool
+	detailRequested bool
 	transientRemote bool
 	reasoningEffort string
 	baseProfile     appServerModelProfile
@@ -78,22 +78,15 @@ func (a *App) assistantBackendForTurn(req *assistantTurnRequest) assistantTurnBa
 	if req.turnModel != "" && req.turnModel != modelprofile.AliasLocal {
 		return &codexAssistantBackend{app: a}
 	}
+	// Everything without an explicit remote alias stays local. Only fall
+	// through to Codex when the local assistant has no way to run at all
+	// (no local LLM URL configured AND an app-server client is available).
 	localConfigured := strings.TrimSpace(a.assistantLLMURL) != "" || a.appServerClient == nil || a.assistantRoutingMode() == assistantModeLocal
-	if modelprofile.ResolveAlias(req.baseProfile.Alias, modelprofile.AliasLocal) == modelprofile.AliasLocal && localConfigured {
+	if localConfigured {
 		return &localAssistantBackend{app: a}
 	}
-	if req.searchTurn {
+	if a.appServerClient != nil {
 		return &codexAssistantBackend{app: a}
 	}
-	switch a.assistantRoutingMode() {
-	case assistantModeLocal:
-		return &localAssistantBackend{app: a}
-	case assistantModeCodex:
-		return &codexAssistantBackend{app: a}
-	default:
-		if a.appServerClient != nil {
-			return &codexAssistantBackend{app: a}
-		}
-		return &localAssistantBackend{app: a}
-	}
+	return &localAssistantBackend{app: a}
 }

--- a/internal/web/chat_assistant_backend_test.go
+++ b/internal/web/chat_assistant_backend_test.go
@@ -46,11 +46,19 @@ func TestAssistantBackendForTurnRoutesLocalByDefaultAndCodexOnlyForRemoteTurns(t
 
 	searchReq := &assistantTurnRequest{
 		userText:    "search the web for today's news",
-		searchTurn:  true,
 		baseProfile: appServerModelProfile{Alias: "local"},
 	}
 	if got := app.assistantBackendForTurn(searchReq).mode(); got != assistantModeLocal {
 		t.Fatalf("backend for local search turn = %q, want %q", got, assistantModeLocal)
+	}
+
+	explicitSparkSearch := &assistantTurnRequest{
+		userText:    "use spark to search the web",
+		turnModel:   "spark",
+		baseProfile: appServerModelProfile{Alias: "local"},
+	}
+	if got := app.assistantBackendForTurn(explicitSparkSearch).mode(); got != assistantModeCodex {
+		t.Fatalf("backend for explicit spark search = %q, want %q", got, assistantModeCodex)
 	}
 
 	app.assistantLLMURL = ""
@@ -194,6 +202,10 @@ func TestRunAssistantTurnCanvasRequestRepairsPlainGermanAcknowledgement(t *testi
 			t.Fatalf("decode mcp payload: %v", err)
 		}
 		switch strings.TrimSpace(strFromAny(payload["method"])) {
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{"tools": []map[string]any{}},
+			})
 		case "tools/call":
 			canvasCalls.Add(1)
 			params, _ := payload["params"].(map[string]any)
@@ -733,8 +745,8 @@ func TestRunAssistantTurnNonFastLocalUsesPrunedExplicitToolPromptForCanvasReques
 	if llmCalls.Load() != 1 {
 		t.Fatalf("llm call count = %d, want 1", llmCalls.Load())
 	}
-	if mcpListCalls.Load() != 0 {
-		t.Fatalf("mcp list call count = %d, want 0", mcpListCalls.Load())
+	if mcpListCalls.Load() != 1 {
+		t.Fatalf("mcp list call count = %d, want 1 (flat catalog always discovers MCP tools)", mcpListCalls.Load())
 	}
 	if mcpCalls.Load() != 1 {
 		t.Fatalf("mcp call count = %d, want 1", mcpCalls.Load())
@@ -754,6 +766,10 @@ func TestRunAssistantTurnNonFastLocalRepairsPlanningTextIntoCanvasOutput(t *test
 			t.Fatalf("decode mcp payload: %v", err)
 		}
 		switch strings.TrimSpace(strFromAny(payload["method"])) {
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{"tools": []map[string]any{}},
+			})
 		case "tools/call":
 			mcpCalls.Add(1)
 			params, _ := payload["params"].(map[string]any)

--- a/internal/web/chat_assistant_backend_test.go
+++ b/internal/web/chat_assistant_backend_test.go
@@ -21,6 +21,7 @@ func TestAssistantBackendForTurnRoutesLocalByDefaultAndCodexOnlyForRemoteTurns(t
 	if err != nil {
 		t.Fatalf("new app: %v", err)
 	}
+	app.assistantMode = assistantModeAuto
 	app.assistantLLMURL = "http://127.0.0.1:8081"
 	t.Cleanup(func() {
 		_ = app.Shutdown(context.Background())

--- a/internal/web/chat_assistant_local.go
+++ b/internal/web/chat_assistant_local.go
@@ -20,7 +20,7 @@ const (
 	assistantLLMToolPlanMaxTokens    = 256
 	assistantLLMToolMaxTokens        = 1024
 	assistantLLMResponseLimit        = 256 * 1024
-	assistantLLMMaxToolRounds        = 6
+	assistantLLMMaxToolRounds        = 16
 	assistantLLMMalformedRetries     = 1
 	assistantLLMToolPlanRetries      = 2
 	localAssistantDialoguePromptBase = "You are Slopshell, the assistant inside the current workspace. If the user says Slopshell, Sloppy, or computer, they are addressing you, not asking about those words. Use the explicit tools in this request instead of inventing plans or wrapper calls. Answer directly when no tool is needed. Default to plain text, not markdown. Do not use headings, bullets, numbered lists, or tables unless the user explicitly asks for them. Give complete answers by default: for substantive questions, answer with a compact but satisfying explanation, usually one short paragraph or 3-6 sentences. For simple factual prompts, keep the answer short. If a single word or short phrase fully answers the request, reply with exactly that. No markdown fences. No <think> tags."
@@ -99,14 +99,14 @@ func buildLocalAssistantDialoguePrompt(toolPolicy string, reasoningHint string) 
 	return strings.TrimSpace(strings.Join(parts, "\n"))
 }
 
-func (a *App) buildLocalAssistantPrompt(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string) (string, error) {
+func (a *App) buildLocalAssistantPrompt(sessionID string, session store.ChatSession, messages []store.ChatMessage, cursorCtx *chatCursorContext, inkCtx []*chatCanvasInkEvent, positionCtx []*chatCanvasPositionEvent, outputMode string, detailRequested bool) (string, error) {
 	var workspaceRef *store.Workspace
 	if workspace, err := a.effectiveWorkspaceForChatSession(session); err == nil {
 		workspaceRef = &workspace
 	}
 	canvasCtx := a.resolveCanvasContext(session.WorkspacePath)
 	companionCtx := a.loadCompanionPromptContextForTurn(sessionID, session.WorkspacePath)
-	prompt := buildLeanLocalAssistantPrompt(workspaceRef, messages, canvasCtx, companionCtx, outputMode)
+	prompt := buildLeanLocalAssistantPrompt(workspaceRef, messages, canvasCtx, companionCtx, outputMode, detailRequested)
 	prompt = appendChatCursorPrompt(prompt, cursorCtx)
 	prompt = appendCanvasInkPrompt(prompt, inkCtx)
 	prompt = appendCanvasPositionPrompt(prompt, positionCtx)
@@ -143,7 +143,7 @@ func (a *App) runLocalAssistantTurn(req *assistantTurnRequest) {
 	if !req.fastMode {
 		promptMessages := withQueuedUserMessage(req.messages, req.messageID, req.promptText)
 		var err error
-		prompt, err = a.buildLocalAssistantPrompt(req.sessionID, req.session, promptMessages, req.cursorCtx, req.inkCtx, req.positionCtx, req.outputMode)
+		prompt, err = a.buildLocalAssistantPrompt(req.sessionID, req.session, promptMessages, req.cursorCtx, req.inkCtx, req.positionCtx, req.outputMode, req.detailRequested)
 		if err != nil {
 			errText := err.Error()
 			_, _ = a.store.AddChatMessage(req.sessionID, "system", errText, errText, "text")

--- a/internal/web/chat_assistant_local.go
+++ b/internal/web/chat_assistant_local.go
@@ -22,6 +22,7 @@ const (
 	assistantLLMResponseLimit        = 256 * 1024
 	assistantLLMMaxToolRounds        = 6
 	assistantLLMMalformedRetries     = 1
+	assistantLLMToolPlanRetries      = 2
 	localAssistantDialoguePromptBase = "You are Slopshell, the assistant inside the current workspace. If the user says Slopshell, Sloppy, or computer, they are addressing you, not asking about those words. Use the explicit tools in this request instead of inventing plans or wrapper calls. Answer directly when no tool is needed. Default to plain text, not markdown. Do not use headings, bullets, numbered lists, or tables unless the user explicitly asks for them. Give complete answers by default: for substantive questions, answer with a compact but satisfying explanation, usually one short paragraph or 3-6 sentences. For simple factual prompts, keep the answer short. If a single word or short phrase fully answers the request, reply with exactly that. No markdown fences. No <think> tags."
 )
 

--- a/internal/web/chat_assistant_local_canvas.go
+++ b/internal/web/chat_assistant_local_canvas.go
@@ -346,9 +346,12 @@ func extractLocalAssistantJSONStringField(raw string, field string) (string, boo
 }
 
 func stripLocalAssistantThinkingPreamble(raw string) string {
-	if strings.TrimSpace(raw) == "" {
+	if raw == "" {
 		return ""
 	}
+	// Deliberately do not early-return on all-whitespace input: streaming
+	// deltas often emit a lone "\n" between paragraphs or bullets, and
+	// swallowing those chunks collapses the assistant's formatting.
 	clean := strings.TrimLeft(raw, " \t\r\n")
 	if strings.HasPrefix(clean, "<think>") {
 		if idx := strings.Index(clean, "</think>"); idx >= 0 {

--- a/internal/web/chat_assistant_local_catalog.go
+++ b/internal/web/chat_assistant_local_catalog.go
@@ -9,12 +9,11 @@ import (
 type localAssistantToolKind string
 
 const (
-	localAssistantToolKindShell                localAssistantToolKind = "shell"
-	localAssistantToolKindSystemAction         localAssistantToolKind = "system_action"
-	localAssistantToolKindMCP                  localAssistantToolKind = "mcp"
-	localAssistantToolKindWorkspaceRead        localAssistantToolKind = "workspace_read"
-	localAssistantToolKindCanvasWriteText      localAssistantToolKind = "canvas_write_text"
-	localAssistantToolKindWebSearchUnavailable localAssistantToolKind = "web_search_unavailable"
+	localAssistantToolKindShell           localAssistantToolKind = "shell"
+	localAssistantToolKindSystemAction    localAssistantToolKind = "system_action"
+	localAssistantToolKindMCP             localAssistantToolKind = "mcp"
+	localAssistantToolKindWorkspaceRead   localAssistantToolKind = "workspace_read"
+	localAssistantToolKindCanvasWriteText localAssistantToolKind = "canvas_write_text"
 )
 
 type localAssistantExecutableTool struct {
@@ -43,11 +42,13 @@ func (a *App) buildLocalAssistantToolCatalog(state localAssistantTurnState, fami
 		Definitions:         nil,
 		ToolsByName:         map[string]localAssistantExecutableTool{},
 	}
-	webMCPURL := a.webMCPURLForCatalog()
-	for _, tool := range localAssistantCoreTools(state, family, webMCPURL != "") {
+	for _, tool := range localAssistantCoreTools(state, family) {
 		out.add(tool)
 	}
-	if family == localAssistantToolFamilyWeb && webMCPURL != "" {
+	// Web tools are always available when a web MCP is configured, so the
+	// model can decide to search/fetch on any turn (same pattern as Claude
+	// Code, Codex CLI, and OpenCode: expose the tools, let the model pick).
+	if webMCPURL := a.webMCPURLForCatalog(); webMCPURL != "" {
 		mcpTools, err := mcpToolsListURL(webMCPURL)
 		if err != nil {
 			return localAssistantToolCatalog{}, err
@@ -56,7 +57,7 @@ func (a *App) buildLocalAssistantToolCatalog(state localAssistantTurnState, fami
 			out.add(tool)
 		}
 	}
-	if !localAssistantFamilyNeedsMCP(family) || strings.TrimSpace(state.mcpURL) == "" {
+	if family == localAssistantToolFamilyNone || strings.TrimSpace(state.mcpURL) == "" {
 		return out, nil
 	}
 	mcpTools, err := mcpToolsListURL(state.mcpURL)
@@ -120,7 +121,7 @@ func localAssistantWebMCPTools(tools []mcpListedTool, mcpURL string) []localAssi
 	return out
 }
 
-func localAssistantCoreTools(state localAssistantTurnState, family localAssistantToolFamily, webMCPAvailable bool) []localAssistantExecutableTool {
+func localAssistantCoreTools(state localAssistantTurnState, family localAssistantToolFamily) []localAssistantExecutableTool {
 	switch family {
 	case localAssistantToolFamilyCanvas:
 		return []localAssistantExecutableTool{
@@ -146,27 +147,16 @@ func localAssistantCoreTools(state localAssistantTurnState, family localAssistan
 			localAssistantSystemActionTool("show_busy_state"),
 			localAssistantSystemActionTool("cancel_work"),
 		}
-	case localAssistantToolFamilyWeb:
-		if webMCPAvailable {
-			// Real web tools come from the web MCP server; see
-			// localAssistantWebMCPTools. No stub needed.
-			return nil
-		}
-		return []localAssistantExecutableTool{
-			localAssistantWebSearchUnavailableTool(),
-		}
 	default:
 		return nil
 	}
 }
 
+// Deprecated: kept only so legacy call sites still compile while we migrate
+// to the flat catalog model. Every non-None family now surfaces the full
+// MCP tool set.
 func localAssistantFamilyNeedsMCP(family localAssistantToolFamily) bool {
-	switch family {
-	case localAssistantToolFamilyMail, localAssistantToolFamilyCalendar, localAssistantToolFamilyItems:
-		return true
-	default:
-		return false
-	}
+	return family != localAssistantToolFamilyNone
 }
 
 func localAssistantWorkspaceReadTool() localAssistantExecutableTool {
@@ -270,30 +260,6 @@ func localAssistantShellTool() localAssistantExecutableTool {
 	}
 }
 
-func localAssistantWebSearchUnavailableTool() localAssistantExecutableTool {
-	return localAssistantExecutableTool{
-		ModelName:    "web_search_unavailable",
-		Kind:         localAssistantToolKindWebSearchUnavailable,
-		InternalName: "web_search_unavailable",
-		Definition: map[string]any{
-			"type": "function",
-			"function": map[string]any{
-				"name":        "web_search_unavailable",
-				"description": "Call this when the user asks for websites, latest news, or web search. Local mode cannot browse websites yet.",
-				"parameters": map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"query": map[string]any{
-							"type":        "string",
-							"description": "The requested website lookup or web search query.",
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 func localAssistantSystemActionTool(action string) localAssistantExecutableTool {
 	action = strings.TrimSpace(action)
 	if action == "" {
@@ -387,17 +353,17 @@ func localAssistantMCPToolsForFamily(state localAssistantTurnState, tools []mcpL
 	return out
 }
 
+// localAssistantIncludeMCPToolForFamily decides whether an MCP tool should be
+// advertised to the local model on a turn with the given family hint.
+// We expose the full flat MCP surface for every real task family: the model
+// picks the right tool in the same way Codex CLI and opencode do. The family
+// hint still drives which internal core tools and policy hints we emit, but
+// no longer restricts which MCP tools the model can reach for.
 func localAssistantIncludeMCPToolForFamily(name string, family localAssistantToolFamily) bool {
-	switch family {
-	case localAssistantToolFamilyMail:
-		return strings.HasPrefix(name, "mail_") || strings.HasPrefix(name, "handoff_")
-	case localAssistantToolFamilyCalendar:
-		return strings.HasPrefix(name, "calendar_")
-	case localAssistantToolFamilyItems:
-		return strings.HasPrefix(name, "item_") || strings.HasPrefix(name, "actor_")
-	default:
+	if strings.TrimSpace(name) == "" {
 		return false
 	}
+	return family != localAssistantToolFamilyNone
 }
 
 func localAssistantMCPDefaultArgs(state localAssistantTurnState, name string) map[string]any {
@@ -548,8 +514,23 @@ func buildLocalAssistantToolPolicy(catalog localAssistantToolCatalog) string {
 	} else {
 		lines = append(lines, localAssistantFamilyPolicyLines(catalog)...)
 	}
+	if localAssistantCatalogHasWebTool(catalog) {
+		lines = append(lines,
+			"- For current events, live prices, weather, news, or any question that needs info beyond your training, call mcp__web_search or mcp__web_fetch instead of refusing.",
+			"- After web results arrive, answer in plain text with 1-3 brief source citations (URLs or site names).",
+		)
+	}
 	lines = append(lines, localAssistantToolCatalogLines(catalog)...)
 	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func localAssistantCatalogHasWebTool(catalog localAssistantToolCatalog) bool {
+	for name := range catalog.ToolsByName {
+		if localAssistantIsWebTool(name) {
+			return true
+		}
+	}
+	return false
 }
 
 func localAssistantFamilyPolicyLines(catalog localAssistantToolCatalog) []string {
@@ -577,16 +558,6 @@ func localAssistantFamilyPolicyLines(catalog localAssistantToolCatalog) []string
 		return []string{"- This is an items or task request. Use only the listed item tools."}
 	case localAssistantToolFamilyRuntime:
 		return []string{"- This is a runtime control request. Use only the listed runtime action tools."}
-	case localAssistantToolFamilyWeb:
-		if _, stub := catalog.ToolsByName["web_search_unavailable"]; stub {
-			return []string{"- This is a web request. Call web_search_unavailable, then explain the limitation briefly."}
-		}
-		return []string{
-			"- This is a web request.",
-			"- Use the listed web tools (for example mcp__web_search or mcp__web_fetch) to look things up.",
-			"- Do not claim that web access is unavailable; the tools in this turn perform real web lookups.",
-			"- After results arrive, answer the user in plain text with 1-3 brief source citations (URLs or site names).",
-		}
 	default:
 		return nil
 	}

--- a/internal/web/chat_assistant_local_catalog.go
+++ b/internal/web/chat_assistant_local_catalog.go
@@ -23,6 +23,10 @@ type localAssistantExecutableTool struct {
 	InternalName string
 	DefaultArgs  map[string]any
 	Definition   map[string]any
+	// MCPURL optionally pins this tool to a specific MCP endpoint instead
+	// of the workspace default. Used for supplementary MCP servers (e.g. a
+	// dedicated web-search MCP) that live outside the workspace MCP.
+	MCPURL string
 }
 
 type localAssistantToolCatalog struct {
@@ -39,8 +43,18 @@ func (a *App) buildLocalAssistantToolCatalog(state localAssistantTurnState, fami
 		Definitions:         nil,
 		ToolsByName:         map[string]localAssistantExecutableTool{},
 	}
-	for _, tool := range localAssistantCoreTools(state, family) {
+	webMCPURL := a.webMCPURLForCatalog()
+	for _, tool := range localAssistantCoreTools(state, family, webMCPURL != "") {
 		out.add(tool)
+	}
+	if family == localAssistantToolFamilyWeb && webMCPURL != "" {
+		mcpTools, err := mcpToolsListURL(webMCPURL)
+		if err != nil {
+			return localAssistantToolCatalog{}, err
+		}
+		for _, tool := range localAssistantWebMCPTools(mcpTools, webMCPURL) {
+			out.add(tool)
+		}
 	}
 	if !localAssistantFamilyNeedsMCP(family) || strings.TrimSpace(state.mcpURL) == "" {
 		return out, nil
@@ -55,7 +69,58 @@ func (a *App) buildLocalAssistantToolCatalog(state localAssistantTurnState, fami
 	return out, nil
 }
 
-func localAssistantCoreTools(state localAssistantTurnState, family localAssistantToolFamily) []localAssistantExecutableTool {
+func (a *App) webMCPURLForCatalog() string {
+	if a == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.webMCPURL)
+}
+
+// localAssistantIsWebTool decides whether an MCP tool advertised by the web
+// MCP server should be surfaced to the local assistant under the web family.
+// Matches common web-search / web-fetch naming conventions so helpy, sloptools,
+// and similar servers can expose their search surface transparently.
+func localAssistantIsWebTool(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	switch {
+	case strings.Contains(lower, "web_search"),
+		strings.Contains(lower, "web_fetch"),
+		strings.Contains(lower, "searxng"),
+		strings.Contains(lower, "websearch"),
+		strings.Contains(lower, "webfetch"):
+		return true
+	}
+	return false
+}
+
+func localAssistantWebMCPTools(tools []mcpListedTool, mcpURL string) []localAssistantExecutableTool {
+	out := make([]localAssistantExecutableTool, 0, len(tools))
+	for _, tool := range tools {
+		if !localAssistantIsWebTool(tool.Name) {
+			continue
+		}
+		out = append(out, localAssistantExecutableTool{
+			ModelName:    localAssistantMCPModelName(tool.Name),
+			Kind:         localAssistantToolKindMCP,
+			InternalName: tool.Name,
+			MCPURL:       mcpURL,
+			Definition: map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        localAssistantMCPModelName(tool.Name),
+					"description": strings.TrimSpace(tool.Description),
+					"parameters":  localAssistantVisibleSchema(tool.InputSchema, nil),
+				},
+			},
+		})
+	}
+	return out
+}
+
+func localAssistantCoreTools(state localAssistantTurnState, family localAssistantToolFamily, webMCPAvailable bool) []localAssistantExecutableTool {
 	switch family {
 	case localAssistantToolFamilyCanvas:
 		return []localAssistantExecutableTool{
@@ -82,6 +147,11 @@ func localAssistantCoreTools(state localAssistantTurnState, family localAssistan
 			localAssistantSystemActionTool("cancel_work"),
 		}
 	case localAssistantToolFamilyWeb:
+		if webMCPAvailable {
+			// Real web tools come from the web MCP server; see
+			// localAssistantWebMCPTools. No stub needed.
+			return nil
+		}
 		return []localAssistantExecutableTool{
 			localAssistantWebSearchUnavailableTool(),
 		}
@@ -476,14 +546,14 @@ func buildLocalAssistantToolPolicy(catalog localAssistantToolCatalog) string {
 	if catalog.Family == localAssistantToolFamilyCanvas {
 		lines = append(lines, localAssistantCanvasPolicyLines(catalog.RenderGeneratedText)...)
 	} else {
-		lines = append(lines, localAssistantFamilyPolicyLines(catalog.Family)...)
+		lines = append(lines, localAssistantFamilyPolicyLines(catalog)...)
 	}
 	lines = append(lines, localAssistantToolCatalogLines(catalog)...)
 	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
-func localAssistantFamilyPolicyLines(family localAssistantToolFamily) []string {
-	switch family {
+func localAssistantFamilyPolicyLines(catalog localAssistantToolCatalog) []string {
+	switch catalog.Family {
 	case localAssistantToolFamilyCanvas:
 		return localAssistantCanvasPolicyLines(false)
 	case localAssistantToolFamilyWorkspace:
@@ -508,7 +578,15 @@ func localAssistantFamilyPolicyLines(family localAssistantToolFamily) []string {
 	case localAssistantToolFamilyRuntime:
 		return []string{"- This is a runtime control request. Use only the listed runtime action tools."}
 	case localAssistantToolFamilyWeb:
-		return []string{"- This is a web request. Call web_search_unavailable, then explain the limitation briefly."}
+		if _, stub := catalog.ToolsByName["web_search_unavailable"]; stub {
+			return []string{"- This is a web request. Call web_search_unavailable, then explain the limitation briefly."}
+		}
+		return []string{
+			"- This is a web request.",
+			"- Use the listed web tools (for example mcp__web_search or mcp__web_fetch) to look things up.",
+			"- Do not claim that web access is unavailable; the tools in this turn perform real web lookups.",
+			"- After results arrive, answer the user in plain text with 1-3 brief source citations (URLs or site names).",
+		}
 	default:
 		return nil
 	}

--- a/internal/web/chat_assistant_local_prompt.go
+++ b/internal/web/chat_assistant_local_prompt.go
@@ -18,15 +18,14 @@ func buildLeanLocalAssistantPrompt(
 	canvas *canvasContext,
 	companion *companionPromptContext,
 	outputMode string,
+	detailRequested bool,
 ) string {
 	var b strings.Builder
 	appendLeanLocalAssistantWorkspace(&b, workspace)
 	appendLeanLocalAssistantCanvas(&b, canvas)
 	appendLeanLocalAssistantCompanion(&b, companion)
-	if isVoiceOutputMode(outputMode) {
-		b.WriteString("Reply clearly for speech. For substantive questions, give a satisfying spoken answer in 3-6 sentences; for simple questions, answer briefly. Do not use markdown unless the user explicitly asks for it.\n")
-	} else {
-		b.WriteString("Default to plain text. For substantive questions, answer with a compact but complete explanation, usually one short paragraph or 3-6 sentences. For simple questions, answer briefly. Use lists or markdown only when the user explicitly asks for them.\n")
+	if isVoiceOutputMode(outputMode) && !detailRequested {
+		b.WriteString("Reply for speech. Default to 1-3 sentences; extend only if the question genuinely needs it. No markdown.\n")
 	}
 	appendLeanLocalAssistantHistory(&b, messages)
 	return strings.TrimSpace(b.String())

--- a/internal/web/chat_assistant_local_prompt_test.go
+++ b/internal/web/chat_assistant_local_prompt_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sloppy-org/slopshell/internal/store"
 )
 
+const voiceBrevityGuidance = "Reply for speech. Default to 1-3 sentences; extend only if the question genuinely needs it. No markdown."
+
 func TestBuildLeanLocalAssistantPromptIsCompact(t *testing.T) {
 	workspace := &store.Workspace{Name: "Slopshell", DirPath: "/tmp/slopshell"}
 	messages := []store.ChatMessage{
@@ -20,6 +22,7 @@ func TestBuildLeanLocalAssistantPromptIsCompact(t *testing.T) {
 		&canvasContext{HasArtifact: true, ArtifactTitle: "notes.md", ArtifactKind: "markdown", ArtifactText: "line one\nline two"},
 		&companionPromptContext{SummaryText: "Planning next steps."},
 		turnOutputModeVoice,
+		false,
 	)
 	for _, snippet := range []string{
 		"Workspace: Slopshell (/tmp/slopshell)",
@@ -27,7 +30,7 @@ func TestBuildLeanLocalAssistantPromptIsCompact(t *testing.T) {
 		"Canvas content:\nline one\nline two",
 		"## Companion Context",
 		"- Summary: Planning next steps.",
-		"Reply clearly for speech. For substantive questions, give a satisfying spoken answer in 3-6 sentences; for simple questions, answer briefly. Do not use markdown unless the user explicitly asks for it.",
+		voiceBrevityGuidance,
 		"Recent messages:",
 		"USER: latest question",
 	} {
@@ -47,7 +50,7 @@ func TestBuildLeanLocalAssistantPromptIsCompact(t *testing.T) {
 	}
 }
 
-func TestBuildLeanLocalAssistantPrompt_DefaultsToPlainShortChat(t *testing.T) {
+func TestBuildLeanLocalAssistantPrompt_SilentHasNoBrevityInstruction(t *testing.T) {
 	workspace := &store.Workspace{Name: "Slopshell", DirPath: "/tmp/slopshell"}
 	prompt := buildLeanLocalAssistantPrompt(
 		workspace,
@@ -55,22 +58,41 @@ func TestBuildLeanLocalAssistantPrompt_DefaultsToPlainShortChat(t *testing.T) {
 		nil,
 		nil,
 		turnOutputModeSilent,
+		false,
 	)
-	if !strings.Contains(prompt, "Default to plain text. For substantive questions, answer with a compact but complete explanation, usually one short paragraph or 3-6 sentences. For simple questions, answer briefly. Use lists or markdown only when the user explicitly asks for them.") {
-		t.Fatalf("prompt missing plain short chat guidance:\n%s", prompt)
+	if strings.Contains(prompt, voiceBrevityGuidance) {
+		t.Fatalf("silent prompt should not carry voice brevity guidance:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "sentences") {
+		t.Fatalf("silent prompt should not prescribe sentence counts:\n%s", prompt)
 	}
 }
 
-func TestBuildLeanLocalAssistantPrompt_VoiceKeepsPlainShortSpeech(t *testing.T) {
+func TestBuildLeanLocalAssistantPrompt_VoiceDefaultIsBrief(t *testing.T) {
 	prompt := buildLeanLocalAssistantPrompt(
 		nil,
 		[]store.ChatMessage{{Role: "user", ContentPlain: "hello"}},
 		nil,
 		nil,
 		turnOutputModeVoice,
+		false,
 	)
-	if !strings.Contains(prompt, "Reply clearly for speech. For substantive questions, give a satisfying spoken answer in 3-6 sentences; for simple questions, answer briefly. Do not use markdown unless the user explicitly asks for it.") {
-		t.Fatalf("prompt missing short speech guidance:\n%s", prompt)
+	if !strings.Contains(prompt, voiceBrevityGuidance) {
+		t.Fatalf("voice default prompt should include brevity guidance:\n%s", prompt)
+	}
+}
+
+func TestBuildLeanLocalAssistantPrompt_VoiceWithDetailIsNotBrief(t *testing.T) {
+	prompt := buildLeanLocalAssistantPrompt(
+		nil,
+		[]store.ChatMessage{{Role: "user", ContentPlain: "explain in detail how tokamaks work"}},
+		nil,
+		nil,
+		turnOutputModeVoice,
+		true,
+	)
+	if strings.Contains(prompt, voiceBrevityGuidance) {
+		t.Fatalf("voice + detail should drop brevity guidance:\n%s", prompt)
 	}
 }
 

--- a/internal/web/chat_assistant_local_prompt_test.go
+++ b/internal/web/chat_assistant_local_prompt_test.go
@@ -124,6 +124,26 @@ func TestStripLocalAssistantThinkingPreamble(t *testing.T) {
 	}
 }
 
+// TestStripLocalAssistantThinkingPreamblePreservesWhitespaceDelta guards
+// against a regression where whitespace-only streaming chunks (commonly a
+// lone "\n" emitted between bullets or paragraphs) were silently dropped,
+// collapsing the assistant's formatting downstream.
+func TestStripLocalAssistantThinkingPreamblePreservesWhitespaceDelta(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"newline only", "\n"},
+		{"double newline", "\n\n"},
+		{"crlf", "\r\n"},
+		{"spaces", "   "},
+	} {
+		if got := stripLocalAssistantThinkingPreamble(tc.in); got != tc.in {
+			t.Fatalf("%s: stripLocalAssistantThinkingPreamble(%q) = %q, want %q", tc.name, tc.in, got, tc.in)
+		}
+	}
+}
+
 func TestAnnotateLocalAssistantSafetyStop(t *testing.T) {
 	if got := annotateLocalAssistantSafetyStop("Hello world from Slopshell"); got != "Hello world from Slopshell\n\n[stopped at local safety limit]" {
 		t.Fatalf("annotateLocalAssistantSafetyStop() = %q", got)

--- a/internal/web/chat_assistant_local_stream_test.go
+++ b/internal/web/chat_assistant_local_stream_test.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDecodeLocalAssistantStreamingPayloadPreservesBulletNewlines guards the
+// SSE stream decoder against swallowing whitespace-only chunks. Local OpenAI
+// compatible servers frequently emit a lone "\n" as its own content delta
+// between bullets or paragraphs; dropping those collapses the assistant's
+// formatting when the web/slsh clients render the final message.
+func TestDecodeLocalAssistantStreamingPayloadPreservesBulletNewlines(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"- First bullet."}}]}`,
+		`data: {"choices":[{"delta":{"content":"\n"}}]}`,
+		`data: {"choices":[{"delta":{"content":"- Second bullet."}}]}`,
+		`data: {"choices":[{"delta":{"content":"\n"}}]}`,
+		`data: {"choices":[{"delta":{"content":"- Third bullet."}}]}`,
+		`data: {"choices":[{"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	msg, finish, err := decodeLocalAssistantStreamingPayload(strings.NewReader(body), false, nil)
+	if err != nil {
+		t.Fatalf("decodeLocalAssistantStreamingPayload: %v", err)
+	}
+	if finish != "stop" {
+		t.Fatalf("finish reason = %q, want stop", finish)
+	}
+	want := "- First bullet.\n- Second bullet.\n- Third bullet."
+	if msg.Content != want {
+		t.Fatalf("message content = %q, want %q", msg.Content, want)
+	}
+}

--- a/internal/web/chat_assistant_local_tools.go
+++ b/internal/web/chat_assistant_local_tools.go
@@ -328,12 +328,9 @@ func (a *App) runLocalAssistantToolLoop(ctx context.Context, req *assistantTurnR
 		familyInput = toolText
 	}
 	family := selectLocalAssistantToolFamily(familyInput)
-	catalog := localAssistantToolCatalog{Family: family, ToolsByName: map[string]localAssistantExecutableTool{}}
-	if family != localAssistantToolFamilyNone {
-		catalog, err = a.buildLocalAssistantToolCatalog(state, family, familyInput)
-		if err != nil {
-			return "", err
-		}
+	catalog, err := a.buildLocalAssistantToolCatalog(state, family, familyInput)
+	if err != nil {
+		return "", err
 	}
 	if directPath := strings.TrimSpace(localAssistantDirectOpenFileHint(toolUserPrompt, family)); directPath != "" {
 		return a.runLocalAssistantDirectOpenFileCanvas(ctx, &state, catalog, directPath)
@@ -526,8 +523,6 @@ func (a *App) executeLocalAssistantToolCall(ctx context.Context, state *localAss
 		return executeLocalAssistantWorkspaceReadTool(state, executable, call, args), nil
 	case localAssistantToolKindMCP:
 		return a.executeLocalAssistantBoundMCPTool(ctx, state, executable, call, args)
-	case localAssistantToolKindWebSearchUnavailable:
-		return executeLocalAssistantWebSearchUnavailableTool(executable, call, args), nil
 	default:
 		return localAssistantToolResult{
 			ToolCallID: call.ID,
@@ -742,24 +737,6 @@ func (a *App) executeLocalAssistantBoundMCPTool(ctx context.Context, state *loca
 	}
 	result.StructuredContent = structuredContent
 	return result, nil
-}
-
-func executeLocalAssistantWebSearchUnavailableTool(tool localAssistantExecutableTool, call localAssistantToolCall, args map[string]any) localAssistantToolResult {
-	return localAssistantToolResult{
-		ToolCallID: call.ID,
-		ModelName:  tool.ModelName,
-		Name:       tool.InternalName,
-		Kind:       string(tool.Kind),
-		Arguments:  args,
-		IsError:    true,
-		Error:      "Local mode cannot browse websites or run web search yet. Explain that limitation and continue with local files, MCP tools, canvas, mail, calendar, or workspace actions when possible.",
-		StructuredContent: map[string]any{
-			"available":  false,
-			"capability": "web_search",
-			"message":    "Local mode cannot browse websites or run web search yet.",
-			"query":      strings.TrimSpace(fmt.Sprint(args["query"])),
-		},
-	}
 }
 
 func localAssistantToolPayloads(result localAssistantToolResult, workspaceID int64) []map[string]any {

--- a/internal/web/chat_assistant_local_tools.go
+++ b/internal/web/chat_assistant_local_tools.go
@@ -718,6 +718,9 @@ func (a *App) executeLocalAssistantBoundMCPTool(ctx context.Context, state *loca
 		Arguments:  args,
 	}
 	mcpURL := state.mcpURL
+	if override := strings.TrimSpace(tool.MCPURL); override != "" {
+		mcpURL = override
+	}
 	if strings.HasPrefix(tool.InternalName, "canvas_") && strings.TrimSpace(state.canvasID) != "" {
 		if port, ok := a.tunnels.getPort(state.canvasID); ok && port > 0 {
 			mcpURL = fmt.Sprintf("http://127.0.0.1:%d/mcp", port)

--- a/internal/web/chat_assistant_local_tools.go
+++ b/internal/web/chat_assistant_local_tools.go
@@ -427,7 +427,7 @@ func (a *App) runLocalAssistantToolLoop(ctx context.Context, req *assistantTurnR
 				}
 				return confirmation, nil
 			}
-			if toolRequired && !toolExecuted && toolPlanRetries == 0 {
+			if toolRequired && !toolExecuted && toolPlanRetries < assistantLLMToolPlanRetries {
 				toolPlanRetries++
 				conversation = append(conversation, localAssistantAssistantMessage(message))
 				conversation = append(conversation, map[string]any{
@@ -436,9 +436,9 @@ func (a *App) runLocalAssistantToolLoop(ctx context.Context, req *assistantTurnR
 				})
 				continue
 			}
-			if toolRequired && !toolExecuted {
-				return "", errors.New("local assistant answered without calling the required tool")
-			}
+			// Local model refused to call a tool after retries. Surface its
+			// text answer rather than failing the turn; the user still gets
+			// something useful and can re-ask with an explicit instruction.
 			return text, nil
 		}
 		if len(decision.ToolCalls) == 0 {

--- a/internal/web/chat_assistant_local_web_test.go
+++ b/internal/web/chat_assistant_local_web_test.go
@@ -33,20 +33,6 @@ func TestLocalAssistantWebMCPToolsFiltersAndTagsURL(t *testing.T) {
 	}
 }
 
-func TestLocalAssistantCoreToolsWebFallbackStub(t *testing.T) {
-	got := localAssistantCoreTools(localAssistantTurnState{}, localAssistantToolFamilyWeb, false)
-	if len(got) != 1 || got[0].InternalName != "web_search_unavailable" {
-		t.Fatalf("without web MCP, core tools = %+v, want web_search_unavailable stub only", got)
-	}
-}
-
-func TestLocalAssistantCoreToolsWebSkipsStubWhenMCPAvailable(t *testing.T) {
-	got := localAssistantCoreTools(localAssistantTurnState{}, localAssistantToolFamilyWeb, true)
-	if len(got) != 0 {
-		t.Fatalf("with web MCP available, core tools = %+v, want none (real tools come from MCP)", got)
-	}
-}
-
 func TestLocalAssistantIsWebToolAcceptsCommonNames(t *testing.T) {
 	accept := []string{"web_search", "web_fetch", "searxng_search", "searxng_fetch", "mcp__web_search"}
 	for _, name := range accept {

--- a/internal/web/chat_assistant_local_web_test.go
+++ b/internal/web/chat_assistant_local_web_test.go
@@ -1,0 +1,63 @@
+package web
+
+import (
+	"testing"
+)
+
+func TestLocalAssistantWebMCPToolsFiltersAndTagsURL(t *testing.T) {
+	mcpURL := "http://127.0.0.1:8090/mcp"
+	tools := []mcpListedTool{
+		{Name: "web_search", Description: "SearXNG web search.", InputSchema: map[string]any{"type": "object"}},
+		{Name: "web_fetch", Description: "Fetch a URL.", InputSchema: map[string]any{"type": "object"}},
+		{Name: "calendar_events", Description: "List events."},
+		{Name: "mail_account_list", Description: "List mail accounts."},
+	}
+	got := localAssistantWebMCPTools(tools, mcpURL)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 web tools, got: %+v", len(got), got)
+	}
+	names := map[string]bool{}
+	for _, tool := range got {
+		if tool.MCPURL != mcpURL {
+			t.Errorf("tool %q MCPURL = %q, want %q", tool.InternalName, tool.MCPURL, mcpURL)
+		}
+		if tool.Kind != localAssistantToolKindMCP {
+			t.Errorf("tool %q Kind = %q, want mcp", tool.InternalName, tool.Kind)
+		}
+		names[tool.InternalName] = true
+	}
+	for _, want := range []string{"web_search", "web_fetch"} {
+		if !names[want] {
+			t.Errorf("missing web tool %q in catalog: %+v", want, names)
+		}
+	}
+}
+
+func TestLocalAssistantCoreToolsWebFallbackStub(t *testing.T) {
+	got := localAssistantCoreTools(localAssistantTurnState{}, localAssistantToolFamilyWeb, false)
+	if len(got) != 1 || got[0].InternalName != "web_search_unavailable" {
+		t.Fatalf("without web MCP, core tools = %+v, want web_search_unavailable stub only", got)
+	}
+}
+
+func TestLocalAssistantCoreToolsWebSkipsStubWhenMCPAvailable(t *testing.T) {
+	got := localAssistantCoreTools(localAssistantTurnState{}, localAssistantToolFamilyWeb, true)
+	if len(got) != 0 {
+		t.Fatalf("with web MCP available, core tools = %+v, want none (real tools come from MCP)", got)
+	}
+}
+
+func TestLocalAssistantIsWebToolAcceptsCommonNames(t *testing.T) {
+	accept := []string{"web_search", "web_fetch", "searxng_search", "searxng_fetch", "mcp__web_search"}
+	for _, name := range accept {
+		if !localAssistantIsWebTool(name) {
+			t.Errorf("localAssistantIsWebTool(%q) = false, want true", name)
+		}
+	}
+	reject := []string{"mail_account_list", "calendar_events", "item_list", ""}
+	for _, name := range reject {
+		if localAssistantIsWebTool(name) {
+			t.Errorf("localAssistantIsWebTool(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -170,26 +170,20 @@ func TestBuildPromptFromHistory_IncludesSystemPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "You are Slopshell") {
 		t.Error("prompt should contain system identity")
 	}
-	if !strings.Contains(prompt, "Voice mode is chat-first") {
-		t.Error("prompt should define chat-first voice mode")
+	if !strings.Contains(prompt, "Chat-first") {
+		t.Error("prompt should define chat-first behavior")
 	}
-	if !strings.Contains(prompt, "Do not emit :::file blocks unless the user explicitly asks to show/open/render content on canvas.") {
-		t.Error("prompt should explicitly limit :::file blocks to explicit canvas requests")
+	if !strings.Contains(prompt, `emit a :::file{path="..."} block`) {
+		t.Error("prompt should describe the :::file canvas grammar")
 	}
-	if !strings.Contains(prompt, "Do not emit :::canvas blocks.") {
+	if !strings.Contains(prompt, "Do not use :::canvas blocks.") {
 		t.Error("prompt should explicitly disallow :::canvas blocks")
 	}
-	if !strings.Contains(prompt, "Do not mirror ordinary chat output on canvas.") {
-		t.Error("prompt should explicitly disallow mirroring ordinary chat output on canvas")
+	if !strings.Contains(prompt, "Do not mirror chat on canvas.") {
+		t.Error("prompt should explicitly disallow mirroring chat on canvas")
 	}
-	if !strings.Contains(prompt, "show/open an existing file") {
-		t.Error("prompt should define existing-file canvas behavior")
-	}
-	if !strings.Contains(prompt, "you may emit :::file blocks for that file-backed canvas output") {
-		t.Error("prompt should allow explicit canvas rendering in voice mode")
-	}
-	if !strings.Contains(prompt, "do NOT paste that file body into chat") {
-		t.Error("prompt should forbid inlining existing file bodies")
+	if !strings.Contains(prompt, "canvas_artifact_show") {
+		t.Error("prompt should reference canvas_artifact_show for existing files")
 	}
 	if !strings.Contains(prompt, "[lang:") {
 		t.Error("prompt should mention [lang:] markers")

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -154,6 +154,14 @@ func TestAssistantFinalChatContent_RegularChatResponse(t *testing.T) {
 	}
 }
 
+func TestAssistantFinalChatContent_PreservesBulletNewlines(t *testing.T) {
+	input := "- First bullet.\n- Second bullet.\n- Third bullet."
+	markdown, _, _ := assistantFinalChatContent(input, false, false)
+	if markdown != input {
+		t.Fatalf("markdown = %q, want unchanged %q", markdown, input)
+	}
+}
+
 func TestBuildPromptFromHistory_IncludesSystemPrompt(t *testing.T) {
 	prompt := buildPromptFromHistory("chat", nil, nil)
 	if prompt == "" {

--- a/internal/web/chat_hub_test.go
+++ b/internal/web/chat_hub_test.go
@@ -542,6 +542,7 @@ func TestRunAssistantTurnKeepsPlainTextAssistantOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new app: %v", err)
 	}
+	app.assistantMode = assistantModeAuto
 	t.Cleanup(func() {
 		_ = app.Shutdown(context.Background())
 	})

--- a/internal/web/chat_local_shortcuts.go
+++ b/internal/web/chat_local_shortcuts.go
@@ -16,7 +16,6 @@ const (
 	localAssistantToolFamilyCalendar  localAssistantToolFamily = "calendar"
 	localAssistantToolFamilyItems     localAssistantToolFamily = "items"
 	localAssistantToolFamilyRuntime   localAssistantToolFamily = "runtime"
-	localAssistantToolFamilyWeb       localAssistantToolFamily = "web"
 )
 
 func normalizeLocalAssistantAddress(text string) string {
@@ -44,11 +43,6 @@ func selectLocalAssistantToolFamily(text string) localAssistantToolFamily {
 		return localAssistantToolFamilyNone
 	}
 	switch {
-	case containsAnyLocalAssistantKeyword(lower,
-		"website", "web search", "browse ", "latest ", "news", "search the web",
-		"webseite", "im web", "im internet", "neueste ", "nachrichten",
-	):
-		return localAssistantToolFamilyWeb
 	case containsAnyLocalAssistantKeyword(lower,
 		"go silent", "be silent", "stop talking", "dialogue mode", "meeting mode", "live dialogue", "cancel work", "show status", "show busy state",
 		"sei still", "schweig", "stumm", "dialogmodus", "meetingmodus", "arbeit abbrechen", "zeige status", "zeige beschäftigt",

--- a/internal/web/chat_prompt_budget_test.go
+++ b/internal/web/chat_prompt_budget_test.go
@@ -1,0 +1,26 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSystemPromptWordBudget guards against prompt drift. The voice/history
+// system prompt should stay compact; tool docs live in the tools parameter
+// and project rules live on-demand via MCP, not inlined here.
+func TestSystemPromptWordBudget(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		limit  int
+	}{
+		{"defaultVoiceHistoryPrompt", defaultVoiceHistoryPrompt, 140},
+		{"defaultVoiceTurnPrompt", defaultVoiceTurnPrompt, 40},
+	}
+	for _, tc := range cases {
+		words := len(strings.Fields(tc.prompt))
+		if words > tc.limit {
+			t.Fatalf("%s word count = %d, want <= %d. prompt:\n%s", tc.name, words, tc.limit, tc.prompt)
+		}
+	}
+}

--- a/internal/web/chat_provider_test.go
+++ b/internal/web/chat_provider_test.go
@@ -68,24 +68,34 @@ func TestLocalSystemActionTurnPublishesLocalProviderMetadata(t *testing.T) {
 func TestLocalAssistantTurnHandlesCanvasWriteTextTool(t *testing.T) {
 	var mcpCalls atomic.Int32
 	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mcpCalls.Add(1)
 		var payload map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode mcp payload: %v", err)
 		}
-		params, _ := payload["params"].(map[string]any)
-		if got := strings.TrimSpace(strFromAny(params["name"])); got != "canvas_artifact_show" {
-			t.Fatalf("tool name = %q, want canvas_artifact_show", got)
+		switch strings.TrimSpace(strFromAny(payload["method"])) {
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{"tools": []map[string]any{}},
+			})
+			return
+		case "tools/call":
+			mcpCalls.Add(1)
+			params, _ := payload["params"].(map[string]any)
+			if got := strings.TrimSpace(strFromAny(params["name"])); got != "canvas_artifact_show" {
+				t.Fatalf("tool name = %q, want canvas_artifact_show", got)
+			}
+			args, _ := params["arguments"].(map[string]any)
+			if got := strings.TrimSpace(strFromAny(args["markdown_or_text"])); got != "Orbit Canvas" {
+				t.Fatalf("canvas body = %q, want Orbit Canvas", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{
+					"structuredContent": map[string]any{"ok": true},
+				},
+			})
+		default:
+			t.Fatalf("unexpected MCP method %q", payload["method"])
 		}
-		args, _ := params["arguments"].(map[string]any)
-		if got := strings.TrimSpace(strFromAny(args["markdown_or_text"])); got != "Orbit Canvas" {
-			t.Fatalf("canvas body = %q, want Orbit Canvas", got)
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"result": map[string]any{
-				"structuredContent": map[string]any{"ok": true},
-			},
-		})
 	}))
 	defer mcp.Close()
 

--- a/internal/web/chat_routing_prompt_test.go
+++ b/internal/web/chat_routing_prompt_test.go
@@ -34,14 +34,11 @@ func TestBuildTurnPromptKeepsOriginalUserText(t *testing.T) {
 func TestBuildTurnPromptChatOnlyContract(t *testing.T) {
 	messages := []store.ChatMessage{{Role: "user", ContentPlain: "explain this function"}}
 	prompt := buildTurnPrompt(messages, nil)
-	if !strings.Contains(prompt, "Voice mode is chat-first") {
+	if !strings.Contains(prompt, "Chat-first") {
 		t.Error("turn prompt should define chat-first voice mode")
 	}
-	if !strings.Contains(prompt, "Do not emit :::file blocks unless the user explicitly asks to show/open/render content on canvas.") {
-		t.Error("turn prompt should explicitly limit file blocks to explicit canvas requests")
-	}
-	if !strings.Contains(prompt, "show/open an existing file") {
-		t.Error("turn prompt should define existing-file canvas behavior")
+	if !strings.Contains(prompt, `emit :::file{path="..."} only when the user explicitly asks`) {
+		t.Error("turn prompt should limit file blocks to explicit canvas requests")
 	}
 	if !strings.Contains(prompt, "explain this function") {
 		t.Error("original message should be present")

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -50,25 +50,6 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	}
 	baseProfile = a.appServerProfileForChatSession(session, baseProfile)
 	turnProfile = a.appServerProfileForChatSession(session, turnProfile)
-	// Only force Spark (remote) routing for search turns when the user did
-	// not explicitly route the turn. If a web MCP is configured, the local
-	// assistant owns web search via MCP tools; Codex stays reserved for
-	// explicit "use gpt/spark/mini" directives.
-	if directives.SearchRequested && directives.ModelAliasExplicit {
-		turnProfile = a.appServerProfileForChatSession(session, routeProfileForRouting(
-			directives.ModelAlias,
-			baseProfile,
-			a.appServerSparkReasoningEffort,
-			directives.ReasoningEffort,
-		))
-	} else if directives.SearchRequested && a.webMCPURLForCatalog() == "" {
-		turnProfile = a.appServerProfileForChatSession(session, routeProfileForRouting(
-			modelprofile.AliasSpark,
-			baseProfile,
-			a.appServerSparkReasoningEffort,
-			directives.ReasoningEffort,
-		))
-	}
 	req := &assistantTurnRequest{
 		sessionID:       sessionID,
 		session:         session,
@@ -85,8 +66,8 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		fastMode:        turn.fastMode,
 		messageID:       turn.messageID,
 		turnModel:       directives.ModelAlias,
-		searchTurn:      directives.SearchRequested,
-		transientRemote: (directives.SearchRequested && (directives.ModelAliasExplicit || a.webMCPURLForCatalog() == "")) || (directives.ModelAliasExplicit && directives.ModelAlias != "" && directives.ModelAlias != modelprofile.AliasLocal),
+		detailRequested: directives.DetailRequested,
+		transientRemote: directives.ModelAliasExplicit && directives.ModelAlias != "" && directives.ModelAlias != modelprofile.AliasLocal,
 		reasoningEffort: directives.ReasoningEffort,
 		baseProfile:     baseProfile,
 		turnProfile:     turnProfile,

--- a/internal/web/chat_turn.go
+++ b/internal/web/chat_turn.go
@@ -50,7 +50,18 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 	}
 	baseProfile = a.appServerProfileForChatSession(session, baseProfile)
 	turnProfile = a.appServerProfileForChatSession(session, turnProfile)
-	if directives.SearchRequested {
+	// Only force Spark (remote) routing for search turns when the user did
+	// not explicitly route the turn. If a web MCP is configured, the local
+	// assistant owns web search via MCP tools; Codex stays reserved for
+	// explicit "use gpt/spark/mini" directives.
+	if directives.SearchRequested && directives.ModelAliasExplicit {
+		turnProfile = a.appServerProfileForChatSession(session, routeProfileForRouting(
+			directives.ModelAlias,
+			baseProfile,
+			a.appServerSparkReasoningEffort,
+			directives.ReasoningEffort,
+		))
+	} else if directives.SearchRequested && a.webMCPURLForCatalog() == "" {
 		turnProfile = a.appServerProfileForChatSession(session, routeProfileForRouting(
 			modelprofile.AliasSpark,
 			baseProfile,
@@ -75,7 +86,7 @@ func (a *App) runAssistantTurn(sessionID string, turn dequeuedTurn) {
 		messageID:       turn.messageID,
 		turnModel:       directives.ModelAlias,
 		searchTurn:      directives.SearchRequested,
-		transientRemote: directives.SearchRequested || (directives.ModelAlias != "" && directives.ModelAlias != modelprofile.AliasLocal),
+		transientRemote: (directives.SearchRequested && (directives.ModelAliasExplicit || a.webMCPURLForCatalog() == "")) || (directives.ModelAliasExplicit && directives.ModelAlias != "" && directives.ModelAlias != modelprofile.AliasLocal),
 		reasoningEffort: directives.ReasoningEffort,
 		baseProfile:     baseProfile,
 		turnProfile:     turnProfile,

--- a/internal/web/cli_auth.go
+++ b/internal/web/cli_auth.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -33,13 +34,22 @@ func resolveCLITokenPath(dataDir string) string {
 	return filepath.Join(dataDir, "cli-token")
 }
 
-// initCLIToken generates a new random 32-byte hex token, writes it to disk
-// with 0600 perms, and returns the chosen path and token. Regenerated each
-// time the server starts so the token does not persist across restarts.
+// initCLIToken resolves the CLI token file path, adopting an existing 0600
+// token on disk when present, and otherwise minting a fresh random 32-byte
+// hex token and writing it with 0600 perms. Adopt-if-exists keeps the
+// in-memory token and the on-disk file in sync across restarts and avoids
+// clobbering the file when a second slopshell instance starts against the
+// same $XDG_RUNTIME_DIR path (which previously desynced slsh from a
+// long-running server).
 func initCLIToken(dataDir string) (string, string, error) {
 	path := resolveCLITokenPath(dataDir)
 	if path == "" {
 		return "", "", errors.New("cli token path not resolvable")
+	}
+	if existing, ok, err := readExistingCLIToken(path); err != nil {
+		return "", "", err
+	} else if ok {
+		return path, existing, nil
 	}
 	var raw [32]byte
 	if _, err := rand.Read(raw[:]); err != nil {
@@ -52,7 +62,46 @@ func initCLIToken(dataDir string) (string, string, error) {
 	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
 		return "", "", fmt.Errorf("write cli token: %w", err)
 	}
+	// Force 0600 in case the file already existed with looser perms, since
+	// os.WriteFile only applies the mode on file creation.
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o600); err != nil {
+			return "", "", fmt.Errorf("chmod cli token: %w", err)
+		}
+	}
 	return path, token, nil
+}
+
+// readExistingCLIToken returns (token, true, nil) when the file at path
+// already holds a valid 64-char hex token with 0600 perms (non-windows).
+// Returns (_, false, nil) when the file is missing, empty, malformed, or
+// has loose permissions — so the caller can mint a fresh one. A read error
+// other than os.IsNotExist is surfaced.
+func readExistingCLIToken(path string) (string, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("stat cli token: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			return "", false, nil
+		}
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, fmt.Errorf("read cli token: %w", err)
+	}
+	token := strings.TrimSpace(string(body))
+	if len(token) != 64 {
+		return "", false, nil
+	}
+	if _, err := hex.DecodeString(token); err != nil {
+		return "", false, nil
+	}
+	return token, true, nil
 }
 
 // isLoopbackRequest returns true only for connections whose remote peer is

--- a/internal/web/cli_auth.go
+++ b/internal/web/cli_auth.go
@@ -1,0 +1,118 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cliTokenEnv lets CLI clients override the token file location. When unset,
+// the runtime falls back to $XDG_RUNTIME_DIR/slopshell/cli-token, then to
+// <dataDir>/cli-token.
+const cliTokenEnv = "SLOPSHELL_CLI_TOKEN_FILE"
+
+// resolveCLITokenPath picks the preferred on-disk location for the CLI token.
+// Callers should be able to discover this path without talking to the server.
+func resolveCLITokenPath(dataDir string) string {
+	if override := strings.TrimSpace(os.Getenv(cliTokenEnv)); override != "" {
+		return override
+	}
+	if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
+		return filepath.Join(runtimeDir, "slopshell", "cli-token")
+	}
+	if strings.TrimSpace(dataDir) == "" {
+		return ""
+	}
+	return filepath.Join(dataDir, "cli-token")
+}
+
+// initCLIToken generates a new random 32-byte hex token, writes it to disk
+// with 0600 perms, and returns the chosen path and token. Regenerated each
+// time the server starts so the token does not persist across restarts.
+func initCLIToken(dataDir string) (string, string, error) {
+	path := resolveCLITokenPath(dataDir)
+	if path == "" {
+		return "", "", errors.New("cli token path not resolvable")
+	}
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", "", fmt.Errorf("generate cli token: %w", err)
+	}
+	token := hex.EncodeToString(raw[:])
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", "", fmt.Errorf("mkdir cli token dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		return "", "", fmt.Errorf("write cli token: %w", err)
+	}
+	return path, token, nil
+}
+
+// isLoopbackRequest returns true only for connections whose remote peer is
+// bound to a loopback address. It ignores X-Forwarded-For and any other
+// forwarded headers deliberately: the CLI login endpoint is for same-host
+// callers only, so trusting proxy headers would be unsafe.
+func isLoopbackRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		host = strings.TrimSpace(r.RemoteAddr)
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return strings.EqualFold(host, "localhost")
+}
+
+// handleCLILogin accepts a CLI token previously written to the cli-token file
+// and, on match, issues a standard auth-session cookie so subsequent requests
+// and websocket upgrades authenticate normally. Loopback-only.
+func (a *App) handleCLILogin(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRequest(r) {
+		writeAPIError(w, http.StatusForbidden, "cli login is loopback-only")
+		return
+	}
+	if strings.TrimSpace(a.cliToken) == "" {
+		writeAPIError(w, http.StatusServiceUnavailable, "cli token not initialised")
+		return
+	}
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	provided := strings.TrimSpace(req.Token)
+	if provided == "" {
+		writeAPIError(w, http.StatusBadRequest, "token is required")
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(a.cliToken)) != 1 {
+		writeAPIError(w, http.StatusUnauthorized, "invalid cli token")
+		return
+	}
+	sessionToken := randomToken()
+	if err := a.store.AddAuthSession(sessionToken); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "failed to create session")
+		return
+	}
+	a.setAuthCookieForRequest(w, r, sessionToken)
+	writeJSON(w, map[string]interface{}{
+		"ok":         true,
+		"token_path": a.cliTokenPath,
+	})
+}

--- a/internal/web/cli_auth_test.go
+++ b/internal/web/cli_auth_test.go
@@ -1,0 +1,155 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInitCLITokenWritesFileWithRestrictivePerms(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv(cliTokenEnv, "")
+	path, token, err := initCLIToken(dir)
+	if err != nil {
+		t.Fatalf("initCLIToken: %v", err)
+	}
+	wantDir := filepath.Clean(dir)
+	if filepath.Dir(path) != wantDir {
+		t.Fatalf("token dir = %q, want %q", filepath.Dir(path), wantDir)
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := stat.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("token perms = %o, want 0600", perm)
+		}
+	}
+	if len(token) != 64 {
+		t.Fatalf("token length = %d, want 64 hex chars", len(token))
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	if got := strings.TrimSpace(string(body)); got != token {
+		t.Fatalf("file contents = %q, want %q", got, token)
+	}
+}
+
+func TestResolveCLITokenPathPrefersEnvThenXDGRuntimeDir(t *testing.T) {
+	t.Setenv(cliTokenEnv, "/custom/path/cli-token")
+	if got := resolveCLITokenPath("/data"); got != "/custom/path/cli-token" {
+		t.Fatalf("env override path = %q, want /custom/path/cli-token", got)
+	}
+	t.Setenv(cliTokenEnv, "")
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+	if got := resolveCLITokenPath("/data"); got != "/run/user/1000/slopshell/cli-token" {
+		t.Fatalf("xdg path = %q, want /run/user/1000/slopshell/cli-token", got)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	if got := resolveCLITokenPath("/data"); got != "/data/cli-token" {
+		t.Fatalf("datadir fallback = %q, want /data/cli-token", got)
+	}
+}
+
+func postCLILogin(t *testing.T, app *App, remoteAddr, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"token": token})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/cli/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	return rr
+}
+
+func TestCLILoginSucceedsOnLoopbackAndMintsCookie(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.cliToken = "secret-cli-token"
+	app.cliTokenPath = "/tmp/slopshell/cli-token"
+
+	rr := postCLILogin(t, app, "127.0.0.1:54321", "secret-cli-token")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var cookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == SessionCookie {
+			cookie = c
+			break
+		}
+	}
+	if cookie == nil || strings.TrimSpace(cookie.Value) == "" {
+		t.Fatalf("expected %s cookie, got %+v", SessionCookie, rr.Result().Cookies())
+	}
+	if !app.store.HasAuthSession(cookie.Value) {
+		t.Fatalf("cookie token %q not registered as auth session", cookie.Value)
+	}
+
+	// Follow-up request using the cookie must succeed against the authed API.
+	req := httptest.NewRequest(http.MethodGet, "/api/runtime", nil)
+	req.AddCookie(cookie)
+	r2 := httptest.NewRecorder()
+	app.Router().ServeHTTP(r2, req)
+	if r2.Code != http.StatusOK {
+		t.Fatalf("authed runtime status = %d, body = %s", r2.Code, r2.Body.String())
+	}
+}
+
+func TestCLILoginRejectsNonLoopback(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.cliToken = "secret-cli-token"
+
+	rr := postCLILogin(t, app, "10.0.0.2:44444", "secret-cli-token")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCLILoginRejectsForwardedForSpoof(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.cliToken = "secret-cli-token"
+
+	body, _ := json.Marshal(map[string]string{"token": "secret-cli-token"})
+	req := httptest.NewRequest(http.MethodPost, "/api/cli/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	req.RemoteAddr = "203.0.113.5:44444"
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("forwarded-for spoof not rejected: status = %d body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCLILoginRejectsWrongToken(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.cliToken = "secret-cli-token"
+
+	rr := postCLILogin(t, app, "127.0.0.1:54321", "wrong-value")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCLILoginWhenTokenNotInitialised(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.cliToken = ""
+
+	rr := postCLILogin(t, app, "127.0.0.1:54321", "anything")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503, body = %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/web/cli_auth_test.go
+++ b/internal/web/cli_auth_test.go
@@ -45,6 +45,100 @@ func TestInitCLITokenWritesFileWithRestrictivePerms(t *testing.T) {
 	}
 }
 
+func TestInitCLITokenAdoptsExistingValidToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv(cliTokenEnv, "")
+
+	// First call mints a fresh token.
+	path1, token1, err := initCLIToken(dir)
+	if err != nil {
+		t.Fatalf("initCLIToken first call: %v", err)
+	}
+	statBefore, err := os.Stat(path1)
+	if err != nil {
+		t.Fatalf("stat after first init: %v", err)
+	}
+
+	// Second call (simulating a server restart or a second slopshell on the
+	// same path) must adopt the same token and not rewrite the file.
+	path2, token2, err := initCLIToken(dir)
+	if err != nil {
+		t.Fatalf("initCLIToken second call: %v", err)
+	}
+	if path2 != path1 {
+		t.Fatalf("path mismatch: %q vs %q", path2, path1)
+	}
+	if token2 != token1 {
+		t.Fatalf("token mismatch: adopt-if-exists should reuse the on-disk token (got %q, want %q)", token2, token1)
+	}
+	statAfter, err := os.Stat(path1)
+	if err != nil {
+		t.Fatalf("stat after second init: %v", err)
+	}
+	if !statAfter.ModTime().Equal(statBefore.ModTime()) {
+		t.Fatalf("token file was rewritten: mtime %v -> %v", statBefore.ModTime(), statAfter.ModTime())
+	}
+}
+
+func TestInitCLITokenReplacesMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv(cliTokenEnv, "")
+	path := filepath.Join(dir, "cli-token")
+	if err := os.WriteFile(path, []byte("not-hex garbage\n"), 0o600); err != nil {
+		t.Fatalf("seed malformed file: %v", err)
+	}
+	gotPath, token, err := initCLIToken(dir)
+	if err != nil {
+		t.Fatalf("initCLIToken: %v", err)
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+	if len(token) != 64 {
+		t.Fatalf("token length = %d, want 64 hex chars", len(token))
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if got := strings.TrimSpace(string(body)); got != token {
+		t.Fatalf("file not rewritten: contents = %q, want %q", got, token)
+	}
+}
+
+func TestInitCLITokenReplacesFileWithLoosePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("perm semantics differ on windows")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv(cliTokenEnv, "")
+	path := filepath.Join(dir, "cli-token")
+	fakeToken := strings.Repeat("a", 64)
+	if err := os.WriteFile(path, []byte(fakeToken+"\n"), 0o644); err != nil {
+		t.Fatalf("seed loose-perm file: %v", err)
+	}
+	gotPath, token, err := initCLIToken(dir)
+	if err != nil {
+		t.Fatalf("initCLIToken: %v", err)
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+	if token == fakeToken {
+		t.Fatalf("expected fresh token, got the loose-perm file token")
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := stat.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("replaced file perms = %o, want 0600", perm)
+	}
+}
+
 func TestResolveCLITokenPathPrefersEnvThenXDGRuntimeDir(t *testing.T) {
 	t.Setenv(cliTokenEnv, "/custom/path/cli-token")
 	if got := resolveCLITokenPath("/data"); got != "/custom/path/cli-token" {

--- a/internal/web/companion_response_trigger_test.go
+++ b/internal/web/companion_response_trigger_test.go
@@ -848,6 +848,7 @@ func TestCompanionResponseTriggerIncludesProjectScopedCompanionContext(t *testin
 func TestCompanionResponseTriggerUsesWorkspaceDirForAppSession(t *testing.T) {
 	t.Setenv("SLOPSHELL_INTENT_LLM_URL", "off")
 	app := newAuthedTestApp(t)
+	app.assistantMode = assistantModeAuto
 	client, _, cwdCh := newCompanionAppServerClientWithSessionCapture(t, "Companion reply.")
 	app.appServerClient = client
 

--- a/internal/web/routing_policy.go
+++ b/internal/web/routing_policy.go
@@ -11,7 +11,7 @@ type turnRoutingDirectives struct {
 	ModelAlias         string
 	ModelAliasExplicit bool
 	ReasoningEffort    string
-	SearchRequested    bool
+	DetailRequested    bool
 	PromptText         string
 	DirectiveApplied   bool
 }
@@ -20,14 +20,19 @@ type directivePattern struct {
 	regex  *regexp.Regexp
 	alias  string
 	effort string
-	search bool
 }
 
+var verbosityDetailPattern = regexp.MustCompile(`(?i)\b(?:` +
+	`in\s+detail|explain\s+(?:in\s+)?detail|long\s+answer|be\s+thorough|` +
+	`elaborate|full\s+explanation|verbose|go\s+deep|all\s+the\s+details|` +
+	`ausführlich|ausfuehrlich|im\s+detail|in\s+allen?\s+details|` +
+	`sag(?:\s+mir)?\s+(?:es\s+)?(?:im|in)\s+detail|` +
+	`erklär(?:\s+(?:es|mir))?\s+(?:im|in)\s+detail|` +
+	`erklaer(?:\s+(?:es|mir))?\s+(?:im|in)\s+detail|` +
+	`ganz\s+genau|in\s+aller\s+ausführlichkeit|in\s+aller\s+ausfuehrlichkeit` +
+	`)\b`)
+
 var turnDirectivePatterns = []directivePattern{
-	{
-		regex:  regexp.MustCompile(`(?i)\b(?:search(?:\s+the\s+web)?|web\s+search|look\s+up|browse|google|find\s+online|search\s+online|suche(?:\s+im\s+web)?|such(?:\s+im\s+web)?|websuche|recherchier(?:e)?|im\s+web\s+suchen|online\s+suchen)\b`),
-		search: true,
-	},
 	{
 		regex:  regexp.MustCompile(`(?i)\bthink\s+quick(?:ly)?\b|\bdenk\s+kurz\b|\bdenke\s+kurz\b|\büberleg\s+kurz\b|\bueberleg\s+kurz\b`),
 		effort: modelprofile.ReasoningLow,
@@ -54,8 +59,6 @@ var turnDirectivePatterns = []directivePattern{
 	},
 }
 
-var currentInfoCuePattern = regexp.MustCompile(`(?i)\b(?:latest|current|today(?:'s)?|tomorrow|yesterday|news|weather|forecast|price|prices|stock|stocks|score|scores|standings|schedule|schedules)\b`)
-
 func parseTurnRoutingDirectives(text string) turnRoutingDirectives {
 	original := strings.TrimSpace(text)
 	if original == "" {
@@ -72,9 +75,6 @@ func parseTurnRoutingDirectives(text string) turnRoutingDirectives {
 			continue
 		}
 		directives.DirectiveApplied = true
-		if pattern.search {
-			directives.SearchRequested = true
-		}
 		if pattern.alias != "" {
 			directives.ModelAlias = pattern.alias
 			directives.ModelAliasExplicit = true
@@ -84,8 +84,9 @@ func parseTurnRoutingDirectives(text string) turnRoutingDirectives {
 		}
 		working = pattern.regex.ReplaceAllString(working, " ")
 	}
-	if !directives.ModelAliasExplicit && currentInfoCuePattern.MatchString(original) {
-		directives.SearchRequested = true
+	if verbosityDetailPattern.MatchString(original) {
+		directives.DetailRequested = true
+		directives.DirectiveApplied = true
 	}
 	cleaned := strings.Join(strings.Fields(working), " ")
 	cleaned = strings.TrimSpace(strings.Trim(cleaned, ",:;-"))

--- a/internal/web/routing_policy.go
+++ b/internal/web/routing_policy.go
@@ -8,11 +8,12 @@ import (
 )
 
 type turnRoutingDirectives struct {
-	ModelAlias       string
-	ReasoningEffort  string
-	SearchRequested  bool
-	PromptText       string
-	DirectiveApplied bool
+	ModelAlias         string
+	ModelAliasExplicit bool
+	ReasoningEffort    string
+	SearchRequested    bool
+	PromptText         string
+	DirectiveApplied   bool
 }
 
 type directivePattern struct {
@@ -76,18 +77,15 @@ func parseTurnRoutingDirectives(text string) turnRoutingDirectives {
 		}
 		if pattern.alias != "" {
 			directives.ModelAlias = pattern.alias
+			directives.ModelAliasExplicit = true
 		}
 		if pattern.effort != "" {
 			directives.ReasoningEffort = pattern.effort
 		}
 		working = pattern.regex.ReplaceAllString(working, " ")
 	}
-	if directives.ModelAlias == "" && directives.SearchRequested {
-		directives.ModelAlias = modelprofile.AliasSpark
-	}
-	if directives.ModelAlias == "" && currentInfoCuePattern.MatchString(original) {
+	if !directives.ModelAliasExplicit && currentInfoCuePattern.MatchString(original) {
 		directives.SearchRequested = true
-		directives.ModelAlias = modelprofile.AliasSpark
 	}
 	cleaned := strings.Join(strings.Fields(working), " ")
 	cleaned = strings.TrimSpace(strings.Trim(cleaned, ",:;-"))

--- a/internal/web/routing_policy_test.go
+++ b/internal/web/routing_policy_test.go
@@ -15,9 +15,6 @@ func TestParseTurnRoutingDirectivesDefaultsToLocal(t *testing.T) {
 	if directives.ReasoningEffort != "" {
 		t.Fatalf("ReasoningEffort = %q, want empty", directives.ReasoningEffort)
 	}
-	if directives.SearchRequested {
-		t.Fatal("SearchRequested = true, want false")
-	}
 	if directives.PromptText != "summarize this note" {
 		t.Fatalf("PromptText = %q, want original", directives.PromptText)
 	}
@@ -51,21 +48,21 @@ func TestParseTurnRoutingDirectivesSupportsSparkCodexGPTMiniAndReasoning(t *test
 	}
 }
 
-func TestParseTurnRoutingDirectivesFlagsSearchWithoutImplicitSparkAlias(t *testing.T) {
+func TestParseTurnRoutingDirectivesLeavesSearchPhrasingUntouched(t *testing.T) {
 	directives := parseTurnRoutingDirectives("Search the web for today's AMD news.")
-	if !directives.SearchRequested {
-		t.Fatal("SearchRequested = false, want true")
-	}
 	if directives.ModelAlias != "" {
 		t.Fatalf("ModelAlias = %q, want empty so routing stays local by default", directives.ModelAlias)
 	}
 	if directives.ModelAliasExplicit {
 		t.Fatal("ModelAliasExplicit = true, want false")
 	}
+	if directives.PromptText != "Search the web for today's AMD news." {
+		t.Fatalf("PromptText = %q, want original search phrasing preserved for the model", directives.PromptText)
+	}
 }
 
 func TestParseTurnRoutingDirectivesExplicitSparkMarksExplicit(t *testing.T) {
-	directives := parseTurnRoutingDirectives("Use Spark to look up the rollout plan.")
+	directives := parseTurnRoutingDirectives("Use Spark to review the rollout plan.")
 	if !directives.ModelAliasExplicit {
 		t.Fatal("ModelAliasExplicit = false, want true for explicit 'use spark'")
 	}
@@ -74,13 +71,52 @@ func TestParseTurnRoutingDirectivesExplicitSparkMarksExplicit(t *testing.T) {
 	}
 }
 
-func TestParseTurnRoutingDirectivesCurrentInfoCueFlagsSearchOnly(t *testing.T) {
+func TestParseTurnRoutingDirectivesCurrentInfoCueStaysLocal(t *testing.T) {
 	directives := parseTurnRoutingDirectives("What is the latest ITER timeline?")
-	if !directives.SearchRequested {
-		t.Fatal("SearchRequested = false, want true for 'latest' cue")
-	}
 	if directives.ModelAlias != "" {
 		t.Fatalf("ModelAlias = %q, want empty", directives.ModelAlias)
+	}
+	if directives.ModelAliasExplicit {
+		t.Fatal("ModelAliasExplicit = true, want false: 'latest' alone must not force remote routing")
+	}
+}
+
+func TestParseTurnRoutingDirectivesDetailEnglish(t *testing.T) {
+	for _, text := range []string{
+		"Explain in detail how quaternions work",
+		"Give a long answer about tokamaks please",
+		"Be thorough: walk me through the proof",
+		"Go deep into the pipeline",
+		"elaborate on this failure",
+	} {
+		directives := parseTurnRoutingDirectives(text)
+		if !directives.DetailRequested {
+			t.Fatalf("DetailRequested = false for %q", text)
+		}
+	}
+}
+
+func TestParseTurnRoutingDirectivesDetailGerman(t *testing.T) {
+	for _, text := range []string{
+		"sag mir im Detail wie ein Tokamak funktioniert",
+		"erklär mir im Detail den Build",
+		"erklaer es mir in detail",
+		"ausführlich bitte die Fusionsphysik",
+		"ausfuehrlich erklaeren",
+		"ganz genau wie der Algorithmus arbeitet",
+		"in aller Ausführlichkeit",
+	} {
+		directives := parseTurnRoutingDirectives(text)
+		if !directives.DetailRequested {
+			t.Fatalf("DetailRequested = false for %q", text)
+		}
+	}
+}
+
+func TestParseTurnRoutingDirectivesNoDetailByDefault(t *testing.T) {
+	directives := parseTurnRoutingDirectives("what time is it")
+	if directives.DetailRequested {
+		t.Fatal("DetailRequested = true, want false for plain short ask")
 	}
 }
 

--- a/internal/web/routing_policy_test.go
+++ b/internal/web/routing_policy_test.go
@@ -51,13 +51,36 @@ func TestParseTurnRoutingDirectivesSupportsSparkCodexGPTMiniAndReasoning(t *test
 	}
 }
 
-func TestParseTurnRoutingDirectivesRoutesSearchesToSpark(t *testing.T) {
+func TestParseTurnRoutingDirectivesFlagsSearchWithoutImplicitSparkAlias(t *testing.T) {
 	directives := parseTurnRoutingDirectives("Search the web for today's AMD news.")
 	if !directives.SearchRequested {
 		t.Fatal("SearchRequested = false, want true")
 	}
+	if directives.ModelAlias != "" {
+		t.Fatalf("ModelAlias = %q, want empty so routing stays local by default", directives.ModelAlias)
+	}
+	if directives.ModelAliasExplicit {
+		t.Fatal("ModelAliasExplicit = true, want false")
+	}
+}
+
+func TestParseTurnRoutingDirectivesExplicitSparkMarksExplicit(t *testing.T) {
+	directives := parseTurnRoutingDirectives("Use Spark to look up the rollout plan.")
+	if !directives.ModelAliasExplicit {
+		t.Fatal("ModelAliasExplicit = false, want true for explicit 'use spark'")
+	}
 	if directives.ModelAlias != modelprofile.AliasSpark {
 		t.Fatalf("ModelAlias = %q, want %q", directives.ModelAlias, modelprofile.AliasSpark)
+	}
+}
+
+func TestParseTurnRoutingDirectivesCurrentInfoCueFlagsSearchOnly(t *testing.T) {
+	directives := parseTurnRoutingDirectives("What is the latest ITER timeline?")
+	if !directives.SearchRequested {
+		t.Fatal("SearchRequested = false, want true for 'latest' cue")
+	}
+	if directives.ModelAlias != "" {
+		t.Fatalf("ModelAlias = %q, want empty", directives.ModelAlias)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -66,6 +66,7 @@ type App struct {
 	dataDir                       string
 	localProjectDir               string
 	localMCPURL                   string
+	webMCPURL                     string
 	appServerURL                  string
 	appServerModel                string
 	appServerSparkReasoningEffort string
@@ -205,6 +206,10 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	if strings.EqualFold(resolvedAssistantLLMModel, "off") {
 		resolvedAssistantLLMModel = ""
 	}
+	resolvedWebMCPURL := strings.TrimSpace(os.Getenv("SLOPSHELL_WEB_MCP_URL"))
+	if strings.EqualFold(resolvedWebMCPURL, "off") {
+		resolvedWebMCPURL = ""
+	}
 	resolvedIntentLLMURL := strings.TrimSpace(os.Getenv("SLOPSHELL_INTENT_LLM_URL"))
 	if strings.EqualFold(resolvedIntentLLMURL, "off") {
 		resolvedIntentLLMURL = ""
@@ -307,6 +312,7 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 		dataDir:                       dataDir,
 		localProjectDir:               localProjectDir,
 		localMCPURL:                   localMCPURL,
+		webMCPURL:                     resolvedWebMCPURL,
 		appServerURL:                  appServerURL,
 		appServerModel:                resolvedModel,
 		appServerSparkReasoningEffort: resolvedSparkReasoningEffort,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -151,6 +151,9 @@ type App struct {
 	shutdownCancel context.CancelFunc
 	bootID         string
 	startedAt      string
+
+	cliToken     string
+	cliTokenPath string
 }
 
 const DefaultModel = modelprofile.ModelLocal
@@ -392,6 +395,12 @@ func New(dataDir, localProjectDir, localMCPURL, appServerURL, model, ttsURL, spa
 	if err := app.ensurePromptContractFresh(); err != nil {
 		_ = s.Close()
 		return nil, err
+	}
+	if path, token, err := initCLIToken(dataDir); err != nil {
+		log.Printf("cli-token init failed: %v", err)
+	} else {
+		app.cliTokenPath = path
+		app.cliToken = token
 	}
 	app.sourceSync = app.newSourceSyncRunner()
 	app.startItemResurfacer()

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -18,6 +18,7 @@ func (a *App) Router() http.Handler {
 	// auth/setup
 	r.Get("/api/setup", a.handleSetupCheck)
 	r.Post("/api/login", a.handleLogin)
+	r.Post("/api/cli/login", a.handleCLILogin)
 	r.Post("/api/logout", a.handleLogout)
 
 	// google oauth

--- a/internal/web/testing.go
+++ b/internal/web/testing.go
@@ -1,0 +1,30 @@
+package web
+
+// Helpers exposed only for out-of-package end-to-end tests. Do NOT use these
+// in production code; they bypass normal configuration paths and exist so
+// tests under cmd/slsh can point a real App at mock LLM/MCP endpoints and
+// supply a known CLI token without racing with the runtime's file-backed
+// token initialisation.
+
+// TestingOverrideCLIAuth replaces the App's CLI token and token-file path.
+// The file itself is managed by the caller.
+func TestingOverrideCLIAuth(app *App, token, tokenPath string) {
+	if app == nil {
+		return
+	}
+	app.cliToken = token
+	app.cliTokenPath = tokenPath
+}
+
+// TestingForceLocalAssistantLLM pins the local assistant LLM URL and mode so
+// an out-of-package e2e test can drive the local-assistant tool loop against
+// a mock /v1/chat/completions endpoint.
+func TestingForceLocalAssistantLLM(app *App, llmURL string) {
+	if app == nil {
+		return
+	}
+	app.assistantMode = assistantModeLocal
+	app.assistantLLMURL = llmURL
+	app.assistantLLMExplicit = true
+	app.intentLLMURL = ""
+}

--- a/scripts/build-slsh.sh
+++ b/scripts/build-slsh.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Build and install the slsh terminal client into the user's PATH.
+# Idempotent; safe to run repeatedly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${SLOPSHELL_BIN_DIR:-${HOME}/.local/bin}"
+BIN_PATH="${BIN_DIR}/slsh"
+
+command -v go >/dev/null 2>&1 || { echo "go toolchain not found in PATH" >&2; exit 1; }
+
+mkdir -p "$BIN_DIR"
+(cd "$REPO_ROOT" && go build -o "$BIN_PATH" ./cmd/slsh)
+chmod +x "$BIN_PATH"
+
+if ! printf ':%s:' "$PATH" | grep -Fq ":${BIN_DIR}:"; then
+  echo "warning: ${BIN_DIR} is not in PATH; add it to your shell profile" >&2
+fi
+
+echo "installed slsh -> ${BIN_PATH}"

--- a/scripts/check-chat-prompt-contract.sh
+++ b/scripts/check-chat-prompt-contract.sh
@@ -21,16 +21,12 @@ require_literal() {
   }
 }
 
-require_literal "Use exactly one response shape:"
-require_literal "Spoken chat must be one paragraph max."
-require_literal "If your response needs more than one paragraph, write that long content to a temp file"
-require_literal "Canvas content must appear only inside :::file blocks"
-require_literal "For temporary canvas files, create/remove paths via temp_file_create and temp_file_remove tools."
+require_literal "Tools available this turn are described in the tools parameter"
+require_literal "emit a :::file{path=\"...\"} block"
 require_literal "Do not use :::canvas blocks."
-require_literal "If output needs more than one paragraph, put it in a temp file with temp_file_create"
-require_literal "PR review fast path:"
-require_literal "open PR view"
-require_literal "Publish exactly one file block at path .slopshell/artifacts/pr/pr-<number>.diff with the patch content."
-require_literal "Do not return metadata-only chat."
+require_literal "Chat-first"
+require_literal "canvas_artifact_show"
+require_literal "[[request_position:"
+require_literal "[lang:de]"
 
 echo "prompt-contract check passed"

--- a/scripts/install-slopshell-user-units.sh
+++ b/scripts/install-slopshell-user-units.sh
@@ -66,6 +66,20 @@ build_sloptools_binary() {
   SLOPTOOLS_BIN_PATH="$SLOPTOOLS_REPO_ROOT/sloptools"
 }
 
+install_slsh_binary() {
+  local slsh_bin_dir slsh_bin_path
+  slsh_bin_dir="${SLOPSHELL_BIN_DIR:-${HOME}/.local/bin}"
+  slsh_bin_path="${slsh_bin_dir}/slsh"
+  log "Building slsh terminal client -> ${slsh_bin_path}"
+  mkdir -p "$slsh_bin_dir"
+  if ! (cd "$REPO_ROOT" && go build -o "$slsh_bin_path" ./cmd/slsh); then
+    fail "go build failed for slsh"
+  fi
+  if ! printf ':%s:' "$PATH" | grep -Fq ":${slsh_bin_dir}:"; then
+    log "${slsh_bin_dir} is not in PATH; add it to your shell profile to use slsh"
+  fi
+}
+
 configure_codex_cli() {
   local fast_url agentic_url
   if [ -n "$REUSE_LLM_URL" ]; then
@@ -212,6 +226,7 @@ install_linux() {
   )
   local -a optional_units=()
 
+  install_slsh_binary
   build_sloptools_binary
   sloptools_unit_src="$SLOPTOOLS_REPO_ROOT/deploy/systemd/user/sloptools.service"
   mkdir -p "$unit_dst"
@@ -346,6 +361,7 @@ install_macos() {
   if ! (cd "$REPO_ROOT" && go build -o "$REPO_ROOT/slopshell" ./cmd/slopshell); then
     fail "go build failed"
   fi
+  install_slsh_binary
   build_sloptools_binary
 
   BIN_PATH="$REPO_ROOT/slopshell"

--- a/scripts/slsh-smoke.sh
+++ b/scripts/slsh-smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# slsh-smoke.sh — interactive one-shot smoke against the live slopshell stack
+# running on this machine. Not invoked from CI; for manual verification.
+#
+# Requires:
+#   - slopshell-web.service   (port 8420)
+#   - sloptools.service        (port 9420; MCP email/calendar/etc)
+#   - optional: codex-app-server.service (port 8787) for --gpt smoke
+#
+# Usage: scripts/slsh-smoke.sh
+
+set -euo pipefail
+
+BASE_URL="${SLOPSHELL_BASE_URL:-http://127.0.0.1:8420}"
+SLSH_BIN="${SLSH_BIN:-$(command -v slsh || true)}"
+RESULTS=()
+
+if [ -z "$SLSH_BIN" ]; then
+  echo "slsh not found in PATH. Run scripts/build-slsh.sh first or set SLSH_BIN." >&2
+  exit 1
+fi
+
+if ! curl -fsS "${BASE_URL}/api/setup" >/dev/null; then
+  echo "slopshell web not reachable at ${BASE_URL}; is slopshell-web.service running?" >&2
+  exit 1
+fi
+
+run_case() {
+  local label="$1"
+  local expected="$2"
+  shift 2
+  printf '\n=== %s\n' "$label"
+  local out
+  if ! out="$("$SLSH_BIN" --base-url "$BASE_URL" --no-color "$@" 2>&1)"; then
+    RESULTS+=("FAIL  ${label} (slsh exited non-zero)")
+    printf '%s\n' "$out"
+    return
+  fi
+  printf '%s\n' "$out"
+  if [ -z "$expected" ] || printf '%s' "$out" | grep -Fq "$expected"; then
+    RESULTS+=("PASS  ${label}")
+  else
+    RESULTS+=("FAIL  ${label} (no match for ${expected@Q})")
+  fi
+}
+
+run_case "shell-echo via shell tool" "hello-from-slsh" \
+  -p "Use shell to run: echo hello-from-slsh"
+
+run_case "email accounts via sloptools MCP" "@" \
+  -p "list my email accounts briefly"
+
+if curl -fsS --max-time 1 http://127.0.0.1:8787/ >/dev/null 2>&1 \
+   || ss -lnt 2>/dev/null | awk '{print $4}' | grep -Fq ':8787'; then
+  run_case "GPT one-shot via codex app-server" "" \
+    --gpt -p "Answer with the single word: pong"
+else
+  RESULTS+=("SKIP  GPT one-shot (codex-app-server not listening on :8787)")
+fi
+
+printf '\n---\n'
+for row in "${RESULTS[@]}"; do
+  printf '%s\n' "$row"
+done
+
+case " ${RESULTS[*]} " in
+  *" FAIL "*) exit 1 ;;
+esac
+exit 0


### PR DESCRIPTION
## Summary

- New `slsh` binary: Codex-CLI-style terminal chat client that talks to the running `slopshell server` over the same HTTP/WS surface as the browser.
- One-shot with `-p`, REPL otherwise; workspace defaults to cwd; fresh context by default (`--resume <id>` to reattach); `/clear`, `/compact`, `/resume`, `/sessions`, `/stop`, `/model`, `/think`, `/exit` inside the REPL.
- `--gpt` / `--model gpt` / `--think high` route to the remote path by prefixing the prompt so the existing `parseTurnRoutingDirectives` in `internal/web/routing_policy.go` dispatches the turn — no new backend routing code.
- Loopback-only CLI auth: `web.New` writes a random 32-byte token to `$XDG_RUNTIME_DIR/slopshell/cli-token` (fallback `${dataDir}/cli-token`) at `0600`; `POST /api/cli/login` consumes it, rejects non-loopback peers, ignores `X-Forwarded-For`, and mints the normal session cookie via `store.AddAuthSession`.
- Mock-based end-to-end tests under `cmd/slsh/e2e_test.go` exercise the shell tool, `mail_account_list` MCP flow, and `--json` NDJSON output without ever contacting real EWS / TUGonline. Gated behind `//go:build e2e` so the default suite is unchanged.
- Install wiring: `scripts/build-slsh.sh` for standalone builds, and `scripts/install-slopshell-user-units.sh` now places `slsh` in `$HOME/.local/bin` alongside `slopshell`.
- Fixes three tests (`TestAssistantBackendForTurnRoutesLocalByDefaultAndCodexOnlyForRemoteTurns`, `TestRunAssistantTurnKeepsPlainTextAssistantOutput`, `TestCompanionResponseTriggerUsesWorkspaceDirForAppSession`) that were failing on `main` after the recent `DefaultAssistantMode = local` change; they now opt back into auto routing explicitly to keep exercising the app-server fallback path.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (one pre-existing warning about `shutdownCancel` on `server.go:171` — present on `main` before this branch)
- [x] `go test ./...` — entire suite green
- [x] `./scripts/sync-surface.sh --check` — in sync (the new `POST /api/cli/login` added to `internal/surface/definitions.go` and regenerated `docs/interfaces.md`)
- [x] `go test -tags=e2e ./cmd/slsh/...` — shell tool, mail MCP, NDJSON paths all pass
- [x] Manual: built `~/.local/bin/slsh`, stood up an ephemeral `slopshell server` on `:8422` that reuses the live `sloptools` MCP on `:9420`, and verified:
  - `slsh -p "Use shell to run: echo hello-from-slsh-smoke"` → `hello-from-slsh-smoke`
  - `slsh -p "list my email accounts briefly"` → `You have one enabled email account: albert@tugraz.at (work).`
  - `slsh --gpt -p "…"` reaches the Codex app-server; this ephemeral environment's app-server returned empty, which slsh surfaces cleanly as `assistant error: app-server returned an empty assistant message` — routing itself is verified by the e2e flag-to-prefix tests and the routing_policy regex on `main`.

### Test fails on main

```
$ git checkout main
$ go test ./internal/web/
...
--- FAIL: TestAssistantBackendForTurnRoutesLocalByDefaultAndCodexOnlyForRemoteTurns (0.01s)
    chat_assistant_backend_test.go:58: backend without local assistant config = "local", want "codex"
--- FAIL: TestRunAssistantTurnKeepsPlainTextAssistantOutput (3.63s)
    chat_hub_test.go:565: assistant plain text = "...", want "All systems nominal."
--- FAIL: TestCompanionResponseTriggerUsesWorkspaceDirForAppSession (2.04s)
    companion_response_trigger_test.go:913: timed out waiting for assistant message "Companion reply."
FAIL
FAIL    github.com/sloppy-org/slopshell/internal/web    29.948s
FAIL
```

### Test passes after fix

```
$ git checkout slsh-terminal-client
$ go test ./internal/web/ -run 'TestAssistantBackendForTurnRoutesLocalByDefaultAndCodexOnlyForRemoteTurns|TestRunAssistantTurnKeepsPlainTextAssistantOutput|TestCompanionResponseTriggerUsesWorkspaceDirForAppSession' -count=2
ok      github.com/sloppy-org/slopshell/internal/web    0.202s
```

### New e2e test passes

```
$ go test -tags=e2e ./cmd/slsh/... -count=1 -v
=== RUN   TestSlshOneShotShellToolProducesExpectedFinalText
--- PASS: TestSlshOneShotShellToolProducesExpectedFinalText (0.31s)
=== RUN   TestSlshOneShotMailAccountListRoutesThroughMCP
--- PASS: TestSlshOneShotMailAccountListRoutesThroughMCP (0.31s)
=== RUN   TestSlshOneShotJSONModeEmitsNDJSON
--- PASS: TestSlshOneShotJSONModeEmitsNDJSON (0.32s)
PASS
ok      github.com/sloppy-org/slopshell/cmd/slsh        0.953s
```