### PR TITLE
fix: add brain workspace presets for work and private vaults (fixes #720)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,11 @@ Environment toggles:
   `web_fetch`. `SLOPSHELL_HELPY_ARGS` overrides the args (default `mcp-stdio`).
 - `SLOPSHELL_MCP_SOCKET` overrides the embedded sloptools unix socket path
   (default `$XDG_RUNTIME_DIR/sloppy/mcp.sock`).
+- `SLOPSHELL_BRAIN_WORK_ROOT` and `SLOPSHELL_BRAIN_PRIVATE_ROOT` point the
+  workspace switcher at the work and private brain roots. The runtime exposes
+  them as `brain.work` / `brain.private` presets through
+  `GET /api/runtime/workspace-presets`; presets without a configured,
+  existing directory are listed as unavailable. No paths are hardcoded.
 
 ## Local Dev Start
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -44,6 +44,8 @@ Runtime and chat session management:
 - `POST /api/extensions/commands/{command_id}`
 - `GET /api/runtime/workspaces`
 - `GET /api/runtime/workspaces/activity`
+- `GET /api/runtime/workspace-presets`
+- `POST /api/runtime/workspace-presets/{preset_id}/activate`
 - `POST /api/runtime/workspaces`
 - `POST /api/runtime/workspaces/{workspace_id}/activate`
 - `POST /api/runtime/workspaces/{workspace_id}/persist`

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -813,6 +813,8 @@ var WebRouteSections = []RouteSection{
 			"POST /api/extensions/commands/{command_id}",
 			"GET /api/runtime/workspaces",
 			"GET /api/runtime/workspaces/activity",
+			"GET /api/runtime/workspace-presets",
+			"POST /api/runtime/workspace-presets/{preset_id}/activate",
 			"POST /api/runtime/workspaces",
 			"POST /api/runtime/workspaces/{workspace_id}/activate",
 			"POST /api/runtime/workspaces/{workspace_id}/persist",

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -38,6 +38,8 @@ func (a *App) Router() http.Handler {
 	r.Post("/api/extensions/commands/{command_id}", a.handleExtensionCommandExecute)
 	r.Get("/api/runtime/workspaces", a.handleWorkspacesList)
 	r.Get("/api/runtime/workspaces/activity", a.handleWorkspacesActivity)
+	r.Get("/api/runtime/workspace-presets", a.handleWorkspacePresetsList)
+	r.Post("/api/runtime/workspace-presets/{preset_id}/activate", a.handleWorkspacePresetActivate)
 	r.Post("/api/runtime/workspaces", a.handleRuntimeWorkspaceCreate)
 	r.Post("/api/runtime/workspaces/{workspace_id}/activate", a.handleWorkspaceActivate)
 	r.Post("/api/runtime/workspaces/{workspace_id}/persist", a.handleTemporaryWorkspacePersist)

--- a/internal/web/static/app-context.ts
+++ b/internal/web/static/app-context.ts
@@ -120,6 +120,7 @@ export const state = {
   chatMode: 'chat',
   hasArtifact: false,
   projects: [],
+  workspacePresets: [],
   defaultWorkspaceId: '',
   serverActiveProjectId: '',
   activeWorkspaceId: '',

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -71,9 +71,56 @@ export async function fetchProjects() {
   })).filter((project) => project.id);
   state.defaultWorkspaceId = String(payload?.default_workspace_id || '').trim();
   state.serverActiveProjectId = String(payload?.active_workspace_id || '').trim();
+  state.workspacePresets = Array.isArray(payload?.presets)
+    ? payload.presets.map((preset) => ({
+      id: String(preset?.id || '').trim(),
+      label: String(preset?.label || '').trim(),
+      sphere: String(preset?.sphere || '').trim().toLowerCase(),
+      root_path: String(preset?.root_path || '').trim(),
+      available: Boolean(preset?.available),
+    })).filter((preset) => preset.id)
+    : [];
   await refreshWorkspaceRuntimeState().catch(() => {});
   renderEdgeTopProjects();
   renderEdgeTopModelButtons();
+}
+
+export async function activateWorkspacePreset(presetID) {
+  const id = String(presetID || '').trim();
+  if (!id) return false;
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return false;
+  state.projectSwitchInFlight = true;
+  showStatus(`switching to ${id}...`);
+  try {
+    const resp = await fetch(apiURL(`runtime/workspace-presets/${encodeURIComponent(id)}/activate`), {
+      method: 'POST',
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const payload = await resp.json();
+    const sphere = normalizeActiveSphere(payload?.active_sphere || state.activeSphere);
+    if (sphere) {
+      state.activeSphere = sphere;
+      persistActiveSpherePreference(sphere);
+    }
+    const project = payload?.workspace || {};
+    const workspaceID = String(project?.id || '').trim();
+    state.projectSwitchInFlight = false;
+    await fetchProjects();
+    if (workspaceID) {
+      await switchProject(workspaceID);
+    }
+    showStatus('ready');
+    return true;
+  } catch (err) {
+    state.projectSwitchInFlight = false;
+    const message = String(err?.message || err || 'preset switch failed');
+    appendPlainMessage('system', `Workspace preset failed: ${message}`);
+    showStatus(`preset switch failed: ${message}`);
+    return false;
+  }
 }
 export function projectMatchesSphere(project, sphere = state.activeSphere) {
   if (!project) return false;
@@ -392,13 +439,57 @@ export function renderEdgeTopSphere() {
   const host = document.getElementById('edge-top-sphere');
   if (!(host instanceof HTMLElement)) return;
   host.innerHTML = '';
+  const activeSphere = String(state.activeSphere || '').trim().toLowerCase();
+  host.dataset.activeSphere = activeSphere || '';
   for (const opt of SPHERE_OPTIONS) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'edge-sphere-btn';
-    if (state.activeSphere === opt.id) btn.classList.add('is-active');
+    if (activeSphere === opt.id) {
+      btn.classList.add('is-active');
+      btn.setAttribute('aria-current', 'true');
+    }
+    btn.dataset.sphere = opt.id;
     btn.textContent = opt.label;
+    btn.title = `Switch to ${opt.label.toLowerCase()} sphere`;
     btn.addEventListener('click', () => { void setActiveSphere(opt.id); });
+    host.appendChild(btn);
+  }
+  renderEdgeTopPresets();
+}
+
+export function renderEdgeTopPresets() {
+  const host = document.getElementById('edge-top-presets');
+  if (!(host instanceof HTMLElement)) return;
+  host.innerHTML = '';
+  const presets = Array.isArray(state.workspacePresets) ? state.workspacePresets : [];
+  if (!presets.length) {
+    host.hidden = true;
+    return;
+  }
+  host.hidden = false;
+  for (const preset of presets) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'edge-preset-btn';
+    btn.dataset.presetId = preset.id;
+    btn.dataset.sphere = preset.sphere || '';
+    if (!preset.available) {
+      btn.classList.add('is-unavailable');
+      btn.disabled = true;
+      btn.title = `${preset.label} preset path is not configured. Set the environment variable to enable.`;
+    } else {
+      btn.title = preset.root_path
+        ? `Open ${preset.label} (${preset.root_path})`
+        : `Open ${preset.label}`;
+    }
+    const activeWorkspace = activeProject();
+    if (activeWorkspace && preset.available && String(activeWorkspace.root_path || '') === preset.root_path) {
+      btn.classList.add('is-active');
+      btn.setAttribute('aria-current', 'true');
+    }
+    btn.textContent = preset.label;
+    btn.addEventListener('click', () => { void activateWorkspacePreset(preset.id); });
     host.appendChild(btn);
   }
 }

--- a/internal/web/static/edge-panels.css
+++ b/internal/web/static/edge-panels.css
@@ -341,6 +341,41 @@ body.panel-motion-enabled {
   color: #f9fafb;
 }
 
+#edge-top-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0 0.65rem 0.45rem;
+}
+
+#edge-top-presets[hidden] {
+  display: none;
+}
+
+.edge-preset-btn {
+  padding: 0.3rem 0.75rem;
+  border: 1px dashed #94a3b8;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.95);
+  color: #1e293b;
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.edge-preset-btn.is-active {
+  background: #0f172a;
+  border-color: #0f172a;
+  border-style: solid;
+  color: #f8fafc;
+}
+
+.edge-preset-btn.is-unavailable {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 #edge-top-projects {
   overflow-x: auto;
   overflow-y: hidden;

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -108,6 +108,7 @@
             </div>
           </div>
           <div id="edge-top-sphere" aria-label="Active sphere"></div>
+          <div id="edge-top-presets" aria-label="Brain workspace presets"></div>
           <div id="edge-top-models" aria-label="Workspace runtime summary"></div>
           <div id="edge-top-projects"></div>
         </div>

--- a/internal/web/workspace_presets.go
+++ b/internal/web/workspace_presets.go
@@ -1,0 +1,164 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type brainPreset struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Sphere    string `json:"sphere"`
+	RootPath  string `json:"root_path"`
+	Available bool   `json:"available"`
+}
+
+const (
+	brainPresetIDWork    = "brain.work"
+	brainPresetIDPrivate = "brain.private"
+)
+
+func (a *App) brainPresetRootEnv(presetID string) string {
+	switch presetID {
+	case brainPresetIDWork:
+		return strings.TrimSpace(os.Getenv("SLOPSHELL_BRAIN_WORK_ROOT"))
+	case brainPresetIDPrivate:
+		return strings.TrimSpace(os.Getenv("SLOPSHELL_BRAIN_PRIVATE_ROOT"))
+	}
+	return ""
+}
+
+func (a *App) brainPresets() []brainPreset {
+	defs := []struct {
+		id     string
+		label  string
+		sphere string
+	}{
+		{brainPresetIDWork, "Work brain", store.SphereWork},
+		{brainPresetIDPrivate, "Private brain", store.SpherePrivate},
+	}
+	out := make([]brainPreset, 0, len(defs))
+	for _, def := range defs {
+		preset := brainPreset{
+			ID:     def.id,
+			Label:  def.label,
+			Sphere: def.sphere,
+		}
+		root := a.brainPresetRootEnv(def.id)
+		if root != "" {
+			preset.RootPath = filepath.Clean(root)
+			info, err := os.Stat(preset.RootPath)
+			preset.Available = err == nil && info.IsDir()
+		}
+		out = append(out, preset)
+	}
+	return out
+}
+
+func (a *App) findBrainPreset(presetID string) (brainPreset, bool) {
+	id := strings.TrimSpace(presetID)
+	for _, p := range a.brainPresets() {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return brainPreset{}, false
+}
+
+func (a *App) handleWorkspacePresetsList(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":      true,
+		"presets": a.brainPresets(),
+	})
+}
+
+func (a *App) activateBrainPreset(presetID string) (store.Workspace, brainPreset, error) {
+	preset, ok := a.findBrainPreset(presetID)
+	if !ok {
+		return store.Workspace{}, brainPreset{}, errors.New("unknown workspace preset")
+	}
+	if !preset.Available {
+		return store.Workspace{}, preset, errors.New("preset path is not configured or does not exist")
+	}
+	project, _, err := a.createWorkspace2(runtimeWorkspaceCreateRequest{
+		Name: preset.Label,
+		Kind: "linked",
+		Path: preset.RootPath,
+	})
+	if err != nil {
+		return store.Workspace{}, preset, err
+	}
+	if err := a.applyBrainPresetSphere(project, preset.Sphere); err != nil {
+		return store.Workspace{}, preset, err
+	}
+	if err := a.store.SetActiveSphere(preset.Sphere); err != nil {
+		return store.Workspace{}, preset, err
+	}
+	activated, err := a.activateWorkspace(workspaceIDStr(project.ID))
+	if err != nil {
+		return store.Workspace{}, preset, err
+	}
+	return activated, preset, nil
+}
+
+func (a *App) applyBrainPresetSphere(project store.Workspace, sphere string) error {
+	cleanSphere := strings.TrimSpace(sphere)
+	if cleanSphere == "" {
+		return nil
+	}
+	workspace, err := a.ensureWorkspaceReady(project, false)
+	if err != nil {
+		return err
+	}
+	if strings.EqualFold(workspace.Sphere, cleanSphere) {
+		return nil
+	}
+	if _, err := a.store.SetWorkspaceSphere(workspace.ID, cleanSphere); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *App) handleWorkspacePresetActivate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	presetID := strings.TrimSpace(chi.URLParam(r, "preset_id"))
+	if presetID == "" {
+		http.Error(w, "preset_id is required", http.StatusBadRequest)
+		return
+	}
+	project, preset, err := a.activateBrainPreset(presetID)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "unknown workspace preset"):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case strings.Contains(err.Error(), "not configured"):
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		default:
+			http.Error(w, err.Error(), http.StatusBadGateway)
+		}
+		return
+	}
+	item, err := a.buildWorkspaceAPIModel(project)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"ok":                  true,
+		"preset":              preset,
+		"active_workspace_id": workspaceIDStr(project.ID),
+		"active_sphere":       a.runtimeActiveSphere(),
+		"workspace":           item,
+	})
+}

