### PR TITLE
fix: add sls agent-here command for resolved source folders (fixes #734)

### DIFF
--- a/cmd/sls/agent_here.go
+++ b/cmd/sls/agent_here.go
@@ -98,14 +98,17 @@ func resolveAgentHereSpec(spec, cwd string) (agentHereResolution, error) {
 	}
 	var sourcePath string
 	var cursor *chatMessageCursor
+	var sourceSphere string
 	if hasSource {
 		var err error
-		sourcePath, cursor, err = resolveAgentHereSource(sourceRaw, baseDir)
+		sourcePath, cursor, sourceSphere, err = resolveAgentHereSource(sourceRaw, baseDir)
 		if err != nil {
 			return agentHereResolution{}, err
 		}
+	} else {
+		sourcePath, cursor, sourceSphere = resolveAgentHereCurrentSource(baseDir)
 	}
-	targetPath, targetIsDir, err := resolveAgentHereTarget(targetRaw, baseDir, sourcePath)
+	targetPath, targetIsDir, err := resolveAgentHereTarget(targetRaw, baseDir, sourcePath, sourceSphere)
 	if err != nil {
 		return agentHereResolution{}, err
 	}
@@ -128,59 +131,105 @@ func splitAgentHereSpec(spec string) (string, string, bool) {
 	return strings.TrimSpace(left), strings.TrimSpace(right), true
 }
 
-func resolveAgentHereSource(raw, cwd string) (string, *chatMessageCursor, error) {
+func resolveAgentHereSource(raw, cwd string) (string, *chatMessageCursor, string, error) {
 	clean := cleanAgentHerePath(raw)
 	if clean == "" {
-		return "", nil, errors.New("source note is required")
+		return "", nil, "", errors.New("source note is required")
 	}
-	path, isDir, err := resolveAgentHereExistingPath(clean, cwd)
+	sourceSphere := agentHereSphereForResolvedContext(cwd)
+	if info, err := os.Stat(cwd); err == nil && !info.IsDir() {
+		if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, cwd); ok {
+			if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
+				return "", nil, "", err
+			}
+			return path, &chatMessageCursor{
+				Path:  clean,
+				IsDir: isDir,
+			}, sourceSphere, nil
+		}
+	}
+	path, isDir, err := resolveAgentHereExistingPath(clean, cwd, sourceSphere)
 	if err != nil {
-		return "", nil, fmt.Errorf("source note %q not found", raw)
+		return "", nil, "", fmt.Errorf("source note %q not found", raw)
 	}
-	if err := rejectAgentHerePersonalPath(path); err != nil {
-		return "", nil, err
+	if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
+		return "", nil, "", err
 	}
 	return path, &chatMessageCursor{
 		Path:  clean,
 		IsDir: isDir,
-	}, nil
+	}, sourceSphere, nil
 }
 
-func resolveAgentHereTarget(raw, cwd, sourcePath string) (string, bool, error) {
+func resolveAgentHereCurrentSource(cwd string) (string, *chatMessageCursor, string) {
+	sphere := agentHereSphereForResolvedContext(cwd)
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", nil, sphere
+	}
+	if info.IsDir() {
+		return "", nil, sphere
+	}
+	path := absoluteCleanPath(cwd)
+	if path == "" {
+		return "", nil, sphere
+	}
+	return path, &chatMessageCursor{
+		Path:  path,
+		IsDir: false,
+	}, sphere
+}
+
+func resolveAgentHereTarget(raw, cwd, sourcePath, sourceSphere string) (string, bool, error) {
 	clean := cleanAgentHerePath(raw)
 	if clean == "" {
 		return "", false, errors.New("target path is required")
 	}
 	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainPath(clean); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+	if path, isDir, ok := resolveAgentHereBrainPath(clean, sourceSphere); ok {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainBasename(clean); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+	if path, isDir, ok := resolveAgentHereBrainBasename(clean, sourceSphere); ok {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
+	}
+	if err := resolveAgentHereCrossSphereGuard(clean, sourceSphere); err != nil {
+		return "", false, err
 	}
 	return "", false, fmt.Errorf("target %q not found", raw)
 }
 
-func resolveAgentHereExistingPath(raw, cwd string) (string, bool, error) {
+func resolveAgentHereExistingPath(raw, cwd, sourceSphere string) (string, bool, error) {
 	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, ""); ok {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
+			return "", false, err
+		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainPath(raw); ok {
+	if path, isDir, ok := resolveAgentHereBrainPath(raw, sourceSphere); ok {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
+			return "", false, err
+		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainBasename(raw); ok {
+	if path, isDir, ok := resolveAgentHereBrainBasename(raw, sourceSphere); ok {
+		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
+			return "", false, err
+		}
 		return path, isDir, nil
+	}
+	if err := resolveAgentHereCrossSphereGuard(raw, sourceSphere); err != nil {
+		return "", false, err
 	}
 	return "", false, fmt.Errorf("target %q not found", raw)
 }
@@ -195,8 +244,8 @@ func resolveAgentHereDirectPath(raw, cwd, sourcePath string) (string, bool, bool
 	return "", false, false
 }
 
-func resolveAgentHereBrainPath(raw string) (string, bool, bool) {
-	roots := sortedBrainRoots(findBrainRoots())
+func resolveAgentHereBrainPath(raw, sourceSphere string) (string, bool, bool) {
+	roots := agentHereBrainRoots(sourceSphere)
 	if len(roots) == 0 {
 		return "", false, false
 	}
@@ -212,7 +261,7 @@ func resolveAgentHereBrainPath(raw string) (string, bool, bool) {
 	return "", false, false
 }
 
-func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
+func resolveAgentHereBrainBasename(raw, sourceSphere string) (string, bool, bool) {
 	if raw == "" || strings.ContainsAny(raw, `/\`) {
 		return "", false, false
 	}
@@ -221,7 +270,7 @@ func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
 	if filepath.Ext(needle) == "" {
 		alts = append(alts, needle+".md")
 	}
-	roots := sortedBrainRoots(findBrainRoots())
+	roots := agentHereBrainRoots(sourceSphere)
 	for _, root := range roots {
 		brainDir := filepath.Join(root, "brain")
 		var matches []string
@@ -257,6 +306,66 @@ func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
 		return matches[0], info.IsDir(), true
 	}
 	return "", false, false
+}
+
+func agentHereBrainRoots(sourceSphere string) []string {
+	roots := findBrainRoots()
+	if strings.TrimSpace(sourceSphere) == "" {
+		return sortedBrainRoots(roots)
+	}
+	root := strings.TrimSpace(roots[sourceSphere])
+	if root == "" {
+		return nil
+	}
+	return []string{root}
+}
+
+func rejectAgentHereResolvedPath(path, sourceSphere string) error {
+	if err := rejectAgentHerePersonalPath(path); err != nil {
+		return err
+	}
+	if strings.TrimSpace(sourceSphere) == "" {
+		return nil
+	}
+	if sphere := agentHereSphereForPath(path); sphere != "" && sphere != sourceSphere {
+		return errors.New("target leaves the originating sphere")
+	}
+	return nil
+}
+
+func agentHereSphereForResolvedContext(path string) string {
+	return agentHereSphereForPath(path)
+}
+
+func agentHereSphereForPath(path string) string {
+	roots := findBrainRoots()
+	for _, sphere := range []string{"work", "private"} {
+		root := strings.TrimSpace(roots[sphere])
+		if root == "" {
+			continue
+		}
+		if pathInsideOrEqual(path, root) {
+			return sphere
+		}
+	}
+	return ""
+}
+
+func resolveAgentHereCrossSphereGuard(raw, sourceSphere string) error {
+	if strings.TrimSpace(sourceSphere) == "" {
+		return nil
+	}
+	if path, _, ok := resolveAgentHereBrainPath(raw, ""); ok {
+		if sphere := agentHereSphereForPath(path); sphere != "" && sphere != sourceSphere {
+			return errors.New("target leaves the originating sphere")
+		}
+	}
+	if path, _, ok := resolveAgentHereBrainBasename(raw, ""); ok {
+		if sphere := agentHereSphereForPath(path); sphere != "" && sphere != sourceSphere {
+			return errors.New("target leaves the originating sphere")
+		}
+	}
+	return nil
 }
 
 func agentHerePathCandidates(raw, cwd, sourcePath string) []string {

--- a/cmd/sls/agent_here.go
+++ b/cmd/sls/agent_here.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const agentHerePrompt = "Start agent here."
+
+type agentHereResolution struct {
+	StartPath    string
+	TargetPath   string
+	SourceCursor *chatMessageCursor
+}
+
+func isTopLevelAgentHere(args []string) bool {
+	i := firstPositionalArg(args)
+	return i < len(args) && strings.EqualFold(args[i], "agent-here")
+}
+
+func handleAgentHereCommand(args []string, opts cliOptions, stdout, stderr io.Writer) int {
+	if len(args) == 0 || !strings.EqualFold(args[0], "agent-here") {
+		fmt.Fprintln(stderr, "usage: sls agent-here <path-or-link>")
+		return 2
+	}
+	spec := strings.TrimSpace(strings.Join(args[1:], " "))
+	if spec == "" {
+		fmt.Fprintln(stderr, "usage: sls agent-here <path-or-link>")
+		return 2
+	}
+	res, err := resolveAgentHereSpec(spec, opts.projectDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "sls agent-here: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
+	defer cancel()
+
+	client, err := newClient(ctx, clientConfig{
+		baseURL:   opts.resolveBaseURL(),
+		tokenFile: opts.effectiveTokenFile(),
+		verbose:   opts.verbose,
+		stderr:    stderr,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "sls agent-here: %v\n", err)
+		return 1
+	}
+
+	renderer := newRenderer(stdout, opts.jsonOut, !opts.noColor && isTerminal(stdout))
+	if err := runAgentHere(ctx, client, res, renderer, opts, stderr); err != nil {
+		if errors.Is(err, errAssistantError) {
+			fmt.Fprintf(stderr, "sls: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stderr, "sls agent-here: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runAgentHere(ctx context.Context, client *chatClient, res agentHereResolution, renderer *renderer, opts cliOptions, stderr io.Writer) error {
+	workspace, err := client.openLinkedWorkspace(ctx, res.StartPath)
+	if err != nil {
+		return err
+	}
+	if err := persistSessionForWorkspace(workspace.WorkspacePath, workspace.ChatSessionID); err != nil && opts.verbose {
+		fmt.Fprintf(stderr, "sls: warning: persist session: %v\n", err)
+	}
+	turnCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	final, err := client.sendAndWaitForFinal(turnCtx, workspace.ChatSessionID, agentHerePrompt, res.SourceCursor, renderer)
+	if err != nil {
+		return err
+	}
+	if !opts.jsonOut {
+		trimmed := strings.TrimSpace(final)
+		if trimmed != "" && !renderer.didEmitFinalText() {
+			fmt.Fprintln(renderer.out, trimmed)
+		}
+	}
+	return nil
+}
+
+func resolveAgentHereSpec(spec, cwd string) (agentHereResolution, error) {
+	sourceRaw, targetRaw, hasSource := splitAgentHereSpec(spec)
+	baseDir := absoluteCleanPath(cwd)
+	if baseDir == "" {
+		baseDir = "."
+	}
+	var sourcePath string
+	var cursor *chatMessageCursor
+	if hasSource {
+		var err error
+		sourcePath, cursor, err = resolveAgentHereSource(sourceRaw, baseDir)
+		if err != nil {
+			return agentHereResolution{}, err
+		}
+	}
+	targetPath, targetIsDir, err := resolveAgentHereTarget(targetRaw, baseDir, sourcePath)
+	if err != nil {
+		return agentHereResolution{}, err
+	}
+	startPath := targetPath
+	if !targetIsDir {
+		startPath = filepath.Dir(targetPath)
+	}
+	return agentHereResolution{
+		StartPath:    startPath,
+		TargetPath:   targetPath,
+		SourceCursor: cursor,
+	}, nil
+}
+
+func splitAgentHereSpec(spec string) (string, string, bool) {
+	left, right, ok := strings.Cut(spec, "::")
+	if !ok {
+		return "", strings.TrimSpace(spec), false
+	}
+	return strings.TrimSpace(left), strings.TrimSpace(right), true
+}
+
+func resolveAgentHereSource(raw, cwd string) (string, *chatMessageCursor, error) {
+	clean := cleanAgentHerePath(raw)
+	if clean == "" {
+		return "", nil, errors.New("source note is required")
+	}
+	path, isDir, err := resolveAgentHereExistingPath(clean, cwd)
+	if err != nil {
+		return "", nil, fmt.Errorf("source note %q not found", raw)
+	}
+	if err := rejectAgentHerePersonalPath(path); err != nil {
+		return "", nil, err
+	}
+	return path, &chatMessageCursor{
+		Path:  clean,
+		IsDir: isDir,
+	}, nil
+}
+
+func resolveAgentHereTarget(raw, cwd, sourcePath string) (string, bool, error) {
+	clean := cleanAgentHerePath(raw)
+	if clean == "" {
+		return "", false, errors.New("target path is required")
+	}
+	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath); ok {
+		if err := rejectAgentHerePersonalPath(path); err != nil {
+			return "", false, err
+		}
+		return path, isDir, nil
+	}
+	if path, isDir, ok := resolveAgentHereBrainPath(clean); ok {
+		if err := rejectAgentHerePersonalPath(path); err != nil {
+			return "", false, err
+		}
+		return path, isDir, nil
+	}
+	if path, isDir, ok := resolveAgentHereBrainBasename(clean); ok {
+		if err := rejectAgentHerePersonalPath(path); err != nil {
+			return "", false, err
+		}
+		return path, isDir, nil
+	}
+	return "", false, fmt.Errorf("target %q not found", raw)
+}
+
+func resolveAgentHereExistingPath(raw, cwd string) (string, bool, error) {
+	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, ""); ok {
+		return path, isDir, nil
+	}
+	if path, isDir, ok := resolveAgentHereBrainPath(raw); ok {
+		return path, isDir, nil
+	}
+	if path, isDir, ok := resolveAgentHereBrainBasename(raw); ok {
+		return path, isDir, nil
+	}
+	return "", false, fmt.Errorf("target %q not found", raw)
+}
+
+func resolveAgentHereDirectPath(raw, cwd, sourcePath string) (string, bool, bool) {
+	for _, candidate := range agentHerePathCandidates(raw, cwd, sourcePath) {
+		info, err := os.Stat(candidate)
+		if err == nil {
+			return candidate, info.IsDir(), true
+		}
+	}
+	return "", false, false
+}
+
+func resolveAgentHereBrainPath(raw string) (string, bool, bool) {
+	roots := sortedBrainRoots(findBrainRoots())
+	if len(roots) == 0 {
+		return "", false, false
+	}
+	for _, root := range roots {
+		brainDir := filepath.Join(root, "brain")
+		for _, candidate := range agentHereBrainCandidates(brainDir, raw) {
+			info, err := os.Stat(candidate)
+			if err == nil {
+				return candidate, info.IsDir(), true
+			}
+		}
+	}
+	return "", false, false
+}
+
+func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
+	if raw == "" || strings.ContainsAny(raw, `/\`) {
+		return "", false, false
+	}
+	needle := filepath.Base(raw)
+	alts := []string{needle}
+	if filepath.Ext(needle) == "" {
+		alts = append(alts, needle+".md")
+	}
+	roots := sortedBrainRoots(findBrainRoots())
+	for _, root := range roots {
+		brainDir := filepath.Join(root, "brain")
+		var matches []string
+		_ = filepath.WalkDir(brainDir, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if entry.IsDir() {
+				if strings.EqualFold(entry.Name(), "personal") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if pathInWorkPersonalGuardrail(path) {
+				return nil
+			}
+			for _, alt := range alts {
+				if strings.EqualFold(entry.Name(), alt) {
+					matches = append(matches, path)
+					break
+				}
+			}
+			return nil
+		})
+		if len(matches) == 0 {
+			continue
+		}
+		sort.Strings(matches)
+		info, err := os.Stat(matches[0])
+		if err != nil {
+			continue
+		}
+		return matches[0], info.IsDir(), true
+	}
+	return "", false, false
+}
+
+func agentHerePathCandidates(raw, cwd, sourcePath string) []string {
+	clean := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
+	if clean == "" {
+		return nil
+	}
+	candidates := make([]string, 0, 8)
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		cleaned := filepath.Clean(path)
+		for _, existing := range candidates {
+			if existing == cleaned {
+				return
+			}
+		}
+		candidates = append(candidates, cleaned)
+	}
+	addVariants := func(path string) {
+		add(path)
+		if filepath.Ext(path) == "" && !strings.HasSuffix(path, string(filepath.Separator)) {
+			add(path + ".md")
+		}
+	}
+	if filepath.IsAbs(clean) {
+		addVariants(clean)
+		return candidates
+	}
+	if sourcePath != "" {
+		addVariants(filepath.Join(filepath.Dir(sourcePath), filepath.FromSlash(clean)))
+	}
+	addVariants(filepath.Join(cwd, filepath.FromSlash(clean)))
+	for _, root := range sortedBrainRoots(findBrainRoots()) {
+		brainDir := filepath.Join(root, "brain")
+		addVariants(filepath.Join(brainDir, filepath.FromSlash(clean)))
+	}
+	return candidates
+}
+
+func agentHereBrainCandidates(brainDir, raw string) []string {
+	clean := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
+	if clean == "" {
+		return nil
+	}
+	candidates := make([]string, 0, 4)
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		cleaned := filepath.Clean(path)
+		for _, existing := range candidates {
+			if existing == cleaned {
+				return
+			}
+		}
+		candidates = append(candidates, cleaned)
+	}
+	add(filepath.Join(brainDir, filepath.FromSlash(clean)))
+	if filepath.Ext(clean) == "" && !strings.HasSuffix(clean, string(filepath.Separator)) {
+		add(filepath.Join(brainDir, filepath.FromSlash(clean)+".md"))
+	}
+	return candidates
+}
+
+func cleanAgentHerePath(raw string) string {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return ""
+	}
+	if strings.HasPrefix(target, "<") && strings.HasSuffix(target, ">") {
+		target = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(target, "<"), ">"))
+	}
+	if strings.HasPrefix(strings.ToLower(target), "slopshell-wiki:") {
+		if decoded, err := url.PathUnescape(target[len("slopshell-wiki:"):]); err == nil {
+			target = decoded
+		}
+	}
+	if strings.HasPrefix(target, "[[") && strings.HasSuffix(target, "]]") {
+		target = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(target, "[["), "]]"))
+	}
+	if idx := strings.Index(target, "|"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	if idx := strings.Index(target, "#"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	if idx := strings.Index(target, "?"); idx >= 0 {
+		target = strings.TrimSpace(target[:idx])
+	}
+	return strings.TrimSpace(strings.ReplaceAll(target, "\\", "/"))
+}
+
+func rejectAgentHerePersonalPath(path string) error {
+	if pathInWorkPersonalGuardrail(path) {
+		return errors.New("work personal subtree is blocked")
+	}
+	return nil
+}
+
+func pathInWorkPersonalGuardrail(path string) bool {
+	return pathInsideOrEqual(path, workPersonalGuardrailRoot())
+}
+
+func workPersonalGuardrailRoot() string {
+	root := strings.TrimSpace(brainVaultRoot("work"))
+	if root == "" {
+		return ""
+	}
+	clean := filepath.Clean(root)
+	if filepath.Base(clean) == "brain" {
+		return filepath.Join(filepath.Dir(clean), "personal")
+	}
+	return filepath.Join(clean, "personal")
+}
+
+func pathInsideOrEqual(path, root string) bool {
+	cleanPath := absoluteCleanPath(path)
+	cleanRoot := absoluteCleanPath(root)
+	if cleanPath == "" || cleanRoot == "" {
+		return false
+	}
+	if cleanPath == cleanRoot {
+		return true
+	}
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func absoluteCleanPath(path string) string {
+	clean := strings.TrimSpace(path)
+	if clean == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return filepath.Clean(clean)
+	}
+	return filepath.Clean(abs)
+}
+
+func sortedBrainRoots(roots map[string]string) []string {
+	order := []string{"work", "private"}
+	out := make([]string, 0, len(roots))
+	seen := map[string]bool{}
+	for _, sphere := range order {
+		root := strings.TrimSpace(roots[sphere])
+		if root == "" {
+			continue
+		}
+		out = append(out, root)
+		seen[root] = true
+	}
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" || seen[root] {
+			continue
+		}
+		out = append(out, root)
+	}
+	return out
+}

--- a/cmd/sls/agent_here.go
+++ b/cmd/sls/agent_here.go
@@ -138,7 +138,10 @@ func resolveAgentHereSource(raw, cwd string) (string, *chatMessageCursor, string
 	}
 	sourceSphere := agentHereSphereForResolvedContext(cwd)
 	if info, err := os.Stat(cwd); err == nil && !info.IsDir() {
-		if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, cwd); ok {
+		if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, cwd, sourceSphere); ok {
+			if resolvedSphere := agentHereSphereForPath(path); resolvedSphere != "" {
+				sourceSphere = resolvedSphere
+			}
 			if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 				return "", nil, "", err
 			}
@@ -151,6 +154,9 @@ func resolveAgentHereSource(raw, cwd string) (string, *chatMessageCursor, string
 	path, isDir, err := resolveAgentHereExistingPath(clean, cwd, sourceSphere)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("source note %q not found", raw)
+	}
+	if resolvedSphere := agentHereSphereForPath(path); resolvedSphere != "" {
+		sourceSphere = resolvedSphere
 	}
 	if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 		return "", nil, "", err
@@ -185,7 +191,7 @@ func resolveAgentHereTarget(raw, cwd, sourcePath, sourceSphere string) (string, 
 	if clean == "" {
 		return "", false, errors.New("target path is required")
 	}
-	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath); ok {
+	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath, sourceSphere); ok {
 		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 			return "", false, err
 		}
@@ -210,7 +216,7 @@ func resolveAgentHereTarget(raw, cwd, sourcePath, sourceSphere string) (string, 
 }
 
 func resolveAgentHereExistingPath(raw, cwd, sourceSphere string) (string, bool, error) {
-	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, ""); ok {
+	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, "", sourceSphere); ok {
 		if err := rejectAgentHereResolvedPath(path, sourceSphere); err != nil {
 			return "", false, err
 		}
@@ -234,8 +240,8 @@ func resolveAgentHereExistingPath(raw, cwd, sourceSphere string) (string, bool, 
 	return "", false, fmt.Errorf("target %q not found", raw)
 }
 
-func resolveAgentHereDirectPath(raw, cwd, sourcePath string) (string, bool, bool) {
-	for _, candidate := range agentHerePathCandidates(raw, cwd, sourcePath) {
+func resolveAgentHereDirectPath(raw, cwd, sourcePath, sourceSphere string) (string, bool, bool) {
+	for _, candidate := range agentHerePathCandidates(raw, cwd, sourcePath, sourceSphere) {
 		info, err := os.Stat(candidate)
 		if err == nil {
 			return candidate, info.IsDir(), true
@@ -355,20 +361,25 @@ func resolveAgentHereCrossSphereGuard(raw, sourceSphere string) error {
 	if strings.TrimSpace(sourceSphere) == "" {
 		return nil
 	}
-	if path, _, ok := resolveAgentHereBrainPath(raw, ""); ok {
-		if sphere := agentHereSphereForPath(path); sphere != "" && sphere != sourceSphere {
-			return errors.New("target leaves the originating sphere")
+	for _, sphere := range []string{"work", "private"} {
+		if sphere == sourceSphere {
+			continue
 		}
-	}
-	if path, _, ok := resolveAgentHereBrainBasename(raw, ""); ok {
-		if sphere := agentHereSphereForPath(path); sphere != "" && sphere != sourceSphere {
-			return errors.New("target leaves the originating sphere")
+		if path, _, ok := resolveAgentHereBrainPath(raw, sphere); ok {
+			if agentHereSphereForPath(path) == sphere {
+				return errors.New("target leaves the originating sphere")
+			}
+		}
+		if path, _, ok := resolveAgentHereBrainBasename(raw, sphere); ok {
+			if agentHereSphereForPath(path) == sphere {
+				return errors.New("target leaves the originating sphere")
+			}
 		}
 	}
 	return nil
 }
 
-func agentHerePathCandidates(raw, cwd, sourcePath string) []string {
+func agentHerePathCandidates(raw, cwd, sourcePath, sourceSphere string) []string {
 	clean := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
 	if clean == "" {
 		return nil
@@ -398,9 +409,10 @@ func agentHerePathCandidates(raw, cwd, sourcePath string) []string {
 	}
 	if sourcePath != "" {
 		addVariants(filepath.Join(filepath.Dir(sourcePath), filepath.FromSlash(clean)))
+	} else {
+		addVariants(filepath.Join(cwd, filepath.FromSlash(clean)))
 	}
-	addVariants(filepath.Join(cwd, filepath.FromSlash(clean)))
-	for _, root := range sortedBrainRoots(findBrainRoots()) {
+	for _, root := range agentHereBrainRoots(sourceSphere) {
 		brainDir := filepath.Join(root, "brain")
 		addVariants(filepath.Join(brainDir, filepath.FromSlash(clean)))
 	}

--- a/cmd/sls/agent_here_test.go
+++ b/cmd/sls/agent_here_test.go
@@ -113,6 +113,75 @@ func TestResolveAgentHereSpecSourceLinkPreservesCursor(t *testing.T) {
 	}
 }
 
+func TestResolveAgentHereSpecCurrentNotePreservesCursor(t *testing.T) {
+	vaultRoot := t.TempDir()
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	currentNote := filepath.Join(brainRoot, "topics", "current.md")
+	targetDir := filepath.Join(brainRoot, "projects", "path")
+	if err := os.MkdirAll(filepath.Dir(currentNote), 0o755); err != nil {
+		t.Fatalf("mkdir current note dir: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(currentNote, []byte("current"), 0o644); err != nil {
+		t.Fatalf("write current note: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", vaultRoot)
+
+	res, err := resolveAgentHereSpec("../projects/path", currentNote)
+	if err != nil {
+		t.Fatalf("resolveAgentHereSpec() error = %v", err)
+	}
+	if res.TargetPath != targetDir {
+		t.Fatalf("target path = %q, want %q", res.TargetPath, targetDir)
+	}
+	if res.StartPath != targetDir {
+		t.Fatalf("start path = %q, want %q", res.StartPath, targetDir)
+	}
+	if res.SourceCursor == nil {
+		t.Fatal("source cursor = nil, want cursor")
+	}
+	if res.SourceCursor.Path != currentNote {
+		t.Fatalf("source cursor path = %q, want %q", res.SourceCursor.Path, currentNote)
+	}
+	if res.SourceCursor.IsDir {
+		t.Fatal("source cursor IsDir = true, want false")
+	}
+}
+
+func TestResolveAgentHereSpecKeepsWorkSphere(t *testing.T) {
+	workRoot := t.TempDir()
+	privateRoot := t.TempDir()
+	workCurrentNote := filepath.Join(workRoot, "brain", "topics", "current.md")
+	privateTarget := filepath.Join(privateRoot, "brain", "private-only.md")
+	if err := os.MkdirAll(filepath.Dir(workCurrentNote), 0o755); err != nil {
+		t.Fatalf("mkdir work note dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(privateTarget), 0o755); err != nil {
+		t.Fatalf("mkdir private target dir: %v", err)
+	}
+	if err := os.WriteFile(workCurrentNote, []byte("current"), 0o644); err != nil {
+		t.Fatalf("write work note: %v", err)
+	}
+	if err := os.WriteFile(privateTarget, []byte("private"), 0o644); err != nil {
+		t.Fatalf("write private target: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workRoot)
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateRoot)
+
+	_, err := resolveAgentHereSpec("private-only.md", workCurrentNote)
+	if err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want originating sphere guard")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "sphere") {
+		t.Fatalf("resolveAgentHereSpec() error = %v, want sphere guard", err)
+	}
+	if strings.Contains(err.Error(), privateRoot) {
+		t.Fatalf("resolveAgentHereSpec() leaked private root: %v", err)
+	}
+}
+
 func TestResolveAgentHereSpecMissingTarget(t *testing.T) {
 	cwd := t.TempDir()
 	if _, err := resolveAgentHereSpec("missing.md", cwd); err == nil {

--- a/cmd/sls/agent_here_test.go
+++ b/cmd/sls/agent_here_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsTopLevelAgentHere(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "plain", args: []string{"agent-here", "notes/topic.md"}, want: true},
+		{name: "with flags", args: []string{"--base-url", "http://x", "agent-here", "notes/topic.md"}, want: true},
+		{name: "other command", args: []string{"brain", "agent-here"}, want: false},
+		{name: "empty", args: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTopLevelAgentHere(tt.args); got != tt.want {
+				t.Fatalf("isTopLevelAgentHere(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentHereSpecDirectFolder(t *testing.T) {
+	cwd := t.TempDir()
+	target := filepath.Join(cwd, "project", "path")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	res, err := resolveAgentHereSpec("project/path", cwd)
+	if err != nil {
+		t.Fatalf("resolveAgentHereSpec() error = %v", err)
+	}
+	if res.TargetPath != target {
+		t.Fatalf("target path = %q, want %q", res.TargetPath, target)
+	}
+	if res.StartPath != target {
+		t.Fatalf("start path = %q, want %q", res.StartPath, target)
+	}
+	if res.SourceCursor != nil {
+		t.Fatalf("source cursor = %#v, want nil", res.SourceCursor)
+	}
+}
+
+func TestResolveAgentHereSpecDirectFile(t *testing.T) {
+	cwd := t.TempDir()
+	targetDir := filepath.Join(cwd, "project", "path")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	target := filepath.Join(targetDir, "file.md")
+	if err := os.WriteFile(target, []byte("file"), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	res, err := resolveAgentHereSpec("project/path/file.md", cwd)
+	if err != nil {
+		t.Fatalf("resolveAgentHereSpec() error = %v", err)
+	}
+	if res.TargetPath != target {
+		t.Fatalf("target path = %q, want %q", res.TargetPath, target)
+	}
+	if res.StartPath != targetDir {
+		t.Fatalf("start path = %q, want %q", res.StartPath, targetDir)
+	}
+}
+
+func TestResolveAgentHereSpecSourceLinkPreservesCursor(t *testing.T) {
+	vaultRoot := t.TempDir()
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	personalRoot := filepath.Join(vaultRoot, "personal")
+	targetDir := filepath.Join(vaultRoot, "project", "path")
+	sourceDir := filepath.Join(brainRoot, "topics")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.MkdirAll(personalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir personal root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "source.md"), []byte("source"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", vaultRoot)
+
+	res, err := resolveAgentHereSpec("topics/source.md::../../project/path", brainRoot)
+	if err != nil {
+		t.Fatalf("resolveAgentHereSpec() error = %v", err)
+	}
+	if res.TargetPath != targetDir {
+		t.Fatalf("target path = %q, want %q", res.TargetPath, targetDir)
+	}
+	if res.StartPath != targetDir {
+		t.Fatalf("start path = %q, want %q", res.StartPath, targetDir)
+	}
+	if res.SourceCursor == nil {
+		t.Fatal("source cursor = nil, want cursor")
+	}
+	if res.SourceCursor.Path != "topics/source.md" {
+		t.Fatalf("source cursor path = %q, want topics/source.md", res.SourceCursor.Path)
+	}
+	if res.SourceCursor.IsDir {
+		t.Fatal("source cursor IsDir = true, want false")
+	}
+}
+
+func TestResolveAgentHereSpecMissingTarget(t *testing.T) {
+	cwd := t.TempDir()
+	if _, err := resolveAgentHereSpec("missing.md", cwd); err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want missing target error")
+	} else if !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		t.Fatalf("resolveAgentHereSpec() error = %v, want not found", err)
+	}
+}
+
+func TestResolveAgentHereSpecBlocksWorkPersonal(t *testing.T) {
+	vaultRoot := t.TempDir()
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	personalRoot := filepath.Join(vaultRoot, "personal")
+	if err := os.MkdirAll(brainRoot, 0o755); err != nil {
+		t.Fatalf("mkdir brain root: %v", err)
+	}
+	if err := os.MkdirAll(personalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir personal root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(personalRoot, "secret.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write personal note: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", vaultRoot)
+
+	_, err := resolveAgentHereSpec("personal/secret.md", vaultRoot)
+	if err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want personal guard")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "personal") {
+		t.Fatalf("resolveAgentHereSpec() error = %v, want personal guard", err)
+	}
+	if strings.Contains(err.Error(), vaultRoot) {
+		t.Fatalf("resolveAgentHereSpec() leaked absolute path: %v", err)
+	}
+}

--- a/cmd/sls/agent_here_test.go
+++ b/cmd/sls/agent_here_test.go
@@ -113,6 +113,48 @@ func TestResolveAgentHereSpecSourceLinkPreservesCursor(t *testing.T) {
 	}
 }
 
+func TestResolveAgentHereSpecExplicitSourceIgnoresCwdFallback(t *testing.T) {
+	vaultRoot := t.TempDir()
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	privateRoot := t.TempDir()
+	sourceDir := filepath.Join(brainRoot, "topics")
+	sourceNote := filepath.Join(sourceDir, "source.md")
+	cwd := t.TempDir()
+	cwdTarget := filepath.Join(cwd, "relative.md")
+	privateTarget := filepath.Join(privateRoot, "brain", "relative.md")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(privateTarget), 0o755); err != nil {
+		t.Fatalf("mkdir private target dir: %v", err)
+	}
+	if err := os.WriteFile(sourceNote, []byte("source"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	if err := os.WriteFile(cwdTarget, []byte("cwd"), 0o644); err != nil {
+		t.Fatalf("write cwd target: %v", err)
+	}
+	if err := os.WriteFile(privateTarget, []byte("private"), 0o644); err != nil {
+		t.Fatalf("write private target: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", vaultRoot)
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateRoot)
+
+	_, err := resolveAgentHereSpec("topics/source.md::relative.md", cwd)
+	if err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want source-sphere guard")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "sphere") {
+		t.Fatalf("resolveAgentHereSpec() error = %v, want sphere guard", err)
+	}
+	if strings.Contains(err.Error(), cwdTarget) {
+		t.Fatalf("resolveAgentHereSpec() leaked cwd fallback: %v", err)
+	}
+	if strings.Contains(err.Error(), privateTarget) {
+		t.Fatalf("resolveAgentHereSpec() leaked private fallback: %v", err)
+	}
+}
+
 func TestResolveAgentHereSpecCurrentNotePreservesCursor(t *testing.T) {
 	vaultRoot := t.TempDir()
 	brainRoot := filepath.Join(vaultRoot, "brain")

--- a/cmd/sls/client.go
+++ b/cmd/sls/client.go
@@ -43,6 +43,41 @@ type chatSessionInfo struct {
 	CanvasSessionID string `json:"canvas_session_id"`
 }
 
+type chatMessageCursor struct {
+	View          string  `json:"view,omitempty"`
+	Element       string  `json:"element,omitempty"`
+	Title         string  `json:"title,omitempty"`
+	Page          int     `json:"page,omitempty"`
+	Line          int     `json:"line,omitempty"`
+	RelativeX     float64 `json:"relative_x,omitempty"`
+	RelativeY     float64 `json:"relative_y,omitempty"`
+	SelectedText  string  `json:"selected_text,omitempty"`
+	Surrounding   string  `json:"surrounding_text,omitempty"`
+	ItemID        int64   `json:"item_id,omitempty"`
+	ItemTitle     string  `json:"item_title,omitempty"`
+	ItemState     string  `json:"item_state,omitempty"`
+	WorkspaceID   int64   `json:"workspace_id,omitempty"`
+	WorkspaceName string  `json:"workspace_name,omitempty"`
+	Path          string  `json:"path,omitempty"`
+	IsDir         bool    `json:"is_dir,omitempty"`
+}
+
+type linkedWorkspaceInfo struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	RootPath      string `json:"root_path"`
+	WorkspacePath string `json:"workspace_path"`
+	ChatSessionID string `json:"chat_session_id"`
+}
+
+type runtimeWorkspaceCreateResponse struct {
+	OK        bool                `json:"ok"`
+	Created   bool                `json:"created"`
+	Activated bool                `json:"activated"`
+	Workspace linkedWorkspaceInfo `json:"workspace"`
+}
+
 func newClient(ctx context.Context, cfg clientConfig) (*chatClient, error) {
 	base, err := url.Parse(strings.TrimSpace(cfg.baseURL))
 	if err != nil {
@@ -91,6 +126,37 @@ func (c *chatClient) cliLogin(ctx context.Context, tokenFile string) error {
 		return fmt.Errorf("cli login failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
+}
+
+func (c *chatClient) openLinkedWorkspace(ctx context.Context, path string) (*linkedWorkspaceInfo, error) {
+	payload, _ := json.Marshal(map[string]any{
+		"kind":     "linked",
+		"path":     strings.TrimSpace(path),
+		"activate": true,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/runtime/workspaces"), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("open linked workspace: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var wrapped runtimeWorkspaceCreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wrapped); err != nil {
+		return nil, fmt.Errorf("decode workspace: %w", err)
+	}
+	workspace := wrapped.Workspace
+	if strings.TrimSpace(workspace.ChatSessionID) == "" {
+		return nil, errors.New("server returned empty chat session id for linked workspace")
+	}
+	return &workspace, nil
 }
 
 // newClientForBrain creates a minimal HTTP client for brain commands that
@@ -314,7 +380,7 @@ func (c *chatClient) sendCommand(ctx context.Context, sessionID, command string)
 	return result, nil
 }
 
-func (c *chatClient) sendAndWaitForFinal(ctx context.Context, sessionID, prompt string, renderer *renderer) (string, error) {
+func (c *chatClient) sendAndWaitForFinal(ctx context.Context, sessionID, prompt string, cursor *chatMessageCursor, renderer *renderer) (string, error) {
 	ws, err := c.dialChatWS(ctx, sessionID)
 	if err != nil {
 		return "", fmt.Errorf("ws dial: %w", err)
@@ -326,6 +392,7 @@ func (c *chatClient) sendAndWaitForFinal(ctx context.Context, sessionID, prompt 
 		"text":        prompt,
 		"output_mode": "silent",
 		"local_only":  false,
+		"cursor":      cursor,
 	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.urlFor("/api/chat/sessions/"+url.PathEscape(sessionID)+"/messages"), bytes.NewReader(payload))
 	if err != nil {

--- a/cmd/sls/main.go
+++ b/cmd/sls/main.go
@@ -215,6 +215,7 @@ Brain commands (standalone, before chat flags):
 Link follow (top-level):
   sls link follow <note> <target> [<sphere>]    same as sls brain link follow
   sls agent-here <path-or-link>       start an agent in a resolved folder
+                                      source::target keeps explicit source context
 
 REPL commands (type inside sls):
   /help                 show this help

--- a/cmd/sls/main.go
+++ b/cmd/sls/main.go
@@ -43,12 +43,15 @@ func main() {
 }
 
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	if isBrainSubcommand(args) || isTopLevelLinkFollow(args) {
+	if isBrainSubcommand(args) || isTopLevelLinkFollow(args) || isTopLevelAgentHere(args) {
 		brainArgs := commandArgs(args)
 		opts, _, err := parseFlags(args)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 2
+		}
+		if isTopLevelAgentHere(args) {
+			return handleAgentHereCommand(brainArgs, opts, stdout, stderr)
 		}
 		return handleBrainCommand(brainArgs, opts)
 	}
@@ -211,6 +214,7 @@ Brain commands (standalone, before chat flags):
 
 Link follow (top-level):
   sls link follow <note> <target> [<sphere>]    same as sls brain link follow
+  sls agent-here <path-or-link>       start an agent in a resolved folder
 
 REPL commands (type inside sls):
   /help                 show this help
@@ -285,7 +289,7 @@ func runOneShot(ctx context.Context, client *chatClient, session *chatSessionInf
 	}
 	turnCtx, cancel := context.WithTimeout(ctx, opts.timeout)
 	defer cancel()
-	final, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, renderer)
+	final, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, nil, renderer)
 	if err != nil {
 		if errors.Is(err, errAssistantError) {
 			fmt.Fprintf(stderr, "sls: %v\n", err)
@@ -357,7 +361,7 @@ func runREPL(ctx context.Context, client *chatClient, session *chatSessionInfo, 
 		}
 		prompt := buildPromptWithDirectives(line, activeOpts)
 		turnCtx, cancel := context.WithTimeout(ctx, activeOpts.timeout)
-		_, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, renderer)
+		_, err := client.sendAndWaitForFinal(turnCtx, session.ID, prompt, nil, renderer)
 		cancel()
 		if err != nil {
 			fmt.Fprintln(stderr, renderer.colorize(colorRed, fmt.Sprintf("turn failed: %v", err)))


### PR DESCRIPTION
## Summary

- Add `sls agent-here <path-or-link>` for resolved folders and files.
- Resolve links relative to the current note or an explicit source note.
- Keep target resolution inside the originating sphere, preserve the source cursor, and enforce work/private + `personal/` guardrails.
- Start a linked workspace in the resolved folder so the server loads the nearest workspace instructions.

## Verification

### Top-level routing
Requirement: `sls agent-here <path-or-link>` is recognized as a top-level command.

```text
$ go test ./cmd/sls -run 'TestIsTopLevelAgentHere' -v
=== RUN   TestIsTopLevelAgentHere
--- PASS: TestIsTopLevelAgentHere (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/sls 0.004s
```

### Resolved folders and files
Requirement: direct folder and direct file targets resolve to the right start path.

```text
$ go test ./cmd/sls -run 'TestResolveAgentHereSpecDirectFolder|TestResolveAgentHereSpecDirectFile' -v
=== RUN   TestResolveAgentHereSpecDirectFolder
--- PASS: TestResolveAgentHereSpecDirectFolder (0.00s)
=== RUN   TestResolveAgentHereSpecDirectFile
--- PASS: TestResolveAgentHereSpecDirectFile (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/sls 0.004s
```

### Source-relative links
Requirement: targets resolve relative to the current note or explicit source note, and the source cursor is preserved.

```text
$ go test ./cmd/sls -run 'TestResolveAgentHereSpecSourceLinkPreservesCursor|TestResolveAgentHereSpecExplicitSourceIgnoresCwdFallback|TestResolveAgentHereSpecCurrentNotePreservesCursor' -v
=== RUN   TestResolveAgentHereSpecSourceLinkPreservesCursor
--- PASS: TestResolveAgentHereSpecSourceLinkPreservesCursor (0.00s)
=== RUN   TestResolveAgentHereSpecExplicitSourceIgnoresCwdFallback
--- PASS: TestResolveAgentHereSpecExplicitSourceIgnoresCwdFallback (0.00s)
=== RUN   TestResolveAgentHereSpecCurrentNotePreservesCursor
--- PASS: TestResolveAgentHereSpecCurrentNotePreservesCursor (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/sls 0.005s
```

### Sphere guardrails
Requirement: resolution stays within the originating sphere and work/private `personal/` paths are blocked.

```text
$ go test ./cmd/sls -run 'TestResolveAgentHereSpecKeepsWorkSphere|TestResolveAgentHereSpecBlocksWorkPersonal' -v
=== RUN   TestResolveAgentHereSpecKeepsWorkSphere
--- PASS: TestResolveAgentHereSpecKeepsWorkSphere (0.00s)
=== RUN   TestResolveAgentHereSpecBlocksWorkPersonal
--- PASS: TestResolveAgentHereSpecBlocksWorkPersonal (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/sls 0.004s
```

### Missing targets
Requirement: missing targets fail cleanly.

```text
$ go test ./cmd/sls -run 'TestResolveAgentHereSpecMissingTarget' -v
=== RUN   TestResolveAgentHereSpecMissingTarget
--- PASS: TestResolveAgentHereSpecMissingTarget (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/cmd/sls 0.004s
```

### Nearest instructions
Requirement: linked workspaces load the nearest `AGENTS.md` or `CLAUDE.md`.

```text
$ go test ./internal/web -run TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions -v
=== RUN   TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions
=== RUN   TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions/prefers_AGENTS_over_CLAUDE_in_the_same_directory
=== RUN   TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions/nearest_ancestor_wins
--- PASS: TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions (0.00s)
    --- PASS: TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions/prefers_AGENTS_over_CLAUDE_in_the_same_directory (0.00s)
    --- PASS: TestBuildLeanLocalAssistantPromptLoadsNearestWorkspaceInstructions/nearest_ancestor_wins (0.00s)
PASS
ok   github.com/sloppy-org/slopshell/internal/web 0.014s
```

### Package check

```text
$ go test ./cmd/sls/...
ok   github.com/sloppy-org/slopshell/cmd/sls 0.036s
```

Logs: `/tmp/slopshell-cmd-sls-resolver.log`, `/tmp/slopshell-cmd-sls-test.log`, `/tmp/slopshell-web-nearest-instructions.log`
