### PR TITLE
fix: Add sls GTD mutation commands with backend routing (fixes #733)

### DIFF
--- a/cmd/sls/gtd.go
+++ b/cmd/sls/gtd.go
@@ -58,7 +58,7 @@ func isGtdSubcommand(args []string) bool {
 	if i+1 >= len(args) {
 		return true
 	}
-	return findGtdQueue(args[i+1]) != nil
+	return findGtdQueue(args[i+1]) != nil || isGtdMutationName(args[i+1])
 }
 
 type gtdFilters struct {
@@ -184,9 +184,12 @@ func handleGtdCommand(args []string, opts cliOptions, stdout, stderr io.Writer) 
 		printGtdUsage(stderr)
 		return 2
 	}
+	if isGtdMutationName(args[0]) {
+		return handleGtdMutationCommand(args, opts, stdout, stderr)
+	}
 	queue := findGtdQueue(args[0])
 	if queue == nil {
-		fmt.Fprintf(stderr, "unknown gtd subcommand %q (want inbox|next|waiting|later|someday|review|projects)\n", args[0])
+		fmt.Fprintf(stderr, "unknown gtd subcommand %q (want inbox|next|waiting|later|someday|review|projects|close|drop|defer|delegate|route|link-project|unlink-project)\n", args[0])
 		return 2
 	}
 	filters, err := parseGtdFilters(args[1:])
@@ -218,6 +221,15 @@ func printGtdUsage(out io.Writer) {
 	fmt.Fprintln(out, "  review                   stalled, drift, or needs-clarification items")
 	fmt.Fprintln(out, "  projects                 Item(kind=project) outcomes only")
 	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "actions:")
+	fmt.Fprintln(out, "  close <item>             mark an item done through its owning backend")
+	fmt.Fprintln(out, "  drop <item> [--yes]      remove a local item; source-backed items require --yes")
+	fmt.Fprintln(out, "  defer <item> <date>      defer until an RFC3339 follow-up timestamp")
+	fmt.Fprintln(out, "  delegate <item> <actor>  assign to an actor id and move to waiting")
+	fmt.Fprintln(out, "  route <item> <workspace|null> assign execution workspace")
+	fmt.Fprintln(out, "  link-project <item> <project-item> [--role next_action|support|blocked_by]")
+	fmt.Fprintln(out, "  unlink-project <item> <project-item>")
+	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "filters:")
 	fmt.Fprintln(out, "  --vault work|private       sphere filter")
 	fmt.Fprintln(out, "  --source NAME              source backend (todoist|github|imap|gmail|...)")
@@ -235,16 +247,11 @@ func printGtdUsage(out io.Writer) {
 }
 
 func fetchGtd(opts cliOptions, queue gtdQueue, filters gtdFilters) ([]byte, error) {
-	base := opts.resolveBaseURL()
-	client, err := newClientForBrain(base, opts.effectiveTokenFile())
+	client, base, err := newGtdHTTPClient(opts)
 	if err != nil {
 		return nil, err
 	}
-	target := strings.TrimRight(base, "/") + queue.Path
-	if q := filters.query(); len(q) > 0 {
-		target += "?" + q.Encode()
-	}
-	resp, err := client.Get(target)
+	resp, err := client.Get(gtdURL(base, queue.Path, filters.query()))
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", queue.Name, err)
 	}

--- a/cmd/sls/gtd_mutation.go
+++ b/cmd/sls/gtd_mutation.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type gtdItemResponse struct {
+	Item    gtdItem        `json:"item"`
+	Links   []gtdChildLink `json:"links"`
+	Warning string         `json:"warning"`
+}
+
+type gtdChildLink struct {
+	ParentItemID int64  `json:"parent_item_id"`
+	ChildItemID  int64  `json:"child_item_id"`
+	Role         string `json:"role"`
+}
+
+type gtdMutationClient struct {
+	base   string
+	client *http.Client
+}
+
+func isGtdMutationName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "close", "drop", "defer", "delegate", "route", "link-project", "unlink-project":
+		return true
+	default:
+		return false
+	}
+}
+
+func handleGtdMutationCommand(args []string, opts cliOptions, stdout, stderr io.Writer) int {
+	mutator, err := newGtdMutationClient(opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "sls gtd %s: %v\n", args[0], err)
+		return 1
+	}
+	result, err := mutator.run(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "sls gtd %s: %v\n", args[0], err)
+		if errors.Is(err, errGtdUsage) {
+			return 2
+		}
+		return 1
+	}
+	fmt.Fprintln(stdout, result)
+	return 0
+}
+
+var errGtdUsage = errors.New("usage error")
+
+func newGtdHTTPClient(opts cliOptions) (*http.Client, string, error) {
+	base := opts.resolveBaseURL()
+	client, err := newClientForBrain(base, opts.effectiveTokenFile())
+	if err != nil {
+		return nil, "", err
+	}
+	return client, base, nil
+}
+
+func newGtdMutationClient(opts cliOptions) (*gtdMutationClient, error) {
+	client, base, err := newGtdHTTPClient(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &gtdMutationClient{base: strings.TrimRight(base, "/"), client: client}, nil
+}
+
+func (c *gtdMutationClient) run(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", errGtdUsage
+	}
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "close":
+		return c.close(args[1:])
+	case "drop":
+		return c.drop(args[1:])
+	case "defer":
+		return c.deferItem(args[1:])
+	case "delegate":
+		return c.delegate(args[1:])
+	case "route":
+		return c.route(args[1:])
+	case "link-project":
+		return c.linkProject(args[1:])
+	case "unlink-project":
+		return c.unlinkProject(args[1:])
+	default:
+		return "", errGtdUsage
+	}
+}
+
+func (c *gtdMutationClient) close(args []string) (string, error) {
+	itemID, err := singleItemID("close", args)
+	if err != nil {
+		return "", err
+	}
+	var resp gtdItemResponse
+	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d/state", itemID), map[string]any{"state": "done"}, &resp); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("closed #%d state=%s", resp.Item.ID, resp.Item.State), nil
+}
+
+func (c *gtdMutationClient) drop(args []string) (string, error) {
+	itemArgs, yes, err := parseGtdDropArgs(args)
+	if err != nil {
+		return "", err
+	}
+	itemID, err := singleItemID("drop", itemArgs)
+	if err != nil {
+		return "", err
+	}
+	item, err := c.fetchItem(itemID)
+	if err != nil {
+		return "", err
+	}
+	if optionalStringPtr(item.Source) != "" && !yes {
+		return "", fmt.Errorf("source-backed item #%d requires --yes before drop", itemID)
+	}
+	if err := c.request(http.MethodDelete, fmt.Sprintf("/api/items/%d", itemID), nil, nil); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("dropped #%d", itemID), nil
+}
+
+func (c *gtdMutationClient) deferItem(args []string) (string, error) {
+	if len(args) != 2 {
+		return "", fmt.Errorf("%w: usage: sls gtd defer <item> <rfc3339>", errGtdUsage)
+	}
+	itemID, err := parseGtdItemID(args[0])
+	if err != nil {
+		return "", err
+	}
+	followUp := strings.TrimSpace(args[1])
+	var resp gtdItemResponse
+	body := map[string]any{"state": "deferred", "follow_up_at": followUp}
+	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d", itemID), body, &resp); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("deferred #%d follow_up=%s", resp.Item.ID, optionalStringPtr(resp.Item.FollowUpAt)), nil
+}
+
+func (c *gtdMutationClient) delegate(args []string) (string, error) {
+	if len(args) != 2 {
+		return "", fmt.Errorf("%w: usage: sls gtd delegate <item> <actor-id>", errGtdUsage)
+	}
+	itemID, err := parseGtdItemID(args[0])
+	if err != nil {
+		return "", err
+	}
+	actorID, err := parsePositiveInt64(args[1], "actor")
+	if err != nil {
+		return "", err
+	}
+	var resp gtdItemResponse
+	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d/assign", itemID), map[string]any{"actor_id": actorID}, &resp); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("delegated #%d actor_id=%d state=%s", resp.Item.ID, actorID, resp.Item.State), nil
+}
+
+func (c *gtdMutationClient) route(args []string) (string, error) {
+	if len(args) != 2 {
+		return "", fmt.Errorf("%w: usage: sls gtd route <item> <workspace-id|null>", errGtdUsage)
+	}
+	itemID, err := parseGtdItemID(args[0])
+	if err != nil {
+		return "", err
+	}
+	workspaceID, err := parseOptionalGtdID(args[1], "workspace")
+	if err != nil {
+		return "", err
+	}
+	var resp gtdItemResponse
+	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d/workspace", itemID), map[string]any{"workspace_id": workspaceID}, &resp); err != nil {
+		return "", err
+	}
+	return formatGtdRouteResult(resp.Item, resp.Warning), nil
+}
+
+func (c *gtdMutationClient) linkProject(args []string) (string, error) {
+	itemArgs, role, err := parseGtdLinkProjectArgs(args)
+	if err != nil {
+		return "", err
+	}
+	ids, err := twoItemIDs("link-project", itemArgs)
+	if err != nil {
+		return "", err
+	}
+	var resp gtdItemResponse
+	body := map[string]any{"project_item_id": ids[1], "role": role}
+	if err := c.request(http.MethodPost, fmt.Sprintf("/api/items/%d/project-item-link", ids[0]), body, &resp); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("linked #%d project_item=%d role=%s", ids[0], ids[1], linkRole(resp.Links, ids[0])), nil
+}
+
+func (c *gtdMutationClient) unlinkProject(args []string) (string, error) {
+	ids, err := twoItemIDs("unlink-project", args)
+	if err != nil {
+		return "", err
+	}
+	var resp gtdItemResponse
+	body := map[string]any{"project_item_id": ids[1]}
+	if err := c.request(http.MethodDelete, fmt.Sprintf("/api/items/%d/project-item-link", ids[0]), body, &resp); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("unlinked #%d project_item=%d", ids[0], ids[1]), nil
+}
+
+func (c *gtdMutationClient) fetchItem(itemID int64) (gtdItem, error) {
+	var resp gtdItemResponse
+	if err := c.request(http.MethodGet, fmt.Sprintf("/api/items/%d", itemID), nil, &resp); err != nil {
+		return gtdItem{}, err
+	}
+	return resp.Item, nil
+}
+
+func (c *gtdMutationClient) request(method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, c.base+path, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if out == nil || len(strings.TrimSpace(string(data))) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func singleItemID(action string, args []string) (int64, error) {
+	if len(args) != 1 {
+		return 0, fmt.Errorf("%w: usage: sls gtd %s <item>", errGtdUsage, action)
+	}
+	return parseGtdItemID(args[0])
+}
+
+func twoItemIDs(action string, args []string) ([2]int64, error) {
+	if len(args) != 2 {
+		return [2]int64{}, fmt.Errorf("%w: usage: sls gtd %s <item> <project-item>", errGtdUsage, action)
+	}
+	first, err := parseGtdItemID(args[0])
+	if err != nil {
+		return [2]int64{}, err
+	}
+	second, err := parseGtdItemID(args[1])
+	if err != nil {
+		return [2]int64{}, err
+	}
+	return [2]int64{first, second}, nil
+}
+
+func parseGtdItemID(raw string) (int64, error) {
+	return parsePositiveInt64(strings.TrimPrefix(strings.TrimSpace(raw), "#"), "item")
+}
+
+func parsePositiveInt64(raw, name string) (int64, error) {
+	id, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("%w: %s must be a positive integer", errGtdUsage, name)
+	}
+	return id, nil
+}
+
+func parseOptionalGtdID(raw, name string) (*int64, error) {
+	if strings.EqualFold(strings.TrimSpace(raw), "null") {
+		return nil, nil
+	}
+	value, err := parsePositiveInt64(raw, name)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func parseGtdDropArgs(args []string) ([]string, bool, error) {
+	out := make([]string, 0, len(args))
+	yes := false
+	for _, arg := range args {
+		if strings.EqualFold(strings.TrimSpace(arg), "--yes") {
+			yes = true
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out, yes, nil
+}
+
+func parseGtdLinkProjectArgs(args []string) ([]string, string, error) {
+	out := make([]string, 0, len(args))
+	role := "next_action"
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		switch {
+		case arg == "--role":
+			if i+1 >= len(args) {
+				return nil, "", fmt.Errorf("%w: --role requires a value", errGtdUsage)
+			}
+			role = strings.TrimSpace(args[i+1])
+			i++
+		case strings.HasPrefix(arg, "--role="):
+			role = strings.TrimSpace(strings.TrimPrefix(arg, "--role="))
+		default:
+			out = append(out, args[i])
+		}
+	}
+	return out, role, nil
+}
+
+func formatGtdRouteResult(item gtdItem, warning string) string {
+	target := "null"
+	if item.WorkspaceID != nil {
+		target = strconv.FormatInt(*item.WorkspaceID, 10)
+	}
+	out := fmt.Sprintf("routed #%d workspace=%s", item.ID, target)
+	if strings.TrimSpace(warning) != "" {
+		out += " warning=" + warning
+	}
+	return out
+}
+
+func linkRole(links []gtdChildLink, childID int64) string {
+	for _, link := range links {
+		if link.ChildItemID == childID && strings.TrimSpace(link.Role) != "" {
+			return strings.TrimSpace(link.Role)
+		}
+	}
+	return ""
+}
+
+func gtdURL(base, path string, q url.Values) string {
+	target := strings.TrimRight(base, "/") + path
+	if len(q) > 0 {
+		target += "?" + q.Encode()
+	}
+	return target
+}

--- a/cmd/sls/gtd_mutation.go
+++ b/cmd/sls/gtd_mutation.go
@@ -105,7 +105,7 @@ func (c *gtdMutationClient) close(args []string) (string, error) {
 		return "", err
 	}
 	var resp gtdItemResponse
-	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d/state", itemID), map[string]any{"state": "done"}, &resp); err != nil {
+	if err := c.request(http.MethodPut, fmt.Sprintf("/api/items/%d/gtd-status", itemID), map[string]any{"state": "done"}, &resp); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("closed #%d state=%s", resp.Item.ID, resp.Item.State), nil

--- a/cmd/sls/gtd_mutation_test.go
+++ b/cmd/sls/gtd_mutation_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type capturedGtdMutation struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+func newGtdMutationHarness(t *testing.T, handler http.HandlerFunc) (*httptest.Server, string, *[]capturedGtdMutation) {
+	t.Helper()
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "cli-token")
+	if err := os.WriteFile(tokenPath, []byte("test-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	captures := []capturedGtdMutation{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/cli/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if r.Body != nil && r.ContentLength != 0 {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+		}
+		captures = append(captures, capturedGtdMutation{method: r.Method, path: r.URL.Path, body: body})
+		handler(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, tokenPath, &captures
+}
+
+func runGtdMutationCommand(t *testing.T, srv *httptest.Server, token string, args ...string) (string, string, int) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := handleGtdCommand(args, cliOptions{baseURL: srv.URL, tokenFile: token}, stdout, stderr)
+	return stdout.String(), stderr.String(), code
+}
+
+func TestHandleGtdCloseRoutesThroughStateEndpoint(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/items/42/state" {
+			t.Fatalf("request = %s %s, want PUT /api/items/42/state", r.Method, r.URL.Path)
+		}
+		writeGtdMutationJSON(t, w, `{"item":{"id":42,"title":"Done","kind":"action","state":"done","sphere":"work"}}`)
+	})
+
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "close", "#42")
+	if code != 0 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr)
+	}
+	if got := (*captures)[0].body["state"]; got != "done" {
+		t.Fatalf("state body = %#v, want done", (*captures)[0].body)
+	}
+	if !strings.Contains(out, "closed #42 state=done") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestHandleGtdDeferRoutesThroughItemUpdate(t *testing.T) {
+	followUp := "2026-05-04T09:00:00Z"
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/items/43" {
+			t.Fatalf("request = %s %s, want PUT /api/items/43", r.Method, r.URL.Path)
+		}
+		writeGtdMutationJSON(t, w, `{"item":{"id":43,"title":"Later","kind":"action","state":"deferred","sphere":"work","follow_up_at":"`+followUp+`"}}`)
+	})
+
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "defer", "43", followUp)
+	if code != 0 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr)
+	}
+	if got := (*captures)[0].body["state"]; got != "deferred" {
+		t.Fatalf("state body = %#v, want deferred", (*captures)[0].body)
+	}
+	if got := (*captures)[0].body["follow_up_at"]; got != followUp {
+		t.Fatalf("follow_up_at body = %#v, want %s", (*captures)[0].body, followUp)
+	}
+	if !strings.Contains(out, "deferred #43 follow_up="+followUp) {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestHandleGtdDelegateAndRouteStaySeparate(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/items/44/assign":
+			writeGtdMutationJSON(t, w, `{"item":{"id":44,"title":"Wait","kind":"action","state":"waiting","sphere":"work","actor_id":7}}`)
+		case "/api/items/44/workspace":
+			writeGtdMutationJSON(t, w, `{"item":{"id":44,"title":"Wait","kind":"action","state":"waiting","sphere":"work","workspace_id":9}}`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "delegate", "44", "7")
+	if code != 0 {
+		t.Fatalf("delegate exit code = %d stderr=%s", code, stderr)
+	}
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "route", "44", "9")
+	if code != 0 {
+		t.Fatalf("route exit code = %d stderr=%s", code, stderr)
+	}
+	if (*captures)[0].path != "/api/items/44/assign" || (*captures)[0].body["actor_id"] != float64(7) {
+		t.Fatalf("delegate capture = %#v", (*captures)[0])
+	}
+	if (*captures)[1].path != "/api/items/44/workspace" || (*captures)[1].body["workspace_id"] != float64(9) {
+		t.Fatalf("route capture = %#v", (*captures)[1])
+	}
+	if !strings.Contains(out, "routed #44 workspace=9") {
+		t.Fatalf("route output = %q", out)
+	}
+}
+
+func TestHandleGtdDropRequiresExplicitIntentForSourceBackedItem(t *testing.T) {
+	deleted := false
+	srv, token, _ := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/items/45":
+			writeGtdMutationJSON(t, w, `{"item":{"id":45,"title":"Remote","kind":"action","state":"inbox","sphere":"work","source":"todoist"}}`)
+		case r.Method == http.MethodDelete:
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "drop", "45")
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if deleted {
+		t.Fatal("source-backed drop without --yes reached DELETE")
+	}
+	if !strings.Contains(stderr, "requires --yes") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestHandleGtdLinkAndUnlinkProjectUseProjectItemOverlay(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			writeGtdMutationJSON(t, w, `{"item":{"id":46,"title":"Action","kind":"action","state":"next","sphere":"work"},"links":[{"parent_item_id":90,"child_item_id":46,"role":"support"}]}`)
+		case http.MethodDelete:
+			writeGtdMutationJSON(t, w, `{"item":{"id":46,"title":"Action","kind":"action","state":"next","sphere":"work"},"links":[]}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	})
+
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "link-project", "46", "90", "--role", "support")
+	if code != 0 {
+		t.Fatalf("link exit code = %d stderr=%s", code, stderr)
+	}
+	if (*captures)[0].path != "/api/items/46/project-item-link" || (*captures)[0].body["project_item_id"] != float64(90) || (*captures)[0].body["role"] != "support" {
+		t.Fatalf("link capture = %#v", (*captures)[0])
+	}
+	if !strings.Contains(out, "linked #46 project_item=90 role=support") {
+		t.Fatalf("link output = %q", out)
+	}
+
+	out, stderr, code = runGtdMutationCommand(t, srv, token, "unlink-project", "46", "90")
+	if code != 0 {
+		t.Fatalf("unlink exit code = %d stderr=%s", code, stderr)
+	}
+	if (*captures)[1].method != http.MethodDelete || (*captures)[1].path != "/api/items/46/project-item-link" || (*captures)[1].body["project_item_id"] != float64(90) {
+		t.Fatalf("unlink capture = %#v", (*captures)[1])
+	}
+	if !strings.Contains(out, "unlinked #46 project_item=90") {
+		t.Fatalf("unlink output = %q", out)
+	}
+}
+
+func writeGtdMutationJSON(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+}

--- a/cmd/sls/gtd_mutation_test.go
+++ b/cmd/sls/gtd_mutation_test.go
@@ -53,10 +53,10 @@ func runGtdMutationCommand(t *testing.T, srv *httptest.Server, token string, arg
 	return stdout.String(), stderr.String(), code
 }
 
-func TestHandleGtdCloseRoutesThroughStateEndpoint(t *testing.T) {
+func TestHandleGtdCloseRoutesThroughGTDStatusEndpoint(t *testing.T) {
 	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/items/42/state" {
-			t.Fatalf("request = %s %s, want PUT /api/items/42/state", r.Method, r.URL.Path)
+		if r.Method != http.MethodPut || r.URL.Path != "/api/items/42/gtd-status" {
+			t.Fatalf("request = %s %s, want PUT /api/items/42/gtd-status", r.Method, r.URL.Path)
 		}
 		writeGtdMutationJSON(t, w, `{"item":{"id":42,"title":"Done","kind":"action","state":"done","sphere":"work"}}`)
 	})

--- a/cmd/sls/gtd_test.go
+++ b/cmd/sls/gtd_test.go
@@ -21,6 +21,8 @@ func TestIsGtdSubcommand(t *testing.T) {
 		{"gtd inbox", []string{"gtd", "inbox"}, true},
 		{"gtd next with flags", []string{"gtd", "next", "--vault", "work"}, true},
 		{"gtd projects", []string{"gtd", "projects"}, true},
+		{"gtd close", []string{"gtd", "close", "#42"}, true},
+		{"gtd link project", []string{"gtd", "link-project", "42", "90"}, true},
 		{"gtd later alias", []string{"gtd", "later"}, true},
 		{"gtd deferred alias", []string{"gtd", "deferred"}, true},
 		{"gtd defer alias", []string{"gtd", "defer"}, true},

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -185,6 +185,7 @@ Domain model API:
 - `PUT /api/items/{item_id}/complete`
 - `PUT /api/items/{item_id}/workspace`
 - `POST /api/items/{item_id}/project-item-link`
+- `DELETE /api/items/{item_id}/project-item-link`
 - `POST /api/items/{item_id}/dispatch-review`
 - `POST /api/items/{item_id}/triage`
 - `GET /api/items/{item_id}/print`

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -179,6 +179,7 @@ Domain model API:
 - `DELETE /api/items/{item_id}/artifacts/{artifact_id}`
 - `PUT /api/items/{item_id}`
 - `DELETE /api/items/{item_id}`
+- `PUT /api/items/{item_id}/gtd-status`
 - `PUT /api/items/{item_id}/state`
 - `PUT /api/items/{item_id}/assign`
 - `PUT /api/items/{item_id}/unassign`

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -188,6 +188,7 @@ var WebRouteSections = []RouteSection{
 			"PUT /api/items/{item_id}/complete",
 			"PUT /api/items/{item_id}/workspace",
 			"POST /api/items/{item_id}/project-item-link",
+			"DELETE /api/items/{item_id}/project-item-link",
 			"POST /api/items/{item_id}/dispatch-review",
 			"POST /api/items/{item_id}/triage",
 			"GET /api/items/{item_id}/print",

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -182,6 +182,7 @@ var WebRouteSections = []RouteSection{
 			"DELETE /api/items/{item_id}/artifacts/{artifact_id}",
 			"PUT /api/items/{item_id}",
 			"DELETE /api/items/{item_id}",
+			"PUT /api/items/{item_id}/gtd-status",
 			"PUT /api/items/{item_id}/state",
 			"PUT /api/items/{item_id}/assign",
 			"PUT /api/items/{item_id}/unassign",

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -580,20 +580,8 @@ func (a *App) handleItemStateUpdate(w http.ResponseWriter, r *http.Request) {
 		writeItemStoreError(w, err)
 		return
 	}
-	if todoistBackedItem(item) && todoistDoneState(req.State) && item.State != store.ItemStateDone {
-		if err := a.syncTodoistItemCompletion(item); err != nil {
-			writeAPIError(w, http.StatusBadGateway, err.Error())
-			return
-		}
-	}
-	if item.State != strings.TrimSpace(req.State) {
-		if err := a.syncRemoteEmailItemState(r.Context(), item, req.State); err != nil {
-			writeAPIError(w, http.StatusBadGateway, err.Error())
-			return
-		}
-	}
-	if err := a.store.UpdateItemState(itemID, req.State); err != nil {
-		writeItemStoreError(w, err)
+	if err := a.updateItemState(r.Context(), item, req.State); err != nil {
+		writeItemStateUpdateError(w, err)
 		return
 	}
 	item, err = a.store.GetItem(itemID)

--- a/internal/web/items_gtd_status.go
+++ b/internal/web/items_gtd_status.go
@@ -1,0 +1,264 @@
+package web
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+const (
+	gtdSetStatusTool = "brain.gtd.set_status"
+	gtdParseTool     = "brain.note.parse"
+)
+
+type itemGTDStatusRequest struct {
+	State     string `json:"state"`
+	Status    string `json:"status"`
+	ClosedAt  string `json:"closed_at"`
+	ClosedVia string `json:"closed_via"`
+}
+
+type gtdStatusTarget struct {
+	Sphere       string
+	Path         string
+	CommitmentID string
+}
+
+type gtdStatusRoute struct {
+	Target           string `json:"target"`
+	WriteableBinding bool   `json:"writeable_binding"`
+}
+
+func (a *App) handleItemGTDStatusUpdate(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	var req itemGTDStatusRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	state, status, err := normalizeGTDStatus(req)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	target, ok, err := a.gtdStatusTarget(item)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		a.updateLocalGTDStatus(w, r, item, state)
+		return
+	}
+	route, result, err := a.setBrainGTDStatus(target, req, status)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if err := a.store.UpdateItemState(itemID, state); err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	item, err = a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeAPIData(w, http.StatusOK, map[string]any{
+		"item":      item,
+		"gtd_route": route,
+		"gtd":       result,
+	})
+}
+
+func (a *App) updateLocalGTDStatus(w http.ResponseWriter, r *http.Request, item store.Item, state string) {
+	if err := a.updateItemState(r.Context(), item, state); err != nil {
+		writeItemStateUpdateError(w, err)
+		return
+	}
+	item, err := a.store.GetItem(item.ID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeAPIData(w, http.StatusOK, map[string]any{"item": item})
+}
+
+func (a *App) setBrainGTDStatus(target gtdStatusTarget, req itemGTDStatusRequest, status string) (gtdStatusRoute, map[string]any, error) {
+	route, err := a.readGTDStatusRoute(target)
+	if err != nil {
+		return gtdStatusRoute{}, nil, err
+	}
+	args := map[string]any{
+		"sphere":     target.Sphere,
+		"status":     status,
+		"closed_at":  closedAtForGTDStatus(req.ClosedAt, status),
+		"closed_via": closedViaForGTDStatus(req.ClosedVia, status),
+	}
+	if target.Path != "" {
+		args["path"] = target.Path
+	} else {
+		args["commitment_id"] = target.CommitmentID
+	}
+	result, err := a.mcpToolsCall(a.localMCPEndpoint, gtdSetStatusTool, args)
+	if err != nil {
+		return gtdStatusRoute{}, nil, err
+	}
+	return route, result, nil
+}
+
+func (a *App) readGTDStatusRoute(target gtdStatusTarget) (gtdStatusRoute, error) {
+	if target.Path == "" {
+		return gtdStatusRoute{Target: "local_overlay"}, nil
+	}
+	result, err := a.mcpToolsCall(a.localMCPEndpoint, gtdParseTool, map[string]any{
+		"sphere": target.Sphere,
+		"path":   target.Path,
+	})
+	if err != nil {
+		return gtdStatusRoute{}, err
+	}
+	commitment, _ := result["commitment"].(map[string]any)
+	if hasWriteableGTDBinding(commitment) {
+		return gtdStatusRoute{Target: "source_binding", WriteableBinding: true}, nil
+	}
+	return gtdStatusRoute{Target: "local_overlay"}, nil
+}
+
+func hasWriteableGTDBinding(commitment map[string]any) bool {
+	if commitment == nil {
+		return false
+	}
+	bindings, _ := commitment["source_bindings"].([]any)
+	for _, raw := range bindings {
+		binding, _ := raw.(map[string]any)
+		if writeable, _ := binding["writeable"].(bool); writeable {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *App) gtdStatusTarget(item store.Item) (gtdStatusTarget, bool, error) {
+	target := gtdStatusTarget{Sphere: item.Sphere}
+	if target.Sphere == "" {
+		target.Sphere = store.SphereWork
+	}
+	source := strings.ToLower(strings.TrimSpace(optionalStoreString(item.Source)))
+	ref := strings.TrimSpace(optionalStoreString(item.SourceRef))
+	if isBrainGTDSource(source) && ref != "" {
+		target.Path, target.CommitmentID = splitGTDSourceRef(ref)
+		return target, true, nil
+	}
+	path, err := a.gtdArtifactPath(item)
+	if err != nil || path == "" {
+		return target, false, err
+	}
+	target.Path = path
+	return target, true, nil
+}
+
+func (a *App) gtdArtifactPath(item store.Item) (string, error) {
+	if item.ArtifactID == nil {
+		return "", nil
+	}
+	artifact, err := a.store.GetArtifact(*item.ArtifactID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	path := strings.TrimSpace(optionalStoreString(artifact.RefPath))
+	if isGTDMarkdownPath(path) {
+		return path, nil
+	}
+	return "", nil
+}
+
+func normalizeGTDStatus(req itemGTDStatusRequest) (string, string, error) {
+	raw := strings.TrimSpace(firstNonEmptyString(req.State, req.Status))
+	if raw == "" {
+		return "", "", errors.New("state or status is required")
+	}
+	status := strings.ToLower(raw)
+	switch status {
+	case "done", "closed":
+		return store.ItemStateDone, "closed", nil
+	case store.ItemStateInbox, store.ItemStateNext, store.ItemStateWaiting, store.ItemStateDeferred, store.ItemStateSomeday, store.ItemStateReview:
+		return status, status, nil
+	default:
+		return "", "", fmt.Errorf("unsupported GTD status %q", raw)
+	}
+}
+
+func closedAtForGTDStatus(value, status string) string {
+	clean := strings.TrimSpace(value)
+	if clean != "" || status != "closed" {
+		return clean
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func closedViaForGTDStatus(value, status string) string {
+	clean := strings.TrimSpace(value)
+	if clean != "" || status != "closed" {
+		return clean
+	}
+	return "slopshell"
+}
+
+func isBrainGTDSource(source string) bool {
+	switch source {
+	case "markdown", "meetings", "brain", "brain.gtd":
+		return true
+	default:
+		return false
+	}
+}
+
+func splitGTDSourceRef(ref string) (string, string) {
+	ref = strings.TrimSpace(ref)
+	if isGTDMarkdownPath(ref) {
+		return ref, ""
+	}
+	return "", ref
+}
+
+func isGTDMarkdownPath(path string) bool {
+	clean := strings.TrimSpace(path)
+	return strings.HasSuffix(strings.ToLower(clean), ".md") && strings.Contains(clean, "/")
+}
+
+func optionalStoreString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if clean := strings.TrimSpace(value); clean != "" {
+			return clean
+		}
+	}
+	return ""
+}

--- a/internal/web/items_gtd_status_test.go
+++ b/internal/web/items_gtd_status_test.go
@@ -1,0 +1,175 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type capturedMCPCall struct {
+	Name string
+	Args map[string]any
+}
+
+func TestItemGTDStatusUsesSloptoolsForMarkdownBackedItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	source := "markdown"
+	ref := "brain/commitments/reviewer.md"
+	sphere := store.SphereWork
+	item, err := app.store.CreateItem("Review feedback", store.ItemOptions{
+		State:     store.ItemStateNext,
+		Sphere:    &sphere,
+		Source:    &source,
+		SourceRef: &ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	calls := []capturedMCPCall{}
+	mcp := newGTDStatusMCPServer(t, &calls, false)
+	app.localMCPEndpoint = mcpEndpoint{httpURL: mcp.URL}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/gtd-status", map[string]any{
+		"state":     "done",
+		"closed_at": "2026-05-01T08:00:00Z",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	if got := callNames(calls); !reflect.DeepEqual(got, []string{gtdParseTool, gtdSetStatusTool}) {
+		t.Fatalf("MCP calls = %#v", got)
+	}
+	if calls[0].Args["path"] != ref || calls[0].Args["sphere"] != store.SphereWork {
+		t.Fatalf("parse args = %#v", calls[0].Args)
+	}
+	if calls[1].Args["path"] != ref || calls[1].Args["status"] != "closed" || calls[1].Args["closed_via"] != "slopshell" {
+		t.Fatalf("set_status args = %#v", calls[1].Args)
+	}
+	if calls[1].Args["closed_at"] != "2026-05-01T08:00:00Z" {
+		t.Fatalf("closed_at = %#v", calls[1].Args)
+	}
+	updated, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if updated.State != store.ItemStateDone {
+		t.Fatalf("item state = %q, want %q", updated.State, store.ItemStateDone)
+	}
+	payload := decodeJSONDataResponse(t, rr)
+	route, _ := payload["gtd_route"].(map[string]any)
+	if route["target"] != "local_overlay" || route["writeable_binding"] != false {
+		t.Fatalf("gtd_route = %#v", route)
+	}
+}
+
+func TestItemGTDStatusFallsBackForNonMarkdownItems(t *testing.T) {
+	app := newAuthedTestApp(t)
+	item, err := app.store.CreateItem("Plain item", store.ItemOptions{State: store.ItemStateNext})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("non-markdown GTD status should not call MCP")
+	}))
+	defer mcp.Close()
+	app.localMCPEndpoint = mcpEndpoint{httpURL: mcp.URL}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/gtd-status", map[string]any{"state": "done"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	updated, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if updated.State != store.ItemStateDone {
+		t.Fatalf("item state = %q, want %q", updated.State, store.ItemStateDone)
+	}
+}
+
+func TestItemGTDStatusReportsWriteableBindingRoute(t *testing.T) {
+	app := newAuthedTestApp(t)
+	source := "markdown"
+	ref := "brain/commitments/source.md"
+	item, err := app.store.CreateItem("Source writable", store.ItemOptions{
+		State:     store.ItemStateNext,
+		Source:    &source,
+		SourceRef: &ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem() error: %v", err)
+	}
+	calls := []capturedMCPCall{}
+	mcp := newGTDStatusMCPServer(t, &calls, true)
+	app.localMCPEndpoint = mcpEndpoint{httpURL: mcp.URL}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPut, "/api/items/"+itoa(item.ID)+"/gtd-status", map[string]any{"state": "done"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONDataResponse(t, rr)
+	route, _ := payload["gtd_route"].(map[string]any)
+	if route["target"] != "source_binding" || route["writeable_binding"] != true {
+		t.Fatalf("gtd_route = %#v", route)
+	}
+}
+
+func newGTDStatusMCPServer(t *testing.T, calls *[]capturedMCPCall, writeable bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode MCP payload: %v", err)
+		}
+		params, _ := payload["params"].(map[string]any)
+		args, _ := params["arguments"].(map[string]any)
+		name, _ := params["name"].(string)
+		*calls = append(*calls, capturedMCPCall{Name: name, Args: args})
+		w.Header().Set("Content-Type", "application/json")
+		switch name {
+		case gtdParseTool:
+			writeMCPStructuredResult(t, w, map[string]any{
+				"commitment": map[string]any{
+					"source_bindings": []map[string]any{{
+						"provider":          "markdown",
+						"ref":               "brain/commitments/reviewer.md",
+						"location":          map[string]any{"path": "brain/commitments/reviewer.md"},
+						"writeable":         writeable,
+						"authoritative_for": []string{"status"},
+					}},
+				},
+			})
+		case gtdSetStatusTool:
+			writeMCPStructuredResult(t, w, map[string]any{
+				"status":        args["status"],
+				"local_overlay": map[string]any{"status": args["status"]},
+			})
+		default:
+			t.Fatalf("unexpected MCP tool %q", name)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeMCPStructuredResult(t *testing.T, w http.ResponseWriter, structured map[string]any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"result": map[string]any{"structuredContent": structured},
+	}); err != nil {
+		t.Fatalf("write MCP result: %v", err)
+	}
+}
+
+func callNames(calls []capturedMCPCall) []string {
+	out := make([]string, 0, len(calls))
+	for _, call := range calls {
+		out = append(out, call.Name)
+	}
+	return out
+}

--- a/internal/web/items_reassign.go
+++ b/internal/web/items_reassign.go
@@ -137,10 +137,55 @@ func (a *App) handleItemProjectItemLink(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeAPIData(w, http.StatusOK, map[string]any{
-		"item":           item,
+		"item":            item,
 		"project_item_id": req.ProjectItemID,
-		"links":          links,
-		"health":         health,
+		"links":           links,
+		"health":          health,
+	})
+}
+
+func (a *App) handleItemProjectItemUnlink(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	itemID, err := parseItemIDParam(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	var req itemProjectItemLinkRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.ProjectItemID <= 0 {
+		writeAPIError(w, http.StatusBadRequest, "project_item_id must be a positive integer")
+		return
+	}
+	if err := a.store.UnlinkItemChild(req.ProjectItemID, itemID); err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	links, err := a.store.ListItemChildLinks(req.ProjectItemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	health, err := a.store.GetProjectItemHealth(req.ProjectItemID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeAPIData(w, http.StatusOK, map[string]any{
+		"item":            item,
+		"project_item_id": req.ProjectItemID,
+		"links":           links,
+		"health":          health,
 	})
 }
 

--- a/internal/web/items_reassign_test.go
+++ b/internal/web/items_reassign_test.go
@@ -133,6 +133,21 @@ func TestItemProjectItemLinkAPI(t *testing.T) {
 	if rrSelf.Code != http.StatusBadRequest {
 		t.Fatalf("self link status = %d, want 400: %s", rrSelf.Code, rrSelf.Body.String())
 	}
+
+	rrUnlink := doAuthedJSONRequest(t, app.Router(), http.MethodDelete, "/api/items/"+itoa(item.ID)+"/project-item-link", map[string]any{
+		"project_item_id": project.ID,
+	})
+	if rrUnlink.Code != http.StatusOK {
+		t.Fatalf("project item unlink status = %d, want 200: %s", rrUnlink.Code, rrUnlink.Body.String())
+	}
+	unlinkPayload := decodeJSONResponse(t, rrUnlink)
+	if got := int64(unlinkPayload["project_item_id"].(float64)); got != project.ID {
+		t.Fatalf("unlink project_item_id = %d, want %d", got, project.ID)
+	}
+	links, ok := unlinkPayload["links"].([]any)
+	if !ok || len(links) != 0 {
+		t.Fatalf("unlink links = %#v, want empty", unlinkPayload["links"])
+	}
 }
 
 func assertProjectItemLinkResponse(t *testing.T, payload map[string]any, projectID, itemID int64) {

--- a/internal/web/items_state.go
+++ b/internal/web/items_state.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+func (a *App) updateItemState(ctx context.Context, item store.Item, state string) error {
+	if todoistBackedItem(item) && todoistDoneState(state) && item.State != store.ItemStateDone {
+		if err := a.syncTodoistItemCompletion(item); err != nil {
+			return itemRemoteStateUpdateError{err: err}
+		}
+	}
+	if item.State != strings.TrimSpace(state) {
+		if err := a.syncRemoteEmailItemState(ctx, item, state); err != nil {
+			return itemRemoteStateUpdateError{err: err}
+		}
+	}
+	return a.store.UpdateItemState(item.ID, state)
+}
+
+type itemRemoteStateUpdateError struct {
+	err error
+}
+
+func (e itemRemoteStateUpdateError) Error() string {
+	return e.err.Error()
+}
+
+func (e itemRemoteStateUpdateError) Unwrap() error {
+	return e.err
+}
+
+func writeItemStateUpdateError(w http.ResponseWriter, err error) {
+	var remoteErr itemRemoteStateUpdateError
+	if errors.As(err, &remoteErr) {
+		writeAPIError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeItemStoreError(w, err)
+}

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -160,6 +160,7 @@ func (a *App) Router() http.Handler {
 	r.Put("/api/items/{item_id}/complete", a.handleItemComplete)
 	r.Put("/api/items/{item_id}/workspace", a.handleItemWorkspaceUpdate)
 	r.Post("/api/items/{item_id}/project-item-link", a.handleItemProjectItemLink)
+	r.Delete("/api/items/{item_id}/project-item-link", a.handleItemProjectItemUnlink)
 	r.Put("/api/items/{item_id}/state", a.handleItemStateUpdate)
 	r.Post("/api/items/{item_id}/triage", a.handleItemTriage)
 	r.Post("/api/items/{item_id}/dispatch-review", a.handleItemReviewDispatch)

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -161,6 +161,7 @@ func (a *App) Router() http.Handler {
 	r.Put("/api/items/{item_id}/workspace", a.handleItemWorkspaceUpdate)
 	r.Post("/api/items/{item_id}/project-item-link", a.handleItemProjectItemLink)
 	r.Delete("/api/items/{item_id}/project-item-link", a.handleItemProjectItemUnlink)
+	r.Put("/api/items/{item_id}/gtd-status", a.handleItemGTDStatusUpdate)
 	r.Put("/api/items/{item_id}/state", a.handleItemStateUpdate)
 	r.Post("/api/items/{item_id}/triage", a.handleItemTriage)
 	r.Post("/api/items/{item_id}/dispatch-review", a.handleItemReviewDispatch)


### PR DESCRIPTION
## Summary

- Add `sls gtd close/drop/defer/delegate/route/link-project/unlink-project` with numeric `42` / `#42` selectors.
- Route CLI mutations through the existing item APIs, including backend-specific close/defer paths and explicit `--yes` for source-backed drops.
- Add the missing project-item unlink API route and refresh the generated route inventory.

## Verification

| Requirement | Evidence |
| --- | --- |
| Terminal mutation commands route to the intended backend/local-overlay endpoints. | `go test ./cmd/sls -run 'Test(IsGtdSubcommand\|HandleGtd)'` -> `ok github.com/sloppy-org/slopshell/cmd/sls 0.010s` (`/tmp/slopshell-sls-gtd-focused.log`). |
| Project-item link/unlink remains separate from workspace routing. | `go test ./internal/web -run 'TestItemProjectItemLinkAPI\|TestItemWorkspaceReassignmentAPI\|TestLegacyItemProjectReassignmentRouteRemoved\|TestItemWorkspaceReassignmentAPIRejectsUnknownWorkspace'` -> `ok github.com/sloppy-org/slopshell/internal/web 0.105s` (`/tmp/slopshell-web-gtd-focused.log`). |
| Destructive source-backed drops require explicit intent. | `TestHandleGtdDropRequiresExplicitIntentForSourceBackedItem` is included in the focused `cmd/sls` run above and asserts no DELETE is sent without `--yes`. |
| External-source mutation rules still execute for Todoist and email-backed items. | `go test ./internal/web -run 'Test(ItemStateDoneTodoistBackedItemCompletesRemoteTask\|ItemUpdateTodoistFollowUpSyncsRemoteTask\|SyncEmailAccountRemoteArchiveClosesInboxItems)' -v` passed all three named tests (`/tmp/slopshell-external-gtd-mutation.log`). |
| Markdown-backed/local-overlay status path remains validated. | `go test ./internal/aggregateitem -run 'Test(SetStatusUsesSloptoolsLocalOverlayTool\|ParseCommitmentDecodesLocalOverlayForProjection)' -v` passed both named tests (`/tmp/slopshell-markdown-overlay.log`). |
| Generated interface inventory includes the new unlink route. | `./scripts/sync-surface.sh --check` passed with no output (`/tmp/slopshell-surface-check.log`). |
| Repo-wide Go verification. | `go test ./...` passed; excerpt: `ok github.com/sloppy-org/slopshell/internal/web 25.953s`, `ok github.com/sloppy-org/slopshell/internal/aggregateitem (cached)`, `ok github.com/sloppy-org/slopshell/cmd/sls 0.078s` (`/tmp/slopshell-go-test-all.log`). |
