### PR TITLE
Pin helpy binary in user service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,8 @@ Environment toggles:
 - `SLOPSHELL_INTENT_LLM_PROFILE` selects the active local routing profile (default `qwen3.5-9b`)
 - `SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS` exposes selectable local routing profiles (default `qwen3.5-9b,qwen3.5-4b`)
 - `SLOPSHELL_STT_URL=off` disables STT sidecar usage
-- `SLOPSHELL_HELPY_BIN` selects the helpy binary path (default `helpy`); set
+- `SLOPSHELL_HELPY_BIN` selects the helpy binary path. User service installers
+  prefer `$HOME/.local/bin/helpy` when present, then `helpy` from `PATH`; set it
   to `off` to disable spawning the helpy stdio MCP for `web_search` /
   `web_fetch`. `SLOPSHELL_HELPY_ARGS` overrides the args (default `mcp-stdio`).
 - `SLOPSHELL_MCP_SOCKET` overrides the embedded sloptools unix socket path

--- a/deploy/systemd/user/slopshell-web.service
+++ b/deploy/systemd/user/slopshell-web.service
@@ -14,6 +14,7 @@ Environment=SLOPSHELL_INTENT_LLM_URL=@@SLOPSHELL_INTENT_LLM_URL@@
 Environment=SLOPSHELL_INTENT_LLM_MODEL=local
 Environment=SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b
 Environment=SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b
+Environment=SLOPSHELL_HELPY_BIN=@@SLOPSHELL_HELPY_BIN@@
 ExecStart=/usr/bin/bash -lc 'source ~/.bashrc >/dev/null 2>&1 || true; cd @@REPO_ROOT@@; exec /usr/bin/env go run ./cmd/slopshell server --project-dir @@REPO_ROOT@@ --data-dir %h/.local/share/slopshell-web --local-mcp-url http://127.0.0.1:9420/mcp --web-host @@SLOPSHELL_WEB_HOST@@ --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424 --dev-runtime'
 Restart=on-failure
 RestartSec=2

--- a/scripts/install-slopshell-user-units.sh
+++ b/scripts/install-slopshell-user-units.sh
@@ -45,6 +45,22 @@ SLOPTOOLS_REPO_ROOT="${SLOPTOOLS_REPO_ROOT:-}"
 SLOPTOOLS_DATA_DIR=""
 WEB_DATA_DIR=""
 
+resolve_helpy_bin() {
+  if [ -n "${SLOPSHELL_HELPY_BIN:-}" ]; then
+    printf '%s' "$SLOPSHELL_HELPY_BIN"
+    return 0
+  fi
+  if [ -x "$HOME/.local/bin/helpy" ]; then
+    printf '%s' "$HOME/.local/bin/helpy"
+    return 0
+  fi
+  if command -v helpy >/dev/null 2>&1; then
+    command -v helpy
+    return 0
+  fi
+  printf 'helpy'
+}
+
 resolve_sloptools_repo() {
   if [ -n "$SLOPTOOLS_REPO_ROOT" ] && [ -d "$SLOPTOOLS_REPO_ROOT" ]; then
     SLOPTOOLS_REPO_ROOT="$(cd "$SLOPTOOLS_REPO_ROOT" && pwd)"
@@ -216,6 +232,7 @@ install_linux() {
   local sloptools_unit_src
   local unit_dst="$HOME/.config/systemd/user"
   local effective_llm_url="${REUSE_LLM_URL:-http://127.0.0.1:8081}"
+  local helpy_bin
   local web_host="${SLOPSHELL_WEB_HOST:-127.0.0.1}"
   local -a core_units=(
     sloptools.service
@@ -228,6 +245,7 @@ install_linux() {
 
   install_slsh_binary
   build_sloptools_binary
+  helpy_bin="$(resolve_helpy_bin)"
   sloptools_unit_src="$SLOPTOOLS_REPO_ROOT/deploy/systemd/user/sloptools.service"
   mkdir -p "$unit_dst"
   sed -e "s|@@SLOPTOOLS_BIN@@|${SLOPTOOLS_BIN_PATH}|g" \
@@ -244,6 +262,7 @@ install_linux() {
         -e "s|@@LLAMA_SERVER_BIN@@|${LLAMA_SERVER_BIN_RESOLVED}|g" \
         -e "s|@@SLOPSHELL_WEB_HOST@@|${web_host}|g" \
         -e "s|@@SLOPSHELL_INTENT_LLM_URL@@|${effective_llm_url}|g" \
+        -e "s|@@SLOPSHELL_HELPY_BIN@@|${helpy_bin}|g" \
         "$f" > "$unit_dst/$base"
   done
   if [ -n "$REUSE_LLM_URL" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,6 +161,22 @@ have_cmd() {
     command -v "$1" >/dev/null 2>&1
 }
 
+resolve_helpy_bin() {
+    if [ -n "${SLOPSHELL_HELPY_BIN:-}" ]; then
+        printf '%s' "$SLOPSHELL_HELPY_BIN"
+        return 0
+    fi
+    if [ -x "$HOME/.local/bin/helpy" ]; then
+        printf '%s' "$HOME/.local/bin/helpy"
+        return 0
+    fi
+    if have_cmd helpy; then
+        command -v helpy
+        return 0
+    fi
+    printf 'helpy'
+}
+
 voxtype_supports_stt_service() {
     local help_text
     if ! have_cmd "$1"; then
@@ -935,8 +951,10 @@ UNIT
     fi
 
     local effective_llm_url="${REUSE_LLM_URL:-http://127.0.0.1:8081}"
+    local helpy_bin
     local web_host="${SLOPSHELL_WEB_HOST:-127.0.0.1}"
     local web_mcp_args="--local-mcp-url http://127.0.0.1:9420/mcp"
+    helpy_bin="$(resolve_helpy_bin)"
 
     cat >"${systemd_dir}/slopshell-web.service" <<UNIT
 [Unit]
@@ -950,6 +968,7 @@ Environment=SLOPSHELL_INTENT_LLM_URL=${effective_llm_url}
 Environment=SLOPSHELL_INTENT_LLM_MODEL=local
 Environment=SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b
 Environment=SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b
+Environment=SLOPSHELL_HELPY_BIN=${helpy_bin}
 Environment=SLOPSHELL_ASSISTANT_LLM_URL=${effective_llm_url}
 Environment=SLOPSHELL_ASSISTANT_LLM_MODEL=local
 ExecStart=${BIN_PATH} server --project-dir ${PROJECT_DIR} --data-dir ${WEB_DATA_DIR} ${web_mcp_args} --web-host ${web_host} --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424


### PR DESCRIPTION
## Summary
- configure generated user services with an explicit SLOPSHELL_HELPY_BIN
- resolve the default to $HOME/.local/bin/helpy before falling back to PATH
- document the installer behavior for the helpy stdio MCP

## Verification
### Test fails on main
A systemd user service with no ~/.local/bin in PATH can start slopshell but later fails web tool calls with helpy not found.

### Test passes after fix
```
bash -n scripts/install.sh scripts/install-slopshell-user-units.sh
go test ./internal/web -run Helpy
go test ./...
go vet ./...
./scripts/sync-surface.sh --check
```

Live service smoke:
```
systemctl --user show slopshell.service -p Environment
/home/ert/.local/bin/helpy mcp-stdio < /dev/null
systemctl --user is-active slopshell.service
```