### PR TITLE
fix: Resolve Markdown links from brain notes to source folders safely (fixes #721)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -54,6 +54,8 @@ Runtime and chat session management:
 - `GET /api/runtime/workspaces/{workspace_id}/snapshot`
 - `GET /api/runtime/workspaces/{workspace_id}/welcome`
 - `GET /api/workspaces/{workspace_id}/files`
+- `GET /api/workspaces/{workspace_id}/markdown-link/resolve`
+- `GET /api/workspaces/{workspace_id}/markdown-link/file`
 - `GET /api/workspaces/{workspace_id}/companion/config`
 - `PUT /api/workspaces/{workspace_id}/companion/config`
 - `GET /api/workspaces/{workspace_id}/companion/state`

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -823,6 +823,8 @@ var WebRouteSections = []RouteSection{
 			"GET /api/runtime/workspaces/{workspace_id}/snapshot",
 			"GET /api/runtime/workspaces/{workspace_id}/welcome",
 			"GET /api/workspaces/{workspace_id}/files",
+			"GET /api/workspaces/{workspace_id}/markdown-link/resolve",
+			"GET /api/workspaces/{workspace_id}/markdown-link/file",
 			"GET /api/workspaces/{workspace_id}/companion/config",
 			"PUT /api/workspaces/{workspace_id}/companion/config",
 			"GET /api/workspaces/{workspace_id}/companion/state",

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -47,6 +47,8 @@ func (a *App) Router() http.Handler {
 	r.Post("/api/runtime/workspaces/{workspace_id}/chat-model", a.handleWorkspaceChatModelUpdate)
 	r.Get("/api/runtime/workspaces/{workspace_id}/snapshot", a.handleWorkspaceContext)
 	r.Get("/api/workspaces/{workspace_id}/files", a.handleWorkspaceFilesList)
+	r.Get("/api/workspaces/{workspace_id}/markdown-link/resolve", a.handleWorkspaceMarkdownLinkResolve)
+	r.Get("/api/workspaces/{workspace_id}/markdown-link/file", a.handleWorkspaceMarkdownLinkFile)
 	r.Get("/api/runtime/workspaces/{workspace_id}/welcome", a.handleWorkspaceWelcome)
 	r.Get("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigGet)
 	r.Put("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigPut)

--- a/internal/web/static/app-pr-review.ts
+++ b/internal/web/static/app-pr-review.ts
@@ -364,6 +364,7 @@ export async function openWorkspaceSidebarFile(path) {
       kind: 'text_artifact',
       event_id: `workspace-file-${Date.now()}`,
       title: filePath,
+      path: filePath,
       text,
     });
     showCanvasColumn('canvas-text');
@@ -400,6 +401,7 @@ export async function openCompanionWorkspaceView(viewKind, filePath) {
       kind: 'text_artifact',
       event_id: `workspace-companion-${viewKind}-${Date.now()}`,
       title: titles[viewKind] || filePath,
+      path: filePath,
       text,
     });
     if (viewKind === 'summary') {

--- a/internal/web/static/canvas-content.ts
+++ b/internal/web/static/canvas-content.ts
@@ -735,6 +735,26 @@ function restoreMathSegments(renderedHtml, mathSegments) {
   return output;
 }
 
+function escapeMarkdownLinkText(textRaw) {
+  return String(textRaw || '')
+    .replaceAll('\\', '\\\\')
+    .replaceAll('[', '\\[')
+    .replaceAll(']', '\\]');
+}
+
+function expandWikiLinks(markdownSource) {
+  return String(markdownSource || '').replace(/\[\[([^\]\n]+)\]\]/g, (_match, innerRaw) => {
+    const inner = String(innerRaw || '').trim();
+    if (!inner) return _match;
+    const pipe = inner.indexOf('|');
+    const target = pipe >= 0 ? inner.slice(0, pipe).trim() : inner;
+    const labelRaw = pipe >= 0 ? inner.slice(pipe + 1).trim() : target;
+    if (!target) return _match;
+    const label = labelRaw || target;
+    return `[${escapeMarkdownLinkText(label)}](slopshell-wiki:${encodeURIComponent(target)})`;
+  });
+}
+
 function typesetMarkdownMath(root, attempt = 0) {
   if (!(root instanceof Element) || !root.isConnected) return;
   const mj = window.MathJax;
@@ -830,7 +850,7 @@ export function renderTextArtifact(root, event, previousState) {
   } else if (looksStructuredTextArtifact(textBody)) {
     root.innerHTML = sanitizeHtml(renderCodeBlock(structuredText, 'plaintext'));
   } else {
-    const { text: markdownText, stash: mathSegments } = extractMathSegments(textBody);
+    const { text: markdownText, stash: mathSegments } = extractMathSegments(expandWikiLinks(textBody));
     const renderedMarkdownHtml = marked.parse(markdownText);
     root.innerHTML = restoreMathSegments(sanitizeHtml(renderedMarkdownHtml), mathSegments);
     typesetMarkdownMath(root);

--- a/internal/web/static/canvas-markdown-links.ts
+++ b/internal/web/static/canvas-markdown-links.ts
@@ -1,0 +1,131 @@
+import { apiURL } from './paths.js';
+import { normalizeCanvasPath } from './canvas-visual.js';
+
+function currentWorkspaceID() {
+  const state = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
+  return String(state.activeWorkspaceId || 'active').trim() || 'active';
+}
+
+function canvasMarkdownSourcePath(event) {
+  return normalizeCanvasPath(event?.path || event?.title || '');
+}
+
+function isLocalMarkdownHref(raw) {
+  const href = String(raw || '').trim();
+  if (!href || href.startsWith('#')) return false;
+  if (href.toLowerCase().startsWith('slopshell-wiki:')) return true;
+  try {
+    const parsed = new URL(href, window.location.href);
+    return parsed.origin === window.location.origin
+      && !/^[a-z][a-z0-9+.-]*:/i.test(href);
+  } catch (_) {
+    return !/^[a-z][a-z0-9+.-]*:/i.test(href);
+  }
+}
+
+function clearMarkdownLinkReason(link) {
+  link.classList.remove('markdown-link-blocked');
+  delete link.dataset.blockedReason;
+  const next = link.nextElementSibling;
+  if (next instanceof HTMLElement && next.classList.contains('markdown-link-blocked-reason')) {
+    next.remove();
+  }
+}
+
+function showMarkdownLinkBlocked(link, reasonRaw) {
+  const reason = String(reasonRaw || 'link blocked').trim();
+  link.classList.add('markdown-link-blocked');
+  link.dataset.blockedReason = reason;
+  link.title = reason;
+  let note = link.nextElementSibling;
+  if (!(note instanceof HTMLElement) || !note.classList.contains('markdown-link-blocked-reason')) {
+    note = document.createElement('span');
+    note.className = 'markdown-link-blocked-reason';
+    link.insertAdjacentElement('afterend', note);
+  }
+  note.textContent = ` ${reason}`;
+}
+
+async function openResolvedMarkdownLink(resolution, renderCanvas) {
+  const link = resolution?.link || resolution || {};
+  const fileURL = String(link.file_url || '').trim();
+  if (!fileURL) throw new Error('link target unavailable');
+  const kind = String(link.kind || 'text').trim();
+  const path = String(link.vault_relative_path || link.resolved_path || '').trim();
+  const title = path || 'Linked note';
+  if (kind === 'image') {
+    renderCanvas({
+      kind: 'image_artifact',
+      event_id: `markdown-link-${Date.now()}`,
+      title,
+      path,
+      url: fileURL,
+    });
+    return;
+  }
+  if (kind === 'pdf') {
+    renderCanvas({
+      kind: 'pdf_artifact',
+      event_id: `markdown-link-${Date.now()}`,
+      title,
+      path,
+      url: fileURL,
+    });
+    return;
+  }
+  const resp = await fetch(fileURL, { cache: 'no-store' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    throw new Error(detail);
+  }
+  const text = await resp.text();
+  renderCanvas({
+    kind: 'text_artifact',
+    event_id: `markdown-link-${Date.now()}`,
+    title,
+    path,
+    text,
+  });
+}
+
+export function hydrateMarkdownArtifactLinks(root, event, renderCanvas) {
+  if (!(root instanceof HTMLElement)) return;
+  const source = canvasMarkdownSourcePath(event);
+  if (!source || typeof renderCanvas !== 'function') return;
+  root.querySelectorAll('a[href]').forEach((node) => {
+    if (!(node instanceof HTMLAnchorElement)) return;
+    const rawHref = node.getAttribute('href') || '';
+    if (!isLocalMarkdownHref(rawHref)) return;
+    const isWikilink = rawHref.toLowerCase().startsWith('slopshell-wiki:');
+    node.dataset.markdownLinkTarget = rawHref;
+    node.dataset.markdownLinkSource = source;
+    node.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      clearMarkdownLinkReason(node);
+      const workspaceID = currentWorkspaceID();
+      const params = new URLSearchParams({
+        source,
+        target: rawHref,
+      });
+      if (isWikilink) params.set('type', 'wikilink');
+      void fetch(apiURL(`workspaces/${encodeURIComponent(workspaceID)}/markdown-link/resolve?${params.toString()}`), { cache: 'no-store' })
+        .then(async (resp) => {
+          if (!resp.ok) {
+            const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+            throw new Error(detail);
+          }
+          return resp.json();
+        })
+        .then(async (payload) => {
+          if (!payload?.ok) {
+            showMarkdownLinkBlocked(node, payload?.reason || 'link blocked');
+            return;
+          }
+          await openResolvedMarkdownLink(payload, renderCanvas);
+        })
+        .catch((err) => {
+          showMarkdownLinkBlocked(node, String(err?.message || err || 'link blocked'));
+        });
+    });
+  });
+}

--- a/internal/web/static/canvas.css
+++ b/internal/web/static/canvas.css
@@ -68,6 +68,14 @@
 }
 
 #canvas-text h1, #canvas-text h2, #canvas-text h3 { color: var(--accent); margin: 1rem 0 0.5rem; }
+#canvas-text a.markdown-link-blocked {
+  color: #9f1239;
+  text-decoration-style: wavy;
+}
+#canvas-text .markdown-link-blocked-reason {
+  color: #9f1239;
+  font-size: 0.9em;
+}
 #canvas-text code { background: var(--bg-elevated); padding: 0.15rem 0.3rem; border-radius: 3px; }
 #canvas-text pre {
   background: transparent;

--- a/internal/web/static/canvas.ts
+++ b/internal/web/static/canvas.ts
@@ -33,8 +33,8 @@ import {
   captureVisualReasoningContext as captureSurfaceVisualReasoningContext,
   getTextImageAnchorFromPoint as getVisualTextImageAnchorFromPoint,
   hydrateTextArtifactImages as hydrateVisualTextArtifactImages,
-  normalizeCanvasPath,
 } from './canvas-visual.js';
+import { hydrateMarkdownArtifactLinks } from './canvas-markdown-links.js';
 import { apiURL } from './paths.js';
 
 export { escapeHtml, sanitizeHtml } from './canvas-content.js';
@@ -507,6 +507,14 @@ function getPdfURL(event) {
   const pdfState = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
   const pdfSid = String(pdfState.sessionId || '');
   const pdfPath = String(event?.path || '');
+  const directURL = String(event?.url || '').trim();
+  if (directURL) {
+    return {
+      sid: pdfSid,
+      path: pdfPath,
+      url: directURL,
+    };
+  }
   return {
     sid: pdfSid,
     path: pdfPath,
@@ -812,6 +820,7 @@ export function renderCanvas(event) {
       previousArtifactTitle = nextState.previousArtifactTitle;
     }
     hydrateVisualTextArtifactImages(e.text, String(event?.path || '').trim(), currentCanvasSessionID());
+    hydrateMarkdownArtifactLinks(e.text, event, renderCanvas);
     const textKey = canvasEventPageKey(event);
     const keepIndex = canvasPageState.kind === 'text' && canvasPageState.key === textKey
       ? canvasPageState.pageIndex
@@ -866,7 +875,7 @@ export function renderCanvas(event) {
     e.image.classList.add('is-active');
     const state = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
     const sid = state.sessionId || '';
-    (e.img as HTMLImageElement).src = apiURL(`files/${encodeURIComponent(sid)}/${encodeURIComponent(event.path)}`);
+    (e.img as HTMLImageElement).src = String(event.url || '').trim() || apiURL(`files/${encodeURIComponent(sid)}/${encodeURIComponent(event.path)}`);
     (e.img as HTMLImageElement).alt = event.title || 'Image';
     activeTextEventId = null;
     activeArtifactTitle = event.title || '';

--- a/internal/web/workspace_markdown_links.go
+++ b/internal/web/workspace_markdown_links.go
@@ -1,0 +1,302 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type workspaceMarkdownLinkResolution struct {
+	OK                bool   `json:"ok"`
+	Blocked           bool   `json:"blocked,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	SourcePath        string `json:"source_path,omitempty"`
+	Target            string `json:"target,omitempty"`
+	ResolvedPath      string `json:"resolved_path,omitempty"`
+	VaultRelativePath string `json:"vault_relative_path,omitempty"`
+	FileURL           string `json:"file_url,omitempty"`
+	Kind              string `json:"kind,omitempty"`
+}
+
+func brainWorkspaceRoots(workspace store.Workspace) (string, string, error) {
+	root := absoluteCleanPath(workspace.DirPath)
+	if root == "" {
+		return "", "", errors.New("workspace path is required")
+	}
+	if filepath.Base(root) == "brain" {
+		return root, filepath.Dir(root), nil
+	}
+	return root, root, nil
+}
+
+func normalizeMarkdownSourcePath(raw string) (string, error) {
+	clean := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	clean = strings.TrimPrefix(clean, "/")
+	if clean == "" || clean == "." {
+		return "", errors.New("source path is required")
+	}
+	return normalizeProjectListPath(clean)
+}
+
+func cleanMarkdownLinkTarget(raw string) string {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return ""
+	}
+	if strings.HasPrefix(target, "<") && strings.HasSuffix(target, ">") {
+		target = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(target, "<"), ">"))
+	}
+	if strings.HasPrefix(strings.ToLower(target), "slopshell-wiki:") {
+		decoded, err := url.PathUnescape(target[len("slopshell-wiki:"):])
+		if err == nil {
+			target = decoded
+		}
+	}
+	if idx := strings.Index(target, "|"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	if idx := strings.Index(target, "#"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	if idx := strings.Index(target, "?"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	return strings.TrimSpace(target)
+}
+
+func isExternalMarkdownLink(raw string) bool {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return false
+	}
+	if strings.HasPrefix(target, "#") {
+		return true
+	}
+	parsed, err := url.Parse(target)
+	if err != nil || parsed.Scheme == "" {
+		return false
+	}
+	return !strings.EqualFold(parsed.Scheme, "file") && !strings.EqualFold(parsed.Scheme, "slopshell-wiki")
+}
+
+func markdownLinkKind(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg":
+		return "image"
+	case ".pdf":
+		return "pdf"
+	default:
+		return "text"
+	}
+}
+
+func markdownLinkCandidatePaths(sourceAbs, brainRoot, vaultRoot, target string, wikilink bool) []string {
+	if target == "" {
+		return []string{sourceAbs}
+	}
+	candidates := []string{}
+	add := func(path string) {
+		clean := filepath.Clean(path)
+		for _, existing := range candidates {
+			if existing == clean {
+				return
+			}
+		}
+		candidates = append(candidates, clean)
+	}
+	addWithMarkdown := func(path string) {
+		add(path)
+		if filepath.Ext(path) == "" {
+			add(path + ".md")
+		}
+	}
+	if filepath.IsAbs(target) {
+		addWithMarkdown(target)
+		return candidates
+	}
+	normalized := strings.ReplaceAll(target, "\\", "/")
+	if strings.HasPrefix(normalized, "/") {
+		addWithMarkdown(filepath.Join(vaultRoot, strings.TrimPrefix(normalized, "/")))
+		return candidates
+	}
+	addWithMarkdown(filepath.Join(filepath.Dir(sourceAbs), filepath.FromSlash(normalized)))
+	if wikilink {
+		addWithMarkdown(filepath.Join(brainRoot, filepath.FromSlash(normalized)))
+		addWithMarkdown(filepath.Join(vaultRoot, filepath.FromSlash(normalized)))
+	}
+	return candidates
+}
+
+func findWikilinkByBasename(brainRoot, target string) (string, error) {
+	if target == "" || strings.ContainsAny(target, `/\`) {
+		return "", os.ErrNotExist
+	}
+	name := target
+	if filepath.Ext(name) == "" {
+		name += ".md"
+	}
+	matches := []string{}
+	err := filepath.WalkDir(brainRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if pathInWorkPersonalGuardrail(path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.EqualFold(entry.Name(), name) {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", os.ErrNotExist
+}
+
+func resolveWorkspaceMarkdownLink(workspace store.Workspace, sourceRaw, targetRaw, linkType string) workspaceMarkdownLinkResolution {
+	result := workspaceMarkdownLinkResolution{
+		Target: strings.TrimSpace(targetRaw),
+	}
+	if isExternalMarkdownLink(targetRaw) {
+		result.Blocked = true
+		result.Reason = "external links open outside the workspace"
+		return result
+	}
+	brainRoot, vaultRoot, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		result.Blocked = true
+		result.Reason = err.Error()
+		return result
+	}
+	sourceRel, err := normalizeMarkdownSourcePath(sourceRaw)
+	if err != nil {
+		result.Blocked = true
+		result.Reason = err.Error()
+		return result
+	}
+	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
+	if !pathInsideOrEqual(sourceAbs, brainRoot) {
+		result.Blocked = true
+		result.Reason = "source note is outside the brain workspace"
+		return result
+	}
+	result.SourcePath = sourceRel
+	target := cleanMarkdownLinkTarget(targetRaw)
+	wikilink := strings.EqualFold(strings.TrimSpace(linkType), "wikilink") || strings.HasPrefix(strings.ToLower(strings.TrimSpace(targetRaw)), "slopshell-wiki:")
+	candidates := markdownLinkCandidatePaths(sourceAbs, brainRoot, vaultRoot, target, wikilink)
+	if wikilink {
+		if found, err := findWikilinkByBasename(brainRoot, target); err == nil {
+			candidates = append(candidates, found)
+		}
+	}
+	for _, candidate := range candidates {
+		if !pathInsideOrEqual(candidate, vaultRoot) {
+			result.Blocked = true
+			result.Reason = "link target leaves the vault"
+			return result
+		}
+		if err := enforceWorkPersonalPath(candidate); err != nil {
+			result.Blocked = true
+			result.Reason = workPersonalGuardrailMessage
+			return result
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		vaultRel, err := filepath.Rel(vaultRoot, candidate)
+		if err != nil {
+			result.Blocked = true
+			result.Reason = "link target leaves the vault"
+			return result
+		}
+		vaultRel = filepath.ToSlash(filepath.Clean(vaultRel))
+		result.OK = true
+		result.ResolvedPath = vaultRel
+		result.VaultRelativePath = vaultRel
+		result.Kind = markdownLinkKind(candidate)
+		result.FileURL = "/api/workspaces/" + workspaceIDStr(workspace.ID) + "/markdown-link/file?path=" + url.QueryEscape(vaultRel)
+		return result
+	}
+	result.Blocked = true
+	result.Reason = "link target was not found in the vault"
+	return result
+}
+
+func (a *App) handleWorkspaceMarkdownLinkResolve(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	workspace, err := a.resolveRuntimeWorkspaceByIDOrActive(chi.URLParam(r, "workspace_id"))
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	result := resolveWorkspaceMarkdownLink(workspace, r.URL.Query().Get("source"), r.URL.Query().Get("target"), r.URL.Query().Get("type"))
+	writeJSON(w, result)
+}
+
+func (a *App) handleWorkspaceMarkdownLinkFile(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	workspace, err := a.resolveRuntimeWorkspaceByIDOrActive(chi.URLParam(r, "workspace_id"))
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	_, vaultRoot, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	relPath, err := normalizeProjectListPath(r.URL.Query().Get("path"))
+	if err != nil || relPath == "" {
+		http.Error(w, "invalid path", http.StatusBadRequest)
+		return
+	}
+	targetPath := filepath.Clean(filepath.Join(vaultRoot, filepath.FromSlash(relPath)))
+	if !pathInsideOrEqual(targetPath, vaultRoot) {
+		http.Error(w, "invalid path", http.StatusForbidden)
+		return
+	}
+	if err := enforceWorkPersonalPath(targetPath); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil || info.IsDir() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	http.ServeFile(w, r, targetPath)
+}

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1045,6 +1046,136 @@ func TestProjectFilesListBlocksWorkPersonalSubtree(t *testing.T) {
 	if strings.Contains(body, "diary.md") || strings.Contains(body, personalRoot) {
 		t.Fatalf("personal list response leaked protected metadata: %q", body)
 	}
+}
+
+func TestWorkspaceMarkdownLinkResolveAllowsBrainAndVaultLinks(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourceRoot := filepath.Join(vaultRoot, "sources")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir brain topics: %v", err)
+	}
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir sources: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("[related](related.md)"), 0o644); err != nil {
+		t.Fatalf("write active note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "related.md"), []byte("related"), 0o644); err != nil {
+		t.Fatalf("write related note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "paper.md"), []byte("paper"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+
+	inBrain := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "related.md", "")
+	if !inBrain.OK || inBrain.ResolvedPath != "brain/topics/related.md" || inBrain.Kind != "text" {
+		t.Fatalf("in-brain resolution = %+v", inBrain)
+	}
+	outToSource := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "../../sources/paper.md", "")
+	if !outToSource.OK || outToSource.ResolvedPath != "sources/paper.md" || outToSource.Kind != "text" {
+		t.Fatalf("out-to-source resolution = %+v", outToSource)
+	}
+	if strings.Contains(outToSource.FileURL, vaultRoot) || filepath.IsAbs(outToSource.ResolvedPath) {
+		t.Fatalf("resolution leaked absolute path: %+v", outToSource)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, outToSource.FileURL, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("linked file status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if strings.TrimSpace(rr.Body.String()) != "paper" {
+		t.Fatalf("linked file body = %q, want paper", rr.Body.String())
+	}
+}
+
+func TestWorkspaceMarkdownLinkResolveSupportsWikilinks(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir brain topics: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("[[Related Note]]"), 0o644); err != nil {
+		t.Fatalf("write active note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "Related Note.md"), []byte("related"), 0o644); err != nil {
+		t.Fatalf("write related note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+
+	resolved := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "Related Note", "wikilink")
+	if !resolved.OK || resolved.ResolvedPath != "brain/topics/Related Note.md" {
+		t.Fatalf("wikilink resolution = %+v", resolved)
+	}
+}
+
+func TestWorkspaceMarkdownLinkResolveRejectsOutOfVaultAndWorkPersonal(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	outsidePath := filepath.Join(filepath.Dir(vaultRoot), "outside.md")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir brain topics: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("active"), 0o644); err != nil {
+		t.Fatalf("write active note: %v", err)
+	}
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o644); err != nil {
+		t.Fatalf("write outside note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(personalRoot, "diary.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write personal note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+
+	outside := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "../../../outside.md", "")
+	if outside.OK || !outside.Blocked || !strings.Contains(outside.Reason, "leaves the vault") {
+		t.Fatalf("out-of-vault resolution = %+v", outside)
+	}
+	personal := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "../../personal/diary.md", "")
+	if personal.OK || !personal.Blocked || !strings.Contains(personal.Reason, "work personal subtree is blocked") {
+		t.Fatalf("personal resolution = %+v", personal)
+	}
+	if strings.Contains(personal.Reason, personalRoot) || strings.Contains(outside.Reason, outsidePath) {
+		t.Fatalf("blocked reason leaked absolute path: personal=%q outside=%q", personal.Reason, outside.Reason)
+	}
+}
+
+func resolveMarkdownLinkForTest(t *testing.T, app *App, workspaceID int64, sourcePath, target, linkType string) workspaceMarkdownLinkResolution {
+	t.Helper()
+	values := url.Values{}
+	values.Set("source", sourcePath)
+	values.Set("target", target)
+	if linkType != "" {
+		values.Set("type", linkType)
+	}
+	rr := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodGet,
+		"/api/workspaces/"+itoa(workspaceID)+"/markdown-link/resolve?"+values.Encode(),
+		nil,
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("resolve status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var payload workspaceMarkdownLinkResolution
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode resolution: %v", err)
+	}
+	return payload
 }
 
 func TestProjectFilesListRejectsTraversal(t *testing.T) {

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -452,3 +452,27 @@ test('markdown image paths are rewritten through the canvas file proxy', async (
   })).toContain('/api/files/');
   await expect(page.locator('#canvas-text img')).toHaveAttribute('src', /docs%2Fimages%2Fdiagram\.png/);
 });
+
+test('blocked markdown note links surface resolver reasons on canvas', async ({ page }) => {
+  await page.evaluate(() => {
+    (window as any).__mockMarkdownLinkResolution = {
+      ok: false,
+      blocked: true,
+      reason: 'link target leaves the vault',
+    };
+    const app = (window as any)._slopshellApp;
+    if (app?.getState) app.getState().activeWorkspaceId = 'active';
+    const mod = (window as any).__canvasModule;
+    mod.renderCanvas({
+      event_id: 'blocked-markdown-link',
+      kind: 'text_artifact',
+      title: 'topics/active.md',
+      path: 'topics/active.md',
+      text: '[Outside](../../../outside.md)\n\n[[Private Note]]',
+    });
+  });
+
+  await page.locator('#canvas-text a', { hasText: 'Outside' }).click();
+  await expect(page.locator('#canvas-text .markdown-link-blocked-reason')).toHaveText('link target leaves the vault');
+  await expect(page.locator('#canvas-text a', { hasText: 'Private Note' })).toHaveAttribute('href', /slopshell-wiki:/);
+});

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1984,6 +1984,23 @@
           topic_timeline: ['Budget'],
         }), { status: 200 });
       }
+      if (u.includes('/api/workspaces/') && u.includes('/markdown-link/resolve')) {
+        const payload = window.__mockMarkdownLinkResolution || {
+          ok: false,
+          blocked: true,
+          reason: 'link blocked',
+        };
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes('/api/workspaces/') && u.includes('/markdown-link/file')) {
+        return new Response(String(window.__mockMarkdownLinkFileText || ''), {
+          status: 200,
+          headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        });
+      }
       if (u.includes('/api/workspaces/') && u.includes('/companion/config') && opts?.method === 'PUT') {
         let body = {};
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }


### PR DESCRIPTION
Fixes #721.

## Summary
- Add workspace markdown-link resolve/file endpoints that keep brain-note links inside the vault root and block work `personal/` targets.
- Hydrate Markdown and wikilink-style note references in canvas text artifacts, including blocked-link reasons.
- Add backend and Playwright coverage for in-brain, vault source, wikilink, out-of-vault, and work-personal cases.

## Verification

### Test fails on main
Not run per branch instruction: main is green by policy and no pre-change baseline was requested. The new regression tests on this branch cover the missing issue requirements.

### Test passes after fix

Requirement evidence:

| Issue requirement | Verification |
| --- | --- |
| Resolve Markdown links from an active brain note | `go test ./internal/web -run 'TestWorkspaceMarkdownLinkResolve|TestProjectFilesListBlocksWorkPersonalSubtree'` covers `TestWorkspaceMarkdownLinkResolveAllowsBrainAndVaultLinks`; `/tmp/slopshell-go-focused-721.log`: `ok github.com/sloppy-org/slopshell/internal/web 0.075s`. |
| Resolve wikilink-like note references | Same focused Go run covers `TestWorkspaceMarkdownLinkResolveSupportsWikilinks`; full suite also passed in `/tmp/slopshell-go-test-721.log`. |
| Allow links that leave `brain/` but stay in the same vault root | `TestWorkspaceMarkdownLinkResolveAllowsBrainAndVaultLinks` verifies `../../sources/paper.md` resolves to `sources/paper.md` and the file endpoint returns the source content. |
| Reject out-of-vault links | `TestWorkspaceMarkdownLinkResolveRejectsOutOfVaultAndWorkPersonal` verifies `../../../outside.md` is blocked with `link target leaves the vault`. |
| Reject work `personal/` links | `TestWorkspaceMarkdownLinkResolveRejectsOutOfVaultAndWorkPersonal` verifies `../../personal/diary.md` is blocked with `work personal subtree is blocked`. |
| Surface blocked-link reasons in UI | `./scripts/playwright.sh` includes `tests/playwright/canvas-cursor-context.spec.ts:456 blocked markdown note links surface resolver reasons on canvas`; `/tmp/slopshell-playwright-721.log`: `392 passed (3.0m)`, `40 skipped`. |
| Durable links are not rewritten as absolute home paths | `TestWorkspaceMarkdownLinkResolveAllowsBrainAndVaultLinks` asserts resolver responses use vault-relative paths and do not contain the temporary vault/home prefix. |
| Output/artifact surface is valid | Canvas artifact hydration lives in `internal/web/static/canvas-markdown-links.ts` and blocked-state styling in `internal/web/static/canvas.css`; `npm run typecheck:frontend` (`> tsc --noEmit -p tsconfig.json`), `npm run build:frontend` (`built 63 frontend modules`), and `./scripts/playwright.sh` all passed. |
| Public interface docs are synchronized | `./scripts/sync-surface.sh --check` passed with no output in `/tmp/slopshell-sync-surface-721.log`. |

Command excerpts:

```text
$ go test ./...
ok  github.com/sloppy-org/slopshell/internal/surface 0.010s
ok  github.com/sloppy-org/slopshell/internal/web 24.316s
ok  github.com/sloppy-org/slopshell/tests/services (cached)
```

```text
$ npm run typecheck:frontend
> tsc --noEmit -p tsconfig.json

$ npm run build:frontend
built 63 frontend modules
```

```text
$ ./scripts/playwright.sh
✓ tests/playwright/canvas-cursor-context.spec.ts:456 blocked markdown note links surface resolver reasons on canvas
40 skipped
392 passed (3.0m)
```
