### PR TITLE
fix: Add sls GTD review commands (fixes #732)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test-results/
 tests/manual/
 /slopshell
 /slopshell-edge
+/sls
 tools/
 .env
 internal/web/static/vad/

--- a/cmd/sls/brain.go
+++ b/cmd/sls/brain.go
@@ -66,9 +66,15 @@ func commandArgs(args []string) []string {
 	if i >= len(args) {
 		return nil
 	}
-	if strings.ToLower(args[i]) == "brain" {
+	switch strings.ToLower(args[i]) {
+	case "brain":
 		if i+1 >= len(args) {
 			return []string{"brain"}
+		}
+		return args[i+1:]
+	case "gtd":
+		if i+1 >= len(args) {
+			return []string{"gtd"}
 		}
 		return args[i+1:]
 	}

--- a/cmd/sls/gtd.go
+++ b/cmd/sls/gtd.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type gtdQueue struct {
+	Name            string
+	Aliases         []string
+	Path            string
+	Label           string
+	IsProjectReview bool
+}
+
+var gtdQueueList = []gtdQueue{
+	{Name: "inbox", Path: "/api/items/inbox", Label: "Inbox"},
+	{Name: "next", Path: "/api/items/next", Label: "Next actions"},
+	{Name: "waiting", Path: "/api/items/waiting", Label: "Waiting for"},
+	{Name: "later", Aliases: []string{"deferred", "defer"}, Path: "/api/items/deferred", Label: "Later / Deferred"},
+	{Name: "someday", Aliases: []string{"maybe"}, Path: "/api/items/someday", Label: "Someday / Maybe"},
+	{Name: "review", Path: "/api/items/review", Label: "Review"},
+	{Name: "projects", Path: "/api/items/projects", Label: "Project items", IsProjectReview: true},
+}
+
+func findGtdQueue(name string) *gtdQueue {
+	target := strings.ToLower(strings.TrimSpace(name))
+	if target == "" {
+		return nil
+	}
+	for i := range gtdQueueList {
+		q := &gtdQueueList[i]
+		if q.Name == target {
+			return q
+		}
+		for _, alias := range q.Aliases {
+			if alias == target {
+				return q
+			}
+		}
+	}
+	return nil
+}
+
+func isGtdSubcommand(args []string) bool {
+	i := firstPositionalArg(args)
+	if i >= len(args) {
+		return false
+	}
+	if !strings.EqualFold(args[i], "gtd") {
+		return false
+	}
+	if i+1 >= len(args) {
+		return true
+	}
+	return findGtdQueue(args[i+1]) != nil
+}
+
+type gtdFilters struct {
+	sphere          string
+	source          string
+	sourceContainer string
+	label           string
+	labelID         string
+	actorID         string
+	workspace       string
+	projectItemID   string
+	dueBefore       string
+	dueAfter        string
+	followUpBefore  string
+	followUpAfter   string
+	jsonOut         bool
+}
+
+func parseGtdFilters(args []string) (gtdFilters, error) {
+	fs := flag.NewFlagSet("sls gtd", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var f gtdFilters
+	fs.StringVar(&f.sphere, "vault", "", "vault sphere: work|private")
+	fs.StringVar(&f.source, "source", "", "filter by source backend (todoist, github, imap, ...)")
+	fs.StringVar(&f.sourceContainer, "source-container", "", "filter by upstream container (Todoist project, mail folder, GitHub Project)")
+	fs.StringVar(&f.label, "label", "", "filter by label name")
+	fs.StringVar(&f.labelID, "label-id", "", "filter by label id")
+	fs.StringVar(&f.actorID, "actor-id", "", "filter by actor id (delegated to)")
+	fs.StringVar(&f.workspace, "workspace", "", "filter by Slopshell workspace id, or 'null' for unassigned")
+	fs.StringVar(&f.projectItemID, "project-item-id", "", "filter by GTD project item id")
+	fs.StringVar(&f.projectItemID, "project-item", "", "alias for --project-item-id")
+	fs.StringVar(&f.projectItemID, "project", "", "alias for --project-item-id")
+	fs.StringVar(&f.dueBefore, "due-before", "", "filter items with due_at before this RFC3339 timestamp")
+	fs.StringVar(&f.dueAfter, "due-after", "", "filter items with due_at after this RFC3339 timestamp")
+	fs.StringVar(&f.followUpBefore, "follow-up-before", "", "filter items with follow_up_at before this timestamp")
+	fs.StringVar(&f.followUpAfter, "follow-up-after", "", "filter items with follow_up_at after this timestamp")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit raw JSON instead of plain text")
+	if err := fs.Parse(args); err != nil {
+		return gtdFilters{}, err
+	}
+	if extra := fs.Args(); len(extra) > 0 {
+		return gtdFilters{}, fmt.Errorf("unexpected positional argument: %s", extra[0])
+	}
+	return f, nil
+}
+
+func (f gtdFilters) query() url.Values {
+	q := url.Values{}
+	setIf := func(key, value string) {
+		if v := strings.TrimSpace(value); v != "" {
+			q.Set(key, v)
+		}
+	}
+	setIf("sphere", f.sphere)
+	setIf("source", f.source)
+	setIf("source_container", f.sourceContainer)
+	setIf("label", f.label)
+	setIf("label_id", f.labelID)
+	setIf("actor_id", f.actorID)
+	setIf("workspace_id", f.workspace)
+	setIf("project_item_id", f.projectItemID)
+	setIf("due_before", f.dueBefore)
+	setIf("due_after", f.dueAfter)
+	setIf("follow_up_before", f.followUpBefore)
+	setIf("follow_up_after", f.followUpAfter)
+	return q
+}
+
+type gtdItem struct {
+	ID           int64   `json:"id"`
+	Title        string  `json:"title"`
+	Kind         string  `json:"kind"`
+	State        string  `json:"state"`
+	Sphere       string  `json:"sphere"`
+	Source       *string `json:"source"`
+	SourceRef    *string `json:"source_ref"`
+	WorkspaceID  *int64  `json:"workspace_id"`
+	ActorID      *int64  `json:"actor_id"`
+	ActorName    *string `json:"actor_name"`
+	DueAt        *string `json:"due_at"`
+	FollowUpAt   *string `json:"follow_up_at"`
+	VisibleAfter *string `json:"visible_after"`
+}
+
+type gtdItemsResponse struct {
+	Items   []gtdItem `json:"items"`
+	Overdue []int64   `json:"overdue"`
+}
+
+type gtdProjectHealth struct {
+	HasNextAction bool `json:"has_next_action"`
+	HasWaiting    bool `json:"has_waiting"`
+	HasDeferred   bool `json:"has_deferred"`
+	HasSomeday    bool `json:"has_someday"`
+	Stalled       bool `json:"stalled"`
+}
+
+type gtdProjectCounts struct {
+	Inbox    int `json:"inbox"`
+	Next     int `json:"next"`
+	Waiting  int `json:"waiting"`
+	Deferred int `json:"deferred"`
+	Someday  int `json:"someday"`
+	Review   int `json:"review"`
+	Done     int `json:"done"`
+	Total    int `json:"total"`
+}
+
+type gtdProjectReview struct {
+	Item     gtdItem          `json:"item"`
+	Health   gtdProjectHealth `json:"health"`
+	Children gtdProjectCounts `json:"children"`
+}
+
+type gtdProjectsResponse struct {
+	ProjectItems []gtdProjectReview `json:"project_items"`
+	Total        int                `json:"total"`
+	Stalled      int                `json:"stalled"`
+}
+
+func handleGtdCommand(args []string, opts cliOptions, stdout, stderr io.Writer) int {
+	if len(args) == 0 || strings.EqualFold(args[0], "gtd") {
+		printGtdUsage(stderr)
+		return 2
+	}
+	queue := findGtdQueue(args[0])
+	if queue == nil {
+		fmt.Fprintf(stderr, "unknown gtd subcommand %q (want inbox|next|waiting|later|someday|review|projects)\n", args[0])
+		return 2
+	}
+	filters, err := parseGtdFilters(args[1:])
+	if err != nil {
+		fmt.Fprintf(stderr, "sls gtd %s: %v\n", queue.Name, err)
+		return 2
+	}
+	body, err := fetchGtd(opts, *queue, filters)
+	if err != nil {
+		fmt.Fprintf(stderr, "sls gtd %s: %v\n", queue.Name, err)
+		return 1
+	}
+	if err := renderGtdResponse(stdout, *queue, filters, body); err != nil {
+		fmt.Fprintf(stderr, "sls gtd %s: %v\n", queue.Name, err)
+		return 1
+	}
+	return 0
+}
+
+func printGtdUsage(out io.Writer) {
+	fmt.Fprintln(out, "usage: sls gtd <queue> [filters...]")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "queues:")
+	fmt.Fprintln(out, "  inbox                    unprocessed captures and imported candidates")
+	fmt.Fprintln(out, "  next                     actionable next actions across all sources")
+	fmt.Fprintln(out, "  waiting                  delegated/awaited items")
+	fmt.Fprintln(out, "  later (deferred)         deferred/tickler items hidden until follow_up")
+	fmt.Fprintln(out, "  someday (maybe)          parked actions and project items")
+	fmt.Fprintln(out, "  review                   stalled, drift, or needs-clarification items")
+	fmt.Fprintln(out, "  projects                 Item(kind=project) outcomes only")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "filters:")
+	fmt.Fprintln(out, "  --vault work|private       sphere filter")
+	fmt.Fprintln(out, "  --source NAME              source backend (todoist|github|imap|gmail|...)")
+	fmt.Fprintln(out, "  --source-container NAME    upstream container (Todoist project, mail folder)")
+	fmt.Fprintln(out, "  --label NAME               filter by label name")
+	fmt.Fprintln(out, "  --label-id N               filter by label id")
+	fmt.Fprintln(out, "  --actor-id N               filter by actor id (delegate)")
+	fmt.Fprintln(out, "  --workspace ID|null        filesystem-backed Slopshell workspace id")
+	fmt.Fprintln(out, "  --project-item-id N        GTD project-item id (alias: --project, --project-item)")
+	fmt.Fprintln(out, "  --due-before TS            ISO timestamp")
+	fmt.Fprintln(out, "  --due-after TS             ISO timestamp")
+	fmt.Fprintln(out, "  --follow-up-before TS      ISO timestamp")
+	fmt.Fprintln(out, "  --follow-up-after TS       ISO timestamp")
+	fmt.Fprintln(out, "  --json                     emit raw JSON")
+}
+
+func fetchGtd(opts cliOptions, queue gtdQueue, filters gtdFilters) ([]byte, error) {
+	base := opts.resolveBaseURL()
+	client, err := newClientForBrain(base, opts.effectiveTokenFile())
+	if err != nil {
+		return nil, err
+	}
+	target := strings.TrimRight(base, "/") + queue.Path
+	if q := filters.query(); len(q) > 0 {
+		target += "?" + q.Encode()
+	}
+	resp, err := client.Get(target)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", queue.Name, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", queue.Name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func renderGtdResponse(out io.Writer, queue gtdQueue, filters gtdFilters, body []byte) error {
+	if filters.jsonOut {
+		_, err := out.Write(append(append([]byte{}, body...), '\n'))
+		return err
+	}
+	if queue.IsProjectReview {
+		return renderGtdProjects(out, queue, body)
+	}
+	return renderGtdItems(out, queue, body)
+}
+
+func renderGtdItems(out io.Writer, queue gtdQueue, body []byte) error {
+	var resp gtdItemsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("decode items: %w", err)
+	}
+	overdue := overdueIDSet(resp.Overdue)
+	if len(resp.Items) == 0 {
+		fmt.Fprintf(out, "%s: (empty)\n", queue.Label)
+		return nil
+	}
+	suffix := ""
+	if len(overdue) > 0 {
+		suffix = fmt.Sprintf(", %d overdue", len(overdue))
+	}
+	fmt.Fprintf(out, "%s (%d items%s)\n", queue.Label, len(resp.Items), suffix)
+	for _, item := range resp.Items {
+		fmt.Fprintln(out, formatGtdItemLine(item, overdue[item.ID]))
+	}
+	return nil
+}
+
+func renderGtdProjects(out io.Writer, queue gtdQueue, body []byte) error {
+	var resp gtdProjectsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("decode project items: %w", err)
+	}
+	if resp.Total == 0 {
+		fmt.Fprintf(out, "%s: (empty)\n", queue.Label)
+		return nil
+	}
+	fmt.Fprintf(out, "%s (%d total, %d stalled)\n", queue.Label, resp.Total, resp.Stalled)
+	for _, review := range resp.ProjectItems {
+		fmt.Fprintln(out, formatGtdProjectLine(review))
+	}
+	return nil
+}
+
+func overdueIDSet(ids []int64) map[int64]bool {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make(map[int64]bool, len(ids))
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out
+}
+
+func formatGtdItemLine(item gtdItem, overdue bool) string {
+	parts := []string{fmt.Sprintf("  #%d", item.ID)}
+	if overdue {
+		parts = append(parts, "[overdue]")
+	}
+	if src := optionalStringPtr(item.Source); src != "" {
+		parts = append(parts, "["+src+"]")
+	} else {
+		parts = append(parts, "[local]")
+	}
+	parts = append(parts, item.Title)
+	tail := gtdItemTail(item)
+	line := strings.Join(parts, " ")
+	if tail != "" {
+		line += "  " + tail
+	}
+	return line
+}
+
+func gtdItemTail(item gtdItem) string {
+	var bits []string
+	if item.Sphere != "" {
+		bits = append(bits, "sphere="+item.Sphere)
+	}
+	if name := optionalStringPtr(item.ActorName); name != "" {
+		bits = append(bits, "actor="+name)
+	} else if item.ActorID != nil {
+		bits = append(bits, fmt.Sprintf("actor_id=%d", *item.ActorID))
+	}
+	if due := optionalStringPtr(item.DueAt); due != "" {
+		bits = append(bits, "due="+due)
+	}
+	if follow := optionalStringPtr(item.FollowUpAt); follow != "" {
+		bits = append(bits, "follow_up="+follow)
+	}
+	if visible := optionalStringPtr(item.VisibleAfter); visible != "" {
+		bits = append(bits, "visible_after="+visible)
+	}
+	if item.WorkspaceID != nil {
+		bits = append(bits, fmt.Sprintf("workspace=%d", *item.WorkspaceID))
+	}
+	return strings.Join(bits, "  ")
+}
+
+func formatGtdProjectLine(review gtdProjectReview) string {
+	flag := "       "
+	if review.Health.Stalled {
+		flag = "[stall]"
+	}
+	line := fmt.Sprintf("  #%d %s %s", review.Item.ID, flag, review.Item.Title)
+	counts := fmt.Sprintf("next=%d waiting=%d deferred=%d someday=%d review=%d done=%d",
+		review.Children.Next,
+		review.Children.Waiting,
+		review.Children.Deferred,
+		review.Children.Someday,
+		review.Children.Review,
+		review.Children.Done,
+	)
+	return line + "  " + counts
+}
+
+func optionalStringPtr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return strings.TrimSpace(*p)
+}

--- a/cmd/sls/gtd_test.go
+++ b/cmd/sls/gtd_test.go
@@ -1,0 +1,469 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsGtdSubcommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"bare gtd", []string{"gtd"}, true},
+		{"gtd inbox", []string{"gtd", "inbox"}, true},
+		{"gtd next with flags", []string{"gtd", "next", "--vault", "work"}, true},
+		{"gtd projects", []string{"gtd", "projects"}, true},
+		{"gtd later alias", []string{"gtd", "later"}, true},
+		{"gtd deferred alias", []string{"gtd", "deferred"}, true},
+		{"gtd defer alias", []string{"gtd", "defer"}, true},
+		{"gtd someday alias", []string{"gtd", "maybe"}, true},
+		{"gtd unknown queue", []string{"gtd", "bogus"}, false},
+		{"top-level flags then gtd", []string{"--base-url", "http://x", "gtd", "review"}, true},
+		{"chat", []string{"chat"}, false},
+		{"empty", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGtdSubcommand(tt.args); got != tt.want {
+				t.Errorf("isGtdSubcommand(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindGtdQueue(t *testing.T) {
+	cases := map[string]string{
+		"inbox":    "inbox",
+		"INBOX":    "inbox",
+		"next":     "next",
+		"waiting":  "waiting",
+		"later":    "later",
+		"deferred": "later",
+		"defer":    "later",
+		"someday":  "someday",
+		"maybe":    "someday",
+		"review":   "review",
+		"projects": "projects",
+		" inbox ":  "inbox",
+	}
+	for input, wantName := range cases {
+		t.Run(input, func(t *testing.T) {
+			q := findGtdQueue(input)
+			if q == nil {
+				t.Fatalf("findGtdQueue(%q) = nil, want %q", input, wantName)
+			}
+			if q.Name != wantName {
+				t.Errorf("findGtdQueue(%q).Name = %q, want %q", input, q.Name, wantName)
+			}
+		})
+	}
+	if findGtdQueue("nope") != nil {
+		t.Error("findGtdQueue(nope) should be nil")
+	}
+	if findGtdQueue("") != nil {
+		t.Error("findGtdQueue(empty) should be nil")
+	}
+}
+
+func TestCommandArgsForGtd(t *testing.T) {
+	args := []string{"--base-url", "http://x", "gtd", "next", "--vault", "work"}
+	got := commandArgs(args)
+	want := []string{"next", "--vault", "work"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("commandArgs(%v) = %v, want %v", args, got, want)
+	}
+}
+
+func TestCommandArgsForBareGtd(t *testing.T) {
+	args := []string{"gtd"}
+	got := commandArgs(args)
+	if len(got) != 1 || got[0] != "gtd" {
+		t.Fatalf("commandArgs(gtd) = %v, want [gtd]", got)
+	}
+}
+
+func TestParseGtdFiltersDefaults(t *testing.T) {
+	f, err := parseGtdFilters(nil)
+	if err != nil {
+		t.Fatalf("parseGtdFilters(nil) err = %v", err)
+	}
+	if f != (gtdFilters{}) {
+		t.Errorf("parseGtdFilters(nil) = %#v, want zero", f)
+	}
+}
+
+func TestParseGtdFiltersAll(t *testing.T) {
+	args := []string{
+		"--vault", "work",
+		"--source", "todoist",
+		"--source-container", "Inbox",
+		"--label", "deep-work",
+		"--actor-id", "5",
+		"--workspace", "12",
+		"--project-item-id", "99",
+		"--due-before", "2026-05-10T00:00:00Z",
+		"--due-after", "2026-04-01T00:00:00Z",
+		"--follow-up-before", "2026-05-15T00:00:00Z",
+		"--follow-up-after", "2026-04-15T00:00:00Z",
+		"--json",
+	}
+	f, err := parseGtdFilters(args)
+	if err != nil {
+		t.Fatalf("parseGtdFilters err = %v", err)
+	}
+	q := f.query()
+	want := url.Values{
+		"sphere":           {"work"},
+		"source":           {"todoist"},
+		"source_container": {"Inbox"},
+		"label":            {"deep-work"},
+		"actor_id":         {"5"},
+		"workspace_id":     {"12"},
+		"project_item_id":  {"99"},
+		"due_before":       {"2026-05-10T00:00:00Z"},
+		"due_after":        {"2026-04-01T00:00:00Z"},
+		"follow_up_before": {"2026-05-15T00:00:00Z"},
+		"follow_up_after":  {"2026-04-15T00:00:00Z"},
+	}
+	if got := q.Encode(); got != want.Encode() {
+		t.Errorf("query() = %q, want %q", got, want.Encode())
+	}
+	if !f.jsonOut {
+		t.Error("--json should set jsonOut")
+	}
+}
+
+func TestParseGtdFiltersProjectAliases(t *testing.T) {
+	for _, alias := range []string{"--project", "--project-item", "--project-item-id"} {
+		t.Run(alias, func(t *testing.T) {
+			f, err := parseGtdFilters([]string{alias, "42"})
+			if err != nil {
+				t.Fatalf("parseGtdFilters(%s) err = %v", alias, err)
+			}
+			if got := f.query().Get("project_item_id"); got != "42" {
+				t.Errorf("project_item_id = %q, want 42", got)
+			}
+		})
+	}
+}
+
+func TestParseGtdFiltersWorkspaceNull(t *testing.T) {
+	f, err := parseGtdFilters([]string{"--workspace", "null"})
+	if err != nil {
+		t.Fatalf("parseGtdFilters err = %v", err)
+	}
+	if got := f.query().Get("workspace_id"); got != "null" {
+		t.Errorf("workspace_id = %q, want null", got)
+	}
+}
+
+func TestParseGtdFiltersRejectsExtraPositional(t *testing.T) {
+	if _, err := parseGtdFilters([]string{"oops"}); err == nil {
+		t.Fatal("parseGtdFilters with extra positional should error")
+	}
+}
+
+func TestParseGtdFiltersRejectsUnknownFlag(t *testing.T) {
+	if _, err := parseGtdFilters([]string{"--bogus"}); err == nil {
+		t.Fatal("parseGtdFilters with unknown flag should error")
+	}
+}
+
+func TestRenderGtdItemsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	body := []byte(`{"items":[]}`)
+	if err := renderGtdResponse(&buf, gtdQueueList[0], gtdFilters{}, body); err != nil {
+		t.Fatalf("renderGtdResponse err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "(empty)") {
+		t.Errorf("expected '(empty)' marker, got %q", buf.String())
+	}
+}
+
+func TestRenderGtdItems(t *testing.T) {
+	var buf bytes.Buffer
+	body := []byte(`{
+		"items":[
+			{"id":42,"title":"Reply to Andrei","kind":"action","state":"next","sphere":"work",
+			 "source":"todoist","actor_id":7,"actor_name":"Andrei","due_at":"2026-04-30T12:00:00Z"},
+			{"id":43,"title":"Read paper","kind":"action","state":"next","sphere":"private","follow_up_at":"2026-05-02T00:00:00Z"}
+		],
+		"overdue":[42]
+	}`)
+	queue := *findGtdQueue("next")
+	if err := renderGtdResponse(&buf, queue, gtdFilters{}, body); err != nil {
+		t.Fatalf("renderGtdResponse err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Next actions (2 items, 1 overdue)") {
+		t.Errorf("missing header, got %q", out)
+	}
+	if !strings.Contains(out, "#42") || !strings.Contains(out, "[overdue]") || !strings.Contains(out, "[todoist]") {
+		t.Errorf("missing overdue/todoist markers: %q", out)
+	}
+	if !strings.Contains(out, "actor=Andrei") {
+		t.Errorf("missing actor name: %q", out)
+	}
+	if !strings.Contains(out, "#43") || !strings.Contains(out, "follow_up=2026-05-02T00:00:00Z") {
+		t.Errorf("missing follow-up details: %q", out)
+	}
+	if !strings.Contains(out, "[local]") {
+		t.Errorf("expected local marker for sourceless item: %q", out)
+	}
+}
+
+func TestRenderGtdProjects(t *testing.T) {
+	var buf bytes.Buffer
+	body := []byte(`{
+		"project_items":[
+			{
+				"item":{"id":100,"title":"Onboarding revamp","kind":"project","state":"next","sphere":"work"},
+				"health":{"has_next_action":false,"stalled":true},
+				"children":{"next":0,"waiting":1,"deferred":0,"someday":0,"review":0,"done":2}
+			},
+			{
+				"item":{"id":101,"title":"Conference talk","kind":"project","state":"next","sphere":"work"},
+				"health":{"has_next_action":true,"stalled":false},
+				"children":{"next":2,"waiting":0,"deferred":0,"someday":0,"review":0,"done":0}
+			}
+		],
+		"total":2,
+		"stalled":1
+	}`)
+	queue := *findGtdQueue("projects")
+	if err := renderGtdResponse(&buf, queue, gtdFilters{}, body); err != nil {
+		t.Fatalf("renderGtdResponse err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Project items (2 total, 1 stalled)") {
+		t.Errorf("missing header, got %q", out)
+	}
+	if !strings.Contains(out, "#100") || !strings.Contains(out, "[stall]") {
+		t.Errorf("missing stalled marker: %q", out)
+	}
+	if !strings.Contains(out, "#101") || strings.Contains(stallLineFor(out, "#101"), "[stall]") {
+		t.Errorf("non-stalled project should not be marked: %q", out)
+	}
+	if !strings.Contains(out, "next=0 waiting=1") {
+		t.Errorf("missing child counts: %q", out)
+	}
+}
+
+func stallLineFor(out, prefix string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, prefix) {
+			return line
+		}
+	}
+	return ""
+}
+
+func TestRenderGtdJSONPassthrough(t *testing.T) {
+	var buf bytes.Buffer
+	body := []byte(`{"items":[{"id":1,"title":"x","kind":"action","state":"inbox","sphere":"work"}]}`)
+	if err := renderGtdResponse(&buf, *findGtdQueue("inbox"), gtdFilters{jsonOut: true}, body); err != nil {
+		t.Fatalf("renderGtdResponse err = %v", err)
+	}
+	out := strings.TrimSpace(buf.String())
+	if out != strings.TrimSpace(string(body)) {
+		t.Errorf("json passthrough = %q, want %q", out, string(body))
+	}
+}
+
+// gtdServerCapture records the request URL of the most recent JSON list call.
+type gtdServerCapture struct {
+	last *http.Request
+}
+
+func newGtdTestServer(t *testing.T, capture *gtdServerCapture, responses map[string]string) (*httptest.Server, string) {
+	t.Helper()
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "cli-token")
+	if err := os.WriteFile(tokenPath, []byte("test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/cli/login", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	for path, body := range responses {
+		body := body
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			capture.last = r.Clone(r.Context())
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		})
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, tokenPath
+}
+
+func runGtdHarness(t *testing.T, queue, body string, args []string) (*gtdServerCapture, string, int) {
+	t.Helper()
+	cap := &gtdServerCapture{}
+	q := findGtdQueue(queue)
+	if q == nil {
+		t.Fatalf("unknown queue %q", queue)
+	}
+	srv, token := newGtdTestServer(t, cap, map[string]string{q.Path: body})
+	opts := cliOptions{baseURL: srv.URL, tokenFile: token}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := handleGtdCommand(append([]string{queue}, args...), opts, stdout, stderr)
+	if code != 0 {
+		t.Logf("stderr: %s", stderr.String())
+	}
+	return cap, stdout.String(), code
+}
+
+func TestHandleGtdInboxForwardsSourceFilter(t *testing.T) {
+	cap, _, code := runGtdHarness(t, "inbox",
+		`{"items":[{"id":1,"title":"capture","kind":"action","state":"inbox","sphere":"work","source":"imap"}]}`,
+		[]string{"--vault", "work", "--source", "imap"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if cap.last == nil {
+		t.Fatal("server received no request")
+	}
+	if got := cap.last.URL.Query().Get("source"); got != "imap" {
+		t.Errorf("source query = %q, want imap", got)
+	}
+	if got := cap.last.URL.Query().Get("sphere"); got != "work" {
+		t.Errorf("sphere query = %q, want work", got)
+	}
+}
+
+func TestHandleGtdNextForwardsWorkspaceFilter(t *testing.T) {
+	cap, _, code := runGtdHarness(t, "next",
+		`{"items":[],"overdue":[]}`,
+		[]string{"--workspace", "12"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if got := cap.last.URL.Query().Get("workspace_id"); got != "12" {
+		t.Errorf("workspace_id = %q, want 12", got)
+	}
+}
+
+func TestHandleGtdWaitingForwardsSourceContainerFilter(t *testing.T) {
+	cap, _, code := runGtdHarness(t, "waiting",
+		`{"items":[]}`,
+		[]string{"--source-container", "Triage"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if got := cap.last.URL.Query().Get("source_container"); got != "Triage" {
+		t.Errorf("source_container = %q, want Triage", got)
+	}
+}
+
+func TestHandleGtdLaterForwardsProjectItemFilter(t *testing.T) {
+	cap, out, code := runGtdHarness(t, "later",
+		`{"items":[{"id":7,"title":"deferred-task","kind":"action","state":"later","sphere":"work"}]}`,
+		[]string{"--project-item-id", "42"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if got := cap.last.URL.Path; got != "/api/items/deferred" {
+		t.Errorf("later alias should hit /api/items/deferred, got %q", got)
+	}
+	if got := cap.last.URL.Query().Get("project_item_id"); got != "42" {
+		t.Errorf("project_item_id = %q, want 42", got)
+	}
+	if !strings.Contains(out, "Later") || !strings.Contains(out, "#7") {
+		t.Errorf("expected later listing, got %q", out)
+	}
+}
+
+func TestHandleGtdProjectsForwardsListFilters(t *testing.T) {
+	cap, out, code := runGtdHarness(t, "projects",
+		`{"project_items":[{"item":{"id":11,"title":"Outcome","kind":"project","state":"next","sphere":"work"},"health":{"stalled":false},"children":{"next":1,"waiting":0,"deferred":0,"someday":0,"review":0,"done":0}}],"total":1,"stalled":0}`,
+		[]string{"--vault", "work", "--label", "deep"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if got := cap.last.URL.Query().Get("sphere"); got != "work" {
+		t.Errorf("sphere = %q, want work", got)
+	}
+	if got := cap.last.URL.Query().Get("label"); got != "deep" {
+		t.Errorf("label = %q, want deep", got)
+	}
+	if !strings.Contains(out, "Project items (1 total, 0 stalled)") {
+		t.Errorf("missing project header, got %q", out)
+	}
+	if !strings.Contains(out, "#11") {
+		t.Errorf("missing project row, got %q", out)
+	}
+}
+
+func TestHandleGtdReviewQueue(t *testing.T) {
+	cap, out, code := runGtdHarness(t, "review",
+		`{"items":[{"id":3,"title":"stalled","kind":"project","state":"review","sphere":"work"}]}`,
+		nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if cap.last.URL.Path != "/api/items/review" {
+		t.Errorf("expected /api/items/review path, got %q", cap.last.URL.Path)
+	}
+	if !strings.Contains(out, "Review") || !strings.Contains(out, "#3") {
+		t.Errorf("missing review output, got %q", out)
+	}
+}
+
+func TestHandleGtdSomedayJSONOutput(t *testing.T) {
+	body := `{"items":[{"id":2,"title":"someday-thing","kind":"action","state":"someday","sphere":"private"}]}`
+	_, out, code := runGtdHarness(t, "someday", body, []string{"--json"})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(body) {
+		t.Errorf("--json passthrough mismatch: got %q, want %q", out, body)
+	}
+}
+
+func TestHandleGtdRejectsUnknownQueue(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := handleGtdCommand([]string{"bogus"}, cliOptions{baseURL: "http://127.0.0.1:1"}, stdout, stderr)
+	if code != 2 {
+		t.Errorf("unknown queue exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown gtd subcommand") {
+		t.Errorf("missing usage error, got %q", stderr.String())
+	}
+}
+
+func TestHandleGtdBareUsage(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := handleGtdCommand([]string{"gtd"}, cliOptions{baseURL: "http://127.0.0.1:1"}, stdout, stderr)
+	if code != 2 {
+		t.Errorf("bare gtd exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "queues:") {
+		t.Errorf("expected usage text, got %q", stderr.String())
+	}
+}
+
+func TestHandleGtdRejectsBadFilter(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := handleGtdCommand([]string{"inbox", "--unknown-flag"}, cliOptions{baseURL: "http://127.0.0.1:1"}, stdout, stderr)
+	if code != 2 {
+		t.Errorf("bad flag exit code = %d, want 2", code)
+	}
+}

--- a/cmd/sls/main.go
+++ b/cmd/sls/main.go
@@ -43,17 +43,20 @@ func main() {
 }
 
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	if isBrainSubcommand(args) || isTopLevelLinkFollow(args) || isTopLevelAgentHere(args) {
-		brainArgs := commandArgs(args)
+	if isBrainSubcommand(args) || isTopLevelLinkFollow(args) || isTopLevelAgentHere(args) || isGtdSubcommand(args) {
+		subArgs := commandArgs(args)
 		opts, _, err := parseFlags(args)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 2
 		}
 		if isTopLevelAgentHere(args) {
-			return handleAgentHereCommand(brainArgs, opts, stdout, stderr)
+			return handleAgentHereCommand(subArgs, opts, stdout, stderr)
 		}
-		return handleBrainCommand(brainArgs, opts)
+		if isGtdSubcommand(args) {
+			return handleGtdCommand(subArgs, opts, stdout, stderr)
+		}
+		return handleBrainCommand(subArgs, opts)
 	}
 
 	opts, tail, err := parseFlags(args)
@@ -211,6 +214,19 @@ Brain commands (standalone, before chat flags):
   sls brain links <note> [<sphere>]  show links in a brain note
   sls brain backlinks <note> [<sphere>] find backlinks to a brain note
   sls brain link follow <note> <target> [<sphere>] resolve a wiki link
+
+GTD commands (standalone, before chat flags):
+  sls gtd inbox       [filters...]   unprocessed captures across all sources
+  sls gtd next        [filters...]   actionable next actions
+  sls gtd waiting     [filters...]   delegated/awaited items
+  sls gtd later       [filters...]   deferred/tickler items (alias: deferred)
+  sls gtd someday     [filters...]   parked actions and project items
+  sls gtd review      [filters...]   stalled or needs-clarification items
+  sls gtd projects    [filters...]   Item(kind=project) outcomes only
+  Filter flags: --vault, --source, --source-container, --label, --label-id,
+                --actor-id, --workspace, --project-item-id (alias --project,
+                --project-item), --due-before, --due-after,
+                --follow-up-before, --follow-up-after, --json
 
 Link follow (top-level):
   sls link follow <note> <target> [<sphere>]    same as sls brain link follow


### PR DESCRIPTION
## Summary

Add `sls gtd <queue>` CLI dispatcher so the trusted-system review can run from the terminal without opening source apps or reading Markdown files. Queues call the existing list endpoints (`/api/items/inbox|next|waiting|deferred|someday|review|projects`) and forward the filter set defined by the issue.

- subcommands: `inbox`, `next`, `waiting`, `later` (alias `deferred`/`defer`), `someday` (alias `maybe`), `review`, `projects`
- filter flags: `--vault`, `--source`, `--source-container`, `--label`, `--label-id`, `--actor-id`, `--workspace` (numeric or `null`), `--project-item-id` (with `--project` and `--project-item` aliases), `--due-before/--due-after`, `--follow-up-before/--follow-up-after`, `--json`
- terminology rule honored: `--workspace` filters Slopshell workspaces, `--project*` filters GTD project items, `--source-container` filters upstream containers
- next-action output flags overdue items separately; project output flags stalled outcomes and shows per-state child counts
- `--json` passes the raw server response through unchanged for scripting

Closes #732.

## Verification

### Acceptance: terminal-only review can list and narrow actionable items

`go test -v -run TestHandleGtd ./cmd/sls/...` — drives `handleGtdCommand` through every queue against an `httptest` server, asserts the request URL and rendered output for each queue:

```
=== RUN   TestHandleGtdInboxForwardsSourceFilter
--- PASS: TestHandleGtdInboxForwardsSourceFilter (0.00s)
=== RUN   TestHandleGtdNextForwardsWorkspaceFilter
--- PASS: TestHandleGtdNextForwardsWorkspaceFilter (0.00s)
=== RUN   TestHandleGtdWaitingForwardsSourceContainerFilter
--- PASS: TestHandleGtdWaitingForwardsSourceContainerFilter (0.00s)
=== RUN   TestHandleGtdLaterForwardsProjectItemFilter
--- PASS: TestHandleGtdLaterForwardsProjectItemFilter (0.00s)
=== RUN   TestHandleGtdProjectsForwardsListFilters
--- PASS: TestHandleGtdProjectsForwardsListFilters (0.00s)
=== RUN   TestHandleGtdReviewQueue
--- PASS: TestHandleGtdReviewQueue (0.00s)
=== RUN   TestHandleGtdSomedayJSONOutput
--- PASS: TestHandleGtdSomedayJSONOutput (0.00s)
=== RUN   TestHandleGtdRejectsUnknownQueue
--- PASS: TestHandleGtdRejectsUnknownQueue (0.00s)
=== RUN   TestHandleGtdBareUsage
--- PASS: TestHandleGtdBareUsage (0.00s)
=== RUN   TestHandleGtdRejectsBadFilter
--- PASS: TestHandleGtdRejectsBadFilter (0.00s)
PASS
```

### Acceptance: commands do not require reading every Markdown file

`fetchGtd` only issues `GET <queue.Path>` against the slopshell API (`cmd/sls/gtd.go:218-238`). No filesystem walk, no rg, no Markdown parse. The HTTP capture in `TestHandleGtdLaterForwardsProjectItemFilter` proves the alias resolves to `/api/items/deferred`:

```
later alias should hit /api/items/deferred → cap.last.URL.Path = "/api/items/deferred"
```

### Acceptance: tests cover source filters, Workspace filters, source-container filters, project-item filters, and GTD list filters

| Filter axis | Test | Asserts |
|---|---|---|
| source | `TestHandleGtdInboxForwardsSourceFilter` | `?source=imap&sphere=work` reaches `/api/items/inbox` |
| Workspace | `TestHandleGtdNextForwardsWorkspaceFilter` | `?workspace_id=12` reaches `/api/items/next` |
| source-container | `TestHandleGtdWaitingForwardsSourceContainerFilter` | `?source_container=Triage` reaches `/api/items/waiting` |
| project-item | `TestHandleGtdLaterForwardsProjectItemFilter` | `?project_item_id=42` reaches `/api/items/deferred` (later alias) |
| GTD list (projects) | `TestHandleGtdProjectsForwardsListFilters` | `?sphere=work&label=deep` reaches `/api/items/projects`, renders header `Project items (1 total, 0 stalled)` |
| GTD list (review) | `TestHandleGtdReviewQueue` | `/api/items/review` rendered with `#3` row |
| GTD list (someday json) | `TestHandleGtdSomedayJSONOutput` | `--json` is exact passthrough of server payload |

Filter parsing is independently exercised by `TestParseGtdFiltersAll`, `TestParseGtdFiltersProjectAliases`, and `TestParseGtdFiltersWorkspaceNull` (all PASS, see log above).

### Rendering evidence (artifact)

`TestRenderGtdItems` asserts that `Next actions (2 items, 1 overdue)` plus the `[overdue]` and `[todoist]` markers, the actor name, and the `[local]` fallback for sourceless rows all render. `TestRenderGtdProjects` asserts the `Project items (2 total, 1 stalled)` header, `[stall]` marker on the stalled outcome, no marker on the healthy one, and the per-state `next=0 waiting=1 …` line. Both PASS in the test run above.

### Regression: full repository test suite

`go test ./...` (log: `/tmp/go-test-all.log`) — all packages green, no regressions:

```
ok  	github.com/sloppy-org/slopshell/cmd/sls	(cached)
ok  	github.com/sloppy-org/slopshell/cmd/slopshell	0.081s
ok  	github.com/sloppy-org/slopshell/internal/store	1.729s
ok  	github.com/sloppy-org/slopshell/internal/web	25.837s
…
```

## Test plan

- [x] `go test ./cmd/sls/...`
- [x] `go test ./...`
- [x] `go vet ./cmd/sls/...`
- [x] `./scripts/sync-surface.sh --check`