### PR TITLE
fix: Block work personal subtree in Slopshell workspace and link flows (fixes #723)

### DIFF
--- a/internal/web/artifacts_materialize.go
+++ b/internal/web/artifacts_materialize.go
@@ -246,9 +246,19 @@ func (a *App) resolveArtifactMaterializeWorkspace(artifact store.Artifact, reque
 		if *requestedWorkspaceID <= 0 {
 			return store.Workspace{}, newArtifactMaterializeError("workspace_id must be a positive integer")
 		}
-		return a.store.GetWorkspace(*requestedWorkspaceID)
+		workspace, err := a.store.GetWorkspace(*requestedWorkspaceID)
+		if err != nil {
+			return store.Workspace{}, err
+		}
+		if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+			return store.Workspace{}, err
+		}
+		return workspace, nil
 	}
 	if artifact.RefPath != nil {
+		if err := enforceWorkPersonalPath(*artifact.RefPath); err != nil {
+			return store.Workspace{}, err
+		}
 		workspaceID, err := a.store.FindWorkspaceContainingPath(*artifact.RefPath)
 		if err != nil {
 			return store.Workspace{}, err
@@ -262,7 +272,14 @@ func (a *App) resolveArtifactMaterializeWorkspace(artifact store.Artifact, reque
 		return store.Workspace{}, err
 	}
 	if workspaceID != nil {
-		return a.store.GetWorkspace(*workspaceID)
+		workspace, err := a.store.GetWorkspace(*workspaceID)
+		if err != nil {
+			return store.Workspace{}, err
+		}
+		if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+			return store.Workspace{}, err
+		}
+		return workspace, nil
 	}
 	items, err := a.store.ListArtifactItems(artifact.ID)
 	if err != nil {
@@ -282,13 +299,23 @@ func (a *App) resolveArtifactMaterializeWorkspace(artifact store.Artifact, reque
 		}
 	}
 	if itemWorkspaceID > 0 {
-		return a.store.GetWorkspace(itemWorkspaceID)
+		workspace, err := a.store.GetWorkspace(itemWorkspaceID)
+		if err != nil {
+			return store.Workspace{}, err
+		}
+		if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+			return store.Workspace{}, err
+		}
+		return workspace, nil
 	}
 	workspaces, err := a.store.ListArtifactLinkWorkspaces(artifact.ID)
 	if err != nil {
 		return store.Workspace{}, err
 	}
 	if len(workspaces) == 1 {
+		if err := enforceWorkPersonalWorkspace(workspaces[0]); err != nil {
+			return store.Workspace{}, err
+		}
 		return workspaces[0], nil
 	}
 	if len(workspaces) > 1 {
@@ -315,6 +342,9 @@ func (a *App) materializeArtifact(artifact store.Artifact, req artifactMateriali
 	}
 	absolutePath, relativePath, err := resolveArtifactMaterializePath(workspace, artifact, req.RelativePath)
 	if err != nil {
+		return store.Workspace{}, store.Artifact{}, "", err
+	}
+	if err := enforceWorkPersonalPath(absolutePath); err != nil {
 		return store.Workspace{}, store.Artifact{}, "", err
 	}
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
@@ -360,6 +390,8 @@ func (a *App) handleArtifactMaterialize(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		var requestErr artifactMaterializeError
 		switch {
+		case isWorkPersonalGuardrailError(err):
+			writeAPIError(w, http.StatusForbidden, err.Error())
 		case errors.As(err, &requestErr):
 			writeAPIError(w, http.StatusBadRequest, requestErr.Error())
 		case errors.Is(err, sql.ErrNoRows):

--- a/internal/web/artifacts_test.go
+++ b/internal/web/artifacts_test.go
@@ -248,6 +248,38 @@ func TestArtifactMaterializeAPIRejectsAlreadyFileBackedArtifacts(t *testing.T) {
 	}
 }
 
+func TestArtifactMaterializeAPIRejectsWorkPersonalWorkspace(t *testing.T) {
+	_, personalRoot := configureWorkPersonalGuardrail(t)
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Personal", personalRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(personal) error: %v", err)
+	}
+	title := "Sensitive Email"
+	metaJSON := `{"subject":"Sensitive Email","body":"private"}`
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindEmail, nil, nil, &title, &metaJSON)
+	if err != nil {
+		t.Fatalf("CreateArtifact() error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/artifacts/"+itoa(artifact.ID)+"/materialize", map[string]any{
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("materialize status = %d, want 403: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "work personal subtree is blocked") {
+		t.Fatalf("materialize response = %q", body)
+	}
+	if strings.Contains(body, personalRoot) || strings.Contains(body, "Sensitive Email") {
+		t.Fatalf("materialize response leaked protected metadata: %q", body)
+	}
+	if _, err := os.Stat(filepath.Join(personalRoot, ".slopshell")); !os.IsNotExist(err) {
+		t.Fatalf("protected workspace materialization side effect err = %v, want no .slopshell", err)
+	}
+}
+
 func TestArtifactListAPIIncludesLinkedArtifactsForWorkspace(t *testing.T) {
 	app := newAuthedTestApp(t)
 

--- a/internal/web/chat_assistant_local_tools.go
+++ b/internal/web/chat_assistant_local_tools.go
@@ -884,6 +884,9 @@ func localAssistantWorkspaceTopLevelEntries(workspaceDir string) ([]string, erro
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		name := entry.Name()
+		if pathInWorkPersonalGuardrail(filepath.Join(workspaceDir, name)) {
+			continue
+		}
 		if entry.IsDir() {
 			name += "/"
 		}
@@ -899,6 +902,9 @@ func localAssistantWorkspaceTopLevelEntries(workspaceDir string) ([]string, erro
 func localAssistantReadWorkspaceFile(workspaceDir string, rawPath string) (string, string, bool, error) {
 	resolved, err := resolveLocalAssistantWorkspacePath(workspaceDir, rawPath)
 	if err != nil {
+		return "", "", false, err
+	}
+	if err := enforceWorkPersonalPath(resolved); err != nil {
 		return "", "", false, err
 	}
 	info, err := os.Stat(resolved)
@@ -933,6 +939,12 @@ func localAssistantFindWorkspaceFiles(workspaceDir string, query string, limit i
 	err := filepath.WalkDir(workspaceDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if pathInWorkPersonalGuardrail(path) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if len(matches) >= limit {
 			return filepath.SkipAll
@@ -979,6 +991,9 @@ func resolveLocalAssistantWorkspacePath(workspaceDir string, raw string) (string
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %q escapes the workspace", raw)
+	}
+	if err := enforceWorkPersonalPath(target); err != nil {
+		return "", err
 	}
 	return target, nil
 }

--- a/internal/web/chat_provider_test.go
+++ b/internal/web/chat_provider_test.go
@@ -222,6 +222,38 @@ func TestLocalAssistantTurnListsDirectoryWithWorkspaceReadTool(t *testing.T) {
 	}
 }
 
+func TestLocalAssistantWorkspaceReadSkipsWorkPersonalSubtree(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	if err := os.WriteFile(filepath.Join(vaultRoot, "README.md"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(personalRoot, "diary.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write protected file: %v", err)
+	}
+
+	entries, err := localAssistantWorkspaceTopLevelEntries(vaultRoot)
+	if err != nil {
+		t.Fatalf("localAssistantWorkspaceTopLevelEntries() error: %v", err)
+	}
+	if strings.Contains(strings.Join(entries, ","), "personal") {
+		t.Fatalf("top-level entries leaked protected directory: %#v", entries)
+	}
+	matches, err := localAssistantFindWorkspaceFiles(vaultRoot, "diary", 10)
+	if err != nil {
+		t.Fatalf("localAssistantFindWorkspaceFiles() error: %v", err)
+	}
+	if strings.Contains(strings.Join(matches, ","), "diary.md") {
+		t.Fatalf("find_file leaked protected file: %#v", matches)
+	}
+	_, _, _, err = localAssistantReadWorkspaceFile(vaultRoot, "personal/diary.md")
+	if !isWorkPersonalGuardrailError(err) {
+		t.Fatalf("localAssistantReadWorkspaceFile() error = %v, want guardrail", err)
+	}
+	if strings.Contains(err.Error(), "diary.md") || strings.Contains(err.Error(), personalRoot) {
+		t.Fatalf("guardrail error leaked protected metadata: %q", err.Error())
+	}
+}
+
 func TestFinalizeAssistantResponseWithMetadataPublishesProviderMetadata(t *testing.T) {
 	app := newAuthedTestApp(t)
 

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -253,6 +253,9 @@ func (a *App) resolveWorkspaceReference(workspacePath string, raw string) (store
 
 	expanded := expandWorkspacePathReference(ref)
 	if strings.ContainsAny(expanded, `/\~.`) {
+		if err := enforceWorkPersonalPath(expanded); err != nil {
+			return store.Workspace{}, err
+		}
 		if workspace, err := a.store.GetWorkspaceByPath(expanded); err == nil {
 			return workspace, nil
 		}
@@ -266,12 +269,21 @@ func (a *App) resolveWorkspaceReference(workspacePath string, raw string) (store
 		return store.Workspace{}, err
 	}
 	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferenceExactMatch); err != nil || ok {
+		if err == nil && ok {
+			err = enforceWorkPersonalWorkspace(workspace)
+		}
 		return workspace, err
 	}
 	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferencePrefixMatch); err != nil || ok {
+		if err == nil && ok {
+			err = enforceWorkPersonalWorkspace(workspace)
+		}
 		return workspace, err
 	}
 	if workspace, ok, err := resolveWorkspaceMatch(workspaces, ref, expanded, workspaceReferenceContainsMatch); err != nil || ok {
+		if err == nil && ok {
+			err = enforceWorkPersonalWorkspace(workspace)
+		}
 		return workspace, err
 	}
 	return store.Workspace{}, fmt.Errorf("workspace %q not found", ref)
@@ -540,6 +552,9 @@ func (a *App) createWorkspaceFromDialogIntent(workspacePath string, action *Syst
 		if dirPath == "" {
 			return store.Workspace{}, false, errors.New("workspace path is required")
 		}
+		if err := enforceWorkPersonalPath(dirPath); err != nil {
+			return store.Workspace{}, false, err
+		}
 		name = filepath.Base(dirPath)
 	}
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {
@@ -565,6 +580,7 @@ func (a *App) executeListWorkspacesAction(_ store.ChatSession, action *SystemAct
 		return "", nil, err
 	}
 	workspaces = filterExplicitWorkspaces(workspaces)
+	workspaces = filterWorkPersonalGuardrailWorkspaces(workspaces)
 	items, err := a.store.ListItems()
 	if err != nil {
 		return "", nil, err

--- a/internal/web/chat_workspace_test.go
+++ b/internal/web/chat_workspace_test.go
@@ -206,6 +206,27 @@ func TestResolveWorkspaceReferenceMatchesContainedName(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspaceReferenceBlocksWorkPersonalPathAndName(t *testing.T) {
+	_, personalRoot := configureWorkPersonalGuardrail(t)
+	app := newAuthedTestApp(t)
+	if err := os.WriteFile(filepath.Join(personalRoot, "diary.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write protected file: %v", err)
+	}
+	if _, err := app.store.CreateWorkspace("Personal", personalRoot, store.SphereWork); err != nil {
+		t.Fatalf("CreateWorkspace(personal) error: %v", err)
+	}
+
+	for _, ref := range []string{filepath.Join(personalRoot, "diary.md"), "Personal"} {
+		_, err := app.resolveWorkspaceReference("", ref)
+		if !isWorkPersonalGuardrailError(err) {
+			t.Fatalf("resolveWorkspaceReference(%q) error = %v, want guardrail", ref, err)
+		}
+		if strings.Contains(err.Error(), "diary.md") || strings.Contains(err.Error(), personalRoot) {
+			t.Fatalf("guardrail error leaked protected metadata: %q", err.Error())
+		}
+	}
+}
+
 func TestClassifyAndExecuteSystemActionListWorkspaceItemsUsesActiveWorkspace(t *testing.T) {
 	app := newAuthedTestApp(t)
 	app.intentLLMURL = ""

--- a/internal/web/projects_import.go
+++ b/internal/web/projects_import.go
@@ -67,6 +67,9 @@ func (a *App) workspaceSourceByID(workspaceID string) (store.Workspace, bool, er
 	if err != nil {
 		return store.Workspace{}, false, err
 	}
+	if err := enforceWorkPersonalWorkspace(project); err != nil {
+		return store.Workspace{}, false, err
+	}
 	return project, true, nil
 }
 
@@ -104,6 +107,9 @@ func (a *App) createWorkspace2(req runtimeWorkspaceCreateRequest) (store.Workspa
 		rootPath := strings.TrimSpace(req.Path)
 		if rootPath == "" {
 			return store.Workspace{}, false, errors.New("path is required for linked projects")
+		}
+		if err := enforceWorkPersonalPath(rootPath); err != nil {
+			return store.Workspace{}, false, err
 		}
 		info, err := os.Stat(rootPath)
 		if err != nil {
@@ -211,6 +217,9 @@ func (a *App) persistTemporaryWorkspaceTarget(project store.Workspace, req tempo
 		targetName = project.Name
 	}
 	if absTarget != filepath.Clean(project.RootPath) {
+		if err := enforceWorkPersonalPath(absTarget); err != nil {
+			return "", "", err
+		}
 		if _, err := os.Stat(absTarget); err == nil {
 			return "", "", errors.New("target path already exists")
 		} else if !errors.Is(err, os.ErrNotExist) {
@@ -378,6 +387,10 @@ func (a *App) handleRuntimeWorkspaceCreate(w http.ResponseWriter, r *http.Reques
 	}
 	project, created, err := a.createWorkspace2(req)
 	if err != nil {
+		if isWorkPersonalGuardrailError(err) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -387,6 +400,10 @@ func (a *App) handleRuntimeWorkspaceCreate(w http.ResponseWriter, r *http.Reques
 	}
 	if activate {
 		if project, err = a.activateWorkspace(workspaceIDStr(project.ID)); err != nil {
+			if isWorkPersonalGuardrailError(err) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
@@ -424,6 +441,10 @@ func (a *App) handleTemporaryWorkspacePersist(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		if isNoRows(err) {
 			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+		if isWorkPersonalGuardrailError(err) {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/web/projects_model.go
+++ b/internal/web/projects_model.go
@@ -245,6 +245,9 @@ func (a *App) activateWorkspace(workspaceID string) (store.Workspace, error) {
 	if err != nil {
 		return store.Workspace{}, err
 	}
+	if err := enforceWorkPersonalWorkspace(project); err != nil {
+		return store.Workspace{}, err
+	}
 	workspaceSphere, err := a.workspaceSphere(project)
 	if err != nil {
 		return store.Workspace{}, err
@@ -285,6 +288,10 @@ func (a *App) handleWorkspaceActivate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if isNoRows(err) {
 			http.Error(w, "project not found", http.StatusNotFound)
+			return
+		}
+		if isWorkPersonalGuardrailError(err) {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -436,6 +443,10 @@ func (a *App) handleWorkspaceContext(w http.ResponseWriter, r *http.Request) {
 	}
 	project, err = a.activateWorkspace(workspaceIDStr(project.ID))
 	if err != nil {
+		if isWorkPersonalGuardrailError(err) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -464,6 +475,10 @@ func (a *App) handleWorkspaceFilesList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
 
 	relPath, err := normalizeProjectListPath(r.URL.Query().Get("path"))
 	if err != nil {
@@ -478,6 +493,10 @@ func (a *App) handleWorkspaceFilesList(w http.ResponseWriter, r *http.Request) {
 	targetPath = filepath.Clean(targetPath)
 	if !pathWithinRoot(targetPath, rootPath) {
 		http.Error(w, "invalid path", http.StatusForbidden)
+		return
+	}
+	if err := enforceWorkPersonalPath(targetPath); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 	info, err := os.Stat(targetPath)
@@ -507,6 +526,9 @@ func (a *App) handleWorkspaceFilesList(w http.ResponseWriter, r *http.Request) {
 		entryPath := name
 		if relPath != "" {
 			entryPath = relPath + "/" + name
+		}
+		if pathInWorkPersonalGuardrail(filepath.Join(targetPath, name)) {
+			continue
 		}
 		items = append(items, workspaceFileEntry{
 			Name:  name,

--- a/internal/web/time_entries.go
+++ b/internal/web/time_entries.go
@@ -129,10 +129,17 @@ func (a *App) startTimeTrackingEntry(activity string) (store.TimeEntry, bool, er
 }
 
 func (a *App) setActiveWorkspaceTracked(id int64, activity string) error {
+	workspace, err := a.store.GetWorkspace(id)
+	if err != nil {
+		return err
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		return err
+	}
 	if err := a.store.SetActiveWorkspace(id); err != nil {
 		return err
 	}
-	_, _, err := a.syncTimeTrackingContext(activity)
+	_, _, err = a.syncTimeTrackingContext(activity)
 	if err == nil {
 		a.broadcastWorkspaceBusyChanged()
 	}

--- a/internal/web/work_personal_guardrail.go
+++ b/internal/web/work_personal_guardrail.go
@@ -1,0 +1,97 @@
+package web
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+const workPersonalGuardrailMessage = "Access to the work personal subtree is blocked by default. It contains local-only personal material; choose another workspace or request an explicit override."
+
+type workPersonalGuardrailError struct{}
+
+func (e workPersonalGuardrailError) Error() string {
+	return workPersonalGuardrailMessage
+}
+
+func isWorkPersonalGuardrailError(err error) bool {
+	var guardrailErr workPersonalGuardrailError
+	return errors.As(err, &guardrailErr)
+}
+
+func workPersonalGuardrailRoot() string {
+	if workBrain := strings.TrimSpace(os.Getenv("SLOPSHELL_BRAIN_WORK_ROOT")); workBrain != "" {
+		clean := filepath.Clean(expandWorkspacePathReference(workBrain))
+		if filepath.Base(clean) == "brain" {
+			return filepath.Join(filepath.Dir(clean), "personal")
+		}
+		return filepath.Join(clean, "personal")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, "Nextcloud", "personal")
+}
+
+func absoluteCleanPath(path string) string {
+	clean := strings.TrimSpace(expandWorkspacePathReference(path))
+	if clean == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return filepath.Clean(clean)
+	}
+	return filepath.Clean(abs)
+}
+
+func pathInsideOrEqual(path, root string) bool {
+	cleanPath := absoluteCleanPath(path)
+	cleanRoot := absoluteCleanPath(root)
+	if cleanPath == "" || cleanRoot == "" {
+		return false
+	}
+	if cleanPath == cleanRoot {
+		return true
+	}
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func pathInWorkPersonalGuardrail(path string) bool {
+	return pathInsideOrEqual(path, workPersonalGuardrailRoot())
+}
+
+func enforceWorkPersonalPath(path string) error {
+	if pathInWorkPersonalGuardrail(path) {
+		return workPersonalGuardrailError{}
+	}
+	return nil
+}
+
+func enforceWorkPersonalWorkspace(workspace store.Workspace) error {
+	for _, path := range []string{workspace.DirPath, workspace.RootPath, workspace.WorkspacePath} {
+		if pathInWorkPersonalGuardrail(path) {
+			return workPersonalGuardrailError{}
+		}
+	}
+	return nil
+}
+
+func filterWorkPersonalGuardrailWorkspaces(workspaces []store.Workspace) []store.Workspace {
+	filtered := workspaces[:0]
+	for _, workspace := range workspaces {
+		if enforceWorkPersonalWorkspace(workspace) != nil {
+			continue
+		}
+		filtered = append(filtered, workspace)
+	}
+	return filtered
+}

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -25,22 +25,22 @@ type runtimeWorkspaceCreateRequest struct {
 }
 
 type workspaceAPIModel struct {
-	ID                       string          `json:"id"`
-	Name                     string          `json:"name"`
-	Kind                     string          `json:"kind"`
-	RootPath                 string          `json:"root_path"`
-	Sphere                   string          `json:"sphere,omitempty"`
-	WorkspacePath            string          `json:"workspace_path"`
-	MCPURL                   string          `json:"mcp_url,omitempty"`
-	IsDefault                bool            `json:"is_default"`
-	ChatSessionID            string          `json:"chat_session_id"`
-	ChatMode                 string          `json:"chat_mode"`
-	ChatModel                string          `json:"chat_model"`
-	ChatModelReasoningEffort string          `json:"chat_model_reasoning_effort"`
-	CanvasSessionID          string          `json:"canvas_session_id"`
+	ID                       string            `json:"id"`
+	Name                     string            `json:"name"`
+	Kind                     string            `json:"kind"`
+	RootPath                 string            `json:"root_path"`
+	Sphere                   string            `json:"sphere,omitempty"`
+	WorkspacePath            string            `json:"workspace_path"`
+	MCPURL                   string            `json:"mcp_url,omitempty"`
+	IsDefault                bool              `json:"is_default"`
+	ChatSessionID            string            `json:"chat_session_id"`
+	ChatMode                 string            `json:"chat_mode"`
+	ChatModel                string            `json:"chat_model"`
+	ChatModelReasoningEffort string            `json:"chat_model_reasoning_effort"`
+	CanvasSessionID          string            `json:"canvas_session_id"`
 	RunState                 workspaceRunState `json:"run_state"`
-	Unread                   bool            `json:"unread"`
-	ReviewPending            bool            `json:"review_pending"`
+	Unread                   bool              `json:"unread"`
+	ReviewPending            bool              `json:"review_pending"`
 }
 
 type workspaceChatModelRequest struct {
@@ -63,38 +63,38 @@ type workspaceWelcomeAction struct {
 }
 
 type workspaceWelcomeCard struct {
-	ID          string               `json:"id"`
-	Title       string               `json:"title"`
-	Subtitle    string               `json:"subtitle,omitempty"`
-	Description string               `json:"description,omitempty"`
+	ID          string                 `json:"id"`
+	Title       string                 `json:"title"`
+	Subtitle    string                 `json:"subtitle,omitempty"`
+	Description string                 `json:"description,omitempty"`
 	Action      workspaceWelcomeAction `json:"action"`
 }
 
 type workspaceWelcomeSection struct {
-	ID    string               `json:"id"`
-	Title string               `json:"title"`
+	ID    string                 `json:"id"`
+	Title string                 `json:"title"`
 	Cards []workspaceWelcomeCard `json:"cards"`
 }
 
 type workspaceWelcomeResponse struct {
-	OK          bool                    `json:"ok"`
-	WorkspaceID string                  `json:"workspace_id"`
+	OK          bool                      `json:"ok"`
+	WorkspaceID string                    `json:"workspace_id"`
 	Project     workspaceAPIModel         `json:"workspace"`
-	Scope       string                  `json:"scope"`
-	Title       string                  `json:"title"`
+	Scope       string                    `json:"scope"`
+	Title       string                    `json:"title"`
 	Sections    []workspaceWelcomeSection `json:"sections"`
 }
 
 type workspaceActivityItem struct {
-	WorkspaceID   string          `json:"workspace_id"`
-	WorkspacePath string          `json:"workspace_path"`
-	Name          string          `json:"name"`
-	Kind          string          `json:"kind"`
-	ChatSessionID string          `json:"chat_session_id"`
-	ChatMode      string          `json:"chat_mode"`
+	WorkspaceID   string            `json:"workspace_id"`
+	WorkspacePath string            `json:"workspace_path"`
+	Name          string            `json:"name"`
+	Kind          string            `json:"kind"`
+	ChatSessionID string            `json:"chat_session_id"`
+	ChatMode      string            `json:"chat_mode"`
 	RunState      workspaceRunState `json:"run_state"`
-	Unread        bool            `json:"unread"`
-	ReviewPending bool            `json:"review_pending"`
+	Unread        bool              `json:"unread"`
+	ReviewPending bool              `json:"review_pending"`
 }
 
 func workspaceIDStr(id int64) string {
@@ -404,6 +404,7 @@ func (a *App) listProjectsWithDefault() ([]store.Workspace, store.Workspace, err
 	if err != nil {
 		return nil, store.Workspace{}, err
 	}
+	projects = filterWorkPersonalGuardrailWorkspaces(projects)
 	if len(projects) == 0 {
 		return nil, store.Workspace{}, errors.New("no projects available")
 	}

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -71,6 +71,21 @@ type workspaceFilesListResponse struct {
 	} `json:"entries"`
 }
 
+func configureWorkPersonalGuardrail(t *testing.T) (string, string) {
+	t.Helper()
+	vaultRoot := t.TempDir()
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	personalRoot := filepath.Join(vaultRoot, "personal")
+	if err := os.MkdirAll(brainRoot, 0o755); err != nil {
+		t.Fatalf("mkdir brain root: %v", err)
+	}
+	if err := os.MkdirAll(personalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir personal root: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", brainRoot)
+	return vaultRoot, personalRoot
+}
+
 func TestProjectsListIncludesActiveAndSessions(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -220,6 +235,29 @@ func TestProjectsListIncludesWorkspaceSphere(t *testing.T) {
 	}
 	if project.Sphere != store.SphereWork {
 		t.Fatalf("project sphere = %q, want %q", project.Sphere, store.SphereWork)
+	}
+}
+
+func TestRuntimeWorkspaceCreateRejectsWorkPersonalPath(t *testing.T) {
+	_, personalRoot := configureWorkPersonalGuardrail(t)
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/runtime/workspaces", map[string]any{
+		"name": "Personal",
+		"kind": "linked",
+		"path": personalRoot,
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("create personal workspace status = %d, want 403: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "work personal subtree is blocked") {
+		t.Fatalf("guardrail response = %q", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), personalRoot) {
+		t.Fatalf("guardrail response leaked protected path: %q", rr.Body.String())
+	}
+	if _, err := app.store.GetWorkspaceByPath(personalRoot); !isNoRows(err) {
+		t.Fatalf("GetWorkspaceByPath(personal) error = %v, want no rows", err)
 	}
 }
 
@@ -520,6 +558,26 @@ func TestProjectActivateUpdatesActiveSphere(t *testing.T) {
 	}
 	if activeSphere != store.SphereWork {
 		t.Fatalf("stored active sphere = %q, want %q", activeSphere, store.SphereWork)
+	}
+}
+
+func TestWorkspaceSnapshotRejectsWorkPersonalActivation(t *testing.T) {
+	_, personalRoot := configureWorkPersonalGuardrail(t)
+	app := newAuthedTestApp(t)
+	project, err := app.store.CreateEnrichedWorkspace("Personal", "personal", personalRoot, "linked", "", "", false)
+	if err != nil {
+		t.Fatalf("CreateEnrichedWorkspace(personal) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspaces/"+workspaceIDStr(project.ID)+"/snapshot", nil)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("snapshot status = %d, want 403: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "work personal subtree is blocked") {
+		t.Fatalf("snapshot response = %q", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), personalRoot) {
+		t.Fatalf("snapshot response leaked protected path: %q", rr.Body.String())
 	}
 }
 
@@ -953,6 +1011,39 @@ func TestProjectFilesListReturnsOneLevelAndSupportsSubfolders(t *testing.T) {
 	}
 	if len(subPayload.Entries) == 0 || subPayload.Entries[0].Path != dirName+"/child.md" {
 		t.Fatalf("expected child file path %q in subdirectory listing", dirName+"/child.md")
+	}
+}
+
+func TestProjectFilesListBlocksWorkPersonalSubtree(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	app := newAuthedTestApp(t)
+	if err := os.WriteFile(filepath.Join(personalRoot, "diary.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write protected file: %v", err)
+	}
+	workspace, err := app.store.CreateWorkspace("Work Vault", vaultRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(vault) error: %v", err)
+	}
+
+	rrRoot := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/workspaces/"+itoa(workspace.ID)+"/files", nil)
+	if rrRoot.Code != http.StatusOK {
+		t.Fatalf("root list status = %d, want 200: %s", rrRoot.Code, rrRoot.Body.String())
+	}
+	body := rrRoot.Body.String()
+	if strings.Contains(body, "personal") || strings.Contains(body, "diary.md") {
+		t.Fatalf("root listing leaked protected subtree metadata: %s", body)
+	}
+
+	rrPersonal := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/workspaces/"+itoa(workspace.ID)+"/files?path=personal", nil)
+	if rrPersonal.Code != http.StatusForbidden {
+		t.Fatalf("personal list status = %d, want 403: %s", rrPersonal.Code, rrPersonal.Body.String())
+	}
+	body = rrPersonal.Body.String()
+	if !strings.Contains(body, "work personal subtree is blocked") {
+		t.Fatalf("personal list response = %q", body)
+	}
+	if strings.Contains(body, "diary.md") || strings.Contains(body, personalRoot) {
+		t.Fatalf("personal list response leaked protected metadata: %q", body)
 	}
 }
 

--- a/internal/web/workspaces.go
+++ b/internal/web/workspaces.go
@@ -54,6 +54,7 @@ func (a *App) handleWorkspaceList(w http.ResponseWriter, r *http.Request) {
 		writeDomainStoreError(w, err)
 		return
 	}
+	workspaces = filterWorkPersonalGuardrailWorkspaces(workspaces)
 	if contextQuery != "" {
 		contextWorkspaces, err := a.store.ListWorkspacesByContextPrefix(contextQuery)
 		if err != nil {
@@ -89,6 +90,10 @@ func (a *App) handleWorkspaceCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(req.Sphere) == "" {
 		writeAPIError(w, http.StatusBadRequest, "sphere is required")
+		return
+	}
+	if err := enforceWorkPersonalPath(req.DirPath); err != nil {
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	if _, err := a.store.GetWorkspaceByPath(req.DirPath); err == nil {
@@ -142,6 +147,10 @@ func (a *App) handleWorkspaceUpdate(w http.ResponseWriter, r *http.Request) {
 		writeDomainStoreError(w, err)
 		return
 	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		writeAPIError(w, http.StatusForbidden, err.Error())
+		return
+	}
 	if req.Name != nil {
 		workspace, err = a.store.UpdateWorkspaceName(workspaceID, *req.Name)
 		if err != nil {
@@ -188,6 +197,10 @@ func (a *App) handleWorkspaceGet(w http.ResponseWriter, r *http.Request) {
 	workspace, err := a.store.GetWorkspace(workspaceID)
 	if err != nil {
 		writeDomainStoreError(w, err)
+		return
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	writeAPIData(w, http.StatusOK, map[string]any{


### PR DESCRIPTION
## Summary

- Add a default guardrail for the work personal subtree derived from `SLOPSHELL_BRAIN_WORK_ROOT` or `~/Nextcloud/personal`.
- Apply it to workspace creation, activation, listing, file/link resolution, local assistant traversal, and artifact materialization.

## Verification

### Test fails on main

Not run per issue workflow; main is assumed green and tests were run only after the fix.

### Test passes after fix

- Direct workspace selection: `TestRuntimeWorkspaceCreateRejectsWorkPersonalPath` verifies `/api/runtime/workspaces` returns 403, explains the block, does not leak the protected path, and creates no workspace.
- Link following and default UI metadata: `TestProjectFilesListBlocksWorkPersonalSubtree` and `TestResolveWorkspaceReferenceBlocksWorkPersonalPathAndName` verify root file listing omits `personal`/`diary.md`, direct protected file-list access returns 403, and workspace references by protected path/name are blocked without metadata leaks.
- Source-context activation: `TestWorkspaceSnapshotRejectsWorkPersonalActivation` verifies snapshot/source activation into `personal/` returns 403 without protected path leakage.
- Indexing/materialization requests: `TestLocalAssistantWorkspaceReadSkipsWorkPersonalSubtree` and `TestArtifactMaterializeAPIRejectsWorkPersonalWorkspace` verify local assistant list/find/read skip or reject the protected subtree, materialization returns 403, and no protected artifact path is created (`<personal>/.slopshell` remains absent).
- Clear explanation: guardrail responses include `work personal subtree is blocked`; tests assert this message and check protected filenames/paths are absent.

Commands and output excerpts:

```text
go test ./internal/web 2>&1 | tee /tmp/slopshell-issue-723-web-test.log
ok  	github.com/sloppy-org/slopshell/internal/web	24.503s
```

```text
./scripts/sync-surface.sh --check 2>&1 | tee /tmp/slopshell-issue-723-surface-check.log
# exit 0, no output
```

```text
go test ./... 2>&1 | tee /tmp/slopshell-issue-723-go-test.log
ok  	github.com/sloppy-org/slopshell/internal/web	(cached)
ok  	github.com/sloppy-org/slopshell/internal/store	1.143s
ok  	github.com/sloppy-org/slopshell/internal/surface	0.014s
```

```text
./scripts/playwright.sh 2>&1 | tee /tmp/slopshell-issue-723-playwright.log
40 skipped
391 passed (3.1m)
```