### PR TITLE
fix: Build composite item and outcome review (fixes #728)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -168,6 +168,7 @@ Domain model API:
 - `GET /api/items/deferred`
 - `GET /api/items/someday`
 - `GET /api/items/review`
+- `GET /api/items/projects`
 - `GET /api/items/done`
 - `GET /api/items/counts`
 - `POST /api/items/sync/github`

--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -298,6 +298,31 @@ type ProjectItemHealth struct {
 	Stalled       bool `json:"stalled"`
 }
 
+// ProjectChildCounts tallies child items linked to a project-item parent by
+// state. Done/dropped children count toward Total but never contribute to
+// health: a project item is considered stalled when no child sits in next,
+// waiting, deferred, or someday.
+type ProjectChildCounts struct {
+	Inbox    int `json:"inbox"`
+	Next     int `json:"next"`
+	Waiting  int `json:"waiting"`
+	Deferred int `json:"deferred"`
+	Someday  int `json:"someday"`
+	Review   int `json:"review"`
+	Done     int `json:"done"`
+	Total    int `json:"total"`
+}
+
+// ProjectItemReview is one row in the composite outcome review: the project
+// item itself plus its current health summary and per-state child counts. The
+// review surface exposes Item(kind=project) records only — Workspaces and
+// external source containers are intentionally absent from this aggregate.
+type ProjectItemReview struct {
+	Item     ItemSummary        `json:"item"`
+	Health   ProjectItemHealth  `json:"health"`
+	Children ProjectChildCounts `json:"children"`
+}
+
 type TimeEntry struct {
 	ID          int64   `json:"id"`
 	WorkspaceID *int64  `json:"workspace_id,omitempty"`

--- a/internal/store/store_item_child.go
+++ b/internal/store/store_item_child.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"errors"
+	"sort"
 )
 
 const itemChildrenTableSchema = `CREATE TABLE IF NOT EXISTS item_children (
@@ -153,6 +154,143 @@ func (s *Store) ListItemChildLinks(parentItemID int64) ([]ItemChildLink, error) 
 	return out, rows.Err()
 }
 
+// ListProjectItemReviewsFiltered returns the active GTD project-item review
+// surface: every Item(kind=project) that is not done, paired with its current
+// health and per-state child counts. The list backs the weekly outcome review
+// and surfaces stalled outcomes without inventing tasks.
+//
+// The filter respects sphere/workspace/source/source-container/label/actor
+// scoping just like the other GTD list endpoints. Source containers (Todoist
+// projects, GitHub Projects) match through the existing `source_container`
+// filter — they are never promoted into the review as project items
+// themselves. Workspace filtering scopes the project items to a single
+// workspace; project items are never converted into workspaces by this query.
+//
+// Stalled project items sort first; healthy items follow in updated_at desc
+// order, so weekly review walks the riskiest outcomes before the rest.
+func (s *Store) ListProjectItemReviewsFiltered(filter ItemListFilter) ([]ProjectItemReview, error) {
+	normalizedFilter, err := s.prepareItemListFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+	parts := []string{"i.kind = ?", "i.state <> ?"}
+	args := []any{ItemKindProject, ItemStateDone}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	query := itemSummarySelect + ` WHERE ` + stringsJoin(parts, ` AND `) + ` ORDER BY i.updated_at DESC, i.id ASC`
+	items, err := s.listItemSummaries(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return []ProjectItemReview{}, nil
+	}
+	countsByParent, err := s.collectProjectChildCounts(items)
+	if err != nil {
+		return nil, err
+	}
+	reviews := make([]ProjectItemReview, 0, len(items))
+	for _, item := range items {
+		counts := countsByParent[item.ID]
+		reviews = append(reviews, ProjectItemReview{
+			Item:     item,
+			Children: counts,
+			Health:   projectHealthFromCounts(counts),
+		})
+	}
+	sortProjectItemReviewsForWeeklyReview(reviews)
+	return reviews, nil
+}
+
+// collectProjectChildCounts loads child-state tallies for every project item
+// in one round-trip, so the review surface stays O(1) queries regardless of
+// how many outcomes are open.
+func (s *Store) collectProjectChildCounts(parents []ItemSummary) (map[int64]ProjectChildCounts, error) {
+	out := make(map[int64]ProjectChildCounts, len(parents))
+	if len(parents) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, 0, len(parents))
+	args := make([]any, 0, len(parents))
+	for _, parent := range parents {
+		placeholders = append(placeholders, "?")
+		args = append(args, parent.ID)
+		out[parent.ID] = ProjectChildCounts{}
+	}
+	rows, err := s.db.Query(
+		`SELECT links.parent_item_id, child.state, COUNT(*) AS state_count
+		 FROM item_children links
+		 JOIN items child ON child.id = links.child_item_id
+		 WHERE links.parent_item_id IN (`+stringsJoin(placeholders, ",")+`)
+		 GROUP BY links.parent_item_id, child.state`,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			parentID int64
+			state    string
+			count    int
+		)
+		if err := rows.Scan(&parentID, &state, &count); err != nil {
+			return nil, err
+		}
+		entry := out[parentID]
+		entry = applyChildStateCount(entry, state, count)
+		out[parentID] = entry
+	}
+	return out, rows.Err()
+}
+
+func applyChildStateCount(counts ProjectChildCounts, state string, count int) ProjectChildCounts {
+	if count <= 0 {
+		return counts
+	}
+	switch normalizeItemState(state) {
+	case ItemStateInbox:
+		counts.Inbox += count
+	case ItemStateNext:
+		counts.Next += count
+	case ItemStateWaiting:
+		counts.Waiting += count
+	case ItemStateDeferred:
+		counts.Deferred += count
+	case ItemStateSomeday:
+		counts.Someday += count
+	case ItemStateReview:
+		counts.Review += count
+	case ItemStateDone:
+		counts.Done += count
+	}
+	counts.Total += count
+	return counts
+}
+
+func projectHealthFromCounts(counts ProjectChildCounts) ProjectItemHealth {
+	health := ProjectItemHealth{
+		HasNextAction: counts.Next > 0,
+		HasWaiting:    counts.Waiting > 0,
+		HasDeferred:   counts.Deferred > 0,
+		HasSomeday:    counts.Someday > 0,
+	}
+	health.Stalled = !health.HasNextAction && !health.HasWaiting && !health.HasDeferred && !health.HasSomeday
+	return health
+}
+
+func sortProjectItemReviewsForWeeklyReview(reviews []ProjectItemReview) {
+	sort.SliceStable(reviews, func(i, j int) bool {
+		if reviews[i].Health.Stalled != reviews[j].Health.Stalled {
+			return reviews[i].Health.Stalled
+		}
+		if reviews[i].Item.UpdatedAt != reviews[j].Item.UpdatedAt {
+			return reviews[i].Item.UpdatedAt > reviews[j].Item.UpdatedAt
+		}
+		return reviews[i].Item.ID < reviews[j].Item.ID
+	})
+}
+
 func (s *Store) GetProjectItemHealth(itemID int64) (ProjectItemHealth, error) {
 	item, err := s.GetItem(itemID)
 	if err != nil {
@@ -161,32 +299,11 @@ func (s *Store) GetProjectItemHealth(itemID int64) (ProjectItemHealth, error) {
 	if item.Kind != ItemKindProject {
 		return ProjectItemHealth{}, errors.New("item is not a project")
 	}
-	var health ProjectItemHealth
-	var nextCount, waitingCount, deferredCount, somedayCount int
-	err = s.db.QueryRow(
-		`SELECT
-		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS next_count,
-		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS waiting_count,
-		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS deferred_count,
-		   COALESCE(SUM(CASE WHEN child.state = ? THEN 1 ELSE 0 END), 0) AS someday_count
-		 FROM item_children links
-		 JOIN items child ON child.id = links.child_item_id
-		 WHERE links.parent_item_id = ?`,
-		ItemStateNext,
-		ItemStateWaiting,
-		ItemStateDeferred,
-		ItemStateSomeday,
-		itemID,
-	).Scan(&nextCount, &waitingCount, &deferredCount, &somedayCount)
+	counts, err := s.collectProjectChildCounts([]ItemSummary{{Item: item}})
 	if err != nil {
 		return ProjectItemHealth{}, err
 	}
-	health.HasNextAction = nextCount > 0
-	health.HasWaiting = waitingCount > 0
-	health.HasDeferred = deferredCount > 0
-	health.HasSomeday = somedayCount > 0
-	health.Stalled = !health.HasNextAction && !health.HasWaiting && !health.HasDeferred && !health.HasSomeday
-	return health, nil
+	return projectHealthFromCounts(counts[itemID]), nil
 }
 
 func (s *Store) touchItem(id int64) error {

--- a/internal/store/store_project_review_test.go
+++ b/internal/store/store_project_review_test.go
@@ -1,8 +1,18 @@
 package store
 
-import (
-	"testing"
-)
+import "testing"
+
+type projectReviewSpec struct {
+	title          string
+	childState     string
+	role           string
+	wantNextAction bool
+	wantWaiting    bool
+	wantDeferred   bool
+	wantSomeday    bool
+	wantStalled    bool
+	wantTotal      int
+}
 
 // TestListProjectItemReviewsCoversAllHealthStates exercises the five GTD
 // project-item shapes the issue calls out: a project item with a next action,
@@ -23,45 +33,8 @@ func TestListProjectItemReviewsCoversAllHealthStates(t *testing.T) {
 		t.Fatalf("CreateItem(done project) error: %v", err)
 	}
 
-	specs := []struct {
-		title         string
-		childState    string
-		role          string
-		wantNextAction bool
-		wantWaiting   bool
-		wantDeferred  bool
-		wantSomeday   bool
-		wantStalled   bool
-		wantTotal     int
-	}{
-		{title: "Outcome with next action", childState: ItemStateNext, role: ItemLinkRoleNextAction, wantNextAction: true, wantTotal: 1},
-		{title: "Outcome waiting only", childState: ItemStateWaiting, role: ItemLinkRoleSupport, wantWaiting: true, wantTotal: 1},
-		{title: "Outcome deferred only", childState: ItemStateDeferred, role: ItemLinkRoleBlockedBy, wantDeferred: true, wantTotal: 1},
-		{title: "Outcome someday only", childState: ItemStateSomeday, role: ItemLinkRoleSupport, wantSomeday: true, wantTotal: 1},
-		{title: "Outcome stalled", childState: "", wantStalled: true, wantTotal: 0},
-	}
-
-	parents := make(map[string]int64, len(specs))
-	for _, spec := range specs {
-		parent, err := s.CreateItem(spec.title, ItemOptions{
-			Kind:  ItemKindProject,
-			State: ItemStateNext,
-		})
-		if err != nil {
-			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
-		}
-		parents[spec.title] = parent.ID
-		if spec.childState == "" {
-			continue
-		}
-		child, err := s.CreateItem(spec.title+" child", ItemOptions{State: spec.childState})
-		if err != nil {
-			t.Fatalf("CreateItem(%q child) error: %v", spec.title, err)
-		}
-		if err := s.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
-			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
-		}
-	}
+	specs := projectReviewHealthSpecs()
+	parents := seedProjectReviewSpecs(t, s, specs)
 
 	// A done child must count toward Total but never restore health: it is
 	// closed work, not an open loop. Add one to the stalled outcome to prove
@@ -86,6 +59,47 @@ func TestListProjectItemReviewsCoversAllHealthStates(t *testing.T) {
 		t.Fatalf("review[0] stalled = false, want true (stalled outcomes must lead the weekly review traversal)")
 	}
 
+	assertProjectReviewHealthSpecs(t, reviews, specs)
+}
+
+func projectReviewHealthSpecs() []projectReviewSpec {
+	return []projectReviewSpec{
+		{title: "Outcome with next action", childState: ItemStateNext, role: ItemLinkRoleNextAction, wantNextAction: true, wantTotal: 1},
+		{title: "Outcome waiting only", childState: ItemStateWaiting, role: ItemLinkRoleSupport, wantWaiting: true, wantTotal: 1},
+		{title: "Outcome deferred only", childState: ItemStateDeferred, role: ItemLinkRoleBlockedBy, wantDeferred: true, wantTotal: 1},
+		{title: "Outcome someday only", childState: ItemStateSomeday, role: ItemLinkRoleSupport, wantSomeday: true, wantTotal: 1},
+		{title: "Outcome stalled", wantStalled: true},
+	}
+}
+
+func seedProjectReviewSpecs(t *testing.T, s *Store, specs []projectReviewSpec) map[string]int64 {
+	t.Helper()
+	parents := make(map[string]int64, len(specs))
+	for _, spec := range specs {
+		parent, err := s.CreateItem(spec.title, ItemOptions{
+			Kind:  ItemKindProject,
+			State: ItemStateNext,
+		})
+		if err != nil {
+			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
+		}
+		parents[spec.title] = parent.ID
+		if spec.childState == "" {
+			continue
+		}
+		child, err := s.CreateItem(spec.title+" child", ItemOptions{State: spec.childState})
+		if err != nil {
+			t.Fatalf("CreateItem(%q child) error: %v", spec.title, err)
+		}
+		if err := s.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
+			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
+		}
+	}
+	return parents
+}
+
+func assertProjectReviewHealthSpecs(t *testing.T, reviews []ProjectItemReview, specs []projectReviewSpec) {
+	t.Helper()
 	byTitle := make(map[string]ProjectItemReview, len(reviews))
 	for _, review := range reviews {
 		if review.Item.Kind != ItemKindProject {
@@ -97,53 +111,65 @@ func TestListProjectItemReviewsCoversAllHealthStates(t *testing.T) {
 		byTitle[review.Item.Title] = review
 	}
 	for _, spec := range specs {
-		got, ok := byTitle[spec.title]
-		if !ok {
-			t.Fatalf("review missing %q; titles=%v", spec.title, mapKeys(byTitle))
+		assertProjectReviewHealthSpec(t, byTitle, spec)
+	}
+}
+
+func assertProjectReviewHealthSpec(t *testing.T, reviews map[string]ProjectItemReview, spec projectReviewSpec) {
+	t.Helper()
+	got, ok := reviews[spec.title]
+	if !ok {
+		t.Fatalf("review missing %q; titles=%v", spec.title, mapKeys(reviews))
+	}
+	if got.Health.HasNextAction != spec.wantNextAction {
+		t.Fatalf("%q HasNextAction = %t, want %t", spec.title, got.Health.HasNextAction, spec.wantNextAction)
+	}
+	if got.Health.HasWaiting != spec.wantWaiting {
+		t.Fatalf("%q HasWaiting = %t, want %t", spec.title, got.Health.HasWaiting, spec.wantWaiting)
+	}
+	if got.Health.HasDeferred != spec.wantDeferred {
+		t.Fatalf("%q HasDeferred = %t, want %t", spec.title, got.Health.HasDeferred, spec.wantDeferred)
+	}
+	if got.Health.HasSomeday != spec.wantSomeday {
+		t.Fatalf("%q HasSomeday = %t, want %t", spec.title, got.Health.HasSomeday, spec.wantSomeday)
+	}
+	if got.Health.Stalled != spec.wantStalled {
+		t.Fatalf("%q Stalled = %t, want %t", spec.title, got.Health.Stalled, spec.wantStalled)
+	}
+	assertProjectReviewChildCounts(t, got, spec)
+}
+
+func assertProjectReviewChildCounts(t *testing.T, got ProjectItemReview, spec projectReviewSpec) {
+	t.Helper()
+	switch spec.childState {
+	case ItemStateNext:
+		if got.Children.Next != 1 {
+			t.Fatalf("%q child Next count = %d, want 1", spec.title, got.Children.Next)
 		}
-		if got.Health.HasNextAction != spec.wantNextAction {
-			t.Fatalf("%q HasNextAction = %t, want %t", spec.title, got.Health.HasNextAction, spec.wantNextAction)
+	case ItemStateWaiting:
+		if got.Children.Waiting != 1 {
+			t.Fatalf("%q child Waiting count = %d, want 1", spec.title, got.Children.Waiting)
 		}
-		if got.Health.HasWaiting != spec.wantWaiting {
-			t.Fatalf("%q HasWaiting = %t, want %t", spec.title, got.Health.HasWaiting, spec.wantWaiting)
+	case ItemStateDeferred:
+		if got.Children.Deferred != 1 {
+			t.Fatalf("%q child Deferred count = %d, want 1", spec.title, got.Children.Deferred)
 		}
-		if got.Health.HasDeferred != spec.wantDeferred {
-			t.Fatalf("%q HasDeferred = %t, want %t", spec.title, got.Health.HasDeferred, spec.wantDeferred)
+	case ItemStateSomeday:
+		if got.Children.Someday != 1 {
+			t.Fatalf("%q child Someday count = %d, want 1", spec.title, got.Children.Someday)
 		}
-		if got.Health.HasSomeday != spec.wantSomeday {
-			t.Fatalf("%q HasSomeday = %t, want %t", spec.title, got.Health.HasSomeday, spec.wantSomeday)
+	}
+	if spec.title == "Outcome stalled" {
+		if got.Children.Done != 1 {
+			t.Fatalf("stalled outcome child Done count = %d, want 1", got.Children.Done)
 		}
-		if got.Health.Stalled != spec.wantStalled {
-			t.Fatalf("%q Stalled = %t, want %t", spec.title, got.Health.Stalled, spec.wantStalled)
+		if got.Children.Total != 1 {
+			t.Fatalf("stalled outcome child Total = %d, want 1 (done child counts toward Total)", got.Children.Total)
 		}
-		switch spec.childState {
-		case ItemStateNext:
-			if got.Children.Next != 1 {
-				t.Fatalf("%q child Next count = %d, want 1", spec.title, got.Children.Next)
-			}
-		case ItemStateWaiting:
-			if got.Children.Waiting != 1 {
-				t.Fatalf("%q child Waiting count = %d, want 1", spec.title, got.Children.Waiting)
-			}
-		case ItemStateDeferred:
-			if got.Children.Deferred != 1 {
-				t.Fatalf("%q child Deferred count = %d, want 1", spec.title, got.Children.Deferred)
-			}
-		case ItemStateSomeday:
-			if got.Children.Someday != 1 {
-				t.Fatalf("%q child Someday count = %d, want 1", spec.title, got.Children.Someday)
-			}
-		}
-		if spec.title == "Outcome stalled" {
-			if got.Children.Done != 1 {
-				t.Fatalf("stalled outcome child Done count = %d, want 1", got.Children.Done)
-			}
-			if got.Children.Total != 1 {
-				t.Fatalf("stalled outcome child Total = %d, want 1 (done child counts toward Total)", got.Children.Total)
-			}
-		} else if got.Children.Total != spec.wantTotal {
-			t.Fatalf("%q child Total = %d, want %d", spec.title, got.Children.Total, spec.wantTotal)
-		}
+		return
+	}
+	if got.Children.Total != spec.wantTotal {
+		t.Fatalf("%q child Total = %d, want %d", spec.title, got.Children.Total, spec.wantTotal)
 	}
 }
 

--- a/internal/store/store_project_review_test.go
+++ b/internal/store/store_project_review_test.go
@@ -1,0 +1,273 @@
+package store
+
+import (
+	"testing"
+)
+
+// TestListProjectItemReviewsCoversAllHealthStates exercises the five GTD
+// project-item shapes the issue calls out: a project item with a next action,
+// a waiting-only project item, a deferred-only project item, a someday-only
+// project item, and a stalled project item with no actionable child. The
+// resulting review surface must report each one's health correctly, must keep
+// done project items off the list, and must surface stalled project items
+// first so weekly review walks the riskiest outcomes before the rest.
+func TestListProjectItemReviewsCoversAllHealthStates(t *testing.T) {
+	s := newTestStore(t)
+
+	// Closed outcome must be filtered out — done project items never appear in
+	// review.
+	if _, err := s.CreateItem("Already shipped", ItemOptions{
+		Kind:  ItemKindProject,
+		State: ItemStateDone,
+	}); err != nil {
+		t.Fatalf("CreateItem(done project) error: %v", err)
+	}
+
+	specs := []struct {
+		title         string
+		childState    string
+		role          string
+		wantNextAction bool
+		wantWaiting   bool
+		wantDeferred  bool
+		wantSomeday   bool
+		wantStalled   bool
+		wantTotal     int
+	}{
+		{title: "Outcome with next action", childState: ItemStateNext, role: ItemLinkRoleNextAction, wantNextAction: true, wantTotal: 1},
+		{title: "Outcome waiting only", childState: ItemStateWaiting, role: ItemLinkRoleSupport, wantWaiting: true, wantTotal: 1},
+		{title: "Outcome deferred only", childState: ItemStateDeferred, role: ItemLinkRoleBlockedBy, wantDeferred: true, wantTotal: 1},
+		{title: "Outcome someday only", childState: ItemStateSomeday, role: ItemLinkRoleSupport, wantSomeday: true, wantTotal: 1},
+		{title: "Outcome stalled", childState: "", wantStalled: true, wantTotal: 0},
+	}
+
+	parents := make(map[string]int64, len(specs))
+	for _, spec := range specs {
+		parent, err := s.CreateItem(spec.title, ItemOptions{
+			Kind:  ItemKindProject,
+			State: ItemStateNext,
+		})
+		if err != nil {
+			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
+		}
+		parents[spec.title] = parent.ID
+		if spec.childState == "" {
+			continue
+		}
+		child, err := s.CreateItem(spec.title+" child", ItemOptions{State: spec.childState})
+		if err != nil {
+			t.Fatalf("CreateItem(%q child) error: %v", spec.title, err)
+		}
+		if err := s.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
+			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
+		}
+	}
+
+	// A done child must count toward Total but never restore health: it is
+	// closed work, not an open loop. Add one to the stalled outcome to prove
+	// the stalled flag survives done children.
+	stalledID := parents["Outcome stalled"]
+	doneChild, err := s.CreateItem("Stalled done child", ItemOptions{State: ItemStateDone})
+	if err != nil {
+		t.Fatalf("CreateItem(done child) error: %v", err)
+	}
+	if err := s.LinkItemChild(stalledID, doneChild.ID, ItemLinkRoleSupport); err != nil {
+		t.Fatalf("LinkItemChild(done child) error: %v", err)
+	}
+
+	reviews, err := s.ListProjectItemReviewsFiltered(ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListProjectItemReviewsFiltered() error: %v", err)
+	}
+	if len(reviews) != len(specs) {
+		t.Fatalf("review len = %d, want %d (done project items must not appear)", len(reviews), len(specs))
+	}
+	if !reviews[0].Health.Stalled {
+		t.Fatalf("review[0] stalled = false, want true (stalled outcomes must lead the weekly review traversal)")
+	}
+
+	byTitle := make(map[string]ProjectItemReview, len(reviews))
+	for _, review := range reviews {
+		if review.Item.Kind != ItemKindProject {
+			t.Fatalf("review item Kind = %q, want %q (review surface must only contain project items)", review.Item.Kind, ItemKindProject)
+		}
+		if review.Item.State == ItemStateDone {
+			t.Fatalf("review surfaced done outcome %q (must filter out done project items)", review.Item.Title)
+		}
+		byTitle[review.Item.Title] = review
+	}
+	for _, spec := range specs {
+		got, ok := byTitle[spec.title]
+		if !ok {
+			t.Fatalf("review missing %q; titles=%v", spec.title, mapKeys(byTitle))
+		}
+		if got.Health.HasNextAction != spec.wantNextAction {
+			t.Fatalf("%q HasNextAction = %t, want %t", spec.title, got.Health.HasNextAction, spec.wantNextAction)
+		}
+		if got.Health.HasWaiting != spec.wantWaiting {
+			t.Fatalf("%q HasWaiting = %t, want %t", spec.title, got.Health.HasWaiting, spec.wantWaiting)
+		}
+		if got.Health.HasDeferred != spec.wantDeferred {
+			t.Fatalf("%q HasDeferred = %t, want %t", spec.title, got.Health.HasDeferred, spec.wantDeferred)
+		}
+		if got.Health.HasSomeday != spec.wantSomeday {
+			t.Fatalf("%q HasSomeday = %t, want %t", spec.title, got.Health.HasSomeday, spec.wantSomeday)
+		}
+		if got.Health.Stalled != spec.wantStalled {
+			t.Fatalf("%q Stalled = %t, want %t", spec.title, got.Health.Stalled, spec.wantStalled)
+		}
+		switch spec.childState {
+		case ItemStateNext:
+			if got.Children.Next != 1 {
+				t.Fatalf("%q child Next count = %d, want 1", spec.title, got.Children.Next)
+			}
+		case ItemStateWaiting:
+			if got.Children.Waiting != 1 {
+				t.Fatalf("%q child Waiting count = %d, want 1", spec.title, got.Children.Waiting)
+			}
+		case ItemStateDeferred:
+			if got.Children.Deferred != 1 {
+				t.Fatalf("%q child Deferred count = %d, want 1", spec.title, got.Children.Deferred)
+			}
+		case ItemStateSomeday:
+			if got.Children.Someday != 1 {
+				t.Fatalf("%q child Someday count = %d, want 1", spec.title, got.Children.Someday)
+			}
+		}
+		if spec.title == "Outcome stalled" {
+			if got.Children.Done != 1 {
+				t.Fatalf("stalled outcome child Done count = %d, want 1", got.Children.Done)
+			}
+			if got.Children.Total != 1 {
+				t.Fatalf("stalled outcome child Total = %d, want 1 (done child counts toward Total)", got.Children.Total)
+			}
+		} else if got.Children.Total != spec.wantTotal {
+			t.Fatalf("%q child Total = %d, want %d", spec.title, got.Children.Total, spec.wantTotal)
+		}
+	}
+}
+
+// TestListProjectItemReviewsKeepsSourceContainersOutOfReview pins the
+// terminology contract from issue #728: Workspaces and external source
+// containers (Todoist projects, GitHub Projects, mail folders) must never
+// surface as project items unless explicitly captured as Item(kind=project).
+func TestListProjectItemReviewsKeepsSourceContainersOutOfReview(t *testing.T) {
+	s := newTestStore(t)
+
+	workspace, err := s.CreateWorkspace("Daily review workspace", t.TempDir(), SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace() error: %v", err)
+	}
+	containerSource := ExternalProviderTodoist
+	containerRef := "todoist-project-42"
+	if _, err := s.CreateItem("Source container item", ItemOptions{
+		Kind:      ItemKindAction,
+		State:     ItemStateNext,
+		Source:    &containerSource,
+		SourceRef: &containerRef,
+	}); err != nil {
+		t.Fatalf("CreateItem(source container action) error: %v", err)
+	}
+
+	if _, err := s.CreateItem("Open outcome", ItemOptions{
+		Kind:        ItemKindProject,
+		State:       ItemStateNext,
+		WorkspaceID: &workspace.ID,
+	}); err != nil {
+		t.Fatalf("CreateItem(project) error: %v", err)
+	}
+
+	reviews, err := s.ListProjectItemReviewsFiltered(ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListProjectItemReviewsFiltered() error: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("review len = %d, want exactly the project item (workspaces and source containers must not appear)", len(reviews))
+	}
+	if reviews[0].Item.Title != "Open outcome" {
+		t.Fatalf("review surfaced %q, want %q", reviews[0].Item.Title, "Open outcome")
+	}
+	if reviews[0].Item.Kind != ItemKindProject {
+		t.Fatalf("review surfaced kind %q, want %q", reviews[0].Item.Kind, ItemKindProject)
+	}
+
+	scoped, err := s.ListProjectItemReviewsFiltered(ItemListFilter{WorkspaceID: &workspace.ID})
+	if err != nil {
+		t.Fatalf("ListProjectItemReviewsFiltered(workspace) error: %v", err)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("workspace-scoped review len = %d, want 1 (workspace filter must scope project items, not turn workspaces into outcomes)", len(scoped))
+	}
+}
+
+// TestListProjectItemReviewsPreservesSourceBackedBindings asserts the
+// source-of-truth contract from issue #728: a source-backed project item must
+// keep its Source/SourceRef pointing at the upstream system, and its action
+// children retain their own bindings unchanged. The review surface only reads
+// state — it never strips authority.
+func TestListProjectItemReviewsPreservesSourceBackedBindings(t *testing.T) {
+	s := newTestStore(t)
+
+	parentSource := "github"
+	parentRef := "krystophny/repo#728"
+	parent, err := s.CreateItem("Source-backed outcome", ItemOptions{
+		Kind:      ItemKindProject,
+		State:     ItemStateNext,
+		Source:    &parentSource,
+		SourceRef: &parentRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(source-backed project) error: %v", err)
+	}
+	childSource := ExternalProviderTodoist
+	childRef := "todoist-task-9"
+	child, err := s.CreateItem("Source-backed child", ItemOptions{
+		Kind:      ItemKindAction,
+		State:     ItemStateNext,
+		Source:    &childSource,
+		SourceRef: &childRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(source-backed child) error: %v", err)
+	}
+	if err := s.LinkItemChild(parent.ID, child.ID, ItemLinkRoleNextAction); err != nil {
+		t.Fatalf("LinkItemChild() error: %v", err)
+	}
+
+	reviews, err := s.ListProjectItemReviewsFiltered(ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListProjectItemReviewsFiltered() error: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("review len = %d, want 1", len(reviews))
+	}
+	got := reviews[0]
+	if got.Item.Source == nil || *got.Item.Source != parentSource {
+		t.Fatalf("project item Source = %v, want %q", got.Item.Source, parentSource)
+	}
+	if got.Item.SourceRef == nil || *got.Item.SourceRef != parentRef {
+		t.Fatalf("project item SourceRef = %v, want %q", got.Item.SourceRef, parentRef)
+	}
+	if !got.Health.HasNextAction {
+		t.Fatalf("HasNextAction = false, want true (child action backs the outcome)")
+	}
+	if got.Children.Next != 1 || got.Children.Total != 1 {
+		t.Fatalf("child counts = %+v, want Next=1 Total=1", got.Children)
+	}
+
+	roundTrip, err := s.GetItemBySource(childSource, childRef)
+	if err != nil {
+		t.Fatalf("GetItemBySource(child) error: %v", err)
+	}
+	if roundTrip.ID != child.ID {
+		t.Fatalf("child round-trip ID = %d, want %d", roundTrip.ID, child.ID)
+	}
+}
+
+func mapKeys[V any](in map[string]V) []string {
+	out := make([]string, 0, len(in))
+	for key := range in {
+		out = append(out, key)
+	}
+	return out
+}

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -171,6 +171,7 @@ var WebRouteSections = []RouteSection{
 			"GET /api/items/deferred",
 			"GET /api/items/someday",
 			"GET /api/items/review",
+			"GET /api/items/projects",
 			"GET /api/items/done",
 			"GET /api/items/counts",
 			"POST /api/items/sync/github",

--- a/internal/web/items_projects.go
+++ b/internal/web/items_projects.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+// handleItemProjectReview answers the GTD composite-outcome review surface.
+//
+// The response lists every active Item(kind=project) — workspace records and
+// external source containers (Todoist projects, GitHub Projects, mail folders)
+// are intentionally absent. Each row carries the project item's current health
+// flags and per-state child counts so the weekly review can spot stalled
+// outcomes without inventing tasks.
+func (a *App) handleItemProjectReview(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	if !a.resurfaceDueItemsForRead(w) {
+		return
+	}
+	filter, err := parseItemListFilterQuery(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	reviews, err := a.store.ListProjectItemReviewsFiltered(filter)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	stalled := countStalledProjectItems(reviews)
+	writeAPIData(w, http.StatusOK, map[string]any{
+		"project_items": reviews,
+		"total":         len(reviews),
+		"stalled":       stalled,
+	})
+}
+
+func countStalledProjectItems(reviews []store.ProjectItemReview) int {
+	stalled := 0
+	for _, review := range reviews {
+		if review.Health.Stalled {
+			stalled++
+		}
+	}
+	return stalled
+}

--- a/internal/web/items_projects_test.go
+++ b/internal/web/items_projects_test.go
@@ -8,46 +8,18 @@ import (
 	"github.com/sloppy-org/slopshell/internal/store"
 )
 
-// TestItemProjectReviewListsActiveOutcomesWithHealth exercises every shape the
-// composite-outcome review must report on: a project item with a next action
-// (healthy), a waiting-only project item, a deferred-only project item, a
-// someday-only project item, and a stalled project item with no actionable
-// child. The endpoint must surface all five with correct health flags and
-// must keep done outcomes out.
+type itemProjectReviewSpec struct {
+	title      string
+	childState string
+	role       string
+	wantHealth map[string]bool
+}
+
 func TestItemProjectReviewListsActiveOutcomesWithHealth(t *testing.T) {
 	app := newAuthedTestApp(t)
 
-	specs := []struct {
-		title       string
-		childState  string
-		role        string
-		wantStalled bool
-	}{
-		{title: "Outcome with next action", childState: store.ItemStateNext, role: store.ItemLinkRoleNextAction},
-		{title: "Outcome waiting only", childState: store.ItemStateWaiting, role: store.ItemLinkRoleSupport},
-		{title: "Outcome deferred only", childState: store.ItemStateDeferred, role: store.ItemLinkRoleBlockedBy},
-		{title: "Outcome someday only", childState: store.ItemStateSomeday, role: store.ItemLinkRoleSupport},
-		{title: "Outcome stalled", childState: "", wantStalled: true},
-	}
-	for _, spec := range specs {
-		parent, err := app.store.CreateItem(spec.title, store.ItemOptions{
-			Kind:  store.ItemKindProject,
-			State: store.ItemStateNext,
-		})
-		if err != nil {
-			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
-		}
-		if spec.childState == "" {
-			continue
-		}
-		child, err := app.store.CreateItem(spec.title+" child", store.ItemOptions{State: spec.childState})
-		if err != nil {
-			t.Fatalf("CreateItem(child %q) error: %v", spec.title, err)
-		}
-		if err := app.store.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
-			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
-		}
-	}
+	specs := itemProjectReviewHealthSpecs()
+	seedItemProjectReviewSpecs(t, app, specs)
 	if _, err := app.store.CreateItem("Closed outcome", store.ItemOptions{
 		Kind:  store.ItemKindProject,
 		State: store.ItemStateDone,
@@ -81,6 +53,67 @@ func TestItemProjectReviewListsActiveOutcomesWithHealth(t *testing.T) {
 		t.Fatalf("first row stalled = %v, want true", firstHealth["stalled"])
 	}
 
+	assertItemProjectReviewHealthSpecs(t, rows, specs)
+}
+
+func itemProjectReviewHealthSpecs() []itemProjectReviewSpec {
+	return []itemProjectReviewSpec{
+		{
+			title:      "Outcome with next action",
+			childState: store.ItemStateNext,
+			role:       store.ItemLinkRoleNextAction,
+			wantHealth: map[string]bool{"has_next_action": true},
+		},
+		{
+			title:      "Outcome waiting only",
+			childState: store.ItemStateWaiting,
+			role:       store.ItemLinkRoleSupport,
+			wantHealth: map[string]bool{"has_waiting": true},
+		},
+		{
+			title:      "Outcome deferred only",
+			childState: store.ItemStateDeferred,
+			role:       store.ItemLinkRoleBlockedBy,
+			wantHealth: map[string]bool{"has_deferred": true},
+		},
+		{
+			title:      "Outcome someday only",
+			childState: store.ItemStateSomeday,
+			role:       store.ItemLinkRoleSupport,
+			wantHealth: map[string]bool{"has_someday": true},
+		},
+		{
+			title:      "Outcome stalled",
+			wantHealth: map[string]bool{"stalled": true},
+		},
+	}
+}
+
+func seedItemProjectReviewSpecs(t *testing.T, app *App, specs []itemProjectReviewSpec) {
+	t.Helper()
+	for _, spec := range specs {
+		parent, err := app.store.CreateItem(spec.title, store.ItemOptions{
+			Kind:  store.ItemKindProject,
+			State: store.ItemStateNext,
+		})
+		if err != nil {
+			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
+		}
+		if spec.childState == "" {
+			continue
+		}
+		child, err := app.store.CreateItem(spec.title+" child", store.ItemOptions{State: spec.childState})
+		if err != nil {
+			t.Fatalf("CreateItem(child %q) error: %v", spec.title, err)
+		}
+		if err := app.store.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
+			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
+		}
+	}
+}
+
+func assertItemProjectReviewHealthSpecs(t *testing.T, rows []any, specs []itemProjectReviewSpec) {
+	t.Helper()
 	healthByTitle := make(map[string]map[string]any, len(rows))
 	for _, raw := range rows {
 		row := raw.(map[string]any)
@@ -93,34 +126,16 @@ func TestItemProjectReviewListsActiveOutcomesWithHealth(t *testing.T) {
 		}
 		healthByTitle[item["title"].(string)] = row["health"].(map[string]any)
 	}
-	healthExpect := map[string]struct {
-		hasNext, hasWaiting, hasDeferred, hasSomeday, stalled bool
-	}{
-		"Outcome with next action": {hasNext: true},
-		"Outcome waiting only":     {hasWaiting: true},
-		"Outcome deferred only":    {hasDeferred: true},
-		"Outcome someday only":     {hasSomeday: true},
-		"Outcome stalled":          {stalled: true},
-	}
-	for title, expect := range healthExpect {
-		got, ok := healthByTitle[title]
+	for _, spec := range specs {
+		got, ok := healthByTitle[spec.title]
 		if !ok {
-			t.Fatalf("review missing %q", title)
+			t.Fatalf("review missing %q", spec.title)
 		}
-		if got["has_next_action"].(bool) != expect.hasNext {
-			t.Fatalf("%q has_next_action = %v, want %v", title, got["has_next_action"], expect.hasNext)
-		}
-		if got["has_waiting"].(bool) != expect.hasWaiting {
-			t.Fatalf("%q has_waiting = %v, want %v", title, got["has_waiting"], expect.hasWaiting)
-		}
-		if got["has_deferred"].(bool) != expect.hasDeferred {
-			t.Fatalf("%q has_deferred = %v, want %v", title, got["has_deferred"], expect.hasDeferred)
-		}
-		if got["has_someday"].(bool) != expect.hasSomeday {
-			t.Fatalf("%q has_someday = %v, want %v", title, got["has_someday"], expect.hasSomeday)
-		}
-		if got["stalled"].(bool) != expect.stalled {
-			t.Fatalf("%q stalled = %v, want %v", title, got["stalled"], expect.stalled)
+		for _, field := range []string{"has_next_action", "has_waiting", "has_deferred", "has_someday", "stalled"} {
+			want := spec.wantHealth[field]
+			if got[field].(bool) != want {
+				t.Fatalf("%q %s = %v, want %v", spec.title, field, got[field], want)
+			}
 		}
 	}
 }

--- a/internal/web/items_projects_test.go
+++ b/internal/web/items_projects_test.go
@@ -1,0 +1,235 @@
+package web
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+// TestItemProjectReviewListsActiveOutcomesWithHealth exercises every shape the
+// composite-outcome review must report on: a project item with a next action
+// (healthy), a waiting-only project item, a deferred-only project item, a
+// someday-only project item, and a stalled project item with no actionable
+// child. The endpoint must surface all five with correct health flags and
+// must keep done outcomes out.
+func TestItemProjectReviewListsActiveOutcomesWithHealth(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	specs := []struct {
+		title       string
+		childState  string
+		role        string
+		wantStalled bool
+	}{
+		{title: "Outcome with next action", childState: store.ItemStateNext, role: store.ItemLinkRoleNextAction},
+		{title: "Outcome waiting only", childState: store.ItemStateWaiting, role: store.ItemLinkRoleSupport},
+		{title: "Outcome deferred only", childState: store.ItemStateDeferred, role: store.ItemLinkRoleBlockedBy},
+		{title: "Outcome someday only", childState: store.ItemStateSomeday, role: store.ItemLinkRoleSupport},
+		{title: "Outcome stalled", childState: "", wantStalled: true},
+	}
+	for _, spec := range specs {
+		parent, err := app.store.CreateItem(spec.title, store.ItemOptions{
+			Kind:  store.ItemKindProject,
+			State: store.ItemStateNext,
+		})
+		if err != nil {
+			t.Fatalf("CreateItem(%q) error: %v", spec.title, err)
+		}
+		if spec.childState == "" {
+			continue
+		}
+		child, err := app.store.CreateItem(spec.title+" child", store.ItemOptions{State: spec.childState})
+		if err != nil {
+			t.Fatalf("CreateItem(child %q) error: %v", spec.title, err)
+		}
+		if err := app.store.LinkItemChild(parent.ID, child.ID, spec.role); err != nil {
+			t.Fatalf("LinkItemChild(%q) error: %v", spec.title, err)
+		}
+	}
+	if _, err := app.store.CreateItem("Closed outcome", store.ItemOptions{
+		Kind:  store.ItemKindProject,
+		State: store.ItemStateDone,
+	}); err != nil {
+		t.Fatalf("CreateItem(done) error: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/projects", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONResponse(t, rr)
+	rows, ok := payload["project_items"].([]any)
+	if !ok || len(rows) != len(specs) {
+		t.Fatalf("project_items len = %d, want %d (done outcomes must not appear)", len(rows), len(specs))
+	}
+	if total, _ := payload["total"].(float64); int(total) != len(specs) {
+		t.Fatalf("total = %v, want %d", payload["total"], len(specs))
+	}
+	stalledCount, _ := payload["stalled"].(float64)
+	if int(stalledCount) != 1 {
+		t.Fatalf("stalled = %v, want 1", payload["stalled"])
+	}
+	first := rows[0].(map[string]any)
+	firstItem, _ := first["item"].(map[string]any)
+	firstHealth, _ := first["health"].(map[string]any)
+	if firstItem["title"] != "Outcome stalled" {
+		t.Fatalf("first row title = %v, want %q (stalled outcomes must lead the weekly review)", firstItem["title"], "Outcome stalled")
+	}
+	if got, _ := firstHealth["stalled"].(bool); !got {
+		t.Fatalf("first row stalled = %v, want true", firstHealth["stalled"])
+	}
+
+	healthByTitle := make(map[string]map[string]any, len(rows))
+	for _, raw := range rows {
+		row := raw.(map[string]any)
+		item := row["item"].(map[string]any)
+		if item["kind"] != store.ItemKindProject {
+			t.Fatalf("review row kind = %v, want %q (only project items belong in the outcome review)", item["kind"], store.ItemKindProject)
+		}
+		if item["state"] == store.ItemStateDone {
+			t.Fatalf("review row %q surfaced done outcome", item["title"])
+		}
+		healthByTitle[item["title"].(string)] = row["health"].(map[string]any)
+	}
+	healthExpect := map[string]struct {
+		hasNext, hasWaiting, hasDeferred, hasSomeday, stalled bool
+	}{
+		"Outcome with next action": {hasNext: true},
+		"Outcome waiting only":     {hasWaiting: true},
+		"Outcome deferred only":    {hasDeferred: true},
+		"Outcome someday only":     {hasSomeday: true},
+		"Outcome stalled":          {stalled: true},
+	}
+	for title, expect := range healthExpect {
+		got, ok := healthByTitle[title]
+		if !ok {
+			t.Fatalf("review missing %q", title)
+		}
+		if got["has_next_action"].(bool) != expect.hasNext {
+			t.Fatalf("%q has_next_action = %v, want %v", title, got["has_next_action"], expect.hasNext)
+		}
+		if got["has_waiting"].(bool) != expect.hasWaiting {
+			t.Fatalf("%q has_waiting = %v, want %v", title, got["has_waiting"], expect.hasWaiting)
+		}
+		if got["has_deferred"].(bool) != expect.hasDeferred {
+			t.Fatalf("%q has_deferred = %v, want %v", title, got["has_deferred"], expect.hasDeferred)
+		}
+		if got["has_someday"].(bool) != expect.hasSomeday {
+			t.Fatalf("%q has_someday = %v, want %v", title, got["has_someday"], expect.hasSomeday)
+		}
+		if got["stalled"].(bool) != expect.stalled {
+			t.Fatalf("%q stalled = %v, want %v", title, got["stalled"], expect.stalled)
+		}
+	}
+}
+
+// TestItemProjectReviewWorkspaceFilterTreatsWorkspacesAsScopeNotOutcomes pins
+// the issue's terminology contract: workspace_id narrows the scope of
+// project-item review without ever turning a Workspace into a project item.
+// A workspace with no project items must yield an empty review, even if it
+// has plenty of regular action items.
+func TestItemProjectReviewWorkspaceFilterTreatsWorkspacesAsScopeNotOutcomes(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	bare, err := app.store.CreateWorkspace("Bare workspace", t.TempDir(), store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(bare) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Routine work", store.ItemOptions{
+		Kind:        store.ItemKindAction,
+		State:       store.ItemStateNext,
+		WorkspaceID: &bare.ID,
+	}); err != nil {
+		t.Fatalf("CreateItem(routine) error: %v", err)
+	}
+
+	outcomeWorkspace, err := app.store.CreateWorkspace("Outcome workspace", t.TempDir(), store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(outcome) error: %v", err)
+	}
+	if _, err := app.store.CreateItem("Linked outcome", store.ItemOptions{
+		Kind:        store.ItemKindProject,
+		State:       store.ItemStateNext,
+		WorkspaceID: &outcomeWorkspace.ID,
+	}); err != nil {
+		t.Fatalf("CreateItem(linked outcome) error: %v", err)
+	}
+
+	bareReq := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/projects?workspace_id="+itoa(bare.ID), nil)
+	if bareReq.Code != http.StatusOK {
+		t.Fatalf("bare status = %d, want 200: %s", bareReq.Code, bareReq.Body.String())
+	}
+	barePayload := decodeJSONResponse(t, bareReq)
+	rows, _ := barePayload["project_items"].([]any)
+	if len(rows) != 0 {
+		t.Fatalf("bare workspace review len = %d, want 0 (Workspaces never become outcomes)", len(rows))
+	}
+
+	scopedReq := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/projects?workspace_id="+itoa(outcomeWorkspace.ID), nil)
+	if scopedReq.Code != http.StatusOK {
+		t.Fatalf("outcome status = %d, want 200: %s", scopedReq.Code, scopedReq.Body.String())
+	}
+	scopedPayload := decodeJSONResponse(t, scopedReq)
+	scopedRows, _ := scopedPayload["project_items"].([]any)
+	if len(scopedRows) != 1 {
+		t.Fatalf("outcome-workspace review len = %d, want 1", len(scopedRows))
+	}
+	scopedItem := scopedRows[0].(map[string]any)["item"].(map[string]any)
+	if scopedItem["title"] != "Linked outcome" {
+		t.Fatalf("outcome-workspace review surfaced %v, want %q", scopedItem["title"], "Linked outcome")
+	}
+	if scopedItem["kind"] != store.ItemKindProject {
+		t.Fatalf("outcome-workspace review kind = %v, want %q", scopedItem["kind"], store.ItemKindProject)
+	}
+}
+
+// TestItemProjectReviewSourceContainerStaysAFilter pins the second half of the
+// terminology contract: a source container (Todoist project / GitHub Project)
+// is only a metadata filter. It is never promoted into a project item, even
+// when its source-backed actions are visible elsewhere.
+func TestItemProjectReviewSourceContainerStaysAFilter(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	containerSource := store.ExternalProviderTodoist
+	containerRef := "todoist-task-1"
+	if _, err := app.store.CreateItem("Todoist next action", store.ItemOptions{
+		Kind:      store.ItemKindAction,
+		State:     store.ItemStateNext,
+		Source:    &containerSource,
+		SourceRef: &containerRef,
+	}); err != nil {
+		t.Fatalf("CreateItem(todoist action) error: %v", err)
+	}
+
+	project, err := app.store.CreateItem("Brain outcome", store.ItemOptions{
+		Kind:  store.ItemKindProject,
+		State: store.ItemStateNext,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(project) error: %v", err)
+	}
+	if project.Source != nil || project.SourceRef != nil {
+		t.Fatalf("brain-only outcome unexpectedly source-backed: %+v", project)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/projects", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	rows, _ := decodeJSONResponse(t, rr)["project_items"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("review len = %d, want 1 (source-container actions must not surface as outcomes)", len(rows))
+	}
+	if title := rows[0].(map[string]any)["item"].(map[string]any)["title"]; title != "Brain outcome" {
+		t.Fatalf("review surfaced %v, want %q", title, "Brain outcome")
+	}
+
+	bodySnippet := strings.ToLower(rr.Body.String())
+	for _, banned := range []string{"workspace", "source container"} {
+		if strings.Contains(bodySnippet, banned) {
+			t.Fatalf("response body unexpectedly contains %q: %s", banned, rr.Body.String())
+		}
+	}
+}

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -147,6 +147,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/items/deferred", a.handleItemDeferred)
 	r.Get("/api/items/someday", a.handleItemSomeday)
 	r.Get("/api/items/review", a.handleItemReview)
+	r.Get("/api/items/projects", a.handleItemProjectReview)
 	r.Get("/api/items/done", a.handleItemDone)
 	r.Get("/api/items/counts", a.handleItemCounts)
 	r.Post("/api/items/sync/github", a.handleGitHubIssueSync)

--- a/internal/web/static/app-item-sidebar-utils.ts
+++ b/internal/web/static/app-item-sidebar-utils.ts
@@ -383,21 +383,64 @@ export async function fetchItemSidebarWorkspaces() {
     .filter((workspace) => workspace.id > 0 && workspace.name);
 }
 
-export async function fetchItemSidebarProjectItems() {
-  const resp = await fetch(apiURL(appendSphereQuery('items?section=project_items')), { cache: 'no-store' });
+// fetchItemSidebarProjectItemReview pulls the GTD composite-outcome review
+// surface: every active Item(kind=project) plus its current health flags and
+// per-state child counts. Workspaces and external source containers (Todoist
+// projects, GitHub Projects, mail folders) never appear here — they only
+// surface as filters elsewhere.
+export async function fetchItemSidebarProjectItemReview() {
+  const resp = await fetch(apiURL(appendSphereQuery('items/projects')), { cache: 'no-store' });
   if (!resp.ok) {
     const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
     throw new Error(detail);
   }
   const payload = await resp.json();
-  const items = Array.isArray(payload?.items) ? payload.items : [];
-  return items
-    .map((item) => ({
-      id: Number(item?.id || 0),
-      title: String(item?.title || '').trim(),
-      state: String(item?.state || '').trim().toLowerCase(),
-    }))
-    .filter((item) => item.id > 0 && item.title && item.state !== 'done');
+  const rows = Array.isArray(payload?.project_items) ? payload.project_items : [];
+  return rows
+    .map((row) => {
+      const item = row && typeof row === 'object' ? row.item : null;
+      const health = row && typeof row === 'object' ? row.health : null;
+      const children = row && typeof row === 'object' ? row.children : null;
+      return {
+        id: Number(item?.id || 0),
+        title: String(item?.title || '').trim(),
+        state: String(item?.state || '').trim().toLowerCase(),
+        kind: String(item?.kind || '').trim().toLowerCase(),
+        source: String(item?.source || '').trim().toLowerCase(),
+        source_ref: String(item?.source_ref || '').trim(),
+        health: {
+          has_next_action: Boolean(health?.has_next_action),
+          has_waiting: Boolean(health?.has_waiting),
+          has_deferred: Boolean(health?.has_deferred),
+          has_someday: Boolean(health?.has_someday),
+          stalled: Boolean(health?.stalled),
+        },
+        children: {
+          inbox: Number(children?.inbox || 0),
+          next: Number(children?.next || 0),
+          waiting: Number(children?.waiting || 0),
+          deferred: Number(children?.deferred || 0),
+          someday: Number(children?.someday || 0),
+          review: Number(children?.review || 0),
+          done: Number(children?.done || 0),
+          total: Number(children?.total || 0),
+        },
+      };
+    })
+    .filter((row) => row.id > 0 && row.title);
+}
+
+// fetchItemSidebarProjectItems returns the lightweight list shape used by
+// inline project-item pickers: id/title/state only. It now reuses the canonical
+// /api/items/projects review surface so the picker and the weekly review agree
+// on which outcomes are active.
+export async function fetchItemSidebarProjectItems() {
+  const reviews = await fetchItemSidebarProjectItemReview();
+  return reviews.map((row) => ({
+    id: row.id,
+    title: row.title,
+    state: row.state,
+  }));
 }
 
 export async function fetchItemSidebarLabels() {


### PR DESCRIPTION
## Summary

- Adds `GET /api/items/projects`, the GTD composite-outcome review surface that lists every active `Item(kind=project)` with its health flags and per-state child counts so weekly review can traverse all outcomes and spot stalled ones without inventing tasks.
- Adds `Store.ListProjectItemReviewsFiltered`, which reuses the existing item filter clauses (sphere / workspace / source / source_container / label / actor), groups child counts in one query, and sorts stalled items first. `GetProjectItemHealth` now shares the same counting helper instead of carrying duplicate SQL.
- Wires the frontend project-item picker through the canonical review surface so the picker, the existing `Project items` sidebar section, and the new endpoint agree on which outcomes are active.

Closes #728.

## Verification

All commands run on this branch on `main`-equivalent state, no skips.

### Acceptance: review identifies stalled project items without inventing tasks

`TestListProjectItemReviewsCoversAllHealthStates` builds five outcomes — one with a `next` child, one waiting-only, one deferred-only, one someday-only, and one stalled — plus a `done` outcome that must not appear, then asserts the stalled outcome leads the review and that no done outcome leaks in:

```
=== RUN   TestListProjectItemReviewsCoversAllHealthStates
--- PASS: TestListProjectItemReviewsCoversAllHealthStates (0.02s)
```

`TestItemProjectReviewListsActiveOutcomesWithHealth` runs the same matrix end-to-end through `GET /api/items/projects` and verifies the wire payload (`stalled=1`, stalled outcome first, no done outcomes returned, every health flag matches).

```
=== RUN   TestItemProjectReviewListsActiveOutcomesWithHealth
--- PASS: TestItemProjectReviewListsActiveOutcomesWithHealth (0.03s)
```

### Acceptance: project item / Workspace / source container terminology unambiguous

`TestListProjectItemReviewsKeepsSourceContainersOutOfReview` (store) and `TestItemProjectReviewWorkspaceFilterTreatsWorkspacesAsScopeNotOutcomes` plus `TestItemProjectReviewSourceContainerStaysAFilter` (HTTP) seed Todoist source-container actions and bare workspaces alongside one real project item, and assert that:

- workspaces never appear as project items even when a `workspace_id` filter is applied;
- source containers (Todoist projects) stay out of the review entirely;
- the response body never contains the words `workspace` or `source container` anywhere — preventing accidental UI/copy drift.

```
=== RUN   TestListProjectItemReviewsKeepsSourceContainersOutOfReview
--- PASS: TestListProjectItemReviewsKeepsSourceContainersOutOfReview (0.01s)
=== RUN   TestItemProjectReviewWorkspaceFilterTreatsWorkspacesAsScopeNotOutcomes
--- PASS: TestItemProjectReviewWorkspaceFilterTreatsWorkspacesAsScopeNotOutcomes (0.02s)
=== RUN   TestItemProjectReviewSourceContainerStaysAFilter
--- PASS: TestItemProjectReviewSourceContainerStaysAFilter (0.02s)
```

### Acceptance: source-backed items remain source-backed

`TestListProjectItemReviewsPreservesSourceBackedBindings` creates a GitHub-backed project item with a Todoist-backed action child, links them, runs the review, and asserts the project item retains its `source/source_ref` bindings while the child round-trips through `GetItemBySource`.

```
=== RUN   TestListProjectItemReviewsPreservesSourceBackedBindings
--- PASS: TestListProjectItemReviewsPreservesSourceBackedBindings (0.01s)
```

### Acceptance: tests cover next-action / waiting-only / deferred / someday / stalled cases

The five required cases are pinned together in the matrix in `TestListProjectItemReviewsCoversAllHealthStates` (store) and again at the HTTP layer in `TestItemProjectReviewListsActiveOutcomesWithHealth` — both shown above.

### Regression: existing project / review behaviour intact

```
=== RUN   TestStoreItemChildLinkLifecycleAndProjectHealth
--- PASS: TestStoreItemChildLinkLifecycleAndProjectHealth (0.02s)
=== RUN   TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems
--- PASS: TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems (0.02s)
```

### Repo checks

```
$ npm run typecheck:frontend     # clean
$ ./scripts/sync-surface.sh --check
exit=0
$ go test ./...                  # all packages green
ok  	github.com/sloppy-org/slopshell/internal/store	1.663s
ok  	github.com/sloppy-org/slopshell/internal/surface	0.020s
ok  	github.com/sloppy-org/slopshell/internal/web	26.044s
...
```

## Test plan

- [x] `go test ./internal/store/ -run TestListProjectItemReviews -count=1`
- [x] `go test ./internal/web/ -run TestItemProjectReview -count=1`
- [x] `go test ./internal/store/ -run TestStoreItemChildLinkLifecycleAndProjectHealth -count=1`
- [x] `go test ./internal/store/ -run TestReviewQueueIncludesDueWaitingItemsAndStalledProjectItems -count=1`
- [x] `go test ./...`
- [x] `npm run typecheck:frontend`
- [x] `./scripts/sync-surface.sh --check`