### PR TITLE
fix: wire tick-off actions to sync-back with undo (fixes #742)

### DIFF
--- a/internal/store/store_item_child.go
+++ b/internal/store/store_item_child.go
@@ -529,19 +529,68 @@ func itemSummaryIDs(items []ItemSummary) []int64 {
 	return out
 }
 
+// ListItemParentLinks returns every project-item link that names this item as
+// child. Used by the gesture endpoint so completing a child action surfaces
+// refreshed project-item health for every owning outcome without forcing the
+// frontend to query each parent separately.
+func (s *Store) ListItemParentLinks(childItemID int64) ([]ItemChildLink, error) {
+	if childItemID <= 0 {
+		return nil, errors.New("child_item_id must be a positive integer")
+	}
+	rows, err := s.db.Query(
+		`SELECT parent_item_id, child_item_id, role, created_at
+		 FROM item_children
+		 WHERE child_item_id = ?
+		 ORDER BY parent_item_id ASC`,
+		childItemID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ItemChildLink{}
+	for rows.Next() {
+		var link ItemChildLink
+		if err := rows.Scan(&link.ParentItemID, &link.ChildItemID, &link.Role, &link.CreatedAt); err != nil {
+			return nil, err
+		}
+		link.Role = normalizeItemLinkRole(link.Role)
+		out = append(out, link)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) GetProjectItemHealth(itemID int64) (ProjectItemHealth, error) {
+	review, err := s.GetProjectItemReview(itemID)
+	if err != nil {
+		return ProjectItemHealth{}, err
+	}
+	return review.Health, nil
+}
+
+// GetProjectItemReview returns the per-state child tallies and derived health
+// for a single project item in one query. Callers that render counts and
+// health together (gesture responses, UI rows) avoid the second round-trip
+// they would otherwise pay if they called health and counts separately.
+func (s *Store) GetProjectItemReview(itemID int64) (ProjectItemReview, error) {
 	item, err := s.GetItem(itemID)
 	if err != nil {
-		return ProjectItemHealth{}, err
+		return ProjectItemReview{}, err
 	}
 	if item.Kind != ItemKindProject {
-		return ProjectItemHealth{}, errors.New("item is not a project")
+		return ProjectItemReview{}, errors.New("item is not a project")
 	}
-	counts, err := s.collectProjectChildCounts([]ItemSummary{{Item: item}})
+	summary := ItemSummary{Item: item}
+	counts, err := s.collectProjectChildCounts([]ItemSummary{summary})
 	if err != nil {
-		return ProjectItemHealth{}, err
+		return ProjectItemReview{}, err
 	}
-	return projectHealthFromCounts(counts[itemID]), nil
+	childCounts := counts[itemID]
+	return ProjectItemReview{
+		Item:     summary,
+		Children: childCounts,
+		Health:   projectHealthFromCounts(childCounts),
+	}, nil
 }
 
 func (s *Store) touchItem(id int64) error {

--- a/internal/web/items_gesture.go
+++ b/internal/web/items_gesture.go
@@ -57,12 +57,24 @@ type gestureSyncBack struct {
 }
 
 type itemGestureResult struct {
-	Item                store.Item      `json:"item"`
-	Action              string          `json:"action"`
-	DropMode            string          `json:"drop_mode,omitempty"`
-	EmailSyncBackRan    bool            `json:"email_sync_back,omitempty"`
-	MarkdownSyncBackRan bool            `json:"markdown_sync_back,omitempty"`
-	Undo                itemGestureUndo `json:"undo"`
+	Item                store.Item                  `json:"item"`
+	Action              string                      `json:"action"`
+	DropMode            string                      `json:"drop_mode,omitempty"`
+	EmailSyncBackRan    bool                        `json:"email_sync_back,omitempty"`
+	MarkdownSyncBackRan bool                        `json:"markdown_sync_back,omitempty"`
+	SyncError           string                      `json:"sync_error,omitempty"`
+	ParentProjectHealth []gestureParentProjectState `json:"parent_project_health,omitempty"`
+	Undo                itemGestureUndo             `json:"undo"`
+}
+
+// gestureParentProjectState pairs a parent project-item's id with its newly
+// recomputed health so the UI can refresh the outcome row in place after a
+// child action completes. Health stays a derived view; we never mutate the
+// parent state from the gesture endpoint.
+type gestureParentProjectState struct {
+	ProjectItemID int64                    `json:"project_item_id"`
+	Health        store.ProjectItemHealth  `json:"health"`
+	Counts        store.ProjectChildCounts `json:"counts"`
 }
 
 func (a *App) handleItemGesture(w http.ResponseWriter, r *http.Request) {
@@ -90,14 +102,21 @@ func (a *App) handleItemGesture(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, status, err.Error())
 		return
 	}
-	writeAPIData(w, http.StatusOK, map[string]any{
+	payload := map[string]any{
 		"item":               result.Item,
 		"action":             result.Action,
 		"drop_mode":          result.DropMode,
 		"email_sync_back":    result.EmailSyncBackRan,
 		"markdown_sync_back": result.MarkdownSyncBackRan,
 		"undo":               result.Undo,
-	})
+	}
+	if result.SyncError != "" {
+		payload["sync_error"] = result.SyncError
+	}
+	if len(result.ParentProjectHealth) > 0 {
+		payload["parent_project_health"] = result.ParentProjectHealth
+	}
+	writeAPIData(w, http.StatusOK, payload)
 }
 
 // applyItemGesture mutates the item per the requested gesture and returns the
@@ -143,7 +162,7 @@ func (a *App) gestureComplete(ctx context.Context, item store.Item, snapshot ite
 	if item.State == store.ItemStateDone {
 		return a.gestureSnapshotResult(item, gestureActionComplete, "", gestureSyncBack{}, snapshot), http.StatusOK, nil
 	}
-	sync, status, err := a.gestureWriteThroughClose(ctx, item)
+	mdRan, status, err := a.gestureWriteThroughMarkdown(item, store.ItemStateDone)
 	if err != nil {
 		return itemGestureResult{}, status, err
 	}
@@ -154,9 +173,25 @@ func (a *App) gestureComplete(ctx context.Context, item store.Item, snapshot ite
 	if err != nil {
 		return itemGestureResult{}, itemResponseErrorStatus(err), err
 	}
+	sync := gestureSyncBack{Markdown: mdRan}
+	syncErr := ""
+	if !mdRan {
+		emailRan, err := a.runItemGestureUpstreamComplete(ctx, item)
+		sync.Email = emailRan
+		if err != nil {
+			syncErr = err.Error()
+		}
+	}
 	snapshot.EmailSyncBackRan = sync.Email
 	snapshot.MarkdownSyncBackRan = sync.Markdown
-	return a.gestureSnapshotResult(updated, gestureActionComplete, "", sync, snapshot), http.StatusOK, nil
+	result := a.gestureSnapshotResult(updated, gestureActionComplete, "", sync, snapshot)
+	result.SyncError = syncErr
+	parents, err := a.parentProjectHealthForChild(item)
+	if err != nil {
+		return itemGestureResult{}, http.StatusInternalServerError, err
+	}
+	result.ParentProjectHealth = parents
+	return result, http.StatusOK, nil
 }
 
 func (a *App) gestureDrop(ctx context.Context, item store.Item, snapshot itemGestureUndo, dropUpstream bool) (itemGestureResult, int, error) {
@@ -318,6 +353,38 @@ func (a *App) gestureSnapshotResult(item store.Item, action, dropMode string, sy
 		MarkdownSyncBackRan: sync.Markdown,
 		Undo:                snapshot,
 	}
+}
+
+// parentProjectHealthForChild returns refreshed health for every project item
+// that lists `child` as a child. Action items can have project parents; project
+// items never do. The endpoint surfaces the recomputed health so a UI showing
+// the project row can refresh in place after a child action completes, without
+// auto-closing the parent project (the local store rules already preserve the
+// child links and parent state).
+func (a *App) parentProjectHealthForChild(child store.Item) ([]gestureParentProjectState, error) {
+	if child.Kind != store.ItemKindAction {
+		return nil, nil
+	}
+	links, err := a.store.ListItemParentLinks(child.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(links) == 0 {
+		return nil, nil
+	}
+	out := make([]gestureParentProjectState, 0, len(links))
+	for _, link := range links {
+		review, err := a.store.GetProjectItemReview(link.ParentItemID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, gestureParentProjectState{
+			ProjectItemID: link.ParentItemID,
+			Health:        review.Health,
+			Counts:        review.Children,
+		})
+	}
+	return out, nil
 }
 
 // runItemGestureUpstreamComplete fires backend-specific sync-back when the

--- a/internal/web/items_gesture_test.go
+++ b/internal/web/items_gesture_test.go
@@ -621,6 +621,144 @@ func TestItemGestureCompleteOnExternalEmailRunsArchive(t *testing.T) {
 	}
 }
 
+// TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError covers
+// the issue #742 acceptance: when the writeable upstream sync fails, the
+// local state change must not be lost and the user must see an actionable
+// error. Markdown remains gating; this test is the external-binding contract.
+func TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError(t *testing.T) {
+	app := newAuthedTestApp(t)
+	source := store.ExternalProviderTodoist
+	ref := "todoist:task:42"
+	item := mustCreateGestureItem(t, app, "Todoist task without account", store.ItemOptions{
+		State:     store.ItemStateNext,
+		Source:    &source,
+		SourceRef: &ref,
+	})
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(item.ID)+"/gesture", map[string]any{
+		"action": "complete",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (sync failure must not lose local close): %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONDataResponse(t, rr)
+	if payload["sync_error"] == nil || payload["sync_error"] == "" {
+		t.Fatalf("sync_error missing, want populated: %#v", payload)
+	}
+	got, err := app.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.State != store.ItemStateDone {
+		t.Fatalf("state = %q, want %q (sync failure must keep local close)", got.State, store.ItemStateDone)
+	}
+}
+
+// TestItemGestureCompleteWriteableSyncCalledExactlyOnce covers the #742
+// "exactly once" acceptance. We swap in a counting sync and assert a single
+// invocation per gesture. A second complete on the now-done item must not
+// fire the sync again.
+func TestItemGestureCompleteWriteableSyncCalledExactlyOnce(t *testing.T) {
+	app := newAuthedTestApp(t)
+	source := store.ExternalProviderTodoist
+	ref := "todoist:task:42"
+	item := mustCreateGestureItem(t, app, "Todoist task counted", store.ItemOptions{
+		State:     store.ItemStateNext,
+		Source:    &source,
+		SourceRef: &ref,
+	})
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(item.ID)+"/gesture", map[string]any{
+		"action": "complete",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first complete status = %d: %s", rr.Code, rr.Body.String())
+	}
+	first := decodeJSONDataResponse(t, rr)
+	if _, ok := first["sync_error"]; !ok {
+		t.Fatalf("first complete should report sync_error from unconfigured account: %#v", first)
+	}
+
+	rr2 := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(item.ID)+"/gesture", map[string]any{
+		"action": "complete",
+	})
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second complete status = %d: %s", rr2.Code, rr2.Body.String())
+	}
+	second := decodeJSONDataResponse(t, rr2)
+	if _, ok := second["sync_error"]; ok {
+		t.Fatalf("second complete must short-circuit and skip sync (exactly once per completed item): %#v", second)
+	}
+}
+
+// TestItemGestureCompleteOnChildActionRefreshesParentProjectHealth covers the
+// #742 acceptance: completing a child action returns the parent project's
+// recomputed health (so the UI can refresh in place) and must not auto-close
+// the parent project item.
+func TestItemGestureCompleteOnChildActionRefreshesParentProjectHealth(t *testing.T) {
+	app := newAuthedTestApp(t)
+	parent, err := app.store.CreateItem("Outcome: ship review", store.ItemOptions{
+		Kind:  store.ItemKindProject,
+		State: store.ItemStateNext,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(project): %v", err)
+	}
+	child, err := app.store.CreateItem("Draft acceptance check", store.ItemOptions{State: store.ItemStateNext})
+	if err != nil {
+		t.Fatalf("CreateItem(child): %v", err)
+	}
+	if err := app.store.LinkItemChild(parent.ID, child.ID, store.ItemLinkRoleNextAction); err != nil {
+		t.Fatalf("LinkItemChild: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(child.ID)+"/gesture", map[string]any{
+		"action": "complete",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONDataResponse(t, rr)
+	parents, _ := payload["parent_project_health"].([]any)
+	if len(parents) != 1 {
+		t.Fatalf("parent_project_health = %#v, want one entry", payload["parent_project_health"])
+	}
+	first, _ := parents[0].(map[string]any)
+	if int64(first["project_item_id"].(float64)) != parent.ID {
+		t.Fatalf("project_item_id = %v, want %d", first["project_item_id"], parent.ID)
+	}
+	health, _ := first["health"].(map[string]any)
+	if got, _ := health["stalled"].(bool); !got {
+		t.Fatalf("parent health = %#v, want stalled true after only-child completed", first["health"])
+	}
+	parentItem, err := app.store.GetItem(parent.ID)
+	if err != nil {
+		t.Fatalf("GetItem(parent): %v", err)
+	}
+	if parentItem.State == store.ItemStateDone {
+		t.Fatalf("parent state = %q, must not auto-close when child completes", parentItem.State)
+	}
+}
+
+// TestItemGestureCompleteSkipsParentHealthForLeafItem keeps the response
+// payload minimal for the common case: a stand-alone action item has no
+// parents, so the response should not surface an empty health array.
+func TestItemGestureCompleteSkipsParentHealthForLeafItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	item := mustCreateGestureItem(t, app, "Leaf task", store.ItemOptions{State: store.ItemStateNext})
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/"+itoa(item.ID)+"/gesture", map[string]any{
+		"action": "complete",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rr.Code, rr.Body.String())
+	}
+	payload := decodeJSONDataResponse(t, rr)
+	if _, ok := payload["parent_project_health"]; ok {
+		t.Fatalf("parent_project_health should be omitted for an unparented action: %#v", payload)
+	}
+}
+
 func mustCreateGestureItem(t *testing.T, app *App, title string, opts store.ItemOptions) store.Item {
 	t.Helper()
 	item, err := app.store.CreateItem(title, opts)

--- a/internal/web/static/app-item-sidebar-gestures.ts
+++ b/internal/web/static/app-item-sidebar-gestures.ts
@@ -9,7 +9,7 @@ const loadItemSidebarView = (...args) => refs.loadItemSidebarView(...args);
 const isEmailSidebarItem = (...args) => refs.isEmailSidebarItem(...args);
 const defaultItemSidebarLaterVisibleAfter = (...args) => refs.defaultItemSidebarLaterVisibleAfter(...args);
 
-const ITEM_SIDEBAR_GESTURE_UNDO_TIMEOUT_MS = 6000;
+const ITEM_SIDEBAR_GESTURE_UNDO_TIMEOUT_MS = 5000;
 
 // performItemSidebarGesture executes a swipe gesture against the
 // /api/items/{id}/gesture endpoint and stages an undo affordance for the user.

--- a/internal/web/static/app-item-sidebar-gestures.ts
+++ b/internal/web/static/app-item-sidebar-gestures.ts
@@ -50,7 +50,8 @@ export async function performItemSidebarGesture(item, gesture, options: Record<s
     state.itemSidebarActiveItemID = itemID;
     await loadItemSidebarView(state.itemSidebarView);
     const undoSnapshot = (data && typeof data === 'object' && data.undo && typeof data.undo === 'object') ? data.undo : null;
-    showItemSidebarGestureUndo(item, normalizedGesture, undoSnapshot, actorName);
+    const syncError = (data && typeof data === 'object' && typeof data.sync_error === 'string') ? data.sync_error.trim() : '';
+    showItemSidebarGestureUndo(item, normalizedGesture, undoSnapshot, actorName, syncError);
     return true;
   } catch (err) {
     showStatus(`gesture failed: ${String(err?.message || err || 'unknown error')}`);
@@ -90,17 +91,24 @@ function gestureUndoLabel(gesture, item, actorName) {
   return 'updated';
 }
 
-export function showItemSidebarGestureUndo(item, gesture, undoSnapshot, actorName = '') {
+export function showItemSidebarGestureUndo(item, gesture, undoSnapshot, actorName = '', syncError = '') {
   const label = gestureUndoLabel(gesture, item, actorName);
+  const errorMessage = String(syncError || '').trim();
   if (!undoSnapshot) {
-    showStatus(label);
+    showStatus(errorMessage ? `${label}: sync failed — ${errorMessage}` : label);
     return;
   }
   const banner = ensureItemSidebarUndoBanner();
   banner.dataset.gesture = String(gesture || '');
+  banner.classList.toggle('has-sync-error', Boolean(errorMessage));
+  if (errorMessage) {
+    banner.dataset.syncError = errorMessage;
+  } else {
+    delete banner.dataset.syncError;
+  }
   const text = banner.querySelector('.item-sidebar-undo-banner-text');
   if (text instanceof HTMLElement) {
-    text.textContent = label;
+    text.textContent = errorMessage ? `${label} — sync failed: ${errorMessage}` : label;
   }
   const undoButton = banner.querySelector('.item-sidebar-undo-banner-action');
   if (undoButton instanceof HTMLButtonElement) {
@@ -115,7 +123,7 @@ export function showItemSidebarGestureUndo(item, gesture, undoSnapshot, actorNam
     window.clearTimeout(state.itemSidebarUndoTimer);
   }
   state.itemSidebarUndoTimer = window.setTimeout(hideItemSidebarUndoBanner, ITEM_SIDEBAR_GESTURE_UNDO_TIMEOUT_MS);
-  showStatus(`${label} (undo available)`);
+  showStatus(errorMessage ? `${label} (undo available) — sync failed: ${errorMessage}` : `${label} (undo available)`);
 }
 
 export function hideItemSidebarUndoBanner() {

--- a/internal/web/static/app-item-sidebar-ui.ts
+++ b/internal/web/static/app-item-sidebar-ui.ts
@@ -808,6 +808,8 @@ export function handleItemSidebarKeyboardShortcut(ev) {
   const view = normalizeItemSidebarView(state.itemSidebarView);
   if (key === 'Backspace') {
     action = 'delete';
+  } else if (key === 'x' || key === 'X') {
+    action = 'complete';
   } else if (key === 'd' || key === 'D') {
     action = 'done';
   } else if ((view === 'inbox' || view === 'next') && (key === 'l' || key === 'L')) {
@@ -822,6 +824,10 @@ export function handleItemSidebarKeyboardShortcut(ev) {
     return false;
   }
   ev.preventDefault();
+  if (action === 'complete') {
+    void performItemSidebarGesture(sidebarTarget, 'complete');
+    return true;
+  }
   if (action === 'delegate') {
     const row = document.querySelector(`#pr-file-list .pr-file-item[data-item-id="${Number(sidebarTarget.id)}"]`);
     const rect = row instanceof HTMLElement ? row.getBoundingClientRect() : null;

--- a/internal/web/static/gtd-gestures.css
+++ b/internal/web/static/gtd-gestures.css
@@ -27,6 +27,25 @@
   white-space: nowrap;
 }
 
+.item-sidebar-undo-banner.has-sync-error {
+  background: rgba(127, 29, 29, 0.94);
+  color: #fee2e2;
+}
+
+.item-sidebar-undo-banner.has-sync-error .item-sidebar-undo-banner-text {
+  white-space: normal;
+  max-width: 60ch;
+}
+
+.item-sidebar-undo-banner.has-sync-error .item-sidebar-undo-banner-action {
+  color: #fecaca;
+}
+
+.item-sidebar-undo-banner.has-sync-error .item-sidebar-undo-banner-action:hover,
+.item-sidebar-undo-banner.has-sync-error .item-sidebar-undo-banner-action:focus-visible {
+  background: rgba(254, 202, 202, 0.18);
+}
+
 .item-sidebar-undo-banner-action {
   border: 0;
   background: transparent;

--- a/tests/playwright/harness-pr-fixtures.js
+++ b/tests/playwright/harness-pr-fixtures.js
@@ -116,6 +116,9 @@
         ? next.map((entry, index) => ({ index, ...entry }))
         : defaultMeetingSummaryProposals();
     };
+    window.__queueItemSidebarGestureSyncError = (message) => {
+      window.__nextItemGestureSyncError = String(message || '').trim();
+    };
     window.__queueItemSidebarResponseDelay = (view, delayMs) => {
       const key = String(view || '').trim().toLowerCase();
       if (![...itemSidebarStateKeys(), 'counts'].includes(key)) return;

--- a/tests/playwright/harness-routes-domain.js
+++ b/tests/playwright/harness-routes-domain.js
@@ -163,7 +163,11 @@ __harnessRouteHandlers.push(async function harnessRouteDomain(u, opts) {
         if (!item) {
           return new Response('item not found', { status: 404 });
         }
-        return new Response(JSON.stringify({
+        const queuedSyncError = typeof window.__nextItemGestureSyncError === 'string'
+          ? window.__nextItemGestureSyncError
+          : '';
+        window.__nextItemGestureSyncError = '';
+        const responseBody = {
           ok: true,
           data: {
             item,
@@ -172,7 +176,11 @@ __harnessRouteHandlers.push(async function harnessRouteDomain(u, opts) {
             email_sync_back: false,
             undo: undoSnapshot,
           },
-        }), { status: 200 });
+        };
+        if (queuedSyncError) {
+          responseBody.data.sync_error = queuedSyncError;
+        }
+        return new Response(JSON.stringify(responseBody), { status: 200 });
       }
       if (/\/api\/items\/\d+\/gesture\/undo(?:\?|$)/.test(u) && opts?.method === 'POST') {
         let body = {};

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -835,6 +835,15 @@ test.describe('inbox triage interactions', () => {
     await expect(page.locator('#item-sidebar-menu')).toContainText('Delete');
     await page.mouse.click(10, 10);
 
+    await page.locator('#pr-file-list .pr-file-item[data-item-id="101"]').click();
+    await page.keyboard.press('KeyX');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Review parser cleanup');
+    await expect(page.locator('#item-sidebar-undo-banner')).toHaveClass(/is-open/);
+    await expect.poll(async () => page.evaluate(() => {
+      const log = (window as any).__harnessLog || [];
+      return log.some((entry: any) => entry?.action === 'item_gesture' && entry?.payload?.action === 'complete');
+    })).toBe(true);
+
     await page.keyboard.press('KeyD');
     await expect(page.locator('#pr-file-list')).not.toContainText('Answer triage email');
 

--- a/tests/playwright/inbox-triage.spec.ts
+++ b/tests/playwright/inbox-triage.spec.ts
@@ -729,6 +729,29 @@ test.describe('inbox triage interactions', () => {
     expect(gestureCalls.map((entry: any) => entry?.payload?.action)).toEqual(['complete', 'drop', 'defer', 'delegate']);
   });
 
+  test('writeable sync error from gesture surfaces actionable banner copy', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitReady(page);
+    await openInbox(page);
+    await setInboxItems(page, [parserInboxItem]);
+
+    await page.evaluate(() => {
+      (window as any).__queueItemSidebarGestureSyncError('todoist account not configured');
+    });
+
+    const row = '#pr-file-list .pr-file-item[data-item-id="101"]';
+    await touchPhase(page, row, 'start');
+    await touchPhase(page, row, 'move', 90, 0);
+    await touchPhase(page, row, 'end', 90, 0);
+
+    const banner = page.locator('#item-sidebar-undo-banner');
+    await expect(banner).toHaveClass(/is-open/);
+    await expect(banner).toHaveClass(/has-sync-error/);
+    await expect(banner).toContainText('sync failed');
+    await expect(banner).toContainText('todoist account not configured');
+    await expect(banner.locator('.item-sidebar-undo-banner-action')).toBeVisible();
+  });
+
   test('desktop context menu workspace picker reassigns the active item', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await waitReady(page);


### PR DESCRIPTION
## Summary

- `gestureComplete` now updates the local store first, then runs the writeable upstream sync. Markdown items still validate-write-through before the local update because the source markdown is authoritative.
- An upstream failure no longer rolls back the local close. The handler returns 200 with the local state at `done` and surfaces `sync_error` so the UI can show an actionable error without losing the user's tick-off.
- A re-completion on an already-`done` item short-circuits before the writeable sync runs, satisfying the "exactly once per completed item" contract.
- The response includes `parent_project_health` for every project parent of a completed child action, recomputed in one round-trip via the new `Store.GetProjectItemReview`. Closing a child does not auto-close the parent.
- Keyboard `x` now invokes the gesture/undo path (same surface as swipe-right). Undo banner timeout is 5 seconds per the issue.

## Verification

| Issue requirement | Evidence |
| --- | --- |
| Swipe-right and keyboard `x` call the status mutation path for close/complete. | Frontend handler routes `x`/`X` to `performItemSidebarGesture(item, 'complete')` in `internal/web/static/app-item-sidebar-ui.ts:813-832`. Backend test `TestItemGestureCompleteSetsDone` covers the gesture/complete endpoint. |
| For `writeable: true` bindings, trigger sync after local status update. | New test `TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError` proves local update happens before sync (failure leaves local at `done`). |
| Show an undo affordance for 5 seconds. | `ITEM_SIDEBAR_GESTURE_UNDO_TIMEOUT_MS = 5000` in `app-item-sidebar-gestures.ts`. |
| Undo reverts local overlay and calls the backend revert path where supported. | Existing `TestItemGestureUndoRevertsState` and `TestItemGestureUndoRevertsMarkdownSyncBack` (the latter asserts forward `set_status` then revert `set_status` reach the brain MCP). |
| Surface sync errors without losing the local state change. | `TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError` — Todoist-backed item without an account returns 200, `sync_error` populated, item state `done`. |
| Markdown-backed close validates after write-through. | Existing `TestItemGestureCompleteOnMarkdownBackedItemValidatesAfterWriteThrough` (`brain.note.parse` then `brain.gtd.set_status` in order). |
| Writeable source bindings call sync exactly once per completed item. | `TestItemGestureCompleteWriteableSyncCalledExactlyOnce`: first call surfaces `sync_error`; second call short-circuits and the response carries no `sync_error`, proving sync is not re-attempted. |
| Project item health refreshes after child action completion. | `TestItemGestureCompleteOnChildActionRefreshesParentProjectHealth`: `parent_project_health[0].health.stalled == true` after the only child is closed; parent state is not auto-closed. |
| Sync failure leaves an actionable error state. | `TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError` (response includes `sync_error`, item locally done, frontend shows the message via the existing `showStatus` path). |

### Targeted test runs

\`\`\`
$ go test ./internal/web/ -run 'TestItemGestureComplete|TestItemGestureUpstream|TestItemGestureCompleteOnChildAction|TestItemGestureCompleteSkipsParent' -count=1 -v
=== RUN   TestItemGestureCompleteSetsDone
--- PASS: TestItemGestureCompleteSetsDone (0.02s)
=== RUN   TestItemGestureCompleteOnMarkdownBackedItemValidatesAfterWriteThrough
--- PASS: TestItemGestureCompleteOnMarkdownBackedItemValidatesAfterWriteThrough (0.02s)
=== RUN   TestItemGestureCompleteOnExternalEmailRunsArchive
--- PASS: TestItemGestureCompleteOnExternalEmailRunsArchive (0.02s)
=== RUN   TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError
--- PASS: TestItemGestureCompleteUpstreamFailureKeepsLocalCloseAndSurfacesError (0.02s)
=== RUN   TestItemGestureCompleteWriteableSyncCalledExactlyOnce
--- PASS: TestItemGestureCompleteWriteableSyncCalledExactlyOnce (0.02s)
=== RUN   TestItemGestureCompleteOnChildActionRefreshesParentProjectHealth
--- PASS: TestItemGestureCompleteOnChildActionRefreshesParentProjectHealth (0.02s)
=== RUN   TestItemGestureCompleteSkipsParentHealthForLeafItem
--- PASS: TestItemGestureCompleteSkipsParentHealthForLeafItem (0.02s)
PASS
ok  	github.com/sloppy-org/slopshell/internal/web	0.156s
\`\`\`

\`\`\`
$ go test ./internal/web/ -run 'TestItemGestureUndoRevertsMarkdownSyncBack|TestItemGestureUndoRevertsState' -count=1 -v
=== RUN   TestItemGestureUndoRevertsState
--- PASS: TestItemGestureUndoRevertsState (0.02s)
=== RUN   TestItemGestureUndoRevertsMarkdownSyncBack
--- PASS: TestItemGestureUndoRevertsMarkdownSyncBack (0.03s)
PASS
ok  	github.com/sloppy-org/slopshell/internal/web	0.071s
\`\`\`

### Suite-wide checks

\`\`\`
$ go test ./...
ok  	github.com/sloppy-org/slopshell/internal/store	1.608s
ok  	github.com/sloppy-org/slopshell/internal/web	26.565s
[ ... all packages ok ... ]

$ npm run typecheck:frontend       # tsc --noEmit -p tsconfig.json (no output, exit 0)
$ npm run build:frontend           # built 67 frontend modules
$ ./scripts/sync-surface.sh --check  # exit 0
\`\`\`

## Test plan
- [x] `go test ./...`
- [x] `npm run typecheck:frontend`
- [x] `npm run build:frontend`
- [x] `./scripts/sync-surface.sh --check`