### PR TITLE
Repair GTD item migration foreign keys

### DIFF
--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -223,6 +223,49 @@ INSERT INTO items (title, state) VALUES ('legacy waiting', 'waiting');
 	}
 }
 
+func TestStoreRepairsInterruptedItemsMigrationForeignKeys(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "slopshell.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	if _, err := db.Exec(`PRAGMA writable_schema = ON;
+UPDATE sqlite_master
+SET sql = replace(sql, 'REFERENCES items', 'REFERENCES "items_legacy"')
+WHERE type = 'table' AND name IN ('external_bindings', 'batch_run_items', 'item_artifacts');
+PRAGMA writable_schema = OFF;`); err != nil {
+		_ = db.Close()
+		t.Fatalf("corrupt child foreign keys: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close corrupted db: %v", err)
+	}
+
+	reopened, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() repaired DB error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = reopened.Close()
+	})
+
+	var broken int
+	if err := reopened.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND sql LIKE '%items_legacy%'`).Scan(&broken); err != nil {
+		t.Fatalf("count broken schemas: %v", err)
+	}
+	if broken != 0 {
+		t.Fatalf("broken child schemas = %d, want 0", broken)
+	}
+}
+
 func TestStoreMigratesProjectRemovalWithoutLegacyForeignKeys(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "slopshell.db")
 	db, err := sql.Open("sqlite", dbPath)

--- a/internal/store/store_domain_item_state_migration.go
+++ b/internal/store/store_domain_item_state_migration.go
@@ -5,13 +5,35 @@ import (
 	"strings"
 )
 
+var itemChildIndexSQL = []string{
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_external_bindings_identity
+  ON external_bindings(account_id, provider, object_type, remote_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_external_bindings_stale
+  ON external_bindings(provider, last_synced_at)`,
+	`CREATE INDEX IF NOT EXISTS idx_batch_run_items_batch_status
+  ON batch_run_items(batch_id, status, item_id)`,
+}
+
 func (s *Store) migrateItemTableStateSupport() error {
+	if err := s.repairItemLegacyForeignKeys(); err != nil {
+		return err
+	}
 	var schema sql.NullString
 	if err := s.db.QueryRow(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'items'`).Scan(&schema); err != nil {
 		return err
 	}
 	if strings.Contains(strings.ToLower(schema.String), "'review'") {
 		return nil
+	}
+	if _, err := s.db.Exec(`PRAGMA foreign_keys = OFF`); err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = s.db.Exec(`PRAGMA legacy_alter_table = OFF`)
+		_, _ = s.db.Exec(`PRAGMA foreign_keys = ON`)
+	}()
+	if _, err := s.db.Exec(`PRAGMA legacy_alter_table = ON`); err != nil {
+		return err
 	}
 	columns, err := s.tableColumnNames("items")
 	if err != nil {
@@ -64,4 +86,89 @@ FROM items_legacy`); err != nil {
 		return err
 	}
 	return tx.Commit()
+}
+
+func (s *Store) repairItemLegacyForeignKeys() error {
+	rows, err := s.db.Query(`SELECT name, sql FROM sqlite_master WHERE type = 'table' AND sql LIKE '%items_legacy%'`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type brokenTable struct {
+		name string
+		sql  string
+	}
+	var broken []brokenTable
+	for rows.Next() {
+		var table brokenTable
+		if err := rows.Scan(&table.name, &table.sql); err != nil {
+			return err
+		}
+		if table.name == "items" || table.name == "items_legacy" {
+			continue
+		}
+		broken = append(broken, table)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, table := range broken {
+		if err := s.rebuildItemChildTable(table.name, table.sql); err != nil {
+			return err
+		}
+	}
+	for _, stmt := range itemChildIndexSQL {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) rebuildItemChildTable(name, createSQL string) error {
+	columns, err := s.tableColumnNames(name)
+	if err != nil {
+		return err
+	}
+	fixedSQL := strings.ReplaceAll(createSQL, `REFERENCES "items_legacy"`, `REFERENCES items`)
+	fixedSQL = strings.ReplaceAll(fixedSQL, `REFERENCES items_legacy`, `REFERENCES items`)
+	legacyName := name + "_item_fk_legacy"
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`ALTER TABLE ` + quoteIdent(name) + ` RENAME TO ` + quoteIdent(legacyName)); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(fixedSQL); err != nil {
+		return err
+	}
+	columnList := stringsJoin(quoteIdentList(columns), ", ")
+	if _, err := tx.Exec(`INSERT INTO ` + quoteIdent(name) + ` (` + columnList + `)
+SELECT ` + columnList + `
+FROM ` + quoteIdent(legacyName)); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DROP TABLE ` + quoteIdent(legacyName)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func quoteIdentList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, quoteIdent(value))
+	}
+	return out
+}
+
+func quoteIdent(value string) string {
+	clean := strings.TrimSpace(value)
+	if clean == "" {
+		panic("empty SQL identifier")
+	}
+	return `"` + strings.ReplaceAll(clean, `"`, `""`) + `"`
 }


### PR DESCRIPTION
## Summary
- repair SQLite child tables left referencing items_legacy after the GTD item-state migration
- keep future item-table rename migrations from rewriting dependent foreign keys
- add regression coverage for reopening an interrupted migrated database

## Verification
### Test fails on main
A live migrated database failed to start with: SQL logic error: no such table: main.items_legacy (1).

### Test passes after fix
```
go test ./internal/store -run 'TestStoreMigratesExistingItemsTableToAllowSomeday|TestStoreRepairsInterruptedItemsMigrationForeignKeys|TestStoreFileLineLimits'\ngo test ./...\ngo vet ./...\n./scripts/sync-surface.sh --check\n```