### PR TITLE
Cool down source push errors

### DIFF
--- a/internal/web/source_push.go
+++ b/internal/web/source_push.go
@@ -10,7 +10,8 @@ import (
 
 const (
 	sourcePushReconcileInterval = 15 * time.Second
-	sourcePushRetryDelay        = 5 * time.Second
+	sourcePushReconnectDelay    = 5 * time.Second
+	sourcePushErrorRetryDelay   = 5 * time.Minute
 )
 
 type sourcePushManager struct {
@@ -141,10 +142,14 @@ func (m *sourcePushManager) runWatcher(ctx context.Context, account store.Extern
 		}
 		if err != nil {
 			log.Printf("source push: account %d watch failed: %v", account.ID, err)
+			if !m.waitForAccountRetry(ctx, account, err) {
+				return
+			}
+			continue
 		} else {
 			log.Printf("source push: account %d watch exited; reconnecting", account.ID)
 		}
-		if !m.waitForAccountRetry(ctx, account, err) {
+		if !sleepSourcePush(ctx, sourcePushReconnectDelay) {
 			return
 		}
 	}
@@ -214,8 +219,8 @@ func (m *sourcePushManager) retryDelayForAccount(account store.ExternalAccount, 
 			delay = backoffDelay
 		}
 	}
-	if err != nil && delay < sourcePushRetryDelay {
-		delay = sourcePushRetryDelay
+	if err != nil && delay < sourcePushErrorRetryDelay {
+		delay = sourcePushErrorRetryDelay
 	}
 	return delay
 }

--- a/internal/web/source_push_test.go
+++ b/internal/web/source_push_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -155,7 +156,19 @@ func TestSourcePushManagerWaitForAccountRetryHonorsBackoff(t *testing.T) {
 	app := newAuthedTestApp(t)
 	manager := &sourcePushManager{app: app}
 	account := store.ExternalAccount{ID: 2, Provider: store.ExternalProviderExchangeEWS}
-	if delay := manager.retryDelayForAccount(account, &ews.BackoffError{Backoff: 150 * time.Millisecond}); delay < time.Second {
-		t.Fatalf("delay = %v, want at least 1s minimum backoff", delay)
+	if delay := manager.retryDelayForAccount(account, &ews.BackoffError{Backoff: 150 * time.Millisecond}); delay < sourcePushErrorRetryDelay {
+		t.Fatalf("delay = %v, want at least %v minimum backoff", delay, sourcePushErrorRetryDelay)
+	}
+}
+
+func TestSourcePushManagerWaitForAccountRetryCoolsDownGenericErrors(t *testing.T) {
+	app := newAuthedTestApp(t)
+	manager := &sourcePushManager{app: app}
+	account := store.ExternalAccount{ID: 2, Provider: store.ExternalProviderExchangeEWS}
+	if delay := manager.retryDelayForAccount(account, errors.New("auth failed")); delay != sourcePushErrorRetryDelay {
+		t.Fatalf("delay = %v, want %v", delay, sourcePushErrorRetryDelay)
+	}
+	if delay := manager.retryDelayForAccount(account, nil); delay != 0 {
+		t.Fatalf("delay without error = %v, want 0", delay)
 	}
 }


### PR DESCRIPTION
## Summary
- keep clean source-push reconnects on a short delay
- put real watch/sync errors on a five-minute cooldown instead of retrying every few seconds
- add regression coverage for generic source-push errors and server backoff handling

## Verification
### Test fails on main
Main retries source-push watch/sync errors after 5s and can spam missing/auth-broken account failures in the live service logs.

### Test passes after fix
```
go test ./internal/web -run SourcePush
go test ./...
go vet ./...
./scripts/sync-surface.sh --check
```