### PR TITLE
fix: Add agent handoff action from brain link target (fixes #724)

### DIFF
--- a/cmd/sls/agent_here.go
+++ b/cmd/sls/agent_here.go
@@ -151,20 +151,22 @@ func resolveAgentHereTarget(raw, cwd, sourcePath string) (string, bool, error) {
 	if clean == "" {
 		return "", false, errors.New("target path is required")
 	}
-	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+	sourceVaultRoot := agentHereSourceVaultRoot(sourcePath)
+	brainRoots := agentHereTargetBrainRoots(sourceVaultRoot)
+	if path, isDir, ok := resolveAgentHereDirectPath(clean, cwd, sourcePath, brainRoots); ok {
+		if err := rejectAgentHereTargetPath(path, sourceVaultRoot); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainPath(clean); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+	if path, isDir, ok := resolveAgentHereBrainPath(clean, brainRoots); ok {
+		if err := rejectAgentHereTargetPath(path, sourceVaultRoot); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainBasename(clean); ok {
-		if err := rejectAgentHerePersonalPath(path); err != nil {
+	if path, isDir, ok := resolveAgentHereBrainBasename(clean, brainRoots); ok {
+		if err := rejectAgentHereTargetPath(path, sourceVaultRoot); err != nil {
 			return "", false, err
 		}
 		return path, isDir, nil
@@ -173,20 +175,21 @@ func resolveAgentHereTarget(raw, cwd, sourcePath string) (string, bool, error) {
 }
 
 func resolveAgentHereExistingPath(raw, cwd string) (string, bool, error) {
-	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, ""); ok {
+	brainRoots := agentHereTargetBrainRoots("")
+	if path, isDir, ok := resolveAgentHereDirectPath(raw, cwd, "", brainRoots); ok {
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainPath(raw); ok {
+	if path, isDir, ok := resolveAgentHereBrainPath(raw, brainRoots); ok {
 		return path, isDir, nil
 	}
-	if path, isDir, ok := resolveAgentHereBrainBasename(raw); ok {
+	if path, isDir, ok := resolveAgentHereBrainBasename(raw, brainRoots); ok {
 		return path, isDir, nil
 	}
 	return "", false, fmt.Errorf("target %q not found", raw)
 }
 
-func resolveAgentHereDirectPath(raw, cwd, sourcePath string) (string, bool, bool) {
-	for _, candidate := range agentHerePathCandidates(raw, cwd, sourcePath) {
+func resolveAgentHereDirectPath(raw, cwd, sourcePath string, brainRoots []string) (string, bool, bool) {
+	for _, candidate := range agentHerePathCandidates(raw, cwd, sourcePath, brainRoots) {
 		info, err := os.Stat(candidate)
 		if err == nil {
 			return candidate, info.IsDir(), true
@@ -195,8 +198,7 @@ func resolveAgentHereDirectPath(raw, cwd, sourcePath string) (string, bool, bool
 	return "", false, false
 }
 
-func resolveAgentHereBrainPath(raw string) (string, bool, bool) {
-	roots := sortedBrainRoots(findBrainRoots())
+func resolveAgentHereBrainPath(raw string, roots []string) (string, bool, bool) {
 	if len(roots) == 0 {
 		return "", false, false
 	}
@@ -212,7 +214,7 @@ func resolveAgentHereBrainPath(raw string) (string, bool, bool) {
 	return "", false, false
 }
 
-func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
+func resolveAgentHereBrainBasename(raw string, roots []string) (string, bool, bool) {
 	if raw == "" || strings.ContainsAny(raw, `/\`) {
 		return "", false, false
 	}
@@ -221,7 +223,6 @@ func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
 	if filepath.Ext(needle) == "" {
 		alts = append(alts, needle+".md")
 	}
-	roots := sortedBrainRoots(findBrainRoots())
 	for _, root := range roots {
 		brainDir := filepath.Join(root, "brain")
 		var matches []string
@@ -259,7 +260,7 @@ func resolveAgentHereBrainBasename(raw string) (string, bool, bool) {
 	return "", false, false
 }
 
-func agentHerePathCandidates(raw, cwd, sourcePath string) []string {
+func agentHerePathCandidates(raw, cwd, sourcePath string, brainRoots []string) []string {
 	clean := strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
 	if clean == "" {
 		return nil
@@ -291,7 +292,7 @@ func agentHerePathCandidates(raw, cwd, sourcePath string) []string {
 		addVariants(filepath.Join(filepath.Dir(sourcePath), filepath.FromSlash(clean)))
 	}
 	addVariants(filepath.Join(cwd, filepath.FromSlash(clean)))
-	for _, root := range sortedBrainRoots(findBrainRoots()) {
+	for _, root := range brainRoots {
 		brainDir := filepath.Join(root, "brain")
 		addVariants(filepath.Join(brainDir, filepath.FromSlash(clean)))
 	}
@@ -356,6 +357,36 @@ func rejectAgentHerePersonalPath(path string) error {
 		return errors.New("work personal subtree is blocked")
 	}
 	return nil
+}
+
+func rejectAgentHereTargetPath(path, sourceVaultRoot string) error {
+	if err := rejectAgentHerePersonalPath(path); err != nil {
+		return err
+	}
+	if sourceVaultRoot != "" && !pathInsideOrEqual(path, sourceVaultRoot) {
+		return errors.New("target leaves source vault")
+	}
+	return nil
+}
+
+func agentHereSourceVaultRoot(sourcePath string) string {
+	source := strings.TrimSpace(sourcePath)
+	if source == "" {
+		return ""
+	}
+	for _, root := range sortedBrainRoots(findBrainRoots()) {
+		if pathInsideOrEqual(source, root) {
+			return absoluteCleanPath(root)
+		}
+	}
+	return ""
+}
+
+func agentHereTargetBrainRoots(sourceVaultRoot string) []string {
+	if root := strings.TrimSpace(sourceVaultRoot); root != "" {
+		return []string{absoluteCleanPath(root)}
+	}
+	return sortedBrainRoots(findBrainRoots())
 }
 
 func pathInWorkPersonalGuardrail(path string) bool {

--- a/cmd/sls/agent_here_test.go
+++ b/cmd/sls/agent_here_test.go
@@ -113,6 +113,63 @@ func TestResolveAgentHereSpecSourceLinkPreservesCursor(t *testing.T) {
 	}
 }
 
+func TestResolveAgentHereSpecSourceLinkDoesNotCrossBrainSpheres(t *testing.T) {
+	root := t.TempDir()
+	workVault := filepath.Join(root, "work")
+	privateVault := filepath.Join(root, "private")
+	workBrain := filepath.Join(workVault, "brain")
+	privateBrain := filepath.Join(privateVault, "brain")
+	if err := os.MkdirAll(filepath.Join(workBrain, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir work brain: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(privateBrain, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir private brain: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workBrain, "topics", "source.md"), []byte("source"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(privateBrain, "topics", "private-target.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write private target: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workVault)
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateVault)
+
+	_, err := resolveAgentHereSpec("topics/source.md::private-target", workBrain)
+	if err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want cross-sphere target rejection")
+	}
+	if strings.Contains(err.Error(), privateVault) {
+		t.Fatalf("resolveAgentHereSpec() leaked private path: %v", err)
+	}
+}
+
+func TestResolveAgentHereSpecSourceLinkRejectsAbsoluteTargetOutsideSourceVault(t *testing.T) {
+	root := t.TempDir()
+	workVault := filepath.Join(root, "work")
+	privateVault := filepath.Join(root, "private")
+	workBrain := filepath.Join(workVault, "brain")
+	privateProject := filepath.Join(privateVault, "project")
+	if err := os.MkdirAll(filepath.Join(workBrain, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir work brain: %v", err)
+	}
+	if err := os.MkdirAll(privateProject, 0o755); err != nil {
+		t.Fatalf("mkdir private project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workBrain, "topics", "source.md"), []byte("source"), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	t.Setenv("SLOPSHELL_BRAIN_WORK_ROOT", workVault)
+	t.Setenv("SLOPSHELL_BRAIN_PRIVATE_ROOT", privateVault)
+
+	_, err := resolveAgentHereSpec("topics/source.md::"+privateProject, workBrain)
+	if err == nil {
+		t.Fatal("resolveAgentHereSpec() error = nil, want outside-vault target rejection")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "source vault") {
+		t.Fatalf("resolveAgentHereSpec() error = %v, want source vault guard", err)
+	}
+}
+
 func TestResolveAgentHereSpecMissingTarget(t *testing.T) {
 	cwd := t.TempDir()
 	if _, err := resolveAgentHereSpec("missing.md", cwd); err == nil {

--- a/internal/web/projects_hub.go
+++ b/internal/web/projects_hub.go
@@ -194,8 +194,10 @@ func (a *App) buildProjectWelcomeSections(project store.Workspace) []workspaceWe
 					Subtitle:    filepath.Base(strings.TrimSpace(project.RootPath)),
 					Description: "Use the nearest AGENTS.md or CLAUDE.md from this source folder.",
 					Action: workspaceWelcomeAction{
-						Type: "start_agent_here",
-						Path: project.RootPath,
+						Type:              "start_agent_here",
+						Path:              project.RootPath,
+						SourceWorkspaceID: project.SourceWorkspaceID,
+						SourcePath:        project.SourcePath,
 					},
 				},
 			},

--- a/internal/web/static/app-chat-submit.ts
+++ b/internal/web/static/app-chat-submit.ts
@@ -245,7 +245,13 @@ export async function submitMessage(text, options: Record<string, any> = {}) {
     capture_mode: submitKind === 'voice_transcript' ? 'voice' : 'text',
     fast_mode: Boolean(state.fastMode),
   };
-  const cursorPayload = mergeCursorPayload(buildCursorPayload(anchor), buildSidebarSelectionCursorPayload());
+  const optionCursor = options?.cursor && typeof options.cursor === 'object'
+    ? buildCursorPayload(options.cursor)
+    : null;
+  const cursorPayload = mergeCursorPayload(
+    mergeCursorPayload(buildCursorPayload(anchor), optionCursor),
+    buildSidebarSelectionCursorPayload(),
+  );
   if (cursorPayload) {
     body.cursor = cursorPayload;
   }

--- a/internal/web/static/app-chat-ui.ts
+++ b/internal/web/static/app-chat-ui.ts
@@ -575,6 +575,25 @@ function activeWorkspaceRootMatches(path) {
   return normalizedWorkspaceRootPath(project) === target;
 }
 
+function activeWorkspaceProject() {
+  const activeID = String(state.activeWorkspaceId || '').trim();
+  if (!activeID || !Array.isArray(state.projects)) return null;
+  return state.projects.find((project) => String(project?.id || '').trim() === activeID) || null;
+}
+
+function sourceContextCursor(sourcePath, sourceWorkspaceID = '') {
+  const path = String(sourcePath || '').trim();
+  if (!path) return null;
+  return {
+    view: 'source_context',
+    element: 'agent_handoff',
+    title: path,
+    path,
+    is_dir: false,
+    workspace_name: String(sourceWorkspaceID || '').trim(),
+  };
+}
+
 export async function handleWelcomeAction(action) {
   const type = String(action?.type || '').trim();
   if (!type) return;
@@ -617,10 +636,21 @@ export async function handleWelcomeAction(action) {
     const path = String(action?.path || '').trim();
     if (!path) return;
     if (activeWorkspaceRootMatches(path)) {
-      await submitMessage('Start agent here.', { kind: 'start_agent_here' });
+      const project = activeWorkspaceProject();
+      const sourcePath = String(action?.source_path || project?.source_path || '').trim();
+      const sourceWorkspaceID = String(action?.source_workspace_id || project?.source_workspace_id || '').trim();
+      const cursor = sourceContextCursor(sourcePath, sourceWorkspaceID);
+      await submitMessage('Start agent here.', {
+        kind: 'start_agent_here',
+        ...(cursor ? { cursor } : {}),
+      });
       return;
     }
-    await startAgentHereAtPath(path, String(state.activeWorkspaceId || '').trim());
+    await startAgentHereAtPath(
+      path,
+      String(action?.source_workspace_id || state.activeWorkspaceId || '').trim(),
+      String(action?.source_path || '').trim(),
+    );
   }
 }
 

--- a/internal/web/static/app-workspace-actions.ts
+++ b/internal/web/static/app-workspace-actions.ts
@@ -18,6 +18,19 @@ type WorkspaceActionDeps = {
   submitMessage?: (text: string, options?: Record<string, any>) => Promise<void>;
 };
 
+function startAgentHereCursor(sourceWorkspaceID: string, sourceNotePath: string): Record<string, any> | null {
+  const sourcePath = String(sourceNotePath || '').trim();
+  if (!sourcePath) return null;
+  return {
+    view: 'source_context',
+    element: 'agent_handoff',
+    title: sourcePath,
+    path: sourcePath,
+    is_dir: false,
+    workspace_name: String(sourceWorkspaceID || '').trim(),
+  };
+}
+
 async function postWorkspaceAction(
   deps: WorkspaceActionDeps,
   path: string,
@@ -107,7 +120,11 @@ export async function startAgentHereAtPath(
     sourceNotePath,
   );
   if (!workspaceID || typeof deps.submitMessage !== 'function') return;
-  await deps.submitMessage('Start agent here.', { kind: 'start_agent_here' });
+  const cursor = startAgentHereCursor(sourceWorkspaceID, sourceNotePath);
+  await deps.submitMessage('Start agent here.', {
+    kind: 'start_agent_here',
+    ...(cursor ? { cursor } : {}),
+  });
 }
 
 export async function persistTemporaryProject(

--- a/internal/web/workspace_runtime.go
+++ b/internal/web/workspace_runtime.go
@@ -58,11 +58,13 @@ type workspaceFileEntry struct {
 }
 
 type workspaceWelcomeAction struct {
-	Type          string `json:"type"`
-	WorkspaceID   string `json:"workspace_id,omitempty"`
-	Path          string `json:"path,omitempty"`
-	SilentMode    *bool  `json:"silent_mode,omitempty"`
-	StartupTarget string `json:"startup_behavior,omitempty"`
+	Type              string `json:"type"`
+	WorkspaceID       string `json:"workspace_id,omitempty"`
+	Path              string `json:"path,omitempty"`
+	SourceWorkspaceID string `json:"source_workspace_id,omitempty"`
+	SourcePath        string `json:"source_path,omitempty"`
+	SilentMode        *bool  `json:"silent_mode,omitempty"`
+	StartupTarget     string `json:"startup_behavior,omitempty"`
 }
 
 type workspaceWelcomeCard struct {

--- a/internal/web/workspace_runtime_linked_test.go
+++ b/internal/web/workspace_runtime_linked_test.go
@@ -74,6 +74,12 @@ func TestProjectWelcomeIncludesStartAgentCardForLinkedWorkspaces(t *testing.T) {
 	if !strings.Contains(agentCard.Description, "Use the nearest AGENTS.md or CLAUDE.md from this source folder.") {
 		t.Fatalf("welcome missing nearest-instructions guidance: %s", agentCard.Description)
 	}
+	if agentCard.Action.SourceWorkspaceID != workspaceIDStr(brain.ID) {
+		t.Fatalf("agent source workspace id = %q, want %q", agentCard.Action.SourceWorkspaceID, workspaceIDStr(brain.ID))
+	}
+	if agentCard.Action.SourcePath != "topics/active.md" {
+		t.Fatalf("agent source path = %q, want topics/active.md", agentCard.Action.SourcePath)
+	}
 	if originCard == nil {
 		t.Fatalf("welcome missing origin card: %#v", welcome.Sections)
 	}

--- a/tests/playwright/canvas-cursor-context.spec.ts
+++ b/tests/playwright/canvas-cursor-context.spec.ts
@@ -708,6 +708,12 @@ test('start agent here welcome action preserves the active linked workspace orig
 
   const log = await getLog(page);
   expect(log.some((entry) => entry.type === 'api_fetch' && entry.action === 'project_create')).toBe(false);
+  const startEntry = log.find(
+    (entry) => entry.type === 'message_sent'
+      && String(entry.text || '') === 'Start agent here.',
+  ) as HarnessLogEntry | undefined;
+  expect((startEntry?.cursor as any)?.path).toBe('topics/active.md');
+  expect((startEntry?.cursor as any)?.view).toBe('source_context');
   await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).toBe('linked-1');
 });
 
@@ -782,6 +788,13 @@ test('file markdown links open the parent folder as source context', async ({ pa
       && String(entry.text || '') === 'Start agent here.',
     );
   }, { timeout: 5_000 }).toBe(true);
+
+  const startEntry = (await getLog(page)).find(
+    (entry) => entry.type === 'message_sent'
+      && String(entry.text || '') === 'Start agent here.',
+  ) as HarnessLogEntry | undefined;
+  expect((startEntry?.cursor as any)?.path).toBe('topics/active.md');
+  expect((startEntry?.cursor as any)?.view).toBe('source_context');
 
   await expect.poll(async () => page.evaluate(() => String((window as any)._slopshellApp?.getState?.().activeWorkspaceId || '')), { timeout: 5_000 }).not.toBe('brain');
 

--- a/tests/playwright/harness-fixtures.js
+++ b/tests/playwright/harness-fixtures.js
@@ -117,6 +117,8 @@
           sphere: String(project?.sphere || '').trim().toLowerCase(),
           workspace_path: String(project?.workspace_path || `/tmp/${String(project?.id || '').trim() || 'project'}`).trim(),
           root_path: String(project?.root_path || `/tmp/${String(project?.id || '').trim() || 'project'}`).trim(),
+          source_workspace_id: String(project?.source_workspace_id || '').trim(),
+          source_path: String(project?.source_path || '').trim(),
           chat_session_id: String(project?.chat_session_id || `chat-${String(project?.id || '').trim() || 'project'}`).trim(),
           canvas_session_id: String(project?.canvas_session_id || 'local').trim(),
           chat_mode: String(project?.chat_mode || 'chat').trim().toLowerCase() || 'chat',


### PR DESCRIPTION
Closes #724.

## Verification

Requirement evidence:

| Issue requirement | Evidence |
| --- | --- |
| Add `Start agent here` action from linked source targets | `./scripts/playwright.sh --project=chromium tests/playwright/canvas-cursor-context.spec.ts` passed the linked-workspace welcome and markdown-link start-agent flows. |
| Resolve target folder from note link or selected source context, and start in that folder rather than the brain root | Playwright test `file markdown links open the parent folder as source context` passed; it asserts linked workspace creation with `path: /tmp/vault/project/path`, not the brain workspace. |
| Load nearest `AGENTS.md`/`CLAUDE.md` for the resolved folder | `go test ./internal/web -run 'TestProjectWelcomeIncludesStartAgentCardForLinkedWorkspaces|TestLinkedWorkspaceCreationCopiesSourceSettings|TestApplyWorkspacePromptContextLoadsNearestInstructionsFromLinkedSource|TestApplyWorkspacePromptContextWalksUpToVaultAGENTSWhenLinkedSourceLacksOne'` passed. |
| Preserve source note/artifact context in handoff metadata and prompt cursor | Web welcome action now carries `source_workspace_id`/`source_path`; Playwright asserts starter message cursor `path: topics/active.md` and `view: source_context`. SLS `TestResolveAgentHereSpecSourceLinkPreservesCursor` passed. |
| Enforce work/private and `personal/` guardrails | `go test ./cmd/sls -run 'TestResolveAgentHereSpec|TestIsTopLevelAgentHere'` passed, including cross-sphere rejection, absolute target outside source-vault rejection, and work `personal/` blocking. |

Commands and excerpts:

```console
$ go test ./cmd/sls -run 'TestResolveAgentHereSpec|TestIsTopLevelAgentHere'
ok  	github.com/sloppy-org/slopshell/cmd/sls	0.004s
```

```console
$ go test ./internal/web -run 'TestProjectWelcomeIncludesStartAgentCardForLinkedWorkspaces|TestLinkedWorkspaceCreationCopiesSourceSettings|TestApplyWorkspacePromptContextLoadsNearestInstructionsFromLinkedSource|TestApplyWorkspacePromptContextWalksUpToVaultAGENTSWhenLinkedSourceLacksOne'
ok  	github.com/sloppy-org/slopshell/internal/web	0.116s
```

```console
$ npm run typecheck:frontend
> typecheck:frontend
> tsc --noEmit -p tsconfig.json
```

```console
$ npm run build:frontend
> build:frontend
> node ./scripts/build-frontend.mjs
built 65 frontend modules
```

```console
$ ./scripts/playwright.sh --project=chromium tests/playwright/canvas-cursor-context.spec.ts
14 passed (9.5s)
```

```console
$ ./scripts/sync-surface.sh --check
```

```console
$ go test $(go list ./... | rg -v '/tests/services$')
ok  	github.com/sloppy-org/slopshell/internal/web	(cached)
ok  	github.com/sloppy-org/slopshell/tests/deploy	(cached)
```

Verification logs are in `/tmp/issue-724-sls.log`, `/tmp/issue-724-web-unit.log`, `/tmp/issue-724-frontend-typecheck.log`, `/tmp/issue-724-frontend-build.log`, `/tmp/issue-724-playwright.log`, `/tmp/issue-724-sync-surface.log`, and `/tmp/issue-724-go-test-nonservices.log`.
