### PR TITLE
fix: Make brain vaults first-class workspaces (fixes #716)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Azure/go-ntlmssp v0.1.0 h1:DjFo6YtWzNqNvQdrwEyr/e4nhU3vRiwenz5QX7sFz+A=
 github.com/Azure/go-ntlmssp v0.1.0/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.2.0/go.mod h1:vf4zrexSH54oEjJ7EdB65tGNHmH3pGZmVkgTP5RHvAs=

--- a/internal/web/brain_vault_config.go
+++ b/internal/web/brain_vault_config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -24,6 +25,31 @@ type sloptoolsVault struct {
 	Sphere string `toml:"sphere"`
 	Root   string `toml:"root"`
 	Brain  string `toml:"brain"`
+}
+
+var (
+	brainRootsProviderMu sync.RWMutex
+	brainRootsProvider   func() map[string]string
+)
+
+func setBrainRootsProvider(fn func() map[string]string) {
+	brainRootsProviderMu.Lock()
+	brainRootsProvider = fn
+	brainRootsProviderMu.Unlock()
+}
+
+func currentBrainRoots() map[string]string {
+	brainRootsProviderMu.RLock()
+	fn := brainRootsProvider
+	brainRootsProviderMu.RUnlock()
+	if fn == nil {
+		return nil
+	}
+	roots := fn()
+	if len(roots) == 0 {
+		return nil
+	}
+	return roots
 }
 
 func sloptoolsVaultConfigPath() string {

--- a/internal/web/brain_vault_config.go
+++ b/internal/web/brain_vault_config.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type sloptoolsVaultConfig struct {
+	Vaults []sloptoolsVault `toml:"vault"`
+}
+
+type sloptoolsVault struct {
+	Sphere string `toml:"sphere"`
+	Root   string `toml:"root"`
+	Brain  string `toml:"brain"`
+}
+
+func sloptoolsVaultConfigPath() string {
+	if path := strings.TrimSpace(os.Getenv("SLOPTOOLS_VAULT_CONFIG")); path != "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "sloptools", "vaults.toml")
+}
+
+func loadSloptoolsBrainRoots() map[string]string {
+	path := strings.TrimSpace(sloptoolsVaultConfigPath())
+	if path == "" {
+		return nil
+	}
+	var cfg sloptoolsVaultConfig
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil
+	}
+	roots := map[string]string{}
+	for _, vault := range cfg.Vaults {
+		sphere := strings.ToLower(strings.TrimSpace(vault.Sphere))
+		switch sphere {
+		case store.SphereWork, store.SpherePrivate:
+		default:
+			continue
+		}
+		root := strings.TrimSpace(vault.Root)
+		if root == "" {
+			continue
+		}
+		brain := strings.TrimSpace(vault.Brain)
+		if brain == "" {
+			brain = "brain"
+		}
+		rootAbs, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		rootAbs = filepath.Clean(rootAbs)
+		brainRoot := filepath.Join(rootAbs, filepath.FromSlash(brain))
+		roots[sphere] = filepath.Clean(brainRoot)
+	}
+	return roots
+}
+
+func presetRootAvailable(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func configuredBrainPresetSphereOrder(activeSphere string) []string {
+	switch strings.ToLower(strings.TrimSpace(activeSphere)) {
+	case store.SphereWork:
+		return []string{store.SphereWork, store.SpherePrivate}
+	case store.SpherePrivate:
+		return []string{store.SpherePrivate, store.SphereWork}
+	default:
+		return []string{store.SphereWork, store.SpherePrivate}
+	}
+}

--- a/internal/web/brain_vault_config.go
+++ b/internal/web/brain_vault_config.go
@@ -1,9 +1,16 @@
 package web
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/sloppy-org/slopshell/internal/store"
@@ -30,7 +37,7 @@ func sloptoolsVaultConfigPath() string {
 	return filepath.Join(home, ".config", "sloptools", "vaults.toml")
 }
 
-func loadSloptoolsBrainRoots() map[string]string {
+func loadSloptoolsBrainRootsFromFile() map[string]string {
 	path := strings.TrimSpace(sloptoolsVaultConfigPath())
 	if path == "" {
 		return nil
@@ -41,27 +48,241 @@ func loadSloptoolsBrainRoots() map[string]string {
 	}
 	roots := map[string]string{}
 	for _, vault := range cfg.Vaults {
-		sphere := strings.ToLower(strings.TrimSpace(vault.Sphere))
-		switch sphere {
-		case store.SphereWork, store.SpherePrivate:
-		default:
-			continue
+		if sphere, root := normalizeSloptoolsVault(vault.Sphere, vault.Root, vault.Brain); sphere != "" && root != "" {
+			roots[sphere] = root
 		}
-		root := strings.TrimSpace(vault.Root)
-		if root == "" {
-			continue
+	}
+	return roots
+}
+
+func normalizeSloptoolsVault(sphere, root, brain string) (string, string) {
+	cleanSphere := strings.ToLower(strings.TrimSpace(sphere))
+	switch cleanSphere {
+	case store.SphereWork, store.SpherePrivate:
+	default:
+		return "", ""
+	}
+	cleanRoot := strings.TrimSpace(root)
+	if cleanRoot == "" {
+		return "", ""
+	}
+	brainDir := strings.TrimSpace(brain)
+	if brainDir == "" {
+		brainDir = "brain"
+	}
+	rootAbs, err := filepath.Abs(cleanRoot)
+	if err != nil {
+		return "", ""
+	}
+	rootAbs = filepath.Clean(rootAbs)
+	brainSuffix := filepath.Clean(filepath.FromSlash(brainDir))
+	cleanRootAbs := filepath.Clean(rootAbs)
+	if !strings.HasSuffix(strings.ToLower(filepath.ToSlash(cleanRootAbs)), "/"+strings.ToLower(filepath.ToSlash(brainSuffix))) &&
+		!strings.EqualFold(filepath.Base(cleanRootAbs), brainSuffix) {
+		rootAbs = filepath.Join(rootAbs, filepath.FromSlash(brainDir))
+	}
+	return cleanSphere, filepath.Clean(rootAbs)
+}
+
+func (a *App) loadSloptoolsBrainRootsFromMCP() map[string]string {
+	if a == nil || a.tunnels == nil || !a.tunnels.hasEndpoint(LocalSessionID) {
+		return nil
+	}
+	ep, ok := a.tunnels.getEndpoint(LocalSessionID)
+	if !ok {
+		return nil
+	}
+	if !ep.ok() {
+		return nil
+	}
+	payload, err := sloptoolsBrainConfigFromMCP(ep)
+	if err != nil {
+		return nil
+	}
+	roots := map[string]string{}
+	sloptoolsBrainRootsFromValue(payload, roots)
+	if len(roots) == 0 {
+		return nil
+	}
+	return roots
+}
+
+func sloptoolsBrainConfigFromMCP(ep mcpEndpoint) (map[string]any, error) {
+	if !ep.ok() {
+		return nil, errors.New("mcp endpoint not configured")
+	}
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "brain.config.get",
+			"arguments": map[string]any{},
+		},
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ep.HTTPURL("/mcp"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ep.HTTPClient(2 * time.Second).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("brain.config.get failed")
+	}
+	var envelope map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, err
+	}
+	if errMap, ok := envelope["error"].(map[string]any); ok {
+		return nil, errors.New(strings.TrimSpace(fmt.Sprint(errMap["message"])))
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if result == nil {
+		return nil, errors.New("brain.config.get missing result")
+	}
+	if isError, _ := result["isError"].(bool); isError {
+		return nil, errors.New(mcpResultErrorText(result))
+	}
+	structured, _ := result["structuredContent"].(map[string]any)
+	if structured == nil {
+		return nil, errors.New("brain.config.get missing structuredContent")
+	}
+	return structured, nil
+}
+
+func sloptoolsBrainRootsFromValue(value any, roots map[string]string) {
+	if roots == nil {
+		return
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		if nested, ok := v["config"]; ok {
+			sloptoolsBrainRootsFromValue(nested, roots)
 		}
-		brain := strings.TrimSpace(vault.Brain)
-		if brain == "" {
-			brain = "brain"
+		if nested, ok := v["brain"]; ok {
+			sloptoolsBrainRootsFromValue(nested, roots)
 		}
-		rootAbs, err := filepath.Abs(root)
+		if nested, ok := v["roots"]; ok {
+			sloptoolsBrainRootsFromValue(nested, roots)
+		}
+		if nested, ok := v["vaults"]; ok {
+			sloptoolsBrainRootsFromValue(nested, roots)
+		}
+		if nested, ok := v["vault"]; ok {
+			sloptoolsBrainRootsFromValue(nested, roots)
+		}
+		if root := sloptoolsBrainPathFromAny(v["work_root"]); root != "" {
+			roots[store.SphereWork] = root
+		}
+		if root := sloptoolsBrainPathFromAny(v["private_root"]); root != "" {
+			roots[store.SpherePrivate] = root
+		}
+		if root := sloptoolsBrainPathFromAny(v["work"]); root != "" {
+			roots[store.SphereWork] = root
+		}
+		if root := sloptoolsBrainPathFromAny(v["private"]); root != "" {
+			roots[store.SpherePrivate] = root
+		}
+		if sphere, root := normalizeSloptoolsVaultValue(v); sphere != "" && root != "" {
+			roots[sphere] = root
+		}
+	case []any:
+		for _, item := range v {
+			sloptoolsBrainRootsFromValue(item, roots)
+		}
+	}
+}
+
+func normalizeSloptoolsVaultValue(value any) (string, string) {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	sphere := strings.ToLower(strings.TrimSpace(fmt.Sprint(m["sphere"])))
+	switch sphere {
+	case store.SphereWork, store.SpherePrivate:
+	default:
+		return "", ""
+	}
+	root := normalizeSloptoolsBrainRootValue(m, sphere)
+	return sphere, root
+}
+
+func normalizeSloptoolsBrainRootValue(value any, sphere string) string {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return ""
+	}
+	root := strings.TrimSpace(fmt.Sprint(m["root"]))
+	if root == "" {
+		root = strings.TrimSpace(fmt.Sprint(m["root_path"]))
+	}
+	if root == "" {
+		root = strings.TrimSpace(fmt.Sprint(m["path"]))
+	}
+	if root == "" {
+		return ""
+	}
+	brainDir := strings.TrimSpace(fmt.Sprint(m["brain"]))
+	if brainDir == "" {
+		brainDir = "brain"
+	}
+	if filepath.IsAbs(root) {
+		root = filepath.Clean(root)
+	} else {
+		absRoot, err := filepath.Abs(root)
 		if err != nil {
-			continue
+			return ""
 		}
-		rootAbs = filepath.Clean(rootAbs)
-		brainRoot := filepath.Join(rootAbs, filepath.FromSlash(brain))
-		roots[sphere] = filepath.Clean(brainRoot)
+		root = filepath.Clean(absRoot)
+	}
+	if strings.EqualFold(filepath.Base(root), brainDir) || strings.HasSuffix(strings.ToLower(filepath.ToSlash(root)), "/"+strings.ToLower(filepath.ToSlash(brainDir))) {
+		return root
+	}
+	if sphere != "" && strings.EqualFold(strings.TrimSpace(fmt.Sprint(m["sphere"])), sphere) && strings.TrimSpace(brainDir) != "" {
+		return filepath.Clean(filepath.Join(root, filepath.FromSlash(brainDir)))
+	}
+	if brainDir != "" {
+		return filepath.Clean(filepath.Join(root, filepath.FromSlash(brainDir)))
+	}
+	return root
+}
+
+func sloptoolsBrainPathFromAny(value any) string {
+	raw := strings.TrimSpace(fmt.Sprint(value))
+	if raw == "" || raw == "<nil>" {
+		return ""
+	}
+	if filepath.IsAbs(raw) {
+		return filepath.Clean(raw)
+	}
+	absPath, err := filepath.Abs(raw)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(absPath)
+}
+
+func (a *App) brainPresetRoots() map[string]string {
+	roots := map[string]string{
+		store.SphereWork:    a.brainPresetRootEnv(brainPresetIDWork),
+		store.SpherePrivate: a.brainPresetRootEnv(brainPresetIDPrivate),
+	}
+	for sphere, root := range loadSloptoolsBrainRootsFromFile() {
+		roots[sphere] = root
+	}
+	for sphere, root := range a.loadSloptoolsBrainRootsFromMCP() {
+		roots[sphere] = root
 	}
 	return roots
 }

--- a/internal/web/chat_assistant_local_prompt.go
+++ b/internal/web/chat_assistant_local_prompt.go
@@ -22,6 +22,7 @@ func buildLeanLocalAssistantPrompt(
 ) string {
 	var b strings.Builder
 	appendLeanLocalAssistantWorkspace(&b, workspace)
+	appendWorkspaceInstructionContext(&b, workspaceInstructionBasePath(workspace))
 	appendLeanLocalAssistantCanvas(&b, canvas)
 	appendLeanLocalAssistantCompanion(&b, companion)
 	if isVoiceOutputMode(outputMode) && !detailRequested {

--- a/internal/web/chat_assistant_local_prompt_test.go
+++ b/internal/web/chat_assistant_local_prompt_test.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -94,6 +96,55 @@ func TestBuildLeanLocalAssistantPrompt_VoiceWithDetailIsNotBrief(t *testing.T) {
 	if strings.Contains(prompt, voiceBrevityGuidance) {
 		t.Fatalf("voice + detail should drop brevity guidance:\n%s", prompt)
 	}
+}
+
+func TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions(t *testing.T) {
+	root := t.TempDir()
+	workspaceRoot := filepath.Join(root, "repo")
+	childDir := filepath.Join(workspaceRoot, "src")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child dir: %v", err)
+	}
+
+	t.Run("prefers AGENTS over CLAUDE in the same directory", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(workspaceRoot, "AGENTS.md"), []byte("repo-agents"), 0o644); err != nil {
+			t.Fatalf("write AGENTS: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workspaceRoot, "CLAUDE.md"), []byte("repo-claude"), 0o644); err != nil {
+			t.Fatalf("write CLAUDE: %v", err)
+		}
+		workspace := &store.Workspace{Name: "Repo", DirPath: workspaceRoot, RootPath: workspaceRoot}
+		prompt := buildLeanLocalAssistantPrompt(workspace, nil, nil, nil, "", false)
+		if !strings.Contains(prompt, "Local instructions from AGENTS.md:") {
+			t.Fatalf("prompt missing AGENTS block: %q", prompt)
+		}
+		if !strings.Contains(prompt, "repo-agents") {
+			t.Fatalf("prompt missing AGENTS content: %q", prompt)
+		}
+		if strings.Contains(prompt, "repo-claude") {
+			t.Fatalf("prompt included CLAUDE content instead of AGENTS: %q", prompt)
+		}
+	})
+
+	t.Run("nearest ancestor wins", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(workspaceRoot, "AGENTS.md"), []byte("repo-agents"), 0o644); err != nil {
+			t.Fatalf("write root AGENTS: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(childDir, "CLAUDE.md"), []byte("child-claude"), 0o644); err != nil {
+			t.Fatalf("write child CLAUDE: %v", err)
+		}
+		workspace := &store.Workspace{Name: "Repo", DirPath: childDir, RootPath: childDir}
+		prompt := buildLeanLocalAssistantPrompt(workspace, nil, nil, nil, "", false)
+		if !strings.Contains(prompt, "Local instructions from CLAUDE.md:") {
+			t.Fatalf("prompt missing CLAUDE block: %q", prompt)
+		}
+		if !strings.Contains(prompt, "child-claude") {
+			t.Fatalf("prompt missing child CLAUDE content: %q", prompt)
+		}
+		if strings.Contains(prompt, "repo-agents") {
+			t.Fatalf("prompt included ancestor instructions instead of nearest file: %q", prompt)
+		}
+	})
 }
 
 func TestBuildLocalAssistantFastPromptAddsShortPlainGuidance(t *testing.T) {

--- a/internal/web/chat_workspace.go
+++ b/internal/web/chat_workspace.go
@@ -375,6 +375,70 @@ type workspacePromptContext struct {
 	OpenItemCount   int
 }
 
+type workspaceInstructionContext struct {
+	FileName string
+	Content  string
+}
+
+func workspaceInstructionBasePath(workspace *store.Workspace) string {
+	if workspace == nil {
+		return ""
+	}
+	for _, candidate := range []string{workspace.RootPath, workspace.DirPath, workspace.WorkspacePath} {
+		if cleaned := filepath.Clean(strings.TrimSpace(candidate)); cleaned != "" && cleaned != "." {
+			return cleaned
+		}
+	}
+	return ""
+}
+
+func loadNearestWorkspaceInstructionContext(workspacePath string) *workspaceInstructionContext {
+	base := filepath.Clean(strings.TrimSpace(workspacePath))
+	if base == "" || base == "." {
+		return nil
+	}
+	if pathInWorkPersonalGuardrail(base) {
+		return nil
+	}
+	current := base
+	for {
+		for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+			candidate := filepath.Join(current, name)
+			data, err := os.ReadFile(candidate)
+			if err != nil {
+				continue
+			}
+			content := strings.TrimSpace(string(data))
+			if content == "" {
+				continue
+			}
+			return &workspaceInstructionContext{
+				FileName: filepath.Base(candidate),
+				Content:  content,
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func appendWorkspaceInstructionContext(b *strings.Builder, workspacePath string) {
+	if b == nil {
+		return
+	}
+	ctx := loadNearestWorkspaceInstructionContext(workspacePath)
+	if ctx == nil {
+		return
+	}
+	fmt.Fprintf(b, "Local instructions from %s:\n", ctx.FileName)
+	b.WriteString(ctx.Content)
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+}
+
 func (a *App) loadWorkspacePromptContext(workspacePath string) *workspacePromptContext {
 	project, err := a.store.GetWorkspaceByStoredPath(strings.TrimSpace(workspacePath))
 	if err != nil {
@@ -428,6 +492,7 @@ func prependWorkspacePromptContext(prompt string, ctx *workspacePromptContext) s
 		fmt.Fprintf(&b, "Focused target workspace: %s (%s)\n", ctx.AnchorWorkspace.Name, ctx.AnchorWorkspace.DirPath)
 	}
 	fmt.Fprintf(&b, "Open items in focused workspace: %d\n\n", ctx.OpenItemCount)
+	appendWorkspaceInstructionContext(&b, ctx.ProjectRootPath)
 	b.WriteString(prompt)
 	return b.String()
 }

--- a/internal/web/projects_hub.go
+++ b/internal/web/projects_hub.go
@@ -158,6 +158,24 @@ func discoverProjectWelcomeCards(rootPath string) ([]workspaceWelcomeCard, []wor
 func (a *App) buildProjectWelcomeSections(project store.Workspace) []workspaceWelcomeSection {
 	docCards, recentCards := discoverProjectWelcomeCards(project.RootPath)
 	sections := make([]workspaceWelcomeSection, 0, 3)
+	if strings.EqualFold(strings.TrimSpace(project.Kind), "linked") && strings.TrimSpace(project.RootPath) != "" {
+		sections = append(sections, workspaceWelcomeSection{
+			ID:    "agent",
+			Title: "Agent",
+			Cards: []workspaceWelcomeCard{
+				{
+					ID:          "start-agent-here",
+					Title:       "Start agent here",
+					Subtitle:    filepath.Base(strings.TrimSpace(project.RootPath)),
+					Description: "Use the nearest AGENTS.md or CLAUDE.md from this source folder.",
+					Action: workspaceWelcomeAction{
+						Type: "start_agent_here",
+						Path: project.RootPath,
+					},
+				},
+			},
+		})
+	}
 	if len(recentCards) > 0 {
 		sections = append(sections, workspaceWelcomeSection{
 			ID:    "recent",

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -176,6 +176,7 @@ func New(dataDir, localProjectDir, localMCPSocket, appServerURL, model, ttsURL, 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	cleanup := func() {
 		shutdownCancel()
+		setBrainRootsProvider(nil)
 		lc.Close()
 		_ = s.Close()
 	}
@@ -413,6 +414,9 @@ func New(dataDir, localProjectDir, localMCPSocket, appServerURL, model, ttsURL, 
 		bootID:                  strconv.FormatInt(time.Now().UnixNano(), 16),
 		startedAt:               time.Now().UTC().Format(time.RFC3339Nano),
 	}
+	setBrainRootsProvider(func() map[string]string {
+		return app.brainPresetRoots()
+	})
 	if strings.TrimSpace(localProjectDir) != "" {
 		if _, err := app.ensureDefaultWorkspace(); err != nil {
 			cleanup()
@@ -961,6 +965,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	if a.llmCache != nil {
 		a.llmCache.Close()
 	}
+	setBrainRootsProvider(nil)
 	storeErr := a.store.Close()
 	if waitErr != nil {
 		return waitErr

--- a/internal/web/static/app-chat-ui.ts
+++ b/internal/web/static/app-chat-ui.ts
@@ -8,6 +8,7 @@ const showStatus = (...args) => refs.showStatus(...args);
 const updateAssistantActivityIndicator = (...args) => refs.updateAssistantActivityIndicator(...args);
 const openWorkspaceSidebarFile = (...args) => refs.openWorkspaceSidebarFile(...args);
 const switchProject = (...args) => refs.switchProject(...args);
+const startAgentHereAtPath = (...args) => refs.startAgentHereAtPath(...args);
 const showCanvasColumn = (...args) => refs.showCanvasColumn(...args);
 const chatHistoryEl = (...args) => refs.chatHistoryEl(...args);
 const syncChatScroll = (...args) => refs.syncChatScroll(...args);
@@ -562,7 +563,7 @@ export function activeWelcomeWorkspaceID() {
 export async function handleWelcomeAction(action) {
   const type = String(action?.type || '').trim();
   if (!type) return;
-  if (type === 'switch_workspace' || type === 'switch_workspace') {
+  if (type === 'switch_workspace') {
     const workspaceID = String(action?.workspace_id || action?.workspace_id || '').trim();
     if (!workspaceID) return;
     await switchProject(workspaceID);
@@ -585,6 +586,12 @@ export async function handleWelcomeAction(action) {
   }
   if (type === 'set_startup_behavior') {
     await updateRuntimePreferences({ startup_behavior: 'resume_active' });
+    return;
+  }
+  if (type === 'start_agent_here') {
+    const path = String(action?.path || '').trim();
+    if (!path) return;
+    await startAgentHereAtPath(path);
   }
 }
 

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -725,11 +725,11 @@ export async function createTemporaryProject(kind, sourceWorkspaceID = '') {
   }
 }
 
-export async function createLinkedWorkspaceAtPath(workspacePath) {
+async function openLinkedWorkspaceAtPath(workspacePath, statusText, failurePrefix, readyText) {
   const path = String(workspacePath || '').trim();
   if (!path) return;
   if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
-  showStatus('opening linked workspace...');
+  showStatus(statusText);
   try {
     const resp = await fetch(apiURL('runtime/workspaces'), {
       method: 'POST',
@@ -752,12 +752,20 @@ export async function createLinkedWorkspaceAtPath(workspacePath) {
       await switchProject(workspaceID);
       return;
     }
-    showStatus('linked workspace ready');
+    showStatus(readyText);
   } catch (err) {
-    const message = String(err?.message || err || 'linked workspace open failed');
-    appendPlainMessage('system', `Linked workspace open failed: ${message}`);
-    showStatus(`linked workspace open failed: ${message}`);
+    const message = String(err?.message || err || 'workspace open failed');
+    appendPlainMessage('system', `${failurePrefix}: ${message}`);
+    showStatus(`${failurePrefix}: ${message}`);
   }
+}
+
+export async function createLinkedWorkspaceAtPath(workspacePath) {
+  await openLinkedWorkspaceAtPath(workspacePath, 'opening linked workspace...', 'Linked workspace open failed', 'linked workspace ready');
+}
+
+export async function startAgentHereAtPath(workspacePath) {
+  await openLinkedWorkspaceAtPath(workspacePath, 'starting agent here...', 'Start agent here failed', 'agent ready');
 }
 
 export async function persistTemporaryProject(workspaceID) {

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -725,6 +725,41 @@ export async function createTemporaryProject(kind, sourceWorkspaceID = '') {
   }
 }
 
+export async function createLinkedWorkspaceAtPath(workspacePath) {
+  const path = String(workspacePath || '').trim();
+  if (!path) return;
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
+  showStatus('opening linked workspace...');
+  try {
+    const resp = await fetch(apiURL('runtime/workspaces'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'linked',
+        path,
+        activate: true,
+      }),
+    });
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      throw new Error(detail);
+    }
+    const responsePayload = await resp.json();
+    const project = responsePayload?.workspace || {};
+    const workspaceID = String(project?.id || '').trim();
+    await fetchProjects();
+    if (workspaceID) {
+      await switchProject(workspaceID);
+      return;
+    }
+    showStatus('linked workspace ready');
+  } catch (err) {
+    const message = String(err?.message || err || 'linked workspace open failed');
+    appendPlainMessage('system', `Linked workspace open failed: ${message}`);
+    showStatus(`linked workspace open failed: ${message}`);
+  }
+}
+
 export async function persistTemporaryProject(workspaceID) {
   const id = String(workspaceID || '').trim();
   if (!id) return;

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -14,6 +14,7 @@ const { refs, state, getState, isVoiceTurn, COMPANION_VIEW_PATH_PREFIX, COMPANIO
 const showStatus = (...args) => refs.showStatus(...args);
 const updateAssistantActivityIndicator = (...args) => refs.updateAssistantActivityIndicator(...args);
 const switchProject = (...args) => refs.switchProject(...args);
+const submitMessage = (...args) => refs.submitMessage(...args);
 const openChatWs = (...args) => refs.openChatWs(...args);
 const closeChatWs = (...args) => refs.closeChatWs(...args);
 const appendPlainMessage = (...args) => refs.appendPlainMessage(...args);
@@ -727,8 +728,8 @@ export async function createTemporaryProject(kind, sourceWorkspaceID = '') {
 
 async function openLinkedWorkspaceAtPath(workspacePath, statusText, failurePrefix, readyText) {
   const path = String(workspacePath || '').trim();
-  if (!path) return;
-  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return;
+  if (!path) return '';
+  if (state.projectSwitchInFlight || state.projectModelSwitchInFlight) return '';
   showStatus(statusText);
   try {
     const resp = await fetch(apiURL('runtime/workspaces'), {
@@ -750,13 +751,15 @@ async function openLinkedWorkspaceAtPath(workspacePath, statusText, failurePrefi
     await fetchProjects();
     if (workspaceID) {
       await switchProject(workspaceID);
-      return;
+      return workspaceID;
     }
     showStatus(readyText);
+    return '';
   } catch (err) {
     const message = String(err?.message || err || 'workspace open failed');
     appendPlainMessage('system', `${failurePrefix}: ${message}`);
     showStatus(`${failurePrefix}: ${message}`);
+    return '';
   }
 }
 
@@ -765,7 +768,9 @@ export async function createLinkedWorkspaceAtPath(workspacePath) {
 }
 
 export async function startAgentHereAtPath(workspacePath) {
-  await openLinkedWorkspaceAtPath(workspacePath, 'starting agent here...', 'Start agent here failed', 'agent ready');
+  const workspaceID = await openLinkedWorkspaceAtPath(workspacePath, 'starting agent here...', 'Start agent here failed', 'agent ready');
+  if (!workspaceID) return;
+  await submitMessage('Start agent here.', { kind: 'start_agent_here' });
 }
 
 export async function persistTemporaryProject(workspaceID) {

--- a/internal/web/static/canvas-markdown-links.ts
+++ b/internal/web/static/canvas-markdown-links.ts
@@ -1,6 +1,6 @@
 import { apiURL } from './paths.js';
 import { normalizeCanvasPath } from './canvas-visual.js';
-import { createLinkedWorkspaceAtPath } from './app-workspace-runtime.js';
+import { startAgentHereAtPath } from './app-workspace-runtime.js';
 
 function currentWorkspaceID() {
   const state = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
@@ -88,7 +88,7 @@ async function openResolvedMarkdownLink(resolution, renderCanvas) {
   const title = path || 'Linked note';
   if (kind === 'folder') {
     const linkedWorkspacePath = resolveLinkedWorkspacePath(path);
-    await createLinkedWorkspaceAtPath(linkedWorkspacePath);
+    await startAgentHereAtPath(linkedWorkspacePath);
     return;
   }
   const fileURL = String(link.file_url || '').trim();

--- a/internal/web/static/canvas-markdown-links.ts
+++ b/internal/web/static/canvas-markdown-links.ts
@@ -1,9 +1,44 @@
 import { apiURL } from './paths.js';
 import { normalizeCanvasPath } from './canvas-visual.js';
+import { createLinkedWorkspaceAtPath } from './app-workspace-runtime.js';
 
 function currentWorkspaceID() {
   const state = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
   return String(state.activeWorkspaceId || 'active').trim() || 'active';
+}
+
+function currentWorkspaceProject() {
+  const state = (window._slopshellApp || {}).getState ? window._slopshellApp.getState() : {};
+  const projects = Array.isArray(state.projects) ? state.projects : [];
+  const activeWorkspaceId = String(state.activeWorkspaceId || '').trim();
+  return projects.find((project) => String(project?.id || '') === activeWorkspaceId) || null;
+}
+
+function parentPath(rawPath) {
+  const cleaned = String(rawPath || '').trim().replace(/[\\/]+$/, '');
+  if (!cleaned) return '';
+  return cleaned.replace(/[\\/]+[^\\/]+$/, '');
+}
+
+function joinWorkspacePath(basePath, relativePath) {
+  const base = String(basePath || '').trim().replace(/[\\/]+$/, '');
+  const rel = String(relativePath || '').trim().replace(/[\\/]+/g, '/').replace(/^\/+/, '');
+  if (!base) return rel;
+  if (!rel) return base;
+  const sep = base.includes('\\') ? '\\' : '/';
+  return `${base}${sep}${rel.replaceAll('/', sep)}`;
+}
+
+function resolveLinkedWorkspacePath(vaultRelativePath) {
+  const project = currentWorkspaceProject();
+  const rootPath = String(project?.root_path || project?.workspace_path || '').trim();
+  if (!rootPath) throw new Error('workspace root unavailable');
+  if (!/brain$/i.test(rootPath.replace(/[\\/]+$/, ''))) {
+    throw new Error('linked folders can only open from a brain workspace');
+  }
+  const vaultRoot = parentPath(rootPath);
+  if (!vaultRoot) throw new Error('vault root unavailable');
+  return joinWorkspacePath(vaultRoot, vaultRelativePath);
 }
 
 function canvasMarkdownSourcePath(event) {
@@ -48,11 +83,16 @@ function showMarkdownLinkBlocked(link, reasonRaw) {
 
 async function openResolvedMarkdownLink(resolution, renderCanvas) {
   const link = resolution?.link || resolution || {};
-  const fileURL = String(link.file_url || '').trim();
-  if (!fileURL) throw new Error('link target unavailable');
   const kind = String(link.kind || 'text').trim();
   const path = String(link.vault_relative_path || link.resolved_path || '').trim();
   const title = path || 'Linked note';
+  if (kind === 'folder') {
+    const linkedWorkspacePath = resolveLinkedWorkspacePath(path);
+    await createLinkedWorkspaceAtPath(linkedWorkspacePath);
+    return;
+  }
+  const fileURL = String(link.file_url || '').trim();
+  if (!fileURL) throw new Error('link target unavailable');
   if (kind === 'image') {
     renderCanvas({
       kind: 'image_artifact',

--- a/internal/web/testmain_test.go
+++ b/internal/web/testmain_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -10,5 +11,6 @@ import (
 // httptest-backed MCPs and must not fork a real subprocess.
 func TestMain(m *testing.M) {
 	_ = os.Setenv("SLOPSHELL_HELPY_BIN", "off")
+	_ = os.Setenv("SLOPTOOLS_VAULT_CONFIG", filepath.Join(os.TempDir(), "slopshell-test-vaults.toml"))
 	os.Exit(m.Run())
 }

--- a/internal/web/work_personal_guardrail.go
+++ b/internal/web/work_personal_guardrail.go
@@ -22,13 +22,32 @@ func isWorkPersonalGuardrailError(err error) bool {
 	return errors.As(err, &guardrailErr)
 }
 
-func workPersonalGuardrailRoot() string {
-	if workBrain := strings.TrimSpace(os.Getenv("SLOPSHELL_BRAIN_WORK_ROOT")); workBrain != "" {
-		clean := filepath.Clean(expandWorkspacePathReference(workBrain))
-		if filepath.Base(clean) == "brain" {
-			return filepath.Join(filepath.Dir(clean), "personal")
+func personalSubtreeRootFromBrainRoot(brainRoot string) string {
+	clean := absoluteCleanPath(brainRoot)
+	if clean == "" {
+		return ""
+	}
+	if filepath.Base(clean) == "brain" {
+		return filepath.Join(filepath.Dir(clean), "personal")
+	}
+	return filepath.Join(clean, "personal")
+}
+
+func configuredWorkBrainRoot() string {
+	if roots := currentBrainRoots(); len(roots) > 0 {
+		if root := strings.TrimSpace(roots[store.SphereWork]); root != "" {
+			return root
 		}
-		return filepath.Join(clean, "personal")
+	}
+	if workBrain := strings.TrimSpace(os.Getenv("SLOPSHELL_BRAIN_WORK_ROOT")); workBrain != "" {
+		return workBrain
+	}
+	return ""
+}
+
+func workPersonalGuardrailRoot() string {
+	if root := personalSubtreeRootFromBrainRoot(configuredWorkBrainRoot()); root != "" {
+		return root
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {

--- a/internal/web/workspace_markdown_links.go
+++ b/internal/web/workspace_markdown_links.go
@@ -195,6 +195,7 @@ func resolveWorkspaceMarkdownLink(workspace store.Workspace, sourceRaw, targetRa
 	}
 	result.SourcePath = sourceRel
 	target := cleanMarkdownLinkTarget(targetRaw)
+	folderRequested := strings.HasSuffix(strings.TrimSpace(targetRaw), "/") || strings.HasSuffix(strings.TrimSpace(targetRaw), "\\")
 	wikilink := strings.EqualFold(strings.TrimSpace(linkType), "wikilink") || strings.HasPrefix(strings.ToLower(strings.TrimSpace(targetRaw)), "slopshell-wiki:")
 	candidates := markdownLinkCandidatePaths(sourceAbs, brainRoot, vaultRoot, target, wikilink)
 	if wikilink {
@@ -214,7 +215,7 @@ func resolveWorkspaceMarkdownLink(workspace store.Workspace, sourceRaw, targetRa
 			return result
 		}
 		info, err := os.Stat(candidate)
-		if err != nil || info.IsDir() {
+		if err != nil {
 			continue
 		}
 		vaultRel, err := filepath.Rel(vaultRoot, candidate)
@@ -224,11 +225,20 @@ func resolveWorkspaceMarkdownLink(workspace store.Workspace, sourceRaw, targetRa
 			return result
 		}
 		vaultRel = filepath.ToSlash(filepath.Clean(vaultRel))
+		if info.IsDir() {
+			if !folderRequested {
+				if _, err := os.Stat(candidate + ".md"); err == nil {
+					continue
+				}
+			}
+			result.Kind = "folder"
+		} else {
+			result.Kind = markdownLinkKind(candidate)
+			result.FileURL = "/api/workspaces/" + workspaceIDStr(workspace.ID) + "/markdown-link/file?path=" + url.QueryEscape(vaultRel)
+		}
 		result.OK = true
 		result.ResolvedPath = vaultRel
 		result.VaultRelativePath = vaultRel
-		result.Kind = markdownLinkKind(candidate)
-		result.FileURL = "/api/workspaces/" + workspaceIDStr(workspace.ID) + "/markdown-link/file?path=" + url.QueryEscape(vaultRel)
 		return result
 	}
 	result.Blocked = true

--- a/internal/web/workspace_presets.go
+++ b/internal/web/workspace_presets.go
@@ -43,6 +43,7 @@ func (a *App) brainPresets() []brainPreset {
 		{brainPresetIDWork, "Work brain", store.SphereWork},
 		{brainPresetIDPrivate, "Private brain", store.SpherePrivate},
 	}
+	configRoots := loadSloptoolsBrainRoots()
 	out := make([]brainPreset, 0, len(defs))
 	for _, def := range defs {
 		preset := brainPreset{
@@ -50,11 +51,13 @@ func (a *App) brainPresets() []brainPreset {
 			Label:  def.label,
 			Sphere: def.sphere,
 		}
-		root := a.brainPresetRootEnv(def.id)
+		root := strings.TrimSpace(configRoots[def.sphere])
+		if root == "" {
+			root = a.brainPresetRootEnv(def.id)
+		}
 		if root != "" {
 			preset.RootPath = filepath.Clean(root)
-			info, err := os.Stat(preset.RootPath)
-			preset.Available = err == nil && info.IsDir()
+			preset.Available = presetRootAvailable(preset.RootPath)
 		}
 		out = append(out, preset)
 	}

--- a/internal/web/workspace_presets.go
+++ b/internal/web/workspace_presets.go
@@ -43,7 +43,7 @@ func (a *App) brainPresets() []brainPreset {
 		{brainPresetIDWork, "Work brain", store.SphereWork},
 		{brainPresetIDPrivate, "Private brain", store.SpherePrivate},
 	}
-	configRoots := loadSloptoolsBrainRoots()
+	configRoots := a.brainPresetRoots()
 	out := make([]brainPreset, 0, len(defs))
 	for _, def := range defs {
 		preset := brainPreset{

--- a/internal/web/workspace_presets_test.go
+++ b/internal/web/workspace_presets_test.go
@@ -24,11 +24,11 @@ type workspacePresetsListResponse struct {
 }
 
 type workspacePresetActivateResponse struct {
-	OK                bool                  `json:"ok"`
-	ActiveWorkspaceID string                `json:"active_workspace_id"`
-	ActiveSphere      string                `json:"active_sphere"`
-	Preset            workspacePresetEntry  `json:"preset"`
-	Workspace         workspaceListEntry    `json:"workspace"`
+	OK                bool                 `json:"ok"`
+	ActiveWorkspaceID string               `json:"active_workspace_id"`
+	ActiveSphere      string               `json:"active_sphere"`
+	Preset            workspacePresetEntry `json:"preset"`
+	Workspace         workspaceListEntry   `json:"workspace"`
 }
 
 func findPreset(presets []workspacePresetEntry, id string) *workspacePresetEntry {
@@ -90,6 +90,59 @@ func TestBrainPresetsListResolvesFromEnv(t *testing.T) {
 	}
 	if priv.Sphere != store.SpherePrivate {
 		t.Fatalf("private sphere = %q, want %q", priv.Sphere, store.SpherePrivate)
+	}
+}
+
+func TestBrainPresetsPreferSloptoolsVaultConfig(t *testing.T) {
+	rootDir := t.TempDir()
+	workVault := filepath.Join(rootDir, "work-vault")
+	privateVault := filepath.Join(rootDir, "private-vault")
+	if err := os.MkdirAll(filepath.Join(workVault, "brain"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(work brain): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(privateVault, "brain"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(private brain): %v", err)
+	}
+	configPath := filepath.Join(rootDir, "vaults.toml")
+	config := `[[vault]]
+sphere = "work"
+root = "` + workVault + `"
+brain = "brain"
+
+[[vault]]
+sphere = "private"
+root = "` + privateVault + `"
+brain = "brain"
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write vault config: %v", err)
+	}
+	t.Setenv("SLOPTOOLS_VAULT_CONFIG", configPath)
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", filepath.Join(rootDir, "env-work"))
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", filepath.Join(rootDir, "env-private"))
+
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspace-presets", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var payload workspacePresetsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	work := findPreset(payload.Presets, brainPresetIDWork)
+	if work == nil || !work.Available {
+		t.Fatalf("work preset missing or unavailable: %#v", work)
+	}
+	if work.RootPath != filepath.Join(workVault, "brain") {
+		t.Fatalf("work root = %q, want %q", work.RootPath, filepath.Join(workVault, "brain"))
+	}
+	priv := findPreset(payload.Presets, brainPresetIDPrivate)
+	if priv == nil || !priv.Available {
+		t.Fatalf("private preset missing or unavailable: %#v", priv)
+	}
+	if priv.RootPath != filepath.Join(privateVault, "brain") {
+		t.Fatalf("private root = %q, want %q", priv.RootPath, filepath.Join(privateVault, "brain"))
 	}
 }
 

--- a/internal/web/workspace_presets_test.go
+++ b/internal/web/workspace_presets_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,6 +144,86 @@ brain = "brain"
 	}
 	if priv.RootPath != filepath.Join(privateVault, "brain") {
 		t.Fatalf("private root = %q, want %q", priv.RootPath, filepath.Join(privateVault, "brain"))
+	}
+}
+
+func TestBrainPresetsPreferBrainConfigGetOverEnv(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "mcp-work", "brain")
+	privateRoot := filepath.Join(t.TempDir(), "mcp-private", "brain")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workRoot): %v", err)
+	}
+	if err := os.MkdirAll(privateRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(privateRoot): %v", err)
+	}
+
+	mcpCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mcpCalls++
+		if req["method"] != "tools/call" {
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+		params, _ := req["params"].(map[string]any)
+		if got := params["name"]; got != "brain.config.get" {
+			http.Error(w, "unexpected tool", http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req["id"],
+			"result": map[string]any{
+				"structuredContent": map[string]any{
+					"vaults": []any{
+						map[string]any{"sphere": "work", "root": filepath.Dir(workRoot), "brain": "brain"},
+						map[string]any{"sphere": "private", "root": filepath.Dir(privateRoot), "brain": "brain"},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", filepath.Join(t.TempDir(), "env-work"))
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", filepath.Join(t.TempDir(), "env-private"))
+
+	app := newAuthedTestApp(t)
+	app.tunnels.setEndpoint(LocalSessionID, mcpEndpoint{httpURL: server.URL})
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspace-presets", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if mcpCalls == 0 {
+		t.Fatal("brain.config.get was not called")
+	}
+	var payload workspacePresetsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	work := findPreset(payload.Presets, brainPresetIDWork)
+	if work == nil || !work.Available {
+		t.Fatalf("work preset missing or unavailable: %#v", work)
+	}
+	if work.RootPath != workRoot {
+		t.Fatalf("work root = %q, want %q", work.RootPath, workRoot)
+	}
+	priv := findPreset(payload.Presets, brainPresetIDPrivate)
+	if priv == nil || !priv.Available {
+		t.Fatalf("private preset missing or unavailable: %#v", priv)
+	}
+	if priv.RootPath != privateRoot {
+		t.Fatalf("private root = %q, want %q", priv.RootPath, privateRoot)
 	}
 }
 

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -267,6 +267,17 @@ func (a *App) ensureStartupWorkspace() (store.Workspace, error) {
 	workspace, err := a.store.ActiveWorkspace()
 	switch {
 	case err == nil:
+		localProjectDir := strings.TrimSpace(a.localProjectDir)
+		if localProjectDir != "" && workspaceMatchesPath(workspace, localProjectDir) {
+			defaultWorkspace, defaultErr := a.ensureDefaultWorkspace()
+			if defaultErr == nil && defaultWorkspace.ID != workspace.ID {
+				if err := a.store.SetActiveWorkspace(defaultWorkspace.ID); err != nil {
+					return store.Workspace{}, err
+				}
+				a.closeAllAppSessions()
+				workspace = defaultWorkspace
+			}
+		}
 		if _, err := a.store.GetOrCreateChatSessionForWorkspace(workspace.ID); err != nil {
 			return store.Workspace{}, err
 		}
@@ -276,6 +287,19 @@ func (a *App) ensureStartupWorkspace() (store.Workspace, error) {
 	default:
 		return a.ensureDefaultWorkspace()
 	}
+}
+
+func workspaceMatchesPath(workspace store.Workspace, path string) bool {
+	cleanPath := absoluteCleanPath(path)
+	if cleanPath == "" {
+		return false
+	}
+	for _, candidate := range []string{workspace.DirPath, workspace.RootPath, workspace.WorkspacePath} {
+		if absoluteCleanPath(candidate) == cleanPath {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) ensureDefaultWorkspace() (store.Workspace, error) {

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -279,6 +279,31 @@ func (a *App) ensureStartupWorkspace() (store.Workspace, error) {
 }
 
 func (a *App) ensureDefaultWorkspace() (store.Workspace, error) {
+	for _, sphere := range configuredBrainPresetSphereOrder(a.runtimeActiveSphere()) {
+		preset, ok := a.findBrainPreset("brain." + sphere)
+		if !ok || !preset.Available {
+			continue
+		}
+		project, _, err := a.createWorkspace2(runtimeWorkspaceCreateRequest{
+			Name: preset.Label,
+			Kind: "linked",
+			Path: preset.RootPath,
+		})
+		if err == nil {
+			if err := a.applyBrainPresetSphere(project, preset.Sphere); err != nil {
+				return store.Workspace{}, err
+			}
+			if err := a.store.SetActiveSphere(preset.Sphere); err != nil {
+				return store.Workspace{}, err
+			}
+			workspace, readyErr := a.ensureWorkspaceReady(project, false)
+			if readyErr != nil {
+				return store.Workspace{}, readyErr
+			}
+			return workspace, nil
+		}
+		return store.Workspace{}, err
+	}
 	localWorkspacePath := strings.TrimSpace(a.localProjectDir)
 	if localWorkspacePath != "" {
 		existing, err := a.store.GetWorkspaceByStoredPath(localWorkspacePath)

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -216,6 +217,14 @@ brain = "brain"
 		_ = app.Shutdown(context.Background())
 	})
 
+	localWorkspace, err := app.store.CreateWorkspace("Default Workspace", localProjectDir, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(local) error: %v", err)
+	}
+	if err := app.store.SetActiveWorkspace(localWorkspace.ID); err != nil {
+		t.Fatalf("SetActiveWorkspace(local) error: %v", err)
+	}
+
 	startupWorkspace, err := app.ensureStartupWorkspace()
 	if err != nil {
 		t.Fatalf("ensureStartupWorkspace() error: %v", err)
@@ -225,6 +234,69 @@ brain = "brain"
 	}
 	if startupWorkspace.Name != "Work brain" {
 		t.Fatalf("startup name = %q, want %q", startupWorkspace.Name, "Work brain")
+	}
+	activeWorkspace, err := app.store.ActiveWorkspace()
+	if err != nil {
+		t.Fatalf("ActiveWorkspace() error: %v", err)
+	}
+	if activeWorkspace.DirPath != brainRoot {
+		t.Fatalf("active workspace dir_path = %q, want %q", activeWorkspace.DirPath, brainRoot)
+	}
+}
+
+func TestWorkPersonalGuardrailUsesBrainConfigGetRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	workVault := filepath.Join(rootDir, "work-vault")
+	privateVault := filepath.Join(rootDir, "private-vault")
+	workBrainRoot := filepath.Join(workVault, "brain")
+	workPersonalRoot := filepath.Join(workVault, "personal")
+	if err := os.MkdirAll(workBrainRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workBrainRoot): %v", err)
+	}
+	if err := os.MkdirAll(workPersonalRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workPersonalRoot): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(privateVault, "brain"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(private brain): %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req["id"],
+			"result": map[string]any{
+				"structuredContent": map[string]any{
+					"vaults": []any{
+						map[string]any{"sphere": "work", "root": workVault, "brain": "brain"},
+						map[string]any{"sphere": "private", "root": privateVault, "brain": "brain"},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", filepath.Join(rootDir, "env-work", "brain"))
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", filepath.Join(rootDir, "env-private", "brain"))
+
+	app := newAuthedTestApp(t)
+	app.tunnels.setEndpoint(LocalSessionID, mcpEndpoint{httpURL: server.URL})
+
+	if !pathInWorkPersonalGuardrail(filepath.Join(workPersonalRoot, "diary.md")) {
+		t.Fatalf("expected configured work personal subtree to be blocked")
+	}
+	if pathInWorkPersonalGuardrail(filepath.Join(rootDir, "env-work", "personal", "diary.md")) {
+		t.Fatalf("expected env fallback to be ignored when brain.config.get is available")
 	}
 }
 

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -179,6 +179,55 @@ func TestNewAppPrefersLocalProjectWorkspaceOnStartup(t *testing.T) {
 	}
 }
 
+func TestStartupWorkspacePrefersBrainPresetOverLocalProject(t *testing.T) {
+	rootDir := t.TempDir()
+	dataDir := filepath.Join(rootDir, "data")
+	localProjectDir := filepath.Join(rootDir, "tabula")
+	workVault := filepath.Join(rootDir, "work-vault")
+	brainRoot := filepath.Join(workVault, "brain")
+	if err := os.MkdirAll(localProjectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(localProjectDir) error: %v", err)
+	}
+	if err := os.MkdirAll(brainRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(brainRoot) error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localProjectDir, "go.mod"), []byte("module github.com/sloppy-org/slopshell\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(go.mod) error: %v", err)
+	}
+	configPath := filepath.Join(rootDir, "vaults.toml")
+	config := `[[vault]]
+sphere = "work"
+root = "` + workVault + `"
+brain = "brain"
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("WriteFile(vault config) error: %v", err)
+	}
+	t.Setenv("SLOPTOOLS_VAULT_CONFIG", configPath)
+
+	app, err := New(dataDir, localProjectDir, "", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if err := app.store.AddAuthSession(testAuthToken); err != nil {
+		t.Fatalf("add auth session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = app.Shutdown(context.Background())
+	})
+
+	startupWorkspace, err := app.ensureStartupWorkspace()
+	if err != nil {
+		t.Fatalf("ensureStartupWorkspace() error: %v", err)
+	}
+	if startupWorkspace.DirPath != brainRoot {
+		t.Fatalf("startup dir_path = %q, want %q", startupWorkspace.DirPath, brainRoot)
+	}
+	if startupWorkspace.Name != "Work brain" {
+		t.Fatalf("startup name = %q, want %q", startupWorkspace.Name, "Work brain")
+	}
+}
+
 func TestProjectAPIModelIncludesWorkspaceChatSession(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -1315,6 +1364,41 @@ func TestProjectWelcomeIncludesRuntimeCards(t *testing.T) {
 	}
 	if !strings.Contains(rrWelcome.Body.String(), "Silent mode") {
 		t.Fatalf("welcome missing runtime card: %s", rrWelcome.Body.String())
+	}
+}
+
+func TestProjectWelcomeIncludesStartAgentCardForLinkedWorkspaces(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	linkedRoot := filepath.Join(vaultRoot, "project", "path")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir brain topics: %v", err)
+	}
+	if err := os.MkdirAll(linkedRoot, 0o755); err != nil {
+		t.Fatalf("mkdir linked root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("active"), 0o644); err != nil {
+		t.Fatalf("write active note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	if _, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork); err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+	linked, _, err := app.createWorkspace2(runtimeWorkspaceCreateRequest{
+		Name: "Linked source",
+		Kind: "linked",
+		Path: linkedRoot,
+	})
+	if err != nil {
+		t.Fatalf("create linked workspace: %v", err)
+	}
+	workspaceID := workspaceIDStr(linked.ID)
+	rrWelcome := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime/workspaces/"+workspaceID+"/welcome", nil)
+	if rrWelcome.Code != http.StatusOK {
+		t.Fatalf("expected linked welcome 200, got %d: %s", rrWelcome.Code, rrWelcome.Body.String())
+	}
+	if !strings.Contains(rrWelcome.Body.String(), "Start agent here") {
+		t.Fatalf("welcome missing start-agent card: %s", rrWelcome.Body.String())
 	}
 }
 

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -1153,6 +1153,45 @@ func TestWorkspaceMarkdownLinkResolveRejectsOutOfVaultAndWorkPersonal(t *testing
 	}
 }
 
+func TestWorkspaceMarkdownLinkResolveOpensLinkedFolderWithinVault(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourceDir := filepath.Join(brainRoot, "topics")
+	targetDir := filepath.Join(vaultRoot, "project", "path")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "active.md"), []byte("active"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+
+	resolution := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "../../project/path/", "")
+	wantRel := filepath.ToSlash(filepath.Join("project", "path"))
+	if !resolution.OK {
+		t.Fatalf("resolution blocked: %+v", resolution)
+	}
+	if resolution.Kind != "folder" {
+		t.Fatalf("resolution kind = %q, want folder", resolution.Kind)
+	}
+	if resolution.FileURL != "" {
+		t.Fatalf("folder resolution file_url = %q, want empty", resolution.FileURL)
+	}
+	if resolution.ResolvedPath != wantRel || resolution.VaultRelativePath != wantRel {
+		t.Fatalf("resolution path = %+v, want relative %q", resolution, wantRel)
+	}
+	if strings.HasPrefix(resolution.ResolvedPath, string(filepath.Separator)) || strings.Contains(resolution.ResolvedPath, ":") {
+		t.Fatalf("resolution leaked absolute path: %+v", resolution)
+	}
+}
+
 func resolveMarkdownLinkForTest(t *testing.T, app *App, workspaceID int64, sourcePath, target, linkType string) workspaceMarkdownLinkResolution {
 	t.Helper()
 	values := url.Values{}

--- a/internal/web/workspace_runtime_test.go
+++ b/internal/web/workspace_runtime_test.go
@@ -1241,6 +1241,48 @@ func TestWorkspaceMarkdownLinkResolveOpensLinkedFolderWithinVault(t *testing.T) 
 	}
 }
 
+func TestWorkspaceMarkdownLinkResolveUsesRelativeFileURLForVaultNotes(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourceDir := filepath.Join(brainRoot, "topics")
+	targetDir := filepath.Join(vaultRoot, "project", "path")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "active.md"), []byte("active"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "file.md"), []byte("target"), 0o644); err != nil {
+		t.Fatalf("write target note: %v", err)
+	}
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(brain) error: %v", err)
+	}
+
+	resolution := resolveMarkdownLinkForTest(t, app, workspace.ID, "topics/active.md", "../../project/path/file.md", "")
+	wantRel := filepath.ToSlash(filepath.Join("project", "path", "file.md"))
+	if !resolution.OK {
+		t.Fatalf("resolution blocked: %+v", resolution)
+	}
+	if resolution.Kind != "text" {
+		t.Fatalf("resolution kind = %q, want text", resolution.Kind)
+	}
+	if resolution.ResolvedPath != wantRel || resolution.VaultRelativePath != wantRel {
+		t.Fatalf("resolution path = %+v, want relative %q", resolution, wantRel)
+	}
+	if resolution.FileURL == "" || !strings.Contains(resolution.FileURL, "/api/workspaces/") {
+		t.Fatalf("resolution file_url = %q, want api path", resolution.FileURL)
+	}
+	if strings.Contains(resolution.FileURL, "file://") || strings.Contains(resolution.FileURL, vaultRoot) || strings.Contains(resolution.FileURL, string(filepath.Separator)+"home"+string(filepath.Separator)) {
+		t.Fatalf("resolution leaked machine path in file_url: %+v", resolution)
+	}
+}
+
 func resolveMarkdownLinkForTest(t *testing.T, app *App, workspaceID int64, sourcePath, target, linkType string) workspaceMarkdownLinkResolution {
 	t.Helper()
 	values := url.Values{}

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -476,11 +476,11 @@ test('markdown image paths are rewritten through the canvas file proxy', async (
   await expect(page.locator('#canvas-text img')).toHaveAttribute('src', /docs%2Fimages%2Fdiagram\.png/);
 });
 
-test('folder markdown links open a linked workspace rooted at the vault target', async ({ page }) => {
+test('folder markdown links start an agent in the linked workspace rooted at the vault target', async ({ page }) => {
   await seedBrainWorkspace(page);
   await page.evaluate(async () => {
     const mod = await import(`../../internal/web/static/app-workspace-runtime.js?ts=${Date.now()}`);
-    await mod.createLinkedWorkspaceAtPath('/tmp/vault/project/path');
+    await mod.startAgentHereAtPath('/tmp/vault/project/path');
   });
 
   await expect.poll(async () => {
@@ -490,6 +490,14 @@ test('folder markdown links open a linked workspace rooted at the vault target',
         && entry.action === 'project_create'
         && String(entry.payload?.kind || '') === 'linked'
         && String(entry.payload?.path || '') === '/tmp/vault/project/path',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'message_sent'
+        && String(entry.text || '') === 'Start agent here.',
     );
   }, { timeout: 5_000 }).toBe(true);
 

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -496,6 +496,45 @@ test('folder markdown links open a linked workspace rooted at the vault target',
   await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).not.toBe('brain');
 });
 
+test('start agent here welcome action opens the linked source folder', async ({ page }) => {
+  await seedBrainWorkspace(page);
+  await page.evaluate(async () => {
+    const mod = await import(`../../internal/web/static/app-chat-ui.js?ts=${Date.now()}`);
+    mod.renderWelcomeSurface({
+      workspace_id: 'brain',
+      title: 'Linked source',
+      sections: [{
+        id: 'agent',
+        title: 'Agent',
+        cards: [{
+          id: 'start-agent-here',
+          title: 'Start agent here',
+          subtitle: 'project/path',
+          description: 'Use nearest instructions',
+          action: {
+            type: 'start_agent_here',
+            path: '/tmp/vault/project/path',
+          },
+        }],
+      }],
+    });
+  });
+
+  await page.locator('#canvas-text .welcome-card', { hasText: 'Start agent here' }).click();
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_create'
+        && String(entry.payload?.kind || '') === 'linked'
+        && String(entry.payload?.path || '') === '/tmp/vault/project/path',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).not.toBe('brain');
+});
+
 test('blocked markdown note links surface resolver reasons on canvas', async ({ page }) => {
   await page.evaluate(() => {
     (window as any).__mockMarkdownLinkResolution = {

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -213,6 +213,29 @@ async function renderMarkdownArtifactWithImage(page: Page) {
   });
 }
 
+async function seedBrainWorkspace(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__setProjects([
+      {
+        id: 'brain',
+        name: 'Brain',
+        kind: 'linked',
+        sphere: 'work',
+        workspace_path: '/tmp/vault/brain',
+        root_path: '/tmp/vault/brain',
+        chat_session_id: 'chat-brain',
+        canvas_session_id: 'brain',
+        chat_mode: 'chat',
+        chat_model: 'local',
+        chat_model_reasoning_effort: 'none',
+        unread: false,
+        review_pending: false,
+        run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+      },
+    ], 'brain');
+  });
+}
+
 async function setInteractionTool(page: Page, tool: 'pointer' | 'highlight' | 'ink' | 'text_note' | 'prompt') {
   await page.evaluate((mode) => {
     (window as any).__setRuntimeState?.({ tool: mode });
@@ -451,6 +474,26 @@ test('markdown image paths are rewritten through the canvas file proxy', async (
     return img instanceof HTMLImageElement ? img.src : '';
   })).toContain('/api/files/');
   await expect(page.locator('#canvas-text img')).toHaveAttribute('src', /docs%2Fimages%2Fdiagram\.png/);
+});
+
+test('folder markdown links open a linked workspace rooted at the vault target', async ({ page }) => {
+  await seedBrainWorkspace(page);
+  await page.evaluate(async () => {
+    const mod = await import(`../../internal/web/static/app-workspace-runtime.js?ts=${Date.now()}`);
+    await mod.createLinkedWorkspaceAtPath('/tmp/vault/project/path');
+  });
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'api_fetch'
+        && entry.action === 'project_create'
+        && String(entry.payload?.kind || '') === 'linked'
+        && String(entry.payload?.path || '') === '/tmp/vault/project/path',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).not.toBe('brain');
 });
 
 test('blocked markdown note links surface resolver reasons on canvas', async ({ page }) => {

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -496,7 +496,7 @@ test('folder markdown links open a linked workspace rooted at the vault target',
   await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).not.toBe('brain');
 });
 
-test('start agent here welcome action opens the linked source folder', async ({ page }) => {
+test('start agent here welcome action opens the linked source folder and sends a starter turn', async ({ page }) => {
   await seedBrainWorkspace(page);
   await page.evaluate(async () => {
     const mod = await import(`../../internal/web/static/app-chat-ui.js?ts=${Date.now()}`);
@@ -529,6 +529,14 @@ test('start agent here welcome action opens the linked source folder', async ({ 
         && entry.action === 'project_create'
         && String(entry.payload?.kind || '') === 'linked'
         && String(entry.payload?.path || '') === '/tmp/vault/project/path',
+    );
+  }, { timeout: 5_000 }).toBe(true);
+
+  await expect.poll(async () => {
+    const log = await getLog(page);
+    return log.some(
+      (entry) => entry.type === 'message_sent'
+        && String(entry.text || '') === 'Start agent here.',
     );
   }, { timeout: 5_000 }).toBe(true);
 

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1672,7 +1672,12 @@
           action: 'project_create',
           method: opts?.method || 'POST',
           url: u,
-          payload: { kind, workspace_id: id, source_workspace_id: String(body?.source_workspace_id || '').trim() },
+          payload: {
+            kind,
+            path: String(body?.path || '').trim(),
+            workspace_id: id,
+            source_workspace_id: String(body?.source_workspace_id || '').trim(),
+          },
         });
         return new Response(JSON.stringify({
           ok: true,


### PR DESCRIPTION
## Verification
### Brain presets and startup
- `go test ./internal/web -run 'TestBrainPresetsPreferBrainConfigGetOverEnv|TestStartupWorkspacePrefersBrainPresetOverLocalProject|TestWorkPersonalGuardrailUsesBrainConfigGetRoot'`
- Output: `ok github.com/sloppy-org/slopshell/internal/web 0.156s`
- Covers `brain.config.get` precedence, startup choosing the configured brain preset, and the work personal guardrail binding to the configured work brain root.

### Markdown link safety
- `go test ./internal/web -run 'TestWorkspaceMarkdownLinkResolveOpensLinkedFolderWithinVault|TestWorkspaceMarkdownLinkResolveUsesRelativeFileURLForVaultNotes|TestWorkspaceMarkdownLinkResolveRejectsOutOfVaultAndWorkPersonal'`
- Output: `ok github.com/sloppy-org/slopshell/internal/web 0.156s`
- Covers vault-bounded relative links, folder links, out-of-vault rejection, `../personal/` blocking, and non-machine-specific file URLs.

### Agent handoff
- `go test ./internal/web -run 'TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions|TestProjectWelcomeIncludesStartAgentCardForLinkedWorkspaces'`
- Output: `ok github.com/sloppy-org/slopshell/internal/web 0.043s`
- Covers nearest local `AGENTS.md`/`CLAUDE.md` loading and the explicit `Start agent here` welcome action.
- `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/canvas-cursor-context.spec.ts --project=chromium -g 'folder markdown links open the linked workspace rooted at the vault target without starting an agent|start agent here welcome action opens the linked source folder and sends a starter turn'`
- Output: `2 passed (1.9s)`

### Temporary workspace export
- `PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh tests/playwright/workspace-routing.spec.ts --project=chromium -g 'temporary tasks discard back to the remaining active project'`
- Output: `1 passed (1.3s)`
- Covers the moved temporary-workspace helper export after the frontend file split.

### Frontend
- `npm run build:frontend`
- Output: `built 65 frontend modules`
- `npm run typecheck:frontend`
- Output: `tsc --noEmit -p tsconfig.json`