### PR TITLE
fix: Add per-person open-loops queue view (fixes #741)

### DIFF
--- a/internal/store/store_domain_item_query.go
+++ b/internal/store/store_domain_item_query.go
@@ -392,10 +392,10 @@ func (s *Store) CountSidebarSectionsFiltered(now time.Time, filter ItemListFilte
 		return out, err
 	}
 
-	peopleParts := []string{"items.actor_id IS NOT NULL", "items.state <> ?"}
-	peopleArgs := []any{ItemStateDone}
+	peopleParts := []string{"items.actor_id IS NOT NULL", "items.kind = ?", "items.state IN (?, ?, ?, ?)", "actors.kind = ?"}
+	peopleArgs := []any{ItemKindAction, ItemStateWaiting, ItemStateDeferred, ItemStateNext, ItemStateInbox, ActorKindHuman}
 	peopleParts, peopleArgs = appendItemFilterClauses(peopleParts, peopleArgs, normalizedFilter, "")
-	peopleQuery := `SELECT COUNT(DISTINCT items.actor_id) FROM items WHERE ` + stringsJoin(peopleParts, ` AND `)
+	peopleQuery := `SELECT COUNT(DISTINCT items.actor_id) FROM items JOIN actors ON actors.id = items.actor_id WHERE ` + stringsJoin(peopleParts, ` AND `)
 	if err := s.db.QueryRow(peopleQuery, peopleArgs...).Scan(&out.PeopleOpen); err != nil {
 		return out, err
 	}

--- a/internal/store/store_sidebar_counts_test.go
+++ b/internal/store/store_sidebar_counts_test.go
@@ -147,35 +147,34 @@ func TestCountSidebarSectionsFilteredExcludesAgedMeetings(t *testing.T) {
 func TestCountSidebarSectionsFilteredCountsDistinctPeopleOnOpenItems(t *testing.T) {
 	s := newTestStore(t)
 
-	alice, err := s.CreateActor("Alice", ActorKindHuman)
-	if err != nil {
-		t.Fatalf("CreateActor(Alice) error: %v", err)
+	mustActor := func(name, kind string) Actor {
+		actor, err := s.CreateActor(name, kind)
+		if err != nil {
+			t.Fatalf("CreateActor(%s) error: %v", name, err)
+		}
+		return actor
 	}
-	bob, err := s.CreateActor("Bob", ActorKindHuman)
-	if err != nil {
-		t.Fatalf("CreateActor(Bob) error: %v", err)
-	}
-	carol, err := s.CreateActor("Carol", ActorKindHuman)
-	if err != nil {
-		t.Fatalf("CreateActor(Carol) error: %v", err)
-	}
+	alice := mustActor("Alice", ActorKindHuman)
+	bob := mustActor("Bob", ActorKindHuman)
+	carol := mustActor("Carol", ActorKindHuman)
+	agent := mustActor("Codex Agent", ActorKindAgent)
 
-	if _, err := s.CreateItem("Awaiting Alice", ItemOptions{State: ItemStateWaiting, ActorID: &alice.ID}); err != nil {
-		t.Fatalf("CreateItem(Alice) error: %v", err)
+	items := []struct {
+		title string
+		opts  ItemOptions
+	}{
+		{"Awaiting Alice", ItemOptions{State: ItemStateWaiting, ActorID: &alice.ID}},
+		{"Also awaiting Alice", ItemOptions{State: ItemStateNext, ActorID: &alice.ID}},
+		{"Owe Bob", ItemOptions{State: ItemStateNext, ActorID: &bob.ID}},
+		{"Carol done", ItemOptions{State: ItemStateDone, ActorID: &carol.ID}},
+		{"Agent loop", ItemOptions{State: ItemStateWaiting, ActorID: &agent.ID}},
+		{"Project with actor", ItemOptions{Kind: ItemKindProject, State: ItemStateNext, ActorID: &carol.ID}},
+		{"No actor", ItemOptions{State: ItemStateNext}},
 	}
-	if _, err := s.CreateItem("Also awaiting Alice", ItemOptions{State: ItemStateNext, ActorID: &alice.ID}); err != nil {
-		t.Fatalf("CreateItem(Alice second) error: %v", err)
-	}
-	if _, err := s.CreateItem("Owe Bob", ItemOptions{State: ItemStateNext, ActorID: &bob.ID}); err != nil {
-		t.Fatalf("CreateItem(Bob) error: %v", err)
-	}
-	// Done item should not be counted even if it has an actor.
-	if _, err := s.CreateItem("Carol done", ItemOptions{State: ItemStateDone, ActorID: &carol.ID}); err != nil {
-		t.Fatalf("CreateItem(Carol done) error: %v", err)
-	}
-	// Item without actor should not contribute to people count.
-	if _, err := s.CreateItem("No actor", ItemOptions{State: ItemStateNext}); err != nil {
-		t.Fatalf("CreateItem(no actor) error: %v", err)
+	for _, item := range items {
+		if _, err := s.CreateItem(item.title, item.opts); err != nil {
+			t.Fatalf("CreateItem(%s) error: %v", item.title, err)
+		}
 	}
 
 	now := time.Date(2026, time.April, 30, 10, 0, 0, 0, time.UTC)
@@ -184,7 +183,7 @@ func TestCountSidebarSectionsFilteredCountsDistinctPeopleOnOpenItems(t *testing.
 		t.Fatalf("CountSidebarSectionsFiltered() error: %v", err)
 	}
 	if got.PeopleOpen != 2 {
-		t.Fatalf("PeopleOpen = %d, want 2 (Alice + Bob; Carol's done item excluded; un-actor-ed item ignored)", got.PeopleOpen)
+		t.Fatalf("PeopleOpen = %d, want 2 (Alice + Bob human action loops only)", got.PeopleOpen)
 	}
 }
 


### PR DESCRIPTION
Closes #741.

## Verification

### Requirement evidence
- Counts match the dashboard fixture output: `go test ./internal/store ./internal/web` passed; `TestCountSidebarSectionsFilteredCountsDistinctPeopleOnOpenItems` also passed after the final count cleanup. Evidence: `/tmp/issue-741-go.log`, `/tmp/issue-741-store-rerun.log`.
- Drill-down shows the correct GTD groups: `tests/playwright/compact-sidebar.spec.ts` passed and asserts `Waiting on them`, `I owe them`, `Recently closed`, and `Project items` sections after person click. Evidence: `/tmp/issue-741-playwright.log`.
- Missing person note diagnostic is visible and non-destructive: Go API tests assert `needs_person_note`; Playwright asserts `needs person note` in the people section without creating notes. Evidence: `/tmp/issue-741-go.log`, `/tmp/issue-741-playwright.log`.
- Work/private sphere separation is preserved: Go API tests cover `?sphere=work` excluding private rows; sidebar counts honor scoped filters. Evidence: `/tmp/issue-741-go.log`.
- Person/project item/Workspace terminology stays separate: Playwright covers project-item filters, person drill-down, and the active workspace pin separately. Evidence: `/tmp/issue-741-playwright.log`.

### Commands
```text
./scripts/sync-surface.sh --check
```
Passed with no output.

```text
go test ./internal/store ./internal/web
ok  	github.com/sloppy-org/slopshell/internal/store	1.752s
ok  	github.com/sloppy-org/slopshell/internal/web	26.229s
```

```text
go test ./internal/store -run TestCountSidebarSectionsFilteredCountsDistinctPeopleOnOpenItems -count=1
ok  	github.com/sloppy-org/slopshell/internal/store	0.019s
```

```text
npm run typecheck:frontend
> typecheck:frontend
> tsc --noEmit -p tsconfig.json
```

```text
npm run build:frontend
> build:frontend
> node ./scripts/build-frontend.mjs
built 67 frontend modules
```

```text
./scripts/playwright.sh tests/playwright/compact-sidebar.spec.ts
9 passed (7.3s)
```
