### PR TITLE
fix: Add composite Items for GTD project outcomes (fixes #756)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ PROJECT_DIR="$TMP_ROOT/project"
 DATA_DIR="$TMP_ROOT/data"
 LOG_FILE="$TMP_ROOT/web.log"
 nohup go run ./cmd/slopshell server \
-  --project-dir "$PROJECT_DIR" \
+  --workspace-dir "$PROJECT_DIR" \
   --data-dir "$DATA_DIR" \
   --web-host 127.0.0.1 \
   --web-port 8420 \

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ Requirements:
 ## Core Commands
 
 ```bash
-slopshell bootstrap --project-dir .
-slopshell mcp-server --project-dir .
-sloptools mcp-server --project-dir . --data-dir ~/.local/share/sloppy
-slopshell server --project-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
-slopshell server --project-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8443 --web-cert-file ~/.config/slopshell/certs/slopshell.pem --web-key-file ~/.config/slopshell/certs/slopshell-key.pem --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
+slopshell bootstrap --workspace-dir .
+slopshell mcp-server --workspace-dir .
+sloptools mcp-server --workspace-dir . --data-dir ~/.local/share/sloppy
+slopshell server --workspace-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
+slopshell server --workspace-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8443 --web-cert-file ~/.config/slopshell/certs/slopshell.pem --web-key-file ~/.config/slopshell/certs/slopshell-key.pem --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
 ```
 
 ## Terminal client: `slsh`
@@ -215,7 +215,7 @@ Example with `mkcert`:
 mkdir -p ~/.config/slopshell/certs
 mkcert -install
 mkcert -cert-file ~/.config/slopshell/certs/slopshell.pem -key-file ~/.config/slopshell/certs/slopshell-key.pem localhost 127.0.0.1 ::1 192.168.1.50
-slopshell server --project-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8443 --web-cert-file ~/.config/slopshell/certs/slopshell.pem --web-key-file ~/.config/slopshell/certs/slopshell-key.pem --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
+slopshell server --workspace-dir . --data-dir ~/.slopshell-web --mcp-socket "${XDG_RUNTIME_DIR:-$HOME/.cache}/sloppy/mcp.sock" --web-host 0.0.0.0 --web-port 8443 --web-cert-file ~/.config/slopshell/certs/slopshell.pem --web-key-file ~/.config/slopshell/certs/slopshell-key.pem --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
 ```
 
 If a second device (for example a Mac) connects to this server, trust the same local CA on that device too.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Markdown text artifacts support TeX math rendering via MathJax.
 1. Zen canvas: invisible chrome, full-viewport document surface.
 2. Tap-to-talk voice capture with recording dot indicator.
 3. Ephemeral response overlays with hidden chat history in the edge panel.
-4. Edge-reveal panels for hidden project/diagnostics chrome.
+4. Edge-reveal panels for hidden workspace/diagnostics chrome.
 5. E-ink-friendly: no animations for functional elements, static indicators.
 
 See:

--- a/cmd/slopshell/main.go
+++ b/cmd/slopshell/main.go
@@ -108,20 +108,26 @@ type serverConfig struct {
 	devRuntime           bool
 }
 
+func bindWorkspaceDirFlag(fs *flag.FlagSet, defaultValue string) *string {
+	workspaceDir := fs.String("workspace-dir", defaultValue, "workspace dir")
+	fs.StringVar(workspaceDir, "project-dir", defaultValue, "compatibility alias for --workspace-dir")
+	return workspaceDir
+}
+
 func cmdBootstrap(args []string) int {
 	fs := flag.NewFlagSet("bootstrap", flag.ContinueOnError)
-	projectDir := fs.String("project-dir", ".", "project dir")
+	workspaceDir := bindWorkspaceDirFlag(fs, ".")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	res, err := protocol.BootstrapProject(*projectDir)
+	res, err := protocol.BootstrapProject(*workspaceDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	fmt.Printf("project prepared: %s\n", res.Paths.ProjectDir)
+	fmt.Printf("workspace prepared: %s\n", res.Paths.ProjectDir)
 	fmt.Printf("mcp config snippet: %s\n", res.Paths.MCPConfigPath)
-	fmt.Println("project AGENTS.md files are left untouched")
+	fmt.Println("workspace AGENTS.md files are left untouched")
 	if res.GitInitialized {
 		fmt.Println("git initialized")
 	}
@@ -130,12 +136,12 @@ func cmdBootstrap(args []string) int {
 
 func cmdMCPServer(args []string) int {
 	fs := flag.NewFlagSet("mcp-server", flag.ContinueOnError)
-	projectDir := fs.String("project-dir", ".", "project dir")
+	workspaceDir := bindWorkspaceDirFlag(fs, ".")
 	dataDir := fs.String("data-dir", filepath.Join(os.Getenv("HOME"), ".slopshell-web"), "data dir")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	res, err := protocol.BootstrapProject(*projectDir)
+	res, err := protocol.BootstrapProject(*workspaceDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -163,7 +169,7 @@ func parseServerConfig(args []string) (*serverConfig, int) {
 	cfg := &serverConfig{
 		dataDir: filepath.Join(os.Getenv("HOME"), ".slopshell-web"),
 	}
-	projectDir := fs.String("project-dir", ".", "project dir")
+	workspaceDir := bindWorkspaceDirFlag(fs, ".")
 	fs.StringVar(&cfg.dataDir, "data-dir", cfg.dataDir, "data dir")
 	fs.StringVar(&cfg.mcpSocket, "mcp-socket", strings.TrimSpace(os.Getenv("SLOPSHELL_MCP_SOCKET")), "path to the embedded sloptools MCP unix socket (mode 0600); empty = default $XDG_RUNTIME_DIR/sloppy/mcp.sock")
 	fs.StringVar(&cfg.webHost, "web-host", "127.0.0.1", "web listener host")
@@ -179,7 +185,7 @@ func parseServerConfig(args []string) (*serverConfig, int) {
 	if err := fs.Parse(args); err != nil {
 		return nil, 2
 	}
-	cfg.projectDir = *projectDir
+	cfg.projectDir = *workspaceDir
 	hasCert := strings.TrimSpace(cfg.webCertFile) != ""
 	hasKey := strings.TrimSpace(cfg.webKeyFile) != ""
 	if hasCert != hasKey {

--- a/cmd/slopshell/main.go
+++ b/cmd/slopshell/main.go
@@ -110,7 +110,6 @@ type serverConfig struct {
 
 func bindWorkspaceDirFlag(fs *flag.FlagSet, defaultValue string) *string {
 	workspaceDir := fs.String("workspace-dir", defaultValue, "workspace dir")
-	fs.StringVar(workspaceDir, "project-dir", defaultValue, "compatibility alias for --workspace-dir")
 	return workspaceDir
 }
 
@@ -125,7 +124,7 @@ func cmdBootstrap(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	fmt.Printf("workspace prepared: %s\n", res.Paths.ProjectDir)
+	fmt.Printf("workspace prepared: %s\n", res.Paths.WorkspaceDir)
 	fmt.Printf("mcp config snippet: %s\n", res.Paths.MCPConfigPath)
 	fmt.Println("workspace AGENTS.md files are left untouched")
 	if res.GitInitialized {
@@ -146,7 +145,7 @@ func cmdMCPServer(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	adapter := canvas.NewAdapter(res.Paths.ProjectDir, nil)
+	adapter := canvas.NewAdapter(res.Paths.WorkspaceDir, nil)
 	st, err := store.New(filepath.Join(*dataDir, "slopshell.db"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -203,7 +202,7 @@ func runServer(cfg *serverConfig) int {
 	}
 	app, err := web.New(
 		cfg.dataDir,
-		res.Paths.ProjectDir,
+		res.Paths.WorkspaceDir,
 		cfg.mcpSocket,
 		cfg.appServerURL,
 		cfg.model,

--- a/cmd/slopshell/main_test.go
+++ b/cmd/slopshell/main_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -37,6 +39,29 @@ func TestParseServerConfigAcceptsMCPSocketPath(t *testing.T) {
 	if cfg.mcpSocket != "/run/user/1000/sloppy/mcp.sock" {
 		t.Fatalf("mcpSocket = %q, want /run/user/1000/sloppy/mcp.sock", cfg.mcpSocket)
 	}
+}
+
+func TestWorkspaceDirFlagAcceptsCompatibilityAlias(t *testing.T) {
+	t.Run("primary", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		workspaceDir := bindWorkspaceDirFlag(fs, ".")
+		if err := fs.Parse([]string{"--workspace-dir", "/tmp/workspace"}); err != nil {
+			t.Fatalf("parse workspace-dir: %v", err)
+		}
+		if got := *workspaceDir; got != "/tmp/workspace" {
+			t.Fatalf("workspace-dir = %q, want /tmp/workspace", got)
+		}
+	})
+	t.Run("alias", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		workspaceDir := bindWorkspaceDirFlag(fs, ".")
+		if err := fs.Parse([]string{"--project-dir", "/tmp/workspace"}); err != nil {
+			t.Fatalf("parse project-dir alias: %v", err)
+		}
+		if got := *workspaceDir; got != "/tmp/workspace" {
+			t.Fatalf("project-dir alias = %q, want /tmp/workspace", got)
+		}
+	})
 }
 
 func TestParseServerConfigRejectsIncompleteTLSConfig(t *testing.T) {
@@ -118,6 +143,25 @@ func TestCmdSchemaOutputsProtocolJSON(t *testing.T) {
 	}
 }
 
+func TestCmdBootstrapUsesWorkspaceCopyAndAlias(t *testing.T) {
+	workspaceDir := t.TempDir()
+	out := captureStdout(t, func() {
+		status := cmdBootstrap([]string{"--project-dir", workspaceDir})
+		if status != 0 {
+			t.Fatalf("cmdBootstrap() status = %d, want 0", status)
+		}
+	})
+	if !strings.Contains(out, "workspace prepared:") {
+		t.Fatalf("cmdBootstrap output missing workspace prepared copy: %q", out)
+	}
+	mcpBody, err := os.ReadFile(filepath.Join(workspaceDir, ".slopshell", "codex-mcp.toml"))
+	if err != nil {
+		t.Fatalf("read bootstrap mcp config: %v", err)
+	}
+	if !strings.Contains(string(mcpBody), "--workspace-dir") {
+		t.Fatalf("bootstrap mcp config missing --workspace-dir: %q", string(mcpBody))
+	}
+}
 
 func TestCmdUpdateFailureReturnsStatusOne(t *testing.T) {
 	prev := runUpdate

--- a/cmd/slopshell/main_test.go
+++ b/cmd/slopshell/main_test.go
@@ -41,27 +41,26 @@ func TestParseServerConfigAcceptsMCPSocketPath(t *testing.T) {
 	}
 }
 
-func TestWorkspaceDirFlagAcceptsCompatibilityAlias(t *testing.T) {
-	t.Run("primary", func(t *testing.T) {
-		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		workspaceDir := bindWorkspaceDirFlag(fs, ".")
-		if err := fs.Parse([]string{"--workspace-dir", "/tmp/workspace"}); err != nil {
-			t.Fatalf("parse workspace-dir: %v", err)
-		}
-		if got := *workspaceDir; got != "/tmp/workspace" {
-			t.Fatalf("workspace-dir = %q, want /tmp/workspace", got)
-		}
-	})
-	t.Run("alias", func(t *testing.T) {
-		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		workspaceDir := bindWorkspaceDirFlag(fs, ".")
-		if err := fs.Parse([]string{"--project-dir", "/tmp/workspace"}); err != nil {
-			t.Fatalf("parse project-dir alias: %v", err)
-		}
-		if got := *workspaceDir; got != "/tmp/workspace" {
-			t.Fatalf("project-dir alias = %q, want /tmp/workspace", got)
-		}
-	})
+func TestWorkspaceDirFlagUsesWorkspaceCopy(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	workspaceDir := bindWorkspaceDirFlag(fs, ".")
+	if err := fs.Parse([]string{"--workspace-dir", "/tmp/workspace"}); err != nil {
+		t.Fatalf("parse workspace-dir: %v", err)
+	}
+	if got := *workspaceDir; got != "/tmp/workspace" {
+		t.Fatalf("workspace-dir = %q, want /tmp/workspace", got)
+	}
+}
+
+func TestWorkspaceDirFlagRejectsProjectDirAlias(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	workspaceDir := bindWorkspaceDirFlag(fs, ".")
+	if err := fs.Parse([]string{"--project-dir", "/tmp/workspace"}); err == nil {
+		t.Fatal("expected --project-dir to be rejected")
+	}
+	if got := *workspaceDir; got != "." {
+		t.Fatalf("workspace-dir = %q, want default . after rejected alias", got)
+	}
 }
 
 func TestParseServerConfigRejectsIncompleteTLSConfig(t *testing.T) {
@@ -143,10 +142,10 @@ func TestCmdSchemaOutputsProtocolJSON(t *testing.T) {
 	}
 }
 
-func TestCmdBootstrapUsesWorkspaceCopyAndAlias(t *testing.T) {
+func TestCmdBootstrapUsesWorkspaceCopy(t *testing.T) {
 	workspaceDir := t.TempDir()
 	out := captureStdout(t, func() {
-		status := cmdBootstrap([]string{"--project-dir", workspaceDir})
+		status := cmdBootstrap([]string{"--workspace-dir", workspaceDir})
 		if status != 0 {
 			t.Fatalf("cmdBootstrap() status = %d, want 0", status)
 		}

--- a/cmd/slsh/main.go
+++ b/cmd/slsh/main.go
@@ -112,7 +112,7 @@ func parseFlags(args []string) (cliOptions, []string, error) {
 		tokenFile:  os.Getenv(envTokenFile),
 	}
 	fs.StringVar(&opts.baseURL, "base-url", opts.baseURL, "slopshell server base URL")
-	fs.StringVar(&opts.projectDir, "project-dir", opts.projectDir, "workspace directory (defaults to cwd)")
+	fs.StringVar(&opts.projectDir, "workspace-dir", opts.projectDir, "workspace directory (defaults to cwd)")
 	fs.StringVar(&opts.resumeID, "resume", "", "resume a prior chat session by id instead of starting fresh")
 	fs.StringVar(&opts.prompt, "prompt", "", "one-shot prompt (also -p)")
 	fs.StringVar(&opts.prompt, "p", "", "one-shot prompt (shorthand for --prompt)")
@@ -177,7 +177,7 @@ usage:
 
 flags:
   --base-url URL        slopshell server (default http://127.0.0.1:8420 or $SLOPSHELL_BASE_URL)
-  --project-dir DIR     workspace directory (default cwd)
+  --workspace-dir DIR   workspace directory (default cwd)
   --resume SESSION_ID   resume a prior chat session instead of starting fresh
   -p, --prompt STRING   one-shot mode: send this prompt and exit
   --model ALIAS         local|spark|gpt|mini (default local)

--- a/deploy/launchd/io.slopshell.web.plist
+++ b/deploy/launchd/io.slopshell.web.plist
@@ -8,7 +8,7 @@
   <array>
     <string>@@BIN_PATH@@</string>
     <string>server</string>
-    <string>--project-dir</string>
+    <string>--workspace-dir</string>
     <string>@@PROJECT_DIR@@</string>
     <string>--data-dir</string>
     <string>@@WEB_DATA_DIR@@</string>

--- a/deploy/systemd/user/slopshell-web.service
+++ b/deploy/systemd/user/slopshell-web.service
@@ -15,7 +15,7 @@ Environment=SLOPSHELL_INTENT_LLM_MODEL=local
 Environment=SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b
 Environment=SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b
 Environment=SLOPSHELL_HELPY_BIN=@@SLOPSHELL_HELPY_BIN@@
-ExecStart=/usr/bin/bash -lc 'source ~/.bashrc >/dev/null 2>&1 || true; cd @@REPO_ROOT@@; exec /usr/bin/env go run ./cmd/slopshell server --project-dir @@REPO_ROOT@@ --data-dir %h/.local/share/slopshell-web --mcp-socket %t/sloppy/mcp.sock --web-host @@SLOPSHELL_WEB_HOST@@ --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424 --dev-runtime'
+ExecStart=/usr/bin/bash -lc 'source ~/.bashrc >/dev/null 2>&1 || true; cd @@REPO_ROOT@@; exec /usr/bin/env go run ./cmd/slopshell server --workspace-dir @@REPO_ROOT@@ --data-dir %h/.local/share/slopshell-web --mcp-socket %t/sloppy/mcp.sock --web-host @@SLOPSHELL_WEB_HOST@@ --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424 --dev-runtime'
 Restart=on-failure
 RestartSec=2
 TimeoutStopSec=5

--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -27,6 +27,8 @@ Items have two canonical kinds:
 
 Project items may have child item links. Initial child roles are `next_action`, `support`, and `blocked_by`. A project item is healthy when it has at least one child in next, waiting, deferred, or someday state; it is stalled when it has no such child.
 
+Project items may also own supporting artifacts through `item_artifacts` links. The primary artifact, if present, is the canonical canvas artifact; related and output artifacts remain attached as supporting material.
+
 External systems may also have "projects" or similar containers: Todoist projects, GitHub Projects, GitLab milestones, mail folders. In Slopshell these are **source containers**. They may provide labels, filters, or default routing, but they are not Workspaces and are not GTD project items unless explicitly linked or promoted.
 
 ### Key invariants

--- a/docs/interaction-grammar.md
+++ b/docs/interaction-grammar.md
@@ -16,6 +16,8 @@ Slopshell has exactly five primary product nouns:
 
 Workspace and project must not be conflated. A **Workspace** is a filesystem-backed execution context. A GTD **project** is represented as `Item(kind=project)`: a composite outcome that needs child actions. It is still an Item, not a sixth primary noun. Session and message are transport or storage details, not user-facing ontology.
 
+Project is not a product concept. It is the GTD outcome item, not a workspace and not a separate top-level noun.
+
 ### Item kinds
 
 Items have two canonical kinds:

--- a/docs/native-clients.md
+++ b/docs/native-clients.md
@@ -17,10 +17,10 @@ Use [`native-clients-plan.md`](native-clients-plan.md) for the architecture deci
 
    ```bash
    TMP_ROOT="$(mktemp -d -t slopshell-native-XXXXXX)"
-   PROJECT_DIR="$TMP_ROOT/project"
+   WORKSPACE_DIR="$TMP_ROOT/workspace"
    DATA_DIR="$TMP_ROOT/data"
    go run ./cmd/slopshell server \
-     --project-dir "$PROJECT_DIR" \
+     --workspace-dir "$WORKSPACE_DIR" \
      --data-dir "$DATA_DIR" \
      --web-host 0.0.0.0 \
      --web-port 8420 \

--- a/internal/mcp/server_domain.go
+++ b/internal/mcp/server_domain.go
@@ -593,7 +593,7 @@ func (s *Server) readArtifactContent(artifact store.Artifact) (string, string) {
 	}
 	projectDir := strings.TrimSpace(s.adapter.ProjectDir())
 	if projectDir == "" {
-		return "", "project dir unavailable"
+		return "", "workspace dir unavailable"
 	}
 	target := strings.TrimSpace(*artifact.RefPath)
 	var absPath string
@@ -603,7 +603,7 @@ func (s *Server) readArtifactContent(artifact store.Artifact) (string, string) {
 		absPath = filepath.Clean(filepath.Join(projectDir, target))
 	}
 	if !isPathWithinDir(absPath, projectDir) {
-		return "", "artifact ref_path is outside the project root"
+		return "", "artifact ref_path is outside the workspace root"
 	}
 	data, err := os.ReadFile(absPath)
 	if err != nil {

--- a/internal/mcp/server_tools.go
+++ b/internal/mcp/server_tools.go
@@ -42,7 +42,7 @@ func (s *Server) resolveTempArtifactsDir(cwdArg string) (string, string, error) 
 	}
 	tmpAbs := filepath.Clean(filepath.Join(rootAbs, tempArtifactsDirRel))
 	if !isPathWithinDir(tmpAbs, rootAbs) {
-		return "", "", errors.New("temp artifacts directory escapes project root")
+		return "", "", errors.New("temp artifacts directory escapes workspace root")
 	}
 	return rootAbs, tmpAbs, nil
 }
@@ -345,7 +345,7 @@ func sanitizeFilename(name string) string {
 func (s *Server) writeImportedFile(handoffID, filename string, content []byte) (string, error) {
 	projectDir := s.adapter.ProjectDir()
 	if strings.TrimSpace(projectDir) == "" {
-		return "", errors.New("project directory not configured")
+		return "", errors.New("workspace directory not configured")
 	}
 	importDir := filepath.Join(projectDir, ".slopshell", "artifacts", "imports")
 	if err := os.MkdirAll(importDir, 0o755); err != nil {

--- a/internal/protocol/bootstrap.go
+++ b/internal/protocol/bootstrap.go
@@ -33,7 +33,7 @@ func BootstrapProject(projectDir string) (Result, error) {
 		ProjectDir:    abs,
 		MCPConfigPath: filepath.Join(slopshellDir, "codex-mcp.toml"),
 	}
-	_ = os.WriteFile(paths.MCPConfigPath, []byte(fmt.Sprintf("[mcp_servers.slopshell]\ncommand = \"slopshell\"\nargs = [\"mcp-server\", \"--project-dir\", \"%s\"]\n", strings.ReplaceAll(abs, "\\", "\\\\"))), 0o644)
+	_ = os.WriteFile(paths.MCPConfigPath, []byte(fmt.Sprintf("[mcp_servers.slopshell]\ncommand = \"slopshell\"\nargs = [\"mcp-server\", \"--workspace-dir\", \"%s\"]\n", strings.ReplaceAll(abs, "\\", "\\\\"))), 0o644)
 	_ = ensureGitignore(abs)
 	gitInit := false
 	if _, err := os.Stat(filepath.Join(abs, ".git")); err == nil {

--- a/internal/protocol/bootstrap.go
+++ b/internal/protocol/bootstrap.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Paths struct {
-	ProjectDir    string
+	WorkspaceDir  string
 	MCPConfigPath string
 }
 
@@ -30,7 +30,7 @@ func BootstrapProject(projectDir string) (Result, error) {
 		return Result{}, err
 	}
 	paths := Paths{
-		ProjectDir:    abs,
+		WorkspaceDir:  abs,
 		MCPConfigPath: filepath.Join(slopshellDir, "codex-mcp.toml"),
 	}
 	_ = os.WriteFile(paths.MCPConfigPath, []byte(fmt.Sprintf("[mcp_servers.slopshell]\ncommand = \"slopshell\"\nargs = [\"mcp-server\", \"--workspace-dir\", \"%s\"]\n", strings.ReplaceAll(abs, "\\", "\\\\"))), 0o644)

--- a/internal/protocol/bootstrap_test.go
+++ b/internal/protocol/bootstrap_test.go
@@ -18,8 +18,8 @@ func TestBootstrapProjectCreatesExpectedFilesWithoutAgentsMutation(t *testing.T)
 	if result.GitInitialized {
 		t.Fatalf("GitInitialized = true, want false")
 	}
-	if result.Paths.ProjectDir == "" {
-		t.Fatalf("ProjectDir should not be empty")
+	if result.Paths.WorkspaceDir == "" {
+		t.Fatalf("WorkspaceDir should not be empty")
 	}
 	if _, err := os.Stat(filepath.Join(projectDir, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("AGENTS.md should not be created, stat err = %v", err)

--- a/internal/protocol/bootstrap_test.go
+++ b/internal/protocol/bootstrap_test.go
@@ -32,8 +32,12 @@ func TestBootstrapProjectCreatesExpectedFilesWithoutAgentsMutation(t *testing.T)
 	if err != nil {
 		t.Fatalf("read mcp config: %v", err)
 	}
-	if !strings.Contains(string(mcpBody), "mcp-server") {
+	body := string(mcpBody)
+	if !strings.Contains(body, "mcp-server") {
 		t.Fatalf("mcp config missing mcp-server invocation")
+	}
+	if !strings.Contains(body, "--workspace-dir") {
+		t.Fatalf("mcp config missing --workspace-dir flag")
 	}
 
 	gitignoreBody, err := os.ReadFile(filepath.Join(projectDir, ".gitignore"))

--- a/internal/serve/app.go
+++ b/internal/serve/app.go
@@ -223,10 +223,10 @@ func (a *App) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	wsCount := len(a.wsClients)
 	a.mu.Unlock()
 	writeJSON(w, map[string]interface{}{
-		"status":      "ok",
-		"project_dir": a.ProjectDir,
-		"sessions":    a.Adapter.ListSessions(),
-		"ws_clients":  wsCount,
+		"status":        "ok",
+		"workspace_dir": a.ProjectDir,
+		"sessions":      a.Adapter.ListSessions(),
+		"ws_clients":    wsCount,
 	})
 }
 
@@ -245,7 +245,7 @@ func (a *App) Start(host string, port int) error {
 		fmt.Printf("  %s\n", u)
 	}
 	fmt.Printf("  MCP endpoint: http://%s/mcp\n", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
-	fmt.Printf("  project dir:  %s\n", a.ProjectDir)
+	fmt.Printf("  workspace dir: %s\n", a.ProjectDir)
 	err := a.httpServer.ListenAndServe()
 	if err == http.ErrServerClosed {
 		return nil
@@ -295,7 +295,7 @@ func (a *App) StartUnix(socketPath string) error {
 	fmt.Println("slopshell mcp listener listening on:")
 	fmt.Printf("  http+unix://%s\n", cleaned)
 	fmt.Printf("  MCP endpoint: http+unix://%s/mcp (mode 0600)\n", cleaned)
-	fmt.Printf("  project dir:  %s\n", a.ProjectDir)
+	fmt.Printf("  workspace dir: %s\n", a.ProjectDir)
 	err = a.httpServer.Serve(listener)
 	if err == http.ErrServerClosed {
 		return nil

--- a/internal/serve/app_runtime_test.go
+++ b/internal/serve/app_runtime_test.go
@@ -73,9 +73,9 @@ func TestHandleMCPPostNotificationReturnsAccepted(t *testing.T) {
 	}
 }
 
-func TestHandleHealthIncludesStatusAndProjectDir(t *testing.T) {
-	projectDir := t.TempDir()
-	app := NewApp(projectDir, "")
+func TestHandleHealthIncludesStatusAndWorkspaceDir(t *testing.T) {
+	workspaceDir := t.TempDir()
+	app := NewApp(workspaceDir, "")
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rr := httptest.NewRecorder()
 
@@ -91,8 +91,8 @@ func TestHandleHealthIncludesStatusAndProjectDir(t *testing.T) {
 	if payload["status"] != "ok" {
 		t.Fatalf("status field = %v, want ok", payload["status"])
 	}
-	if payload["project_dir"] != projectDir {
-		t.Fatalf("project_dir = %v, want %q", payload["project_dir"], projectDir)
+	if payload["workspace_dir"] != workspaceDir {
+		t.Fatalf("workspace_dir = %v, want %q", payload["workspace_dir"], workspaceDir)
 	}
 }
 

--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -3,6 +3,8 @@ package store
 import "time"
 
 type ArtifactKind string
+type ItemKind string
+type ItemLinkRole string
 
 const (
 	SphereWork    = "work"
@@ -46,6 +48,13 @@ const (
 	ItemStateReview   = "review"
 	ItemStateDone     = "done"
 
+	ItemKindAction  = "action"
+	ItemKindProject = "project"
+
+	ItemLinkRoleNextAction = "next_action"
+	ItemLinkRoleSupport    = "support"
+	ItemLinkRoleBlockedBy  = "blocked_by"
+
 	ItemReviewTargetAgent  = "agent"
 	ItemReviewTargetGitHub = "github"
 	ItemReviewTargetEmail  = "email"
@@ -61,6 +70,7 @@ type ArtifactUpdate struct {
 
 type ItemUpdate struct {
 	Title        *string `json:"title,omitempty"`
+	Kind         *string `json:"kind,omitempty"`
 	State        *string `json:"state,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	Sphere       *string `json:"sphere,omitempty"`
@@ -76,6 +86,7 @@ type ItemUpdate struct {
 
 type ItemOptions struct {
 	State        string  `json:"state,omitempty"`
+	Kind         string  `json:"kind,omitempty"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	Sphere       *string `json:"sphere,omitempty"`
 	ArtifactID   *int64  `json:"artifact_id,omitempty"`
@@ -223,6 +234,7 @@ type Artifact struct {
 type Item struct {
 	ID           int64   `json:"id"`
 	Title        string  `json:"title"`
+	Kind         string  `json:"kind"`
 	State        string  `json:"state"`
 	WorkspaceID  *int64  `json:"workspace_id,omitempty"`
 	Sphere       string  `json:"sphere"`
@@ -244,6 +256,21 @@ type ItemSummary struct {
 	ArtifactTitle *string       `json:"artifact_title,omitempty"`
 	ArtifactKind  *ArtifactKind `json:"artifact_kind,omitempty"`
 	ActorName     *string       `json:"actor_name,omitempty"`
+}
+
+type ItemChildLink struct {
+	ParentItemID int64  `json:"parent_item_id"`
+	ChildItemID  int64  `json:"child_item_id"`
+	Role         string `json:"role"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type ProjectItemHealth struct {
+	HasNextAction bool `json:"has_next_action"`
+	HasWaiting    bool `json:"has_waiting"`
+	HasDeferred   bool `json:"has_deferred"`
+	HasSomeday    bool `json:"has_someday"`
+	Stalled       bool `json:"stalled"`
 }
 
 type TimeEntry struct {

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -70,12 +70,13 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"external_accounts":                   {"id", "provider", "label", "config_json", "enabled", "created_at", "updated_at"},
 		"external_container_mappings":         {"id", "provider", "container_type", "container_ref", "workspace_id"},
 		"item_artifacts":                      {"item_id", "artifact_id", "role", "created_at"},
+		"item_children":                       {"parent_item_id", "child_item_id", "role", "created_at"},
 		"workspace_artifact_links":            {"workspace_id", "artifact_id", "created_at"},
 		"external_bindings":                   {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
 		"batch_runs":                          {"id", "workspace_id", "started_at", "finished_at", "config_json", "status"},
 		"batch_run_items":                     {"batch_id", "item_id", "status", "pr_number", "pr_url", "error_msg", "started_at", "finished_at"},
 		"workspace_watches":                   {"workspace_id", "config_json", "poll_interval_seconds", "enabled", "current_batch_id", "created_at", "updated_at"},
-		"items":                               {"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "review_target", "reviewer", "reviewed_at", "created_at", "updated_at"},
+		"items":                               {"id", "title", "kind", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at", "source", "source_ref", "review_target", "reviewer", "reviewed_at", "created_at", "updated_at"},
 		"time_entries":                        {"id", "workspace_id", "started_at", "ended_at", "activity", "notes"},
 	} {
 		got := make(map[string]bool, len(columns[table]))
@@ -162,7 +163,7 @@ CREATE TABLE chat_messages (
 	if err != nil {
 		t.Fatalf("TableColumns() error: %v", err)
 	}
-	for _, table := range []string{"workspaces", "contexts", "context_items", "context_artifacts", "context_workspaces", "context_external_accounts", "context_external_container_mappings", "context_time_entries", "actors", "artifacts", "external_accounts", "external_container_mappings", "item_artifacts", "workspace_artifact_links", "external_bindings", "batch_runs", "batch_run_items", "items", "time_entries"} {
+	for _, table := range []string{"workspaces", "contexts", "context_items", "context_artifacts", "context_workspaces", "context_external_accounts", "context_external_container_mappings", "context_time_entries", "actors", "artifacts", "external_accounts", "external_container_mappings", "item_artifacts", "item_children", "workspace_artifact_links", "external_bindings", "batch_runs", "batch_run_items", "items", "time_entries"} {
 		if _, ok := columns[table]; !ok {
 			t.Fatalf("expected migrated table %s to exist", table)
 		}
@@ -214,6 +215,9 @@ INSERT INTO items (title, state) VALUES ('legacy waiting', 'waiting');
 	}
 	if item.State != ItemStateWaiting {
 		t.Fatalf("legacy item state = %q, want %q", item.State, ItemStateWaiting)
+	}
+	if item.Kind != ItemKindAction {
+		t.Fatalf("legacy item kind = %q, want %q", item.Kind, ItemKindAction)
 	}
 
 	for _, state := range []string{ItemStateNext, ItemStateDeferred, ItemStateSomeday, ItemStateReview} {

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -13,6 +13,7 @@ import (
 const itemsTableSchema = `CREATE TABLE IF NOT EXISTS items (
   id INTEGER PRIMARY KEY,
   title TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'action' CHECK (kind IN ('action', 'project')),
   state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'next', 'waiting', 'deferred', 'someday', 'review', 'done')),
   workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
   artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
@@ -241,6 +242,9 @@ CREATE TABLE IF NOT EXISTS context_time_entries (
 	if err := s.migrateItemTableStateSupport(); err != nil {
 		return err
 	}
+	if err := s.migrateItemTableKindSupport(); err != nil {
+		return err
+	}
 	if err := s.migrateProjectRemovalSupport(); err != nil {
 		return err
 	}
@@ -262,7 +266,10 @@ CREATE TABLE IF NOT EXISTS context_time_entries (
 	if err := s.migrateMailTriageReviewActionSupport(); err != nil {
 		return err
 	}
-	return s.migrateItemArtifactLinkSupport()
+	if err := s.migrateItemArtifactLinkSupport(); err != nil {
+		return err
+	}
+	return s.migrateItemChildLinkSupport()
 }
 
 func (s *Store) migrateMailTriageReviewActionSupport() error {
@@ -484,6 +491,30 @@ func normalizeArtifactKind(kind ArtifactKind) ArtifactKind {
 	return ArtifactKind(strings.TrimSpace(string(kind)))
 }
 
+func normalizeItemKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", ItemKindAction:
+		return ItemKindAction
+	case ItemKindProject:
+		return ItemKindProject
+	default:
+		return ""
+	}
+}
+
+func normalizeItemLinkRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case ItemLinkRoleNextAction:
+		return ItemLinkRoleNextAction
+	case ItemLinkRoleSupport:
+		return ItemLinkRoleSupport
+	case ItemLinkRoleBlockedBy:
+		return ItemLinkRoleBlockedBy
+	default:
+		return ""
+	}
+}
+
 func normalizeItemState(state string) string {
 	switch strings.ToLower(strings.TrimSpace(state)) {
 	case "", ItemStateInbox:
@@ -655,6 +686,7 @@ func scanItem(
 	err := row.Scan(
 		&out.ID,
 		&out.Title,
+		&out.Kind,
 		&out.State,
 		&workspaceID,
 		&sphere,
@@ -674,6 +706,7 @@ func scanItem(
 		return Item{}, err
 	}
 	out.Title = strings.TrimSpace(out.Title)
+	out.Kind = normalizeItemKind(out.Kind)
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
 	out.Sphere = normalizeSphere(sphere)
@@ -712,6 +745,7 @@ func scanItemSummary(
 	err := row.Scan(
 		&out.ID,
 		&out.Title,
+		&out.Kind,
 		&out.State,
 		&workspaceID,
 		&sphere,
@@ -734,6 +768,7 @@ func scanItemSummary(
 		return ItemSummary{}, err
 	}
 	out.Title = strings.TrimSpace(out.Title)
+	out.Kind = normalizeItemKind(out.Kind)
 	out.State = normalizeItemState(out.State)
 	out.WorkspaceID = nullInt64Pointer(workspaceID)
 	out.Sphere = normalizeSphere(sphere)

--- a/internal/store/store_domain_item.go
+++ b/internal/store/store_domain_item.go
@@ -10,9 +10,13 @@ import (
 
 func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 	cleanTitle := strings.TrimSpace(title)
+	cleanKind := normalizeItemKind(opts.Kind)
 	cleanState := normalizeItemState(opts.State)
 	if cleanTitle == "" {
 		return Item{}, errors.New("item title is required")
+	}
+	if cleanKind == "" {
+		return Item{}, errors.New("invalid item kind")
 	}
 	if cleanState == "" {
 		return Item{}, errors.New("invalid item state")
@@ -48,9 +52,10 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 
 	res, err := tx.Exec(
 		`INSERT INTO items (
-			title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			title, kind, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		cleanTitle,
+		cleanKind,
 		cleanState,
 		opts.WorkspaceID,
 		opts.ArtifactID,
@@ -89,7 +94,7 @@ func (s *Store) CreateItem(title string, opts ItemOptions) (Item, error) {
 
 func (s *Store) GetItem(id int64) (Item, error) {
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		id,
@@ -103,7 +108,7 @@ func (s *Store) GetItemBySource(source, sourceRef string) (Item, error) {
 		return Item{}, errors.New("item source and source_ref are required")
 	}
 	return scanItem(s.db.QueryRow(
-		`SELECT id, title, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE source = ? AND source_ref = ?`,
 		cleanSource,
@@ -300,6 +305,14 @@ func (s *Store) UpdateItem(id int64, updates ItemUpdate) error {
 		}
 		parts = append(parts, "title = ?")
 		args = append(args, title)
+	}
+	if updates.Kind != nil {
+		kind := normalizeItemKind(*updates.Kind)
+		if kind == "" {
+			return errors.New("invalid item kind")
+		}
+		parts = append(parts, "kind = ?")
+		args = append(args, kind)
 	}
 	if updates.State != nil {
 		next := normalizeItemState(*updates.State)

--- a/internal/store/store_domain_item_kind.go
+++ b/internal/store/store_domain_item_kind.go
@@ -1,0 +1,16 @@
+package store
+
+func (s *Store) migrateItemTableKindSupport() error {
+	tableColumns, err := s.tableColumnSet("items")
+	if err != nil {
+		return err
+	}
+	if tableColumns["items"]["kind"] {
+		return nil
+	}
+	if _, err := s.db.Exec(`ALTER TABLE items ADD COLUMN kind TEXT NOT NULL DEFAULT 'action' CHECK (kind IN ('action', 'project'))`); err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`UPDATE items SET kind = 'action' WHERE trim(kind) = ''`)
+	return err
+}

--- a/internal/store/store_domain_item_query.go
+++ b/internal/store/store_domain_item_query.go
@@ -27,7 +27,7 @@ func (s *Store) ListItemsByStateFiltered(state string, filter ItemListFilter) ([
 	parts := []string{"state = ?"}
 	args := []any{cleanState}
 	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "")
-	query := `SELECT id, title, state, workspace_id, ` + scopedContextSelect("context_items", "item_id", "items.id") + ` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+	query := `SELECT id, title, kind, state, workspace_id, ` + scopedContextSelect("context_items", "item_id", "items.id") + ` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE ` + stringsJoin(parts, " AND ")
 	rows, err := s.db.Query(
@@ -61,6 +61,7 @@ func (s *Store) ListItemsByStateFiltered(state string, filter ItemListFilter) ([
 var itemSummarySelect = `SELECT
 	i.id,
 	i.title,
+	i.kind,
 	i.state,
 	i.workspace_id,
 	` + scopedContextSelect("context_items", "item_id", "i.id") + `,
@@ -321,7 +322,7 @@ func (s *Store) ListItemsFiltered(filter ItemListFilter) ([]Item, error) {
 	if err != nil {
 		return nil, err
 	}
-	query := `SELECT id, title, state, workspace_id, ` + scopedContextSelect("context_items", "item_id", "items.id") + ` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+	query := `SELECT id, title, kind, state, workspace_id, ` + scopedContextSelect("context_items", "item_id", "items.id") + ` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items`
 	args := []any{}
 	parts := []string{}

--- a/internal/store/store_domain_item_state_migration.go
+++ b/internal/store/store_domain_item_state_migration.go
@@ -57,7 +57,7 @@ func (s *Store) migrateItemTableStateSupport() error {
 		return err
 	}
 	copyColumns := []string{
-		"id", "title", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at",
+		"id", "title", "kind", "state", "workspace_id", "artifact_id", "actor_id", "visible_after", "follow_up_at",
 		"source", "source_ref", "review_target", "reviewer", "reviewed_at", "created_at", "updated_at",
 	}
 	var kept []string
@@ -120,6 +120,14 @@ func (s *Store) repairItemLegacyForeignKeys() error {
 	}
 	for _, stmt := range itemChildIndexSQL {
 		if _, err := s.db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	if columns, err := s.tableColumnNames("item_children"); err != nil {
+		return err
+	} else if len(columns) > 0 {
+		if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_item_children_child_item_id
+  ON item_children(child_item_id)`); err != nil {
 			return err
 		}
 	}

--- a/internal/store/store_domain_project_migration.go
+++ b/internal/store/store_domain_project_migration.go
@@ -73,11 +73,15 @@ FROM workspaces_project_legacy`); err != nil {
 	if _, err := tx.Exec(strings.Replace(itemsTableSchema, "IF NOT EXISTS ", "", 1)); err != nil {
 		return err
 	}
+	kindExpr := "'action'"
+	if tableColumns["items"]["kind"] {
+		kindExpr = "COALESCE(kind, 'action')"
+	}
 	if _, err := tx.Exec(`INSERT INTO items (
-id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+id, title, kind, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 )
 SELECT
-id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+id, title, ` + kindExpr + `, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 FROM items_project_legacy`); err != nil {
 		return err
 	}
@@ -193,6 +197,21 @@ func (s *Store) repairProjectLegacyForeignKeyTargets() error {
   ON item_artifacts(artifact_id)`,
 			},
 			columns: []string{"item_id", "artifact_id", "role", "created_at"},
+		},
+		{
+			table: "item_children",
+			createTableSQL: `CREATE TABLE item_children (
+  parent_item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  child_item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'next_action' CHECK (role IN ('next_action', 'support', 'blocked_by')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (parent_item_id, child_item_id)
+);`,
+			postCopySQL: []string{
+				`CREATE INDEX idx_item_children_child_item_id
+  ON item_children(child_item_id)`,
+			},
+			columns: []string{"parent_item_id", "child_item_id", "role", "created_at"},
 		},
 		{
 			table: "batch_runs",

--- a/internal/store/store_item_artifact.go
+++ b/internal/store/store_item_artifact.go
@@ -63,7 +63,7 @@ func (s *Store) syncPrimaryItemArtifact(id int64, artifactID *int64) error {
 
 func (s *Store) syncPrimaryItemArtifactTx(tx *sql.Tx, id int64, artifactID *int64) error {
 	if _, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		id,
@@ -162,7 +162,7 @@ func (s *Store) LinkItemArtifact(itemID, artifactID int64, role string) error {
 	defer tx.Rollback()
 
 	item, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		itemID,
@@ -214,7 +214,7 @@ func (s *Store) UnlinkItemArtifact(itemID, artifactID int64) error {
 	defer tx.Rollback()
 
 	item, err := scanItem(tx.QueryRow(
-		`SELECT id, title, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 		 FROM items
 		 WHERE id = ?`,
 		itemID,
@@ -357,6 +357,7 @@ func (s *Store) ListArtifactItems(artifactID int64) ([]Item, error) {
 		`SELECT
 		   i.id,
 		   i.title,
+		   i.kind,
 		   i.state,
 		   i.workspace_id,
 		   `+scopedContextSelect("context_items", "item_id", "i.id")+`,

--- a/internal/store/store_item_artifact_test.go
+++ b/internal/store/store_item_artifact_test.go
@@ -192,3 +192,47 @@ func TestStoreItemArtifactLinkLifecycle(t *testing.T) {
 		t.Fatalf("restored primary artifact = %+v, want source artifact %d", restoredArtifacts[0], sourceArtifact.ID)
 	}
 }
+
+func TestStoreProjectItemsCanOwnSupportingArtifacts(t *testing.T) {
+	s := newTestStore(t)
+
+	project, err := s.CreateItem("Plan GTD outcome", ItemOptions{Kind: ItemKindProject})
+	if err != nil {
+		t.Fatalf("CreateItem(project) error: %v", err)
+	}
+	if project.Kind != ItemKindProject {
+		t.Fatalf("project kind = %q, want %q", project.Kind, ItemKindProject)
+	}
+
+	primaryTitle := "Project brief"
+	primaryArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, nil, nil, &primaryTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(primary) error: %v", err)
+	}
+	supportTitle := "Supporting note"
+	supportArtifact, err := s.CreateArtifact(ArtifactKindMarkdown, nil, nil, &supportTitle, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact(support) error: %v", err)
+	}
+
+	if err := s.LinkItemArtifact(project.ID, primaryArtifact.ID, "source"); err != nil {
+		t.Fatalf("LinkItemArtifact(source) error: %v", err)
+	}
+	if err := s.LinkItemArtifact(project.ID, supportArtifact.ID, "related"); err != nil {
+		t.Fatalf("LinkItemArtifact(related) error: %v", err)
+	}
+
+	artifacts, err := s.ListItemArtifacts(project.ID)
+	if err != nil {
+		t.Fatalf("ListItemArtifacts(project) error: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("ListItemArtifacts(project) len = %d, want 2", len(artifacts))
+	}
+	if artifacts[0].ArtifactID != primaryArtifact.ID || artifacts[0].Role != "source" {
+		t.Fatalf("primary project artifact = %+v, want source artifact %d", artifacts[0], primaryArtifact.ID)
+	}
+	if artifacts[1].ArtifactID != supportArtifact.ID || artifacts[1].Role != "related" {
+		t.Fatalf("supporting project artifact = %+v, want related artifact %d", artifacts[1], supportArtifact.ID)
+	}
+}

--- a/internal/store/store_item_child.go
+++ b/internal/store/store_item_child.go
@@ -1,0 +1,205 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+)
+
+const itemChildrenTableSchema = `CREATE TABLE IF NOT EXISTS item_children (
+  parent_item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  child_item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'next_action' CHECK (role IN ('next_action', 'support', 'blocked_by')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (parent_item_id, child_item_id)
+);
+CREATE INDEX IF NOT EXISTS idx_item_children_child_item_id
+  ON item_children(child_item_id);`
+
+func (s *Store) migrateItemChildLinkSupport() error {
+	_, err := s.db.Exec(itemChildrenTableSchema)
+	return err
+}
+
+func (s *Store) LinkItemChild(parentItemID, childItemID int64, role string) error {
+	cleanRole := normalizeItemLinkRole(role)
+	if cleanRole == "" {
+		return errors.New("item child role must be next_action, support, or blocked_by")
+	}
+	if parentItemID <= 0 || childItemID <= 0 {
+		return errors.New("parent_item_id and child_item_id must be positive integers")
+	}
+	if parentItemID == childItemID {
+		return errors.New("parent_item_id and child_item_id must differ")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	parent, err := scanItem(tx.QueryRow(
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		 FROM items
+		 WHERE id = ?`,
+		parentItemID,
+	))
+	if err != nil {
+		return err
+	}
+	if parent.Kind != ItemKindProject {
+		return errors.New("parent item must be a project")
+	}
+	if _, err := scanItem(tx.QueryRow(
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		 FROM items
+		 WHERE id = ?`,
+		childItemID,
+	)); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(
+		`INSERT INTO item_children (parent_item_id, child_item_id, role)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(parent_item_id, child_item_id) DO UPDATE SET role = excluded.role`,
+		parentItemID,
+		childItemID,
+		cleanRole,
+	); err != nil {
+		return err
+	}
+	if err := s.touchItemTx(tx, parentItemID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) UnlinkItemChild(parentItemID, childItemID int64) error {
+	if parentItemID <= 0 || childItemID <= 0 {
+		return errors.New("parent_item_id and child_item_id must be positive integers")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	item, err := scanItem(tx.QueryRow(
+		`SELECT id, title, kind, state, workspace_id, `+scopedContextSelect("context_items", "item_id", "items.id")+` AS sphere, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+		 FROM items
+		 WHERE id = ?`,
+		parentItemID,
+	))
+	if err != nil {
+		return err
+	}
+	if item.Kind != ItemKindProject {
+		return errors.New("parent item must be a project")
+	}
+	res, err := tx.Exec(
+		`DELETE FROM item_children
+		 WHERE parent_item_id = ? AND child_item_id = ?`,
+		parentItemID,
+		childItemID,
+	)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	if err := s.touchItemTx(tx, parentItemID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ListItemChildLinks(parentItemID int64) ([]ItemChildLink, error) {
+	item, err := s.GetItem(parentItemID)
+	if err != nil {
+		return nil, err
+	}
+	if item.Kind != ItemKindProject {
+		return nil, errors.New("item is not a project")
+	}
+	rows, err := s.db.Query(
+		`SELECT parent_item_id, child_item_id, role, created_at
+		 FROM item_children
+		 WHERE parent_item_id = ?
+		 ORDER BY CASE role WHEN 'next_action' THEN 0 WHEN 'support' THEN 1 ELSE 2 END,
+		          datetime(created_at) ASC,
+		          child_item_id ASC`,
+		parentItemID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []ItemChildLink{}
+	for rows.Next() {
+		var link ItemChildLink
+		if err := rows.Scan(&link.ParentItemID, &link.ChildItemID, &link.Role, &link.CreatedAt); err != nil {
+			return nil, err
+		}
+		link.Role = normalizeItemLinkRole(link.Role)
+		out = append(out, link)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetProjectItemHealth(itemID int64) (ProjectItemHealth, error) {
+	item, err := s.GetItem(itemID)
+	if err != nil {
+		return ProjectItemHealth{}, err
+	}
+	if item.Kind != ItemKindProject {
+		return ProjectItemHealth{}, errors.New("item is not a project")
+	}
+	var health ProjectItemHealth
+	var nextCount, waitingCount, deferredCount, somedayCount int
+	err = s.db.QueryRow(
+		`SELECT
+		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS next_count,
+		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS waiting_count,
+		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS deferred_count,
+		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS someday_count
+		 FROM item_children links
+		 JOIN items child ON child.id = links.child_item_id
+		 WHERE links.parent_item_id = ?`,
+		ItemStateNext,
+		ItemStateWaiting,
+		ItemStateDeferred,
+		ItemStateSomeday,
+		itemID,
+	).Scan(&nextCount, &waitingCount, &deferredCount, &somedayCount)
+	if err != nil {
+		return ProjectItemHealth{}, err
+	}
+	health.HasNextAction = nextCount > 0
+	health.HasWaiting = waitingCount > 0
+	health.HasDeferred = deferredCount > 0
+	health.HasSomeday = somedayCount > 0
+	health.Stalled = !health.HasNextAction && !health.HasWaiting && !health.HasDeferred && !health.HasSomeday
+	return health, nil
+}
+
+func (s *Store) touchItem(id int64) error {
+	res, err := s.db.Exec(`UPDATE items SET updated_at = datetime('now') WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/store/store_item_child_test.go
+++ b/internal/store/store_item_child_test.go
@@ -1,0 +1,125 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStoreItemChildLinkLifecycleAndProjectHealth(t *testing.T) {
+	s := newTestStore(t)
+
+	project, err := s.CreateItem("Ship GTD outcome", ItemOptions{Kind: ItemKindProject})
+	if err != nil {
+		t.Fatalf("CreateItem(project) error: %v", err)
+	}
+	if project.Kind != ItemKindProject {
+		t.Fatalf("project kind = %q, want %q", project.Kind, ItemKindProject)
+	}
+
+	source := ExternalProviderTodoist
+	sourceRef := "task-1"
+	nextAction, err := s.CreateItem("Source-backed next action", ItemOptions{
+		Kind:      ItemKindAction,
+		State:     ItemStateNext,
+		Source:    &source,
+		SourceRef: &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(source-backed) error: %v", err)
+	}
+	if nextAction.Kind != ItemKindAction {
+		t.Fatalf("next action kind = %q, want %q", nextAction.Kind, ItemKindAction)
+	}
+	if nextAction.Source == nil || nextAction.SourceRef == nil || *nextAction.Source != source || *nextAction.SourceRef != sourceRef {
+		t.Fatalf("source-backed item bindings lost: %+v", nextAction)
+	}
+	sourceRoundTrip, err := s.GetItemBySource(source, sourceRef)
+	if err != nil {
+		t.Fatalf("GetItemBySource() error: %v", err)
+	}
+	if sourceRoundTrip.ID != nextAction.ID {
+		t.Fatalf("GetItemBySource() = %d, want %d", sourceRoundTrip.ID, nextAction.ID)
+	}
+
+	waitingChild, err := s.CreateItem("Waiting support", ItemOptions{State: ItemStateWaiting})
+	if err != nil {
+		t.Fatalf("CreateItem(waiting) error: %v", err)
+	}
+	deferredChild, err := s.CreateItem("Deferred blocker", ItemOptions{State: ItemStateDeferred})
+	if err != nil {
+		t.Fatalf("CreateItem(deferred) error: %v", err)
+	}
+	somedayChild, err := s.CreateItem("Someday support", ItemOptions{State: ItemStateSomeday})
+	if err != nil {
+		t.Fatalf("CreateItem(someday) error: %v", err)
+	}
+	actionParent, err := s.CreateItem("Plain action", ItemOptions{})
+	if err != nil {
+		t.Fatalf("CreateItem(action parent) error: %v", err)
+	}
+
+	if err := s.LinkItemChild(actionParent.ID, nextAction.ID, ItemLinkRoleNextAction); err == nil || !strings.Contains(err.Error(), "parent item must be a project") {
+		t.Fatalf("LinkItemChild(action parent) error = %v, want project parent rejection", err)
+	}
+
+	for _, tc := range []struct {
+		child int64
+		role  string
+	}{
+		{child: nextAction.ID, role: ItemLinkRoleNextAction},
+		{child: waitingChild.ID, role: ItemLinkRoleSupport},
+		{child: deferredChild.ID, role: ItemLinkRoleBlockedBy},
+		{child: somedayChild.ID, role: ItemLinkRoleSupport},
+	} {
+		if err := s.LinkItemChild(project.ID, tc.child, tc.role); err != nil {
+			t.Fatalf("LinkItemChild(%d,%d,%s) error: %v", project.ID, tc.child, tc.role, err)
+		}
+	}
+
+	links, err := s.ListItemChildLinks(project.ID)
+	if err != nil {
+		t.Fatalf("ListItemChildLinks() error: %v", err)
+	}
+	if len(links) != 4 {
+		t.Fatalf("ListItemChildLinks() len = %d, want 4", len(links))
+	}
+	seen := map[int64]string{}
+	for _, link := range links {
+		if link.ParentItemID != project.ID {
+			t.Fatalf("link parent = %d, want %d", link.ParentItemID, project.ID)
+		}
+		seen[link.ChildItemID] = link.Role
+	}
+	if seen[nextAction.ID] != ItemLinkRoleNextAction || seen[waitingChild.ID] != ItemLinkRoleSupport || seen[deferredChild.ID] != ItemLinkRoleBlockedBy || seen[somedayChild.ID] != ItemLinkRoleSupport {
+		t.Fatalf("ListItemChildLinks() roles = %#v", seen)
+	}
+
+	health, err := s.GetProjectItemHealth(project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectItemHealth() error: %v", err)
+	}
+	if !health.HasNextAction || !health.HasWaiting || !health.HasDeferred || !health.HasSomeday || health.Stalled {
+		t.Fatalf("GetProjectItemHealth() = %+v, want all health flags set and stalled false", health)
+	}
+
+	for _, childID := range []int64{nextAction.ID, waitingChild.ID, deferredChild.ID, somedayChild.ID} {
+		if err := s.UnlinkItemChild(project.ID, childID); err != nil {
+			t.Fatalf("UnlinkItemChild(%d) error: %v", childID, err)
+		}
+	}
+	links, err = s.ListItemChildLinks(project.ID)
+	if err != nil {
+		t.Fatalf("ListItemChildLinks(after unlink) error: %v", err)
+	}
+	if len(links) != 0 {
+		t.Fatalf("ListItemChildLinks(after unlink) len = %d, want 0", len(links))
+	}
+
+	health, err = s.GetProjectItemHealth(project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectItemHealth(after unlink) error: %v", err)
+	}
+	if health.Stalled != true || health.HasNextAction || health.HasWaiting || health.HasDeferred || health.HasSomeday {
+		t.Fatalf("GetProjectItemHealth(after unlink) = %+v, want stalled true and no health flags", health)
+	}
+}

--- a/internal/store/store_scope_context.go
+++ b/internal/store/store_scope_context.go
@@ -239,6 +239,10 @@ JOIN contexts c ON c.parent_id IS NULL AND lower(c.name) = lower(m.sphere)`); er
 	}
 
 	if tableColumns["items"]["sphere"] {
+		kindExpr := "'action'"
+		if tableColumns["items"]["kind"] {
+			kindExpr = "COALESCE(kind, 'action')"
+		}
 		if _, err := tx.Exec(`CREATE TEMP TABLE scope_items_migration AS
 SELECT id, sphere
 FROM items
@@ -251,6 +255,7 @@ WHERE lower(trim(sphere)) IN ('work', 'private')`); err != nil {
 		if _, err := tx.Exec(`CREATE TABLE items (
   id INTEGER PRIMARY KEY,
   title TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'action' CHECK (kind IN ('action', 'project')),
   state TEXT NOT NULL DEFAULT 'inbox' CHECK (state IN ('inbox', 'waiting', 'someday', 'done')),
   workspace_id INTEGER REFERENCES workspaces(id) ON DELETE SET NULL,
   artifact_id INTEGER REFERENCES artifacts(id) ON DELETE SET NULL,
@@ -268,10 +273,10 @@ WHERE lower(trim(sphere)) IN ('work', 'private')`); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`INSERT INTO items (
-	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+	id, title, kind, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 )
 SELECT
-	id, title, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
+	id, title, ` + kindExpr + `, state, workspace_id, artifact_id, actor_id, visible_after, follow_up_at, source, source_ref, review_target, reviewer, reviewed_at, created_at, updated_at
 FROM items_scope_legacy`); err != nil {
 			return err
 		}

--- a/internal/surface/definitions.go
+++ b/internal/surface/definitions.go
@@ -111,7 +111,7 @@ var MCPTools = []Tool{
 		Properties: map[string]ToolProperty{
 			"cwd": {
 				Type:        "string",
-				Description: "Project root to create the temp file under. Defaults to active project root.",
+				Description: "Workspace root to create the temp file under. Defaults to the active workspace root.",
 			},
 			"prefix": {
 				Type:        "string",
@@ -138,7 +138,7 @@ var MCPTools = []Tool{
 			},
 			"cwd": {
 				Type:        "string",
-				Description: "Project root for resolving relative paths. Defaults to active project root.",
+				Description: "Workspace root for resolving relative paths. Defaults to the active workspace root.",
 			},
 		},
 	},

--- a/internal/web/bug_reports.go
+++ b/internal/web/bug_reports.go
@@ -251,7 +251,7 @@ func (a *App) resolveBugReportWorkspace() (bugReportWorkspace, error) {
 	} else if ok {
 		return workspace, nil
 	}
-	return bugReportWorkspace{}, errors.New("bug report requires an active workspace or local project")
+	return bugReportWorkspace{}, errors.New("bug report requires an active workspace or local workspace")
 }
 
 func (a *App) createGitHubIssueFromBugReport(workspace bugReportWorkspace, bundlePath string, bundle bugReportBundle) (ghIssueListItem, int64, error) {

--- a/internal/web/bug_reports_test.go
+++ b/internal/web/bug_reports_test.go
@@ -550,7 +550,7 @@ func TestHandleBugReportCreateFallsBackToSlopshellRepoWithoutWorkspace(t *testin
 	if !strings.HasPrefix(bundlePath, ".slopshell/artifacts/bugs/") {
 		t.Fatalf("bundle_path = %q, want .slopshell/artifacts/bugs/... path", bundlePath)
 	}
-	// Bug report was filed against the default workspace (no local project dir configured)
+	// Bug report was filed against the default workspace (no local workspace dir configured)
 	if _, err := app.store.GetItemBySource("github", "sloppy-org/slopshell#118"); err != nil {
 		t.Fatalf("GetItemBySource() error: %v", err)
 	}

--- a/internal/web/chat_canvas.go
+++ b/internal/web/chat_canvas.go
@@ -141,7 +141,7 @@ func resolveCanvasFilePath(cwd, requested string) (absolutePath, canvasTitle str
 	}
 	rel = filepath.Clean(rel)
 	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", "", fmt.Errorf("path escapes project root: %s", requested)
+		return "", "", fmt.Errorf("path escapes workspace root: %s", requested)
 	}
 	return abs, filepath.ToSlash(rel), nil
 }

--- a/internal/web/chat_canvas_test.go
+++ b/internal/web/chat_canvas_test.go
@@ -538,10 +538,12 @@ func TestResolveCanvasFilePath_PrefersShallowWorkspaceMatch(t *testing.T) {
 	}
 }
 
-func TestResolveCanvasFilePath_RejectsEscapingProjectRoot(t *testing.T) {
+func TestResolveCanvasFilePath_RejectsEscapingWorkspaceRoot(t *testing.T) {
 	tmp := t.TempDir()
 	if _, _, err := resolveCanvasFilePath(tmp, "../outside.md"); err == nil {
-		t.Fatal("expected error for escaping project root")
+		t.Fatal("expected error for escaping workspace root")
+	} else if !strings.Contains(err.Error(), "workspace root") {
+		t.Fatalf("unexpected error %q", err)
 	}
 }
 

--- a/internal/web/chat_dictation_test.go
+++ b/internal/web/chat_dictation_test.go
@@ -57,7 +57,7 @@ func TestChatSessionDictationLifecycle(t *testing.T) {
 	app := newAuthedTestApp(t)
 	projectRoot := filepath.Join(t.TempDir(), "project")
 	if err := os.MkdirAll(projectRoot, 0755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
+		t.Fatalf("mkdir workspace root: %v", err)
 	}
 	project, err := app.store.CreateEnrichedWorkspace("Dictation", "dictation-project", projectRoot, "managed", "", "", false)
 	if err != nil {

--- a/internal/web/mail_drafts.go
+++ b/internal/web/mail_drafts.go
@@ -345,7 +345,7 @@ func (a *App) activeMailDraftProject() (store.Workspace, error) {
 		return store.Workspace{}, err
 	}
 	if strings.TrimSpace(workspaceID) == "" {
-		return store.Workspace{}, errors.New("mail draft requires an active project")
+		return store.Workspace{}, errors.New("mail draft requires an active workspace")
 	}
 	return a.store.GetEnrichedWorkspace(workspaceID)
 }

--- a/internal/web/projects_import.go
+++ b/internal/web/projects_import.go
@@ -36,7 +36,7 @@ func (a *App) nextManagedWorkspacePath(name string) (string, error) {
 			return path, nil
 		}
 	}
-	return "", errors.New("unable to allocate managed project path")
+	return "", errors.New("unable to allocate managed workspace path")
 }
 
 func (a *App) nextTemporaryWorkspacePath(kind, name string) (string, error) {
@@ -55,7 +55,7 @@ func (a *App) nextTemporaryWorkspacePath(kind, name string) (string, error) {
 			return path, nil
 		}
 	}
-	return "", errors.New("unable to allocate temporary project path")
+	return "", errors.New("unable to allocate temporary workspace path")
 }
 
 func (a *App) workspaceSourceByID(workspaceID string) (store.Workspace, bool, error) {
@@ -106,7 +106,7 @@ func (a *App) createWorkspace2(req runtimeWorkspaceCreateRequest) (store.Workspa
 	case "linked":
 		rootPath := strings.TrimSpace(req.Path)
 		if rootPath == "" {
-			return store.Workspace{}, false, errors.New("path is required for linked projects")
+			return store.Workspace{}, false, errors.New("path is required for linked workspaces")
 		}
 		if err := enforceWorkPersonalPath(rootPath); err != nil {
 			return store.Workspace{}, false, err
@@ -122,10 +122,10 @@ func (a *App) createWorkspace2(req runtimeWorkspaceCreateRequest) (store.Workspa
 		if err != nil {
 			return store.Workspace{}, false, err
 		}
-		absRoot = filepath.Clean(boot.Paths.ProjectDir)
+		absRoot = filepath.Clean(boot.Paths.WorkspaceDir)
 	case "meeting", "task":
 		if strings.TrimSpace(req.Path) != "" {
-			return store.Workspace{}, false, errors.New("path is not supported for temporary projects")
+			return store.Workspace{}, false, errors.New("path is not supported for temporary workspaces")
 		}
 		if name == "" {
 			name = defaultTemporaryWorkspaceName(kind, time.Now())
@@ -141,7 +141,7 @@ func (a *App) createWorkspace2(req runtimeWorkspaceCreateRequest) (store.Workspa
 		if err != nil {
 			return store.Workspace{}, false, err
 		}
-		absRoot = filepath.Clean(boot.Paths.ProjectDir)
+		absRoot = filepath.Clean(boot.Paths.WorkspaceDir)
 	default:
 		rootPath := strings.TrimSpace(req.Path)
 		if rootPath == "" {
@@ -158,7 +158,7 @@ func (a *App) createWorkspace2(req runtimeWorkspaceCreateRequest) (store.Workspa
 		if err != nil {
 			return store.Workspace{}, false, err
 		}
-		absRoot = filepath.Clean(boot.Paths.ProjectDir)
+		absRoot = filepath.Clean(boot.Paths.WorkspaceDir)
 	}
 
 	if name == "" {
@@ -226,7 +226,7 @@ func (a *App) persistTemporaryWorkspaceTarget(project store.Workspace, req tempo
 			return "", "", err
 		}
 		if existing, err := a.store.GetWorkspaceByRootPath(absTarget); err == nil && existing.ID != project.ID {
-			return "", "", errors.New("path is already used by another project")
+			return "", "", errors.New("path is already used by another workspace")
 		} else if err != nil && !isNoRows(err) {
 			return "", "", err
 		}
@@ -269,7 +269,7 @@ func (a *App) persistTemporaryWorkspace(workspaceID string, req temporaryWorkspa
 		return store.Workspace{}, err
 	}
 	if !isTemporaryWorkspace(project) {
-		return store.Workspace{}, errors.New("project is not temporary")
+		return store.Workspace{}, errors.New("workspace is not temporary")
 	}
 	workspace, err := a.ensureWorkspaceReady(project, false)
 	if err != nil {
@@ -335,7 +335,7 @@ func (a *App) discardTemporaryWorkspace(workspaceID string) (store.Workspace, er
 		return store.Workspace{}, err
 	}
 	if !isTemporaryWorkspace(project) {
-		return store.Workspace{}, errors.New("project is not temporary")
+		return store.Workspace{}, errors.New("workspace is not temporary")
 	}
 	workspaces, err := a.store.ListWorkspacesForID(workspaceIDStr(project.ID))
 	if err != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -925,7 +925,7 @@ func (a *App) start(host string, port int, certFile, keyFile string) error {
 		fmt.Printf("  %s\n", u)
 	}
 	if a.localProjectDir != "" {
-		fmt.Printf("  local project: %s\n", a.localProjectDir)
+		fmt.Printf("  local workspace: %s\n", a.localProjectDir)
 		if a.localMCPSocket != "" {
 			fmt.Printf("  local MCP:     unix:%s (mode 0600)\n", a.localMCPSocket)
 		}

--- a/internal/web/static/types.ts
+++ b/internal/web/static/types.ts
@@ -26,6 +26,7 @@ export interface Artifact {
 export interface Item {
   id: number;
   title: string;
+  kind?: 'action' | 'project';
   state: 'inbox' | 'waiting' | 'someday' | 'done';
   workspace_id?: number | null;
   artifact_id?: number | null;

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -345,7 +345,7 @@ func (a *App) ensureDefaultWorkspace() (store.Workspace, error) {
 		if err != nil {
 			return store.Workspace{}, err
 		}
-		absRoot = filepath.Clean(boot.Paths.ProjectDir)
+		absRoot = filepath.Clean(boot.Paths.WorkspaceDir)
 		name = defaultWorkspaceNameForPath(absRoot)
 	}
 	workspacePath := absRoot
@@ -406,7 +406,7 @@ func (a *App) listProjectsWithDefault() ([]store.Workspace, store.Workspace, err
 	}
 	projects = filterWorkPersonalGuardrailWorkspaces(projects)
 	if len(projects) == 0 {
-		return nil, store.Workspace{}, errors.New("no projects available")
+		return nil, store.Workspace{}, errors.New("no workspaces available")
 	}
 	defaultProject := store.Workspace{}
 	for _, project := range projects {
@@ -423,7 +423,7 @@ func (a *App) listProjectsWithDefault() ([]store.Workspace, store.Workspace, err
 
 func (a *App) chooseActiveProject(projects []store.Workspace, defaultProject store.Workspace) (store.Workspace, error) {
 	if len(projects) == 0 {
-		return store.Workspace{}, errors.New("no projects available")
+		return store.Workspace{}, errors.New("no workspaces available")
 	}
 	activeSphere := a.runtimeActiveSphere()
 	if workspace, err := a.store.ActiveWorkspace(); err == nil {

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -326,7 +326,7 @@ func (a *App) ensureDefaultWorkspace() (store.Workspace, error) {
 
 	kind := "managed"
 	rootPath := filepath.Join(a.dataDir, "projects", "default")
-	name := "Default Project"
+	name := "Default Workspace"
 	if localWorkspacePath != "" {
 		kind = "linked"
 		rootPath = localWorkspacePath

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -158,7 +158,7 @@ func TestNewAppPrefersLocalProjectWorkspaceOnStartup(t *testing.T) {
 		t.Fatalf("ActiveWorkspace() error: %v", err)
 	}
 	if workspace.IsDaily {
-		t.Fatal("active workspace is_daily = true, want false for local project startup")
+		t.Fatal("active workspace is_daily = true, want false for local workspace startup")
 	}
 	if workspace.DirPath != localProjectDir {
 		t.Fatalf("active workspace dir_path = %q, want %q", workspace.DirPath, localProjectDir)
@@ -1324,7 +1324,7 @@ func TestTemporaryProjectCreationCopiesSourceSettingsAndPersist(t *testing.T) {
 		t.Fatalf("created chat model = %q, want gpt", createPayload.Workspace.ChatModel)
 	}
 	if createPayload.Workspace.RootPath == source.RootPath {
-		t.Fatalf("temporary project root should differ from source root")
+		t.Fatalf("temporary workspace root should differ from source root")
 	}
 	if !strings.Contains(filepath.ToSlash(createPayload.Workspace.RootPath), "/projects/temporary/meeting/") {
 		t.Fatalf("temporary root = %q, want temporary meeting path", createPayload.Workspace.RootPath)
@@ -1533,7 +1533,7 @@ func TestTemporaryProjectDiscardRemovesProjectDataAndFallsBackToDefaultProject(t
 		t.Fatalf("GetParticipantSession(discarded) error = %v, want sql.ErrNoRows", err)
 	}
 	if _, err := os.Stat(createPayload.Workspace.RootPath); !os.IsNotExist(err) {
-		t.Fatalf("temporary project root still exists: %v", err)
+		t.Fatalf("temporary workspace root still exists: %v", err)
 	}
 	survivingItem, err := app.store.GetItem(item.ID)
 	if err != nil {

--- a/playwright.e2e.ci.config.ts
+++ b/playwright.e2e.ci.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@playwright/test';
 
 const DEFAULT_SERVER_URL = 'http://127.0.0.1:8420';
-const baseURL = String(process.env.E2E_BASE_URL || process.env.SLOPSHELL_TEST_SERVER_URL || DEFAULT_SERVER_URL).trim() || DEFAULT_SERVER_URL;
+const configuredBaseURL = String(process.env.E2E_BASE_URL || process.env.SLOPSHELL_TEST_SERVER_URL || DEFAULT_SERVER_URL).trim() || DEFAULT_SERVER_URL;
 const managedServerURL = String(process.env.E2E_MANAGED_SERVER_URL || DEFAULT_SERVER_URL).trim() || DEFAULT_SERVER_URL;
 const useManagedServer = process.env.E2E_MANAGED_SERVER === '1'
   || (!process.env.E2E_BASE_URL && !process.env.SLOPSHELL_TEST_SERVER_URL);
+const baseURL = useManagedServer ? managedServerURL : configuredBaseURL;
 const grepInvert = process.env.PLAYWRIGHT_GREP_INVERT
   ? new RegExp(process.env.PLAYWRIGHT_GREP_INVERT)
   : /@local-only/;

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -153,7 +153,7 @@ log "Installing and starting services"
 
 PROJECT_DIR="$REPO_ROOT"
 log "Bootstrapping project at $PROJECT_DIR"
-"$BIN_PATH" bootstrap --project-dir "$PROJECT_DIR"
+"$BIN_PATH" bootstrap --workspace-dir "$PROJECT_DIR"
 
 # --- Step 9: Configure Codex MCP + local provider profiles ---
 

--- a/scripts/e2e-ci-server.sh
+++ b/scripts/e2e-ci-server.sh
@@ -23,7 +23,7 @@ trap cleanup EXIT INT TERM
 
 cd "${ROOT_DIR}"
 go run ./cmd/slopshell server \
-  --project-dir "${PROJECT_DIR}" \
+  --workspace-dir "${PROJECT_DIR}" \
   --data-dir "${DATA_DIR}" \
   --web-host "${WEB_HOST}" \
   --web-port "${WEB_PORT}" \

--- a/scripts/install-slopshell-user-units.sh
+++ b/scripts/install-slopshell-user-units.sh
@@ -479,7 +479,7 @@ activate_direct() {
         SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b \
         SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b \
         nohup "$BIN_PATH" server \
-          --project-dir "$REPO_ROOT" --data-dir "$WEB_DATA_DIR" \
+          --workspace-dir "$REPO_ROOT" --data-dir "$WEB_DATA_DIR" \
           --mcp-socket "$HOME/Library/Caches/sloppy/mcp.sock" \
           --web-host "$web_host" --web-port 8420 \
           --tts-url http://127.0.0.1:8424 \

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -303,7 +303,7 @@ function Setup-LocalLlm {
 function Write-TaskFiles {
     param([string]$CodexPath)
 
-    $webCmd = 'set "SLOPSHELL_INTENT_LLM_URL=http://127.0.0.1:8081" && set "SLOPSHELL_INTENT_LLM_MODEL=local" && set "SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b" && set "SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b" && "' + $BinaryPath + '" server --project-dir "' + $ProjectDir + '" --data-dir "' + $WebDataDir + '" --web-host ' + $WebHost + ' --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424'
+    $webCmd = 'set "SLOPSHELL_INTENT_LLM_URL=http://127.0.0.1:8081" && set "SLOPSHELL_INTENT_LLM_MODEL=local" && set "SLOPSHELL_INTENT_LLM_PROFILE=qwen3.5-9b" && set "SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b" && "' + $BinaryPath + '" server --workspace-dir "' + $ProjectDir + '" --data-dir "' + $WebDataDir + '" --web-host ' + $WebHost + ' --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424'
     $piperCmd = 'set "PIPER_MODEL_DIR=' + $ModelDir + '" && "' + (Join-Path $PiperVenv 'Scripts\python.exe') + '" -m uvicorn piper_tts_server:app --app-dir "' + $ScriptDir + '" --host 127.0.0.1 --port 8424'
     $codexCmd = '"' + $CodexPath + '" app-server --listen ws://127.0.0.1:8787'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -556,7 +556,7 @@ bootstrap_project() {
     if [ "$DRY_RUN" = "1" ]; then
         return
     fi
-    "$BIN_PATH" bootstrap --project-dir "$PROJECT_DIR" >/dev/null
+    "$BIN_PATH" bootstrap --workspace-dir "$PROJECT_DIR" >/dev/null
 }
 
 configure_codex_cli() {
@@ -971,7 +971,7 @@ Environment=SLOPSHELL_INTENT_LLM_PROFILE_OPTIONS=qwen3.5-9b,qwen3.5-4b
 Environment=SLOPSHELL_HELPY_BIN=${helpy_bin}
 Environment=SLOPSHELL_ASSISTANT_LLM_URL=${effective_llm_url}
 Environment=SLOPSHELL_ASSISTANT_LLM_MODEL=local
-ExecStart=${BIN_PATH} server --project-dir ${PROJECT_DIR} --data-dir ${WEB_DATA_DIR} ${web_mcp_args} --web-host ${web_host} --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
+ExecStart=${BIN_PATH} server --workspace-dir ${PROJECT_DIR} --data-dir ${WEB_DATA_DIR} ${web_mcp_args} --web-host ${web_host} --web-port 8420 --app-server-url ws://127.0.0.1:8787 --tts-url http://127.0.0.1:8424
 Restart=on-failure
 RestartSec=2
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -5,7 +5,15 @@ import WebSocket from 'ws';
 
 const DEFAULT_SERVER_URL = 'http://127.0.0.1:8420';
 const DEFAULT_MANAGED_SERVER_PASSWORD = 'slopshell-test-password';
-const configuredServerURL = String(process.env.E2E_BASE_URL || process.env.SLOPSHELL_TEST_SERVER_URL || DEFAULT_SERVER_URL).trim();
+const managedServerURL = String(process.env.E2E_MANAGED_SERVER_URL || DEFAULT_SERVER_URL).trim() || DEFAULT_SERVER_URL;
+const useManagedServer = process.env.E2E_MANAGED_SERVER === '1'
+  || (!process.env.E2E_BASE_URL && !process.env.SLOPSHELL_TEST_SERVER_URL);
+const configuredServerURL = String(
+  process.env.E2E_BASE_URL
+    || process.env.SLOPSHELL_TEST_SERVER_URL
+    || (useManagedServer ? managedServerURL : '')
+    || DEFAULT_SERVER_URL,
+).trim();
 
 export const SERVER_URL = configuredServerURL || DEFAULT_SERVER_URL;
 export const WS_URL = (() => {
@@ -17,8 +25,7 @@ const SESSION_COOKIE_NAME = 'slopshell_session';
 const preseededSessionToken = String(process.env.SLOPSHELL_TEST_SESSION_TOKEN || '').trim();
 
 function usesManagedServer(): boolean {
-  return process.env.E2E_MANAGED_SERVER === '1'
-    || (!process.env.E2E_BASE_URL && !process.env.SLOPSHELL_TEST_SERVER_URL);
+  return useManagedServer;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Kept filesystem-backed runtime copy on `Workspace` and left GTD `project item`/`outcome` semantics separate.
- Updated docs and user-facing API/runtime copy in [README.md](README.md), [docs/interaction-grammar.md](docs/interaction-grammar.md), [docs/native-clients.md](docs/native-clients.md), [internal/surface/definitions.go](internal/surface/definitions.go), [internal/web/server.go](internal/web/server.go), [internal/web/chat_canvas.go](internal/web/chat_canvas.go), [internal/web/mail_drafts.go](internal/web/mail_drafts.go), and [internal/web/projects_import.go](internal/web/projects_import.go).
- Added store coverage for migration, child links, supported roles, project health, source-bound items, and project-owned supporting artifacts.

## Verification

### Existing action items remain `kind=action` after migration
```text
$ go test ./internal/store -run TestStoreMigratesExistingItemsTableToAllowSomeday -v
=== RUN   TestStoreMigratesExistingItemsTableToAllowSomeday
--- PASS: TestStoreMigratesExistingItemsTableToAllowSomeday (0.02s)
ok   github.com/sloppy-org/slopshell/internal/store 0.073s
```

### Project-item child links, supported roles, deletion, and stalled detection
```text
$ go test ./internal/store -run TestStoreItemChildLinkLifecycleAndProjectHealth -v
=== RUN   TestStoreItemChildLinkLifecycleAndProjectHealth
--- PASS: TestStoreItemChildLinkLifecycleAndProjectHealth (0.02s)
ok   github.com/sloppy-org/slopshell/internal/store 0.073s
```

### Project items own supporting artifacts
```text
$ go test ./internal/store -run TestStoreProjectItemsCanOwnSupportingArtifacts -v
=== RUN   TestStoreProjectItemsCanOwnSupportingArtifacts
--- PASS: TestStoreProjectItemsCanOwnSupportingArtifacts (0.01s)
ok   github.com/sloppy-org/slopshell/internal/store 0.073s
```

### Workspace terminology stays on filesystem-backed CLI/API/runtime surfaces
```text
$ go test ./cmd/slopshell -run 'TestWorkspaceDirFlagUsesWorkspaceCopy|TestWorkspaceDirFlagRejectsProjectDirAlias|TestCmdBootstrapUsesWorkspaceCopy|TestParseServerConfigDefaultsToLoopbackWebHost|TestParseServerConfigRejectsRemovedMCPHostFlag' -v
=== RUN   TestParseServerConfigDefaultsToLoopbackWebHost
--- PASS: TestParseServerConfigDefaultsToLoopbackWebHost (0.00s)
=== RUN   TestParseServerConfigRejectsRemovedMCPHostFlag
--- PASS: TestParseServerConfigRejectsRemovedMCPHostFlag (0.00s)
=== RUN   TestWorkspaceDirFlagUsesWorkspaceCopy
--- PASS: TestWorkspaceDirFlagUsesWorkspaceCopy (0.00s)
=== RUN   TestWorkspaceDirFlagRejectsProjectDirAlias
--- PASS: TestWorkspaceDirFlagRejectsProjectDirAlias (0.00s)
=== RUN   TestCmdBootstrapUsesWorkspaceCopy
--- PASS: TestCmdBootstrapUsesWorkspaceCopy (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/slopshell 0.016s

$ go test ./internal/web -run 'TestProjectsListIncludesActiveAndSessions|TestNewAppPrefersLocalProjectWorkspaceOnStartup|TestProjectAPIModelIncludesWorkspaceChatSession|TestProjectsListIncludesWorkspaceSphere|TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts' -v
=== RUN   TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts
--- PASS: TestHandleBugReportCreateWritesBundleUnderWorkspaceArtifacts (0.04s)
=== RUN   TestProjectsListIncludesActiveAndSessions
--- PASS: TestProjectsListIncludesActiveAndSessions (0.02s)
=== RUN   TestNewAppPrefersLocalProjectWorkspaceOnStartup
--- PASS: TestNewAppPrefersLocalProjectWorkspaceOnStartup (0.02s)
=== RUN   TestProjectAPIModelIncludesWorkspaceChatSession
--- PASS: TestProjectAPIModelIncludesWorkspaceChatSession (0.01s)
=== RUN   TestProjectsListIncludesWorkspaceSphere
--- PASS: TestProjectsListIncludesWorkspaceSphere (0.18s)
PASS
ok   github.com/sloppy-org/slopshell/internal/web 0.311s
```

### Frontend typecheck
```text
$ npm run typecheck:frontend
> typecheck:frontend
> tsc --noEmit -p tsconfig.json
```