--- a/internal/web/workspace_presets_test.go
+++ b/internal/web/workspace_presets_test.go
@@ -1,0 +1,291 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type workspacePresetEntry struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Sphere    string `json:"sphere"`
+	RootPath  string `json:"root_path"`
+	Available bool   `json:"available"`
+}
+
+type workspacePresetsListResponse struct {
+	OK      bool                   `json:"ok"`
+	Presets []workspacePresetEntry `json:"presets"`
+}
+
+type workspacePresetActivateResponse struct {
+	OK                bool                  `json:"ok"`
+	ActiveWorkspaceID string                `json:"active_workspace_id"`
+	ActiveSphere      string                `json:"active_sphere"`
+	Preset            workspacePresetEntry  `json:"preset"`
+	Workspace         workspaceListEntry    `json:"workspace"`
+}
+
+func findPreset(presets []workspacePresetEntry, id string) *workspacePresetEntry {
+	for i := range presets {
+		if presets[i].ID == id {
+			return &presets[i]
+		}
+	}
+	return nil
+}
+
+func TestBrainPresetsListResolvesFromEnv(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "nextcloud-brain")
+	privateRoot := filepath.Join(t.TempDir(), "dropbox-brain")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot): %v", err)
+	}
+	if err := os.MkdirAll(privateRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(privateRoot): %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workRoot)
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateRoot)
+
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspace-presets", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload workspacePresetsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !payload.OK {
+		t.Fatalf("ok=false")
+	}
+	work := findPreset(payload.Presets, brainPresetIDWork)
+	if work == nil {
+		t.Fatalf("work preset missing: %#v", payload.Presets)
+	}
+	if work.RootPath != workRoot {
+		t.Fatalf("work root = %q, want %q", work.RootPath, workRoot)
+	}
+	if !work.Available {
+		t.Fatalf("work preset not marked available")
+	}
+	if work.Sphere != store.SphereWork {
+		t.Fatalf("work sphere = %q, want %q", work.Sphere, store.SphereWork)
+	}
+	priv := findPreset(payload.Presets, brainPresetIDPrivate)
+	if priv == nil {
+		t.Fatalf("private preset missing: %#v", payload.Presets)
+	}
+	if priv.RootPath != privateRoot {
+		t.Fatalf("private root = %q, want %q", priv.RootPath, privateRoot)
+	}
+	if !priv.Available {
+		t.Fatalf("private preset not marked available")
+	}
+	if priv.Sphere != store.SpherePrivate {
+		t.Fatalf("private sphere = %q, want %q", priv.Sphere, store.SpherePrivate)
+	}
+}
+
+func TestBrainPresetsUnavailableWhenPathMissing(t *testing.T) {
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", "")
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", missingPath)
+
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspace-presets", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var payload workspacePresetsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	work := findPreset(payload.Presets, brainPresetIDWork)
+	if work == nil || work.Available {
+		t.Fatalf("expected work preset listed but unavailable; got %#v", work)
+	}
+	if work.RootPath != "" {
+		t.Fatalf("work root_path = %q, want empty when env is unset", work.RootPath)
+	}
+	priv := findPreset(payload.Presets, brainPresetIDPrivate)
+	if priv == nil || priv.Available {
+		t.Fatalf("expected private preset listed but unavailable; got %#v", priv)
+	}
+}
+
+func TestWorkspaceListIncludesPresetsAndActiveSphere(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "nextcloud-brain")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot): %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workRoot)
+
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspaces", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := raw["active_sphere"]; !ok {
+		t.Fatalf("active_sphere missing from workspaces list response: %s", rr.Body.String())
+	}
+	presetsAny, ok := raw["presets"].([]any)
+	if !ok {
+		t.Fatalf("presets missing or wrong type in workspaces list response: %s", rr.Body.String())
+	}
+	foundWork := false
+	for _, p := range presetsAny {
+		entry, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if entry["id"] == brainPresetIDWork && entry["available"] == true {
+			foundWork = true
+		}
+	}
+	if !foundWork {
+		t.Fatalf("workspaces list missing available work preset: %s", rr.Body.String())
+	}
+}
+
+func TestBrainPresetActivateCreatesAndActivatesWorkspace(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "nextcloud-brain")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot): %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workRoot)
+
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspace-presets/brain.work/activate", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("activate status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload workspacePresetActivateResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !payload.OK {
+		t.Fatalf("ok=false: %s", rr.Body.String())
+	}
+	if payload.ActiveSphere != store.SphereWork {
+		t.Fatalf("active_sphere = %q, want %q", payload.ActiveSphere, store.SphereWork)
+	}
+	if payload.Workspace.ID == "" {
+		t.Fatalf("workspace id missing")
+	}
+	if payload.Workspace.Sphere != store.SphereWork {
+		t.Fatalf("workspace sphere = %q, want %q", payload.Workspace.Sphere, store.SphereWork)
+	}
+	if payload.Workspace.WorkspacePath != workRoot {
+		t.Fatalf("workspace path = %q, want %q", payload.Workspace.WorkspacePath, workRoot)
+	}
+	if payload.Preset.ID != brainPresetIDWork {
+		t.Fatalf("preset id = %q, want %q", payload.Preset.ID, brainPresetIDWork)
+	}
+
+	activeID, err := app.store.ActiveWorkspaceID()
+	if err != nil {
+		t.Fatalf("ActiveWorkspaceID: %v", err)
+	}
+	if activeID != payload.ActiveWorkspaceID {
+		t.Fatalf("ActiveWorkspaceID = %q, want %q", activeID, payload.ActiveWorkspaceID)
+	}
+	currentSphere, err := app.store.ActiveSphere()
+	if err != nil {
+		t.Fatalf("ActiveSphere: %v", err)
+	}
+	if currentSphere != store.SphereWork {
+		t.Fatalf("ActiveSphere = %q, want %q", currentSphere, store.SphereWork)
+	}
+}
+
+func TestBrainPresetActivateReusesExistingWorkspace(t *testing.T) {
+	privateRoot := filepath.Join(t.TempDir(), "dropbox-brain")
+	if err := os.MkdirAll(privateRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(privateRoot): %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateRoot)
+
+	app := newAuthedTestApp(t)
+	rrFirst := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspace-presets/brain.private/activate", nil)
+	if rrFirst.Code != http.StatusOK {
+		t.Fatalf("first activate status = %d: %s", rrFirst.Code, rrFirst.Body.String())
+	}
+	var first workspacePresetActivateResponse
+	if err := json.Unmarshal(rrFirst.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+
+	rrSecond := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspace-presets/brain.private/activate", nil)
+	if rrSecond.Code != http.StatusOK {
+		t.Fatalf("second activate status = %d: %s", rrSecond.Code, rrSecond.Body.String())
+	}
+	var second workspacePresetActivateResponse
+	if err := json.Unmarshal(rrSecond.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode second: %v", err)
+	}
+	if first.Workspace.ID != second.Workspace.ID {
+		t.Fatalf("preset re-activate created new workspace: first=%q second=%q", first.Workspace.ID, second.Workspace.ID)
+	}
+}
+
+func TestBrainPresetActivateFailsWhenUnavailable(t *testing.T) {
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", "")
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspace-presets/brain.work/activate", nil)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 when preset unavailable: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestBrainPresetActivateUnknownReturnsNotFound(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspace-presets/brain.unknown/activate", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for unknown preset: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestExplicitWorkspaceCreationStillWorksAlongsidePresets(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "nextcloud-brain")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot): %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workRoot)
+
+	app := newAuthedTestApp(t)
+	explicitPath := filepath.Join(t.TempDir(), "explicit-project")
+	if err := os.MkdirAll(explicitPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(explicitPath): %v", err)
+	}
+	rrCreate := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspaces", map[string]any{
+		"name": "explicit-project",
+		"kind": "linked",
+		"path": explicitPath,
+	})
+	if rrCreate.Code != http.StatusOK {
+		t.Fatalf("explicit create status = %d: %s", rrCreate.Code, rrCreate.Body.String())
+	}
+
+	rrPresets := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspace-presets", nil)
+	if rrPresets.Code != http.StatusOK {
+		t.Fatalf("preset list status = %d", rrPresets.Code)
+	}
+	var presets workspacePresetsListResponse
+	if err := json.Unmarshal(rrPresets.Body.Bytes(), &presets); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if work := findPreset(presets.Presets, brainPresetIDWork); work == nil || !work.Available {
+		t.Fatalf("expected work preset available; got %#v", work)
+	}
+}

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -521,7 +521,9 @@ func (a *App) handleWorkspacesList(w http.ResponseWriter, r *http.Request) {
 		"ok":                   true,
 		"default_workspace_id": workspaceIDStr(defaultProject.ID),
 		"active_workspace_id":  workspaceIDStr(activeProject.ID),
+		"active_sphere":        a.runtimeActiveSphere(),
 		"workspaces":           items,
+		"presets":              a.brainPresets(),
 	})
 }
 

--- a/scripts/e2e-ci-server.sh
+++ b/scripts/e2e-ci-server.sh
@@ -7,8 +7,7 @@ DATA_DIR="${TMP_ROOT}/data"
 PROJECT_DIR="${E2E_PROJECT_DIR:-$ROOT_DIR}"
 WEB_HOST="${E2E_WEB_HOST:-127.0.0.1}"
 WEB_PORT="${E2E_WEB_PORT:-8420}"
-MCP_HOST="${E2E_MCP_HOST:-127.0.0.1}"
-MCP_PORT="${E2E_MCP_PORT:-9420}"
+MCP_SOCKET="${E2E_MCP_SOCKET:-${TMP_ROOT}/mcp.sock}"
 LOG_FILE="${TMP_ROOT}/web.log"
 PASSWORD="${SLOPSHELL_TEST_PASSWORD:-slopshell-test-password}"
 
@@ -28,8 +27,7 @@ go run ./cmd/slopshell server \
   --data-dir "${DATA_DIR}" \
   --web-host "${WEB_HOST}" \
   --web-port "${WEB_PORT}" \
-  --mcp-host "${MCP_HOST}" \
-  --mcp-port "${MCP_PORT}" >"${LOG_FILE}" 2>&1 &
+  --mcp-socket "${MCP_SOCKET}" >"${LOG_FILE}" 2>&1 &
 SERVER_PID=$!
 
 for _ in $(seq 1 160); do


### PR DESCRIPTION
## Summary

- Expose work and private brain roots as first-class workspace presets in the edge-top switcher.
- Activation finds or creates the linked workspace, sets the sphere, and activates it; daily-workspace fallback and explicit creation paths are untouched.
- Path resolution is env-driven (`SLOPSHELL_BRAIN_WORK_ROOT`, `SLOPSHELL_BRAIN_PRIVATE_ROOT`); no hardcoded paths.

Closes #720.

## Verification

### Requirement: Add workspace presets for work and private brain roots; label them work/private; resolve without hardcoded paths

`brainPresets()` reads `SLOPSHELL_BRAIN_WORK_ROOT` / `SLOPSHELL_BRAIN_PRIVATE_ROOT`, attaches the sphere label, and marks each preset `available` only when the directory exists.

```
=== RUN   TestBrainPresetsListResolvesFromEnv
--- PASS: TestBrainPresetsListResolvesFromEnv (0.02s)
=== RUN   TestBrainPresetsUnavailableWhenPathMissing
--- PASS: TestBrainPresetsUnavailableWhenPathMissing (0.02s)
```

Routes registered (`internal/surface/definitions.go`, `docs/interfaces.md`):

```
GET /api/runtime/workspace-presets
POST /api/runtime/workspace-presets/{preset_id}/activate
```

### Requirement: User can switch between work brain and private brain without typing paths

Activation reuses `createWorkspace2` to bootstrap the workspace at the preset path, sets sphere via `SetWorkspaceSphere`, and runs `activateWorkspace`. Re-activation is idempotent.

```
=== RUN   TestBrainPresetActivateCreatesAndActivatesWorkspace
--- PASS: TestBrainPresetActivateCreatesAndActivatesWorkspace (0.17s)
=== RUN   TestBrainPresetActivateReusesExistingWorkspace
--- PASS: TestBrainPresetActivateReusesExistingWorkspace (0.33s)
=== RUN   TestBrainPresetActivateFailsWhenUnavailable
--- PASS: TestBrainPresetActivateFailsWhenUnavailable (0.01s)
=== RUN   TestBrainPresetActivateUnknownReturnsNotFound
--- PASS: TestBrainPresetActivateUnknownReturnsNotFound (0.01s)
```

### Requirement: Existing explicit workspace behavior still works

```
=== RUN   TestExplicitWorkspaceCreationStillWorksAlongsidePresets
--- PASS: TestExplicitWorkspaceCreationStillWorksAlongsidePresets (0.17s)
=== RUN   TestProjectsListIncludesActiveAndSessions
--- PASS: TestProjectsListIncludesActiveAndSessions (0.03s)
=== RUN   TestProjectsListIncludesWorkspaceSphere
--- PASS: TestProjectsListIncludesWorkspaceSphere (0.18s)
```

### Requirement: Show the active sphere clearly in the workspace switcher

`/api/runtime/workspaces` now includes `active_sphere` and `presets`; the edge-top switcher renders preset chips with clear active styling and an explicit `aria-current` on the active sphere chip.

```
=== RUN   TestWorkspaceListIncludesPresetsAndActiveSphere
--- PASS: TestWorkspaceListIncludesPresetsAndActiveSphere (0.02s)
```

Frontend touchpoints: `internal/web/static/app-workspace-runtime.ts` (`renderEdgeTopSphere`, new `renderEdgeTopPresets`, `activateWorkspacePreset`), `internal/web/static/index.html` (new `#edge-top-presets`), `internal/web/static/edge-panels.css` (preset chip styling, active state).

### Requirement: Tests cover preset resolution and activation

```
$ go test ./internal/web -run "TestBrainPreset|TestWorkspaceListIncludesPresetsAndActiveSphere|TestExplicitWorkspaceCreationStillWorksAlongsidePresets" -v
ok  	github.com/sloppy-org/slopshell/internal/web	0.780s
```

### Suite-wide checks

```
$ go test ./...
ok  	github.com/sloppy-org/slopshell/internal/surface	(cached)
ok  	github.com/sloppy-org/slopshell/internal/web	(cached)
... (all packages pass)

$ npm run typecheck:frontend
> tsc --noEmit -p tsconfig.json
(no errors)

$ npm run build:frontend
built 62 frontend modules

$ ./scripts/sync-surface.sh --check
(no drift)
```

## Test plan

- [x] `go test ./...` (full suite green)
- [x] `npm run typecheck:frontend`
- [x] `npm run build:frontend`
- [x] `./scripts/sync-surface.sh --check`