### PR TITLE
fix: Add waiting, deferred, someday, and review queues (fixes #729)

### DIFF
--- a/internal/store/store_domain_item_query.go
+++ b/internal/store/store_domain_item_query.go
@@ -209,7 +209,17 @@ func (s *Store) ListDeferredItemsFiltered(filter ItemListFilter) ([]ItemSummary,
 }
 
 func (s *Store) ListReviewItemsFiltered(filter ItemListFilter) ([]ItemSummary, error) {
-	return s.listItemSummariesByState(ItemStateReview, filter)
+	normalizedFilter, err := s.prepareItemListFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+	column := func(name string) string { return "i." + name }
+	reviewClause, reviewArgs := reviewQueueClause(time.Now().UTC(), column, column)
+	parts := []string{reviewClause}
+	args := append([]any{}, reviewArgs...)
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + ` WHERE ` + stringsJoin(parts, ` AND `) + ` ORDER BY i.updated_at DESC, i.id ASC`
+	return s.listItemSummaries(query, args...)
 }
 
 func (s *Store) ListSomedayItems() ([]ItemSummary, error) {
@@ -286,6 +296,9 @@ func (s *Store) CountItemsByStateFiltered(now time.Time, filter ItemListFilter) 
 	}
 	cutoff := now.UTC().Format(time.RFC3339Nano)
 	var inbox, next, waiting, deferred, someday, review, done int
+	column := func(name string) string { return name }
+	outerColumn := func(name string) string { return "items." + name }
+	reviewClause, reviewArgs := reviewQueueClause(now, column, outerColumn)
 	query := `
 SELECT
   COALESCE(SUM(CASE
@@ -300,20 +313,13 @@ SELECT
   COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0) AS waiting_count,
   COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0) AS deferred_count,
   COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0) AS someday_count,
-  COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0) AS review_count,
+  COALESCE(SUM(CASE WHEN ` + reviewClause + ` THEN 1 ELSE 0 END), 0) AS review_count,
   COALESCE(SUM(CASE WHEN state = ? THEN 1 ELSE 0 END), 0) AS done_count
 FROM items
 `
-	args := []any{
-		ItemStateInbox,
-		cutoff,
-		ItemStateNext,
-		ItemStateWaiting,
-		ItemStateDeferred,
-		ItemStateSomeday,
-		ItemStateReview,
-		ItemStateDone,
-	}
+	args := []any{ItemStateInbox, cutoff, ItemStateNext, ItemStateWaiting, ItemStateDeferred, ItemStateSomeday}
+	args = append(args, reviewArgs...)
+	args = append(args, ItemStateDone)
 	parts := []string{}
 	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "")
 	if len(parts) > 0 {
@@ -330,6 +336,24 @@ FROM items
 	counts[ItemStateReview] = review
 	counts[ItemStateDone] = done
 	return counts, nil
+}
+
+func reviewQueueClause(now time.Time, column, outerColumn itemFilterColumnFunc) (string, []any) {
+	cutoff := now.UTC().Format(time.RFC3339Nano)
+	clause := `(` + column("state") + ` = ?
+OR (` + column("state") + ` = ?
+  AND ` + column("follow_up_at") + ` IS NOT NULL AND trim(` + column("follow_up_at") + `) <> ''
+  AND datetime(` + column("follow_up_at") + `) <= datetime(?))
+OR (` + column("kind") + ` = ?
+  AND ` + column("state") + ` <> ?
+  AND NOT EXISTS (
+    SELECT 1 FROM item_children links JOIN items child ON child.id = links.child_item_id
+    WHERE links.parent_item_id = ` + outerColumn("id") + `
+      AND child.state IN (?, ?, ?, ?)
+  )))`
+	args := []any{ItemStateReview, ItemStateWaiting, cutoff, ItemKindProject, ItemStateDone}
+	args = append(args, ItemStateNext, ItemStateWaiting, ItemStateDeferred, ItemStateSomeday)
+	return clause, args
 }
 
 // SidebarSectionCounts captures counts for the compact sidebar's secondary

--- a/internal/store/store_sidebar_counts_test.go
+++ b/internal/store/store_sidebar_counts_test.go
@@ -219,6 +219,87 @@ func TestCountSidebarSectionsFilteredCountsDriftReviewItems(t *testing.T) {
 	}
 }
 
+func TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC()
+	past := now.Add(-time.Hour).Format(time.RFC3339)
+	future := now.Add(time.Hour).Format(time.RFC3339)
+	alice, err := s.CreateActor("Alice", ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	if _, err := s.CreateItem("Explicit review", ItemOptions{State: ItemStateReview}); err != nil {
+		t.Fatalf("CreateItem(review) error: %v", err)
+	}
+	if _, err := s.CreateItem("Follow up Alice", ItemOptions{
+		State:      ItemStateWaiting,
+		ActorID:    &alice.ID,
+		FollowUpAt: &past,
+	}); err != nil {
+		t.Fatalf("CreateItem(due waiting) error: %v", err)
+	}
+	if _, err := s.CreateItem("Not ready waiting", ItemOptions{
+		State:      ItemStateWaiting,
+		ActorID:    &alice.ID,
+		FollowUpAt: &future,
+	}); err != nil {
+		t.Fatalf("CreateItem(future waiting) error: %v", err)
+	}
+	if _, err := s.CreateItem("Stalled outcome", ItemOptions{
+		Kind:  ItemKindProject,
+		State: ItemStateNext,
+	}); err != nil {
+		t.Fatalf("CreateItem(stalled project) error: %v", err)
+	}
+	healthy, err := s.CreateItem("Healthy outcome", ItemOptions{
+		Kind:  ItemKindProject,
+		State: ItemStateNext,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(healthy project) error: %v", err)
+	}
+	child, err := s.CreateItem("Healthy next action", ItemOptions{State: ItemStateNext})
+	if err != nil {
+		t.Fatalf("CreateItem(child) error: %v", err)
+	}
+	if err := s.LinkItemChild(healthy.ID, child.ID, ItemLinkRoleNextAction); err != nil {
+		t.Fatalf("LinkItemChild() error: %v", err)
+	}
+	if _, err := s.CreateItem("Done stalled outcome", ItemOptions{
+		Kind:  ItemKindProject,
+		State: ItemStateDone,
+	}); err != nil {
+		t.Fatalf("CreateItem(done project) error: %v", err)
+	}
+
+	items, err := s.ListReviewItemsFiltered(ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListReviewItemsFiltered() error: %v", err)
+	}
+	titles := map[string]bool{}
+	for _, item := range items {
+		titles[item.Title] = true
+	}
+	for _, title := range []string{"Explicit review", "Follow up Alice", "Stalled outcome"} {
+		if !titles[title] {
+			t.Fatalf("review queue missing %q from titles %#v", title, titles)
+		}
+	}
+	for _, title := range []string{"Not ready waiting", "Healthy outcome", "Done stalled outcome"} {
+		if titles[title] {
+			t.Fatalf("review queue includes %q unexpectedly: %#v", title, titles)
+		}
+	}
+	counts, err := s.CountItemsByStateFiltered(now, ItemListFilter{})
+	if err != nil {
+		t.Fatalf("CountItemsByStateFiltered() error: %v", err)
+	}
+	if counts[ItemStateReview] != 3 {
+		t.Fatalf("review count = %d, want 3", counts[ItemStateReview])
+	}
+}
+
 func TestCountSidebarSectionsFilteredCountsDuplicateSourcePairs(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/web/chat_items_filters.go
+++ b/internal/web/chat_items_filters.go
@@ -55,6 +55,18 @@ func parseInlineItemFilterIntent(text string) *SystemAction {
 				"all_spheres":   allSpheres,
 			},
 		}
+	case "show next", "open next", "show next actions", "open next actions", "zeige naechste aktionen":
+		return showFilteredItemsAction(store.ItemStateNext, true, allSpheres)
+	case "show waiting", "open waiting", "show waiting for", "open waiting for", "zeige warten":
+		return showFilteredItemsAction(store.ItemStateWaiting, true, allSpheres)
+	case "show deferred", "open deferred", "show tickler", "open tickler", "zeige spaeter":
+		return showFilteredItemsAction(store.ItemStateDeferred, true, allSpheres)
+	case "show someday", "open someday", "show someday maybe", "open someday maybe":
+		return showFilteredItemsAction(store.ItemStateSomeday, true, allSpheres)
+	case "show review", "open review", "show review queue", "open review queue",
+		"daily review", "start daily review", "open daily review",
+		"weekly review", "start weekly review", "open weekly review":
+		return showFilteredItemsAction(store.ItemStateReview, true, allSpheres)
 	case "show unassigned items", "show unassigned inbox items", "show items without workspace", "zeige nicht zugeordnete items", "zeige items ohne workspace":
 		return &SystemAction{
 			Action: "show_filtered_items",
@@ -80,17 +92,17 @@ func parseInlineItemFilterIntent(text string) *SystemAction {
 		}
 	}
 	if match := projectItemFilterPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
-		projectRef := cleanWorkspaceReference(match[1])
-		if allSpheres && strings.HasPrefix(strings.ToLower(projectRef), "all ") {
-			projectRef = cleanWorkspaceReference(strings.TrimSpace(projectRef[4:]))
+		workspaceRef := cleanWorkspaceReference(match[1])
+		if allSpheres && strings.HasPrefix(strings.ToLower(workspaceRef), "all ") {
+			workspaceRef = cleanWorkspaceReference(strings.TrimSpace(workspaceRef[4:]))
 		}
-		if projectRef != "" && !strings.EqualFold(projectRef, "unassigned") {
+		if workspaceRef != "" && !strings.EqualFold(workspaceRef, "unassigned") {
 			return &SystemAction{
 				Action: "show_filtered_items",
 				Params: map[string]interface{}{
 					"view": store.ItemStateInbox,
 					"filters": map[string]interface{}{
-						"workspace":   projectRef,
+						"workspace":   workspaceRef,
 						"all_spheres": allSpheres,
 					},
 				},
@@ -98,6 +110,17 @@ func parseInlineItemFilterIntent(text string) *SystemAction {
 		}
 	}
 	return nil
+}
+
+func showFilteredItemsAction(view string, clearFilters, allSpheres bool) *SystemAction {
+	return &SystemAction{
+		Action: "show_filtered_items",
+		Params: map[string]interface{}{
+			"view":          view,
+			"clear_filters": clearFilters,
+			"all_spheres":   allSpheres,
+		},
+	}
 }
 
 func systemActionTruthyParam(params map[string]interface{}, key string) bool {
@@ -173,7 +196,12 @@ func systemActionAllSpheresParam(params map[string]interface{}) bool {
 
 func filteredItemViewMessage(view string, filter store.ItemListFilter, count int, allSpheres bool) string {
 	listName := "inbox"
-	if view == store.ItemStateWaiting || view == store.ItemStateSomeday || view == store.ItemStateDone {
+	if view == store.ItemStateNext ||
+		view == store.ItemStateWaiting ||
+		view == store.ItemStateDeferred ||
+		view == store.ItemStateSomeday ||
+		view == store.ItemStateReview ||
+		view == store.ItemStateDone {
 		listName = view
 	}
 	filterText := ""

--- a/internal/web/chat_items_filters.go
+++ b/internal/web/chat_items_filters.go
@@ -29,7 +29,7 @@ var itemFilterSourceCommands = map[string]string{
 	"show manual items":       "manual",
 }
 
-var projectItemFilterPattern = regexp.MustCompile(`(?i)^(?:show|open|zeige)\s+(.+?)\s+items$`)
+var workspaceItemFilterPattern = regexp.MustCompile(`(?i)^(?:show|open|zeige)\s+(.+?)\s+items$`)
 
 func parseInlineItemFilterIntent(text string) *SystemAction {
 	normalized := normalizeItemCommandText(text)
@@ -91,7 +91,7 @@ func parseInlineItemFilterIntent(text string) *SystemAction {
 			},
 		}
 	}
-	if match := projectItemFilterPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
+	if match := workspaceItemFilterPattern.FindStringSubmatch(strings.TrimSpace(text)); len(match) == 2 {
 		workspaceRef := cleanWorkspaceReference(match[1])
 		if allSpheres && strings.HasPrefix(strings.ToLower(workspaceRef), "all ") {
 			workspaceRef = cleanWorkspaceReference(strings.TrimSpace(workspaceRef[4:]))

--- a/internal/web/chat_items_filters_test.go
+++ b/internal/web/chat_items_filters_test.go
@@ -21,6 +21,12 @@ func TestParseInlineItemIntentFilterCommands(t *testing.T) {
 	}{
 		{text: "show inbox", wantAction: "show_filtered_items", wantClear: true},
 		{text: "show all inbox", wantAction: "show_filtered_items", wantClear: true, wantAll: true},
+		{text: "show next actions", wantAction: "show_filtered_items", wantClear: true},
+		{text: "show waiting", wantAction: "show_filtered_items", wantClear: true},
+		{text: "show deferred", wantAction: "show_filtered_items", wantClear: true},
+		{text: "show review queue", wantAction: "show_filtered_items", wantClear: true},
+		{text: "daily review", wantAction: "show_filtered_items", wantClear: true},
+		{text: "weekly review", wantAction: "show_filtered_items", wantClear: true},
 		{text: "zeige posteingang", wantAction: "show_filtered_items", wantClear: true},
 		{text: "show todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist},
 		{text: "show all todoist tasks", wantAction: "show_filtered_items", wantSource: store.ExternalProviderTodoist, wantAll: true},
@@ -55,6 +61,43 @@ func TestParseInlineItemIntentFilterCommands(t *testing.T) {
 				t.Fatalf("all_spheres = %v, want %v", got, tc.wantAll)
 			}
 		})
+	}
+}
+
+func TestClassifyAndExecuteSystemActionOpensReviewEntryPoint(t *testing.T) {
+	app := newAuthedTestApp(t)
+	app.intentLLMURL = ""
+
+	project, err := app.ensureDefaultWorkspace()
+	if err != nil {
+		t.Fatalf("ensure default project: %v", err)
+	}
+	if _, err := app.store.CreateItem("Review stalled outcome", store.ItemOptions{
+		Kind:  store.ItemKindProject,
+		State: store.ItemStateNext,
+	}); err != nil {
+		t.Fatalf("CreateItem(stalled project) error: %v", err)
+	}
+	session, err := app.store.GetOrCreateChatSession(project.WorkspacePath)
+	if err != nil {
+		t.Fatalf("chat session: %v", err)
+	}
+
+	message, payloads, handled := app.classifyAndExecuteSystemAction(context.Background(), session.ID, session, "daily review")
+	if !handled {
+		t.Fatal("expected daily review command to be handled")
+	}
+	if message != "Opened review with 1 item(s)." {
+		t.Fatalf("message = %q", message)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payloads = %#v", payloads)
+	}
+	if got := strFromAny(payloads[0]["view"]); got != store.ItemStateReview {
+		t.Fatalf("payload view = %q, want %q", got, store.ItemStateReview)
+	}
+	if !boolFromAny(payloads[0]["clear_filters"]) {
+		t.Fatalf("payload clear_filters = %#v, want true", payloads[0])
 	}
 }
 

--- a/internal/web/chat_items_filters_test.go
+++ b/internal/web/chat_items_filters_test.go
@@ -68,9 +68,9 @@ func TestClassifyAndExecuteSystemActionOpensReviewEntryPoint(t *testing.T) {
 	app := newAuthedTestApp(t)
 	app.intentLLMURL = ""
 
-	project, err := app.ensureDefaultWorkspace()
+	workspace, err := app.ensureDefaultWorkspace()
 	if err != nil {
-		t.Fatalf("ensure default project: %v", err)
+		t.Fatalf("ensure default workspace: %v", err)
 	}
 	if _, err := app.store.CreateItem("Review stalled outcome", store.ItemOptions{
 		Kind:  store.ItemKindProject,
@@ -78,7 +78,7 @@ func TestClassifyAndExecuteSystemActionOpensReviewEntryPoint(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateItem(stalled project) error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(project.WorkspacePath)
+	session, err := app.store.GetOrCreateChatSession(workspace.WorkspacePath)
 	if err != nil {
 		t.Fatalf("chat session: %v", err)
 	}
@@ -105,9 +105,9 @@ func TestClassifyAndExecuteSystemActionShowFilteredItems(t *testing.T) {
 	app := newAuthedTestApp(t)
 	app.intentLLMURL = ""
 
-	project, err := app.ensureDefaultWorkspace()
+	workspace, err := app.ensureDefaultWorkspace()
 	if err != nil {
-		t.Fatalf("ensure default project: %v", err)
+		t.Fatalf("ensure default workspace: %v", err)
 	}
 	privateWorkspace, err := app.store.CreateWorkspace("Private", filepath.Join(t.TempDir(), "private"), store.SpherePrivate)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestClassifyAndExecuteSystemActionShowFilteredItems(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateItem(exchange) error: %v", err)
 	}
-	session, err := app.store.GetOrCreateChatSession(project.WorkspacePath)
+	session, err := app.store.GetOrCreateChatSession(workspace.WorkspacePath)
 	if err != nil {
 		t.Fatalf("chat session: %v", err)
 	}

--- a/internal/web/sidebar_counts_test.go
+++ b/internal/web/sidebar_counts_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/sloppy-org/slopshell/internal/store"
 )
@@ -155,6 +156,79 @@ func TestItemListFilterSectionDrillsDownToProjectItems(t *testing.T) {
 	first, _ := items[0].(map[string]any)
 	if first["kind"] != store.ItemKindProject {
 		t.Fatalf("items[0].kind = %v, want %q", first["kind"], store.ItemKindProject)
+	}
+}
+
+func TestItemReviewEndpointIncludesDueWaitingAndStalledProjectItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	now := time.Now().UTC()
+	past := now.Add(-time.Hour).Format(time.RFC3339)
+	future := now.Add(time.Hour).Format(time.RFC3339)
+	alice, err := app.store.CreateActor("Alice", store.ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor() error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Explicit review", store.ItemOptions{State: store.ItemStateReview}); err != nil {
+		t.Fatalf("CreateItem(review) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Follow up Alice", store.ItemOptions{
+		State:      store.ItemStateWaiting,
+		ActorID:    &alice.ID,
+		FollowUpAt: &past,
+	}); err != nil {
+		t.Fatalf("CreateItem(due waiting) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Future waiting", store.ItemOptions{
+		State:      store.ItemStateWaiting,
+		ActorID:    &alice.ID,
+		FollowUpAt: &future,
+	}); err != nil {
+		t.Fatalf("CreateItem(future waiting) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Stalled outcome", store.ItemOptions{
+		Kind:  store.ItemKindProject,
+		State: store.ItemStateNext,
+	}); err != nil {
+		t.Fatalf("CreateItem(stalled project) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/review", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	items, ok := payload["items"].([]any)
+	if !ok {
+		t.Fatalf("items payload = %#v", payload)
+	}
+	titles := map[string]bool{}
+	for _, raw := range items {
+		row, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("item row = %#v", raw)
+		}
+		titles[strFromAny(row["title"])] = true
+	}
+	for _, title := range []string{"Explicit review", "Follow up Alice", "Stalled outcome"} {
+		if !titles[title] {
+			t.Fatalf("review endpoint missing %q from titles %#v", title, titles)
+		}
+	}
+	if titles["Future waiting"] {
+		t.Fatalf("review endpoint includes future waiting item: %#v", titles)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/counts", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("counts status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	counts, ok := decodeJSONResponse(t, rr)["counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("counts payload = %#v", decodeJSONResponse(t, rr))
+	}
+	if got := int(counts[store.ItemStateReview].(float64)); got != 3 {
+		t.Fatalf("counts[review] = %d, want 3", got)
 	}
 }
 

--- a/internal/web/sidebar_counts_test.go
+++ b/internal/web/sidebar_counts_test.go
@@ -17,6 +17,45 @@ import (
 func TestItemCountsExposesSidebarSectionCountsAlongsidePerStateCounts(t *testing.T) {
 	app := newAuthedTestApp(t)
 
+	seedSidebarCountsFixture(t, app)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/counts", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("counts status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	counts, ok := payload["counts"].(map[string]any)
+	if !ok {
+		t.Fatalf("counts payload = %#v", payload)
+	}
+	if got := int(counts[store.ItemStateDone].(float64)); got != 1 {
+		t.Fatalf("counts[done] = %d, want 1", got)
+	}
+
+	sections, ok := payload["sections"].(map[string]any)
+	if !ok {
+		t.Fatalf("sections payload missing in %#v", payload)
+	}
+	if got := int(sections["project_items_open"].(float64)); got != 1 {
+		t.Fatalf("sections[project_items_open] = %d, want 1 (only the open project item; done excluded)", got)
+	}
+	if got := int(sections["people_open"].(float64)); got != 2 {
+		t.Fatalf("sections[people_open] = %d, want 2 (Alice + Bob)", got)
+	}
+	if got := int(sections["drift_review"].(float64)); got != 1 {
+		t.Fatalf("sections[drift_review] = %d, want 1 (review item with review_target set)", got)
+	}
+	if got := int(sections["dedup_review"].(float64)); got != 2 {
+		t.Fatalf("sections[dedup_review] = %d, want 2 (the colliding source/source_ref pair)", got)
+	}
+	if got := int(sections["recent_meetings"].(float64)); got != 1 {
+		t.Fatalf("sections[recent_meetings] = %d, want 1", got)
+	}
+}
+
+func seedSidebarCountsFixture(t *testing.T, app *App) {
+	t.Helper()
+
 	if _, err := app.store.CreateItem("Plan GTD outcome", store.ItemOptions{
 		Kind:  store.ItemKindProject,
 		State: store.ItemStateNext,
@@ -87,39 +126,6 @@ func TestItemCountsExposesSidebarSectionCountsAlongsidePerStateCounts(t *testing
 	transcriptTitle := "Recent transcript"
 	if _, err := app.store.CreateArtifact(store.ArtifactKindTranscript, &transcriptPath, nil, &transcriptTitle, nil); err != nil {
 		t.Fatalf("CreateArtifact(transcript) error: %v", err)
-	}
-
-	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/counts", nil)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("counts status = %d, want 200: %s", rr.Code, rr.Body.String())
-	}
-	payload := decodeJSONResponse(t, rr)
-	counts, ok := payload["counts"].(map[string]any)
-	if !ok {
-		t.Fatalf("counts payload = %#v", payload)
-	}
-	if got := int(counts[store.ItemStateDone].(float64)); got != 1 {
-		t.Fatalf("counts[done] = %d, want 1", got)
-	}
-
-	sections, ok := payload["sections"].(map[string]any)
-	if !ok {
-		t.Fatalf("sections payload missing in %#v", payload)
-	}
-	if got := int(sections["project_items_open"].(float64)); got != 1 {
-		t.Fatalf("sections[project_items_open] = %d, want 1 (only the open project item; done excluded)", got)
-	}
-	if got := int(sections["people_open"].(float64)); got != 2 {
-		t.Fatalf("sections[people_open] = %d, want 2 (Alice + Bob)", got)
-	}
-	if got := int(sections["drift_review"].(float64)); got != 1 {
-		t.Fatalf("sections[drift_review] = %d, want 1 (review item with review_target set)", got)
-	}
-	if got := int(sections["dedup_review"].(float64)); got != 2 {
-		t.Fatalf("sections[dedup_review] = %d, want 2 (the colliding source/source_ref pair)", got)
-	}
-	if got := int(sections["recent_meetings"].(float64)); got != 1 {
-		t.Fatalf("sections[recent_meetings] = %d, want 1", got)
 	}
 }
 

--- a/internal/web/static/app-item-sidebar-utils.ts
+++ b/internal/web/static/app-item-sidebar-utils.ts
@@ -939,8 +939,8 @@ function itemSidebarStateEntries(item, itemState, x, y) {
   }
   return [
     ...review,
-    itemSidebarTriageEntry(item, 'next'),
     itemSidebarTriageEntry(item, 'done'),
+    itemSidebarTriageEntry(item, 'next'),
     ...shared,
     itemSidebarTriageEntry(item, 'later'),
     itemSidebarTriageEntry(item, 'delegate', () => showItemSidebarDelegateMenu(item, x, y)),


### PR DESCRIPTION
## Summary

- Add direct entry points for next, waiting, deferred/tickler, someday, review, daily review, and weekly review item queues.
- Build the review queue from explicit review items, due waiting follow-ups, and stalled project items without conflating project-item filters with workspace filters.
- Keep the desktop inbox action menu ordering covered by Playwright after the queue changes.

## Verification

### Test fails on main

Not run per task instruction: no main checkout or pre-change baseline run.

### Test passes after fix

Requirement: queues are unified across sources and direct queue/review entry points exist.

```text
go test ./internal/web -run 'TestItemReviewEndpointIncludesDueWaitingAndStalledProjectItems|TestClassifyAndExecuteSystemActionOpensReviewEntryPoint|TestParseInlineItemIntentFilterCommands' -v
--- PASS: TestParseInlineItemIntentFilterCommands/show_next_actions
--- PASS: TestParseInlineItemIntentFilterCommands/show_waiting
--- PASS: TestParseInlineItemIntentFilterCommands/show_deferred
--- PASS: TestParseInlineItemIntentFilterCommands/show_review_queue
--- PASS: TestParseInlineItemIntentFilterCommands/daily_review
--- PASS: TestParseInlineItemIntentFilterCommands/weekly_review
--- PASS: TestParseInlineItemIntentFilterCommands/show_todoist_tasks
--- PASS: TestParseInlineItemIntentFilterCommands/show_evernote_notes
--- PASS: TestClassifyAndExecuteSystemActionOpensReviewEntryPoint
PASS
ok  	github.com/sloppy-org/slopshell/internal/web	0.067s
```

Requirement: follow-up-ready waiting/deferred items surface correctly.

```text
go test ./internal/store -run 'TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems|TestResurfaceDueItems' -v
--- PASS: TestResurfaceDueItems (0.02s)
--- PASS: TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems (0.02s)
PASS
ok  	github.com/sloppy-org/slopshell/internal/store	0.038s
```

Requirement: stalled project items surface in review, and workspace filters stay separate from project-item/outcome filters.

```text
go test ./internal/web -run 'TestItemReviewEndpointIncludesDueWaitingAndStalledProjectItems|TestClassifyAndExecuteSystemActionOpensReviewEntryPoint|TestParseInlineItemIntentFilterCommands' -v
--- PASS: TestItemReviewEndpointIncludesDueWaitingAndStalledProjectItems (0.02s)
--- PASS: TestClassifyAndExecuteSystemActionOpensReviewEntryPoint (0.02s)
PASS
ok  	github.com/sloppy-org/slopshell/internal/web	0.067s
```

Broader checks:

```text
go test ./... 2>&1 | tee /tmp/issue-729-go-full.log
ok  	github.com/sloppy-org/slopshell/internal/store	(cached)
ok  	github.com/sloppy-org/slopshell/internal/web	(cached)
```

```text
go test ./internal/store ./internal/web 2>&1 | tee /tmp/issue-729-go-focused-final.log
ok  	github.com/sloppy-org/slopshell/internal/store	(cached)
ok  	github.com/sloppy-org/slopshell/internal/web	25.862s
```

```text
./scripts/sync-surface.sh --check 2>&1 | tee /tmp/issue-729-sync-surface-final.log
# exit 0, no output
```

```text
npm run build:frontend 2>&1 | tee /tmp/issue-729-frontend-build.log
> build:frontend
> node ./scripts/build-frontend.mjs
built 65 frontend modules
```

```text
npm run typecheck:frontend 2>&1 | tee /tmp/issue-729-frontend-typecheck-after-menu.log
> typecheck:frontend
> tsc --noEmit -p tsconfig.json
```

Playwright was run once for the full suite as requested; it exposed one desktop menu-ordering failure, which this branch fixes. The failed case was rerun selectively:

```text
./scripts/playwright.sh tests/playwright/inbox-triage.spec.ts -g "desktop context menu and keyboard shortcuts cover archive, delete, later, and delegate" 2>&1 | tee /tmp/issue-729-playwright-inbox-menu.log
✓  1 [chromium] › tests/playwright/inbox-triage.spec.ts:799:7 › inbox triage interactions › desktop context menu and keyboard shortcuts cover archive, delete, later, and delegate (907ms)
1 passed (2.1s)
```

Full Playwright run log before the targeted fix: `/tmp/issue-729-playwright.log` (`404 passed`, `40 skipped`, `1 failed` in the menu-ordering case above).
