### PR TITLE
fix: Add GTD drift reconciliation queue (fixes #743)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -175,6 +175,7 @@ Domain model API:
 - `GET /api/items/counts`
 - `POST /api/items/sync/github`
 - `POST /api/items/sync/github/reviews`
+- `POST /api/items/drift/{drift_id}/{action}`
 - `GET /api/items/{item_id}`
 - `GET /api/items/{item_id}/artifacts`
 - `POST /api/items/{item_id}/artifacts`

--- a/internal/store/domain.go
+++ b/internal/store/domain.go
@@ -203,6 +203,40 @@ type ExternalBinding struct {
 	LastSyncedAt    string  `json:"last_synced_at"`
 }
 
+const (
+	ExternalBindingDriftActionKeepLocal    = "keep_local"
+	ExternalBindingDriftActionTakeUpstream = "take_upstream"
+	ExternalBindingDriftActionReingest     = "reingest_source"
+	ExternalBindingDriftActionDismiss      = "dismiss"
+)
+
+type ExternalBindingDrift struct {
+	ID                int64    `json:"drift_id"`
+	BindingID         int64    `json:"binding_id"`
+	ItemID            *int64   `json:"item_id,omitempty"`
+	AccountID         int64    `json:"account_id"`
+	Provider          string   `json:"provider"`
+	ObjectType        string   `json:"object_type"`
+	RemoteID          string   `json:"remote_id"`
+	SourceBinding     string   `json:"source_binding"`
+	SourceContainer   *string  `json:"source_container,omitempty"`
+	LocalState        string   `json:"local_state"`
+	UpstreamState     string   `json:"upstream_state"`
+	LocalTitle        string   `json:"local_title"`
+	UpstreamTitle     string   `json:"upstream_title"`
+	LocalUpdatedAt    string   `json:"local_updated_at"`
+	UpstreamUpdatedAt *string  `json:"upstream_updated_at,omitempty"`
+	UpstreamRevision  string   `json:"upstream_revision"`
+	DetectedAt        string   `json:"detected_at"`
+	ResolvedAt        *string  `json:"resolved_at,omitempty"`
+	Resolution        *string  `json:"resolution,omitempty"`
+	ProjectItemLinks  []string `json:"project_item_links,omitempty"`
+	WorkspaceID       *int64   `json:"workspace_id,omitempty"`
+	Title             string   `json:"title"`
+	Kind              string   `json:"kind"`
+	State             string   `json:"state"`
+}
+
 type ExternalContainerMapping struct {
 	ID            int64   `json:"id"`
 	Provider      string  `json:"provider"`

--- a/internal/store/domain_test.go
+++ b/internal/store/domain_test.go
@@ -73,6 +73,7 @@ func TestStoreMigratesDomainTablesOnFreshDatabase(t *testing.T) {
 		"item_children":                       {"parent_item_id", "child_item_id", "role", "created_at"},
 		"workspace_artifact_links":            {"workspace_id", "artifact_id", "created_at"},
 		"external_bindings":                   {"id", "account_id", "provider", "object_type", "remote_id", "item_id", "artifact_id", "container_ref", "remote_updated_at", "last_synced_at"},
+		"external_binding_drifts":             {"id", "binding_id", "item_id", "account_id", "provider", "object_type", "remote_id", "source_container", "local_state", "upstream_state", "local_title", "upstream_title", "local_updated_at", "upstream_updated_at", "upstream_revision", "detected_at", "resolved_at", "resolution"},
 		"batch_runs":                          {"id", "workspace_id", "started_at", "finished_at", "config_json", "status"},
 		"batch_run_items":                     {"batch_id", "item_id", "status", "pr_number", "pr_url", "error_msg", "started_at", "finished_at"},
 		"workspace_watches":                   {"workspace_id", "config_json", "poll_interval_seconds", "enabled", "current_batch_id", "created_at", "updated_at"},
@@ -163,7 +164,7 @@ CREATE TABLE chat_messages (
 	if err != nil {
 		t.Fatalf("TableColumns() error: %v", err)
 	}
-	for _, table := range []string{"workspaces", "contexts", "context_items", "context_artifacts", "context_workspaces", "context_external_accounts", "context_external_container_mappings", "context_time_entries", "actors", "artifacts", "external_accounts", "external_container_mappings", "item_artifacts", "item_children", "workspace_artifact_links", "external_bindings", "batch_runs", "batch_run_items", "items", "time_entries"} {
+	for _, table := range []string{"workspaces", "contexts", "context_items", "context_artifacts", "context_workspaces", "context_external_accounts", "context_external_container_mappings", "context_time_entries", "actors", "artifacts", "external_accounts", "external_container_mappings", "item_artifacts", "item_children", "workspace_artifact_links", "external_bindings", "external_binding_drifts", "batch_runs", "batch_run_items", "items", "time_entries"} {
 		if _, ok := columns[table]; !ok {
 			t.Fatalf("expected migrated table %s to exist", table)
 		}

--- a/internal/store/store_domain.go
+++ b/internal/store/store_domain.go
@@ -132,6 +132,30 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_external_bindings_identity
   ON external_bindings(account_id, provider, object_type, remote_id);
 CREATE INDEX IF NOT EXISTS idx_external_bindings_stale
   ON external_bindings(provider, last_synced_at);
+CREATE TABLE IF NOT EXISTS external_binding_drifts (
+  id INTEGER PRIMARY KEY,
+  binding_id INTEGER NOT NULL REFERENCES external_bindings(id) ON DELETE CASCADE,
+  item_id INTEGER REFERENCES items(id) ON DELETE SET NULL,
+  account_id INTEGER NOT NULL REFERENCES external_accounts(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  object_type TEXT NOT NULL,
+  remote_id TEXT NOT NULL,
+  source_container TEXT,
+  local_state TEXT NOT NULL,
+  upstream_state TEXT NOT NULL,
+  local_title TEXT NOT NULL DEFAULT '',
+  upstream_title TEXT NOT NULL DEFAULT '',
+  local_updated_at TEXT NOT NULL DEFAULT '',
+  upstream_updated_at TEXT,
+  upstream_revision TEXT NOT NULL,
+  detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  resolution TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_binding_drifts_revision
+  ON external_binding_drifts(binding_id, upstream_revision);
+CREATE INDEX IF NOT EXISTS idx_external_binding_drifts_open
+  ON external_binding_drifts(resolved_at, detected_at);
 CREATE TABLE IF NOT EXISTS batch_runs (
   id INTEGER PRIMARY KEY,
   workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,

--- a/internal/store/store_domain_item_query.go
+++ b/internal/store/store_domain_item_query.go
@@ -369,8 +369,7 @@ type SidebarSectionCounts struct {
 
 // CountSidebarSectionsFiltered counts open project items (Item.kind=project,
 // state != done), distinct actors with at least one open delegated/awaiting
-// item (people we owe or await), items currently in the GTD review queue with
-// a review_target set (drift dispatch backlog), open items whose
+// item (people we owe or await), unresolved external-binding drift, open items whose
 // (source, source_ref) pair has duplicates (dedup review backlog), and
 // meeting-note artifacts created within the last seven days. The filter
 // respects sphere/workspace/label scoping so the sidebar matches the active
@@ -400,15 +399,9 @@ func (s *Store) CountSidebarSectionsFiltered(now time.Time, filter ItemListFilte
 		return out, err
 	}
 
-	driftParts := []string{
-		"items.state = ?",
-		"items.review_target IS NOT NULL",
-		"trim(items.review_target) <> ''",
-	}
-	driftArgs := []any{ItemStateReview}
-	driftParts, driftArgs = appendItemFilterClauses(driftParts, driftArgs, normalizedFilter, "")
-	driftQuery := `SELECT COUNT(*) FROM items WHERE ` + stringsJoin(driftParts, ` AND `)
-	if err := s.db.QueryRow(driftQuery, driftArgs...).Scan(&out.DriftReview); err != nil {
+	driftFilter := normalizedFilter
+	driftFilter.Section = ""
+	if out.DriftReview, err = s.CountUnresolvedExternalBindingDrifts(driftFilter); err != nil {
 		return out, err
 	}
 

--- a/internal/store/store_external_binding_reconcile.go
+++ b/internal/store/store_external_binding_reconcile.go
@@ -298,8 +298,23 @@ func (s *Store) ResolveExternalBindingDrift(id int64, action string) (ExternalBi
 			return ExternalBindingDrift{}, err
 		}
 	}
+	return s.markExternalBindingDriftResolved(id, cleanAction)
+}
+
+func (s *Store) MarkExternalBindingDriftReingested(id int64) (ExternalBindingDrift, error) {
+	drift, err := s.GetExternalBindingDrift(id)
+	if err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	if drift.ResolvedAt != nil {
+		return drift, nil
+	}
+	return s.markExternalBindingDriftResolved(id, ExternalBindingDriftActionReingest)
+}
+
+func (s *Store) markExternalBindingDriftResolved(id int64, resolution string) (ExternalBindingDrift, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	if _, err := s.db.Exec(`UPDATE external_binding_drifts SET resolved_at = ?, resolution = ? WHERE id = ?`, now, cleanAction, id); err != nil {
+	if _, err := s.db.Exec(`UPDATE external_binding_drifts SET resolved_at = ?, resolution = ? WHERE id = ?`, now, resolution, id); err != nil {
 		return ExternalBindingDrift{}, err
 	}
 	return s.GetExternalBindingDrift(id)
@@ -328,12 +343,10 @@ func normalizeExternalBindingDriftAction(raw string) (string, error) {
 		return ExternalBindingDriftActionKeepLocal, nil
 	case ExternalBindingDriftActionTakeUpstream:
 		return ExternalBindingDriftActionTakeUpstream, nil
-	case ExternalBindingDriftActionReingest:
-		return ExternalBindingDriftActionReingest, nil
 	case ExternalBindingDriftActionDismiss:
 		return ExternalBindingDriftActionDismiss, nil
 	default:
-		return "", errors.New("action must be keep_local, take_upstream, reingest_source, or dismiss")
+		return "", errors.New("action must be keep_local, take_upstream, or dismiss")
 	}
 }
 

--- a/internal/store/store_external_binding_reconcile.go
+++ b/internal/store/store_external_binding_reconcile.go
@@ -191,11 +191,18 @@ func (s *Store) RecordExternalBindingDrift(binding ExternalBinding, local, upstr
 	if err == nil {
 		return s.updateExternalBindingDrift(existing.ID, binding, local, upstream, revision, now)
 	}
+	openDrift, err := s.getUnresolvedExternalBindingDriftByBinding(binding.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return ExternalBindingDrift{}, err
+	}
+	if err == nil {
+		return s.updateExternalBindingDrift(openDrift.ID, binding, local, upstream, revision, now)
+	}
 	if _, err := s.db.Exec(
 		`INSERT INTO external_binding_drifts (
-binding_id, item_id, account_id, provider, object_type, remote_id, source_container,
-local_state, upstream_state, local_title, upstream_title, local_updated_at,
-upstream_updated_at, upstream_revision, detected_at
+	binding_id, item_id, account_id, provider, object_type, remote_id, source_container,
+	local_state, upstream_state, local_title, upstream_title, local_updated_at,
+	upstream_updated_at, upstream_revision, detected_at
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		binding.ID,
 		local.ID,
@@ -281,7 +288,7 @@ func (s *Store) CountUnresolvedExternalBindingDrifts(filter ItemListFilter) (int
 	return len(drifts), nil
 }
 
-func (s *Store) HasPreservedLocalExternalBindingDrift(bindingID int64, localState string) (bool, error) {
+func (s *Store) HasLocalExternalBindingDrift(bindingID int64, localState string) (bool, error) {
 	state := strings.TrimSpace(localState)
 	if bindingID <= 0 || state == "" {
 		return false, nil
@@ -292,8 +299,10 @@ func (s *Store) HasPreservedLocalExternalBindingDrift(bindingID int64, localStat
 		 FROM external_binding_drifts
 		 WHERE binding_id = ?
 		   AND local_state = ?
-		   AND resolved_at IS NOT NULL
-		   AND resolution IN (?, ?)
+		   AND (
+		     resolved_at IS NULL
+		     OR resolution IN (?, ?)
+		   )
 		 LIMIT 1`,
 		bindingID,
 		state,
@@ -408,6 +417,10 @@ func (s *Store) GetExternalBindingDrift(id int64) (ExternalBindingDrift, error) 
 
 func (s *Store) getExternalBindingDriftByRevision(bindingID int64, revision string) (ExternalBindingDrift, error) {
 	return scanExternalBindingDrift(s.db.QueryRow(externalBindingDriftSelect+` WHERE d.binding_id = ? AND d.upstream_revision = ?`, bindingID, revision))
+}
+
+func (s *Store) getUnresolvedExternalBindingDriftByBinding(bindingID int64) (ExternalBindingDrift, error) {
+	return scanExternalBindingDrift(s.db.QueryRow(externalBindingDriftSelect+` WHERE d.binding_id = ? AND d.resolved_at IS NULL`, bindingID))
 }
 
 func scanExternalBindingDrift(row interface{ Scan(dest ...any) error }) (ExternalBindingDrift, error) {

--- a/internal/store/store_external_binding_reconcile.go
+++ b/internal/store/store_external_binding_reconcile.go
@@ -281,6 +281,31 @@ func (s *Store) CountUnresolvedExternalBindingDrifts(filter ItemListFilter) (int
 	return len(drifts), nil
 }
 
+func (s *Store) HasPreservedLocalExternalBindingDrift(bindingID int64, localState string) (bool, error) {
+	state := strings.TrimSpace(localState)
+	if bindingID <= 0 || state == "" {
+		return false, nil
+	}
+	var found int
+	err := s.db.QueryRow(
+		`SELECT 1
+		 FROM external_binding_drifts
+		 WHERE binding_id = ?
+		   AND local_state = ?
+		   AND resolved_at IS NOT NULL
+		   AND resolution IN (?, ?)
+		 LIMIT 1`,
+		bindingID,
+		state,
+		ExternalBindingDriftActionKeepLocal,
+		ExternalBindingDriftActionDismiss,
+	).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 func (s *Store) ResolveExternalBindingDrift(id int64, action string) (ExternalBindingDrift, error) {
 	cleanAction, err := normalizeExternalBindingDriftAction(action)
 	if err != nil {

--- a/internal/store/store_external_binding_reconcile.go
+++ b/internal/store/store_external_binding_reconcile.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -19,7 +20,6 @@ func (s *Store) ApplyExternalBindingReconcileUpdates(accountID int64, provider s
 	if _, err := s.validateExternalBindingAccount(accountID, provider); err != nil {
 		return err
 	}
-	cleanProvider := normalizeExternalAccountProvider(provider)
 	if len(updates) == 0 {
 		return nil
 	}
@@ -33,122 +33,10 @@ func (s *Store) ApplyExternalBindingReconcileUpdates(accountID int64, provider s
 		}
 	}()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+	cleanProvider := normalizeExternalAccountProvider(provider)
 	for _, update := range updates {
-		objectType := normalizeExternalBindingObjectType(update.ObjectType)
-		if objectType == "" {
-			return errors.New("external binding reconcile update object_type is required")
-		}
-		oldRemoteID := normalizeExternalBindingRemoteID(update.OldRemoteID)
-		newRemoteID := normalizeExternalBindingRemoteID(update.NewRemoteID)
-		if oldRemoteID == "" && newRemoteID == "" {
-			continue
-		}
-		lookupRemoteID := oldRemoteID
-		if lookupRemoteID == "" {
-			lookupRemoteID = newRemoteID
-		}
-
-		var (
-			bindingID       int64
-			itemID          sql.NullInt64
-			artifactID      sql.NullInt64
-			currentID       string
-			container       sql.NullString
-			ignoredRemoteAt sql.NullString
-			ignoredSyncedAt string
-		)
-		err := tx.QueryRow(
-			`SELECT id, item_id, artifact_id, remote_id, container_ref, remote_updated_at, last_synced_at
-			 FROM external_bindings
-			 WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_id = ?`,
-			accountID,
-			cleanProvider,
-			objectType,
-			lookupRemoteID,
-		).Scan(&bindingID, &itemID, &artifactID, &currentID, &container, &ignoredRemoteAt, &ignoredSyncedAt)
-		if errors.Is(err, sql.ErrNoRows) {
-			continue
-		}
-		if err != nil {
+		if err := applyExternalBindingReconcileUpdateTx(tx, accountID, cleanProvider, update, now); err != nil {
 			return err
-		}
-
-		targetRemoteID := currentID
-		if newRemoteID != "" {
-			targetRemoteID = newRemoteID
-		}
-		targetContainer := normalizeOptionalString(update.ContainerRef)
-		if targetContainer == nil {
-			targetContainer = nullStringPointer(container)
-		}
-
-		if targetRemoteID != currentID {
-			var existingID sql.NullInt64
-			err = tx.QueryRow(
-				`SELECT id
-				 FROM external_bindings
-				 WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_id = ?`,
-				accountID,
-				cleanProvider,
-				objectType,
-				targetRemoteID,
-			).Scan(&existingID)
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return err
-			}
-			if existingID.Valid && existingID.Int64 != bindingID {
-				if _, err := tx.Exec(
-					`UPDATE external_bindings
-					 SET item_id = COALESCE(item_id, ?),
-					     artifact_id = COALESCE(artifact_id, ?),
-					     container_ref = ?,
-					     last_synced_at = ?
-					 WHERE id = ?`,
-					nullablePositiveID(itemID.Int64),
-					nullablePositiveID(artifactID.Int64),
-					targetContainer,
-					now,
-					existingID.Int64,
-				); err != nil {
-					return err
-				}
-				if _, err := tx.Exec(`DELETE FROM external_bindings WHERE id = ?`, bindingID); err != nil {
-					return err
-				}
-				bindingID = existingID.Int64
-			} else {
-				if _, err := tx.Exec(
-					`UPDATE external_bindings
-					 SET remote_id = ?, container_ref = ?, last_synced_at = ?
-					 WHERE id = ?`,
-					targetRemoteID,
-					targetContainer,
-					now,
-					bindingID,
-				); err != nil {
-					return err
-				}
-			}
-		} else {
-			if _, err := tx.Exec(
-				`UPDATE external_bindings
-				 SET container_ref = ?, last_synced_at = ?
-				 WHERE id = ?`,
-				targetContainer,
-				now,
-				bindingID,
-			); err != nil {
-				return err
-			}
-		}
-
-		if itemID.Valid && update.FollowUpItemState != nil {
-			state := strings.TrimSpace(*update.FollowUpItemState)
-			if state != "" {
-				if _, err := tx.Exec(`UPDATE items SET state = ? WHERE id = ?`, state, itemID.Int64); err != nil {
-					return err
-				}
-			}
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -156,4 +44,395 @@ func (s *Store) ApplyExternalBindingReconcileUpdates(accountID int64, provider s
 	}
 	tx = nil
 	return nil
+}
+
+type externalBindingReconcileTarget struct {
+	bindingID       int64
+	itemID          sql.NullInt64
+	artifactID      sql.NullInt64
+	currentRemoteID string
+	container       sql.NullString
+}
+
+func applyExternalBindingReconcileUpdateTx(tx *sql.Tx, accountID int64, provider string, update ExternalBindingReconcileUpdate, now string) error {
+	objectType, lookupRemoteID, newRemoteID, err := normalizeExternalBindingReconcileUpdate(update)
+	if err != nil || lookupRemoteID == "" {
+		return err
+	}
+	target, err := loadExternalBindingReconcileTarget(tx, accountID, provider, objectType, lookupRemoteID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	targetRemoteID := firstNonEmptyString(newRemoteID, target.currentRemoteID)
+	targetContainer := normalizeOptionalString(update.ContainerRef)
+	if targetContainer == nil {
+		targetContainer = nullStringPointer(target.container)
+	}
+	if err := updateExternalBindingReconcileTarget(tx, accountID, provider, objectType, target, targetRemoteID, targetContainer, now); err != nil {
+		return err
+	}
+	return updateExternalBindingReconcileItemState(tx, target.itemID, update.FollowUpItemState)
+}
+
+func normalizeExternalBindingReconcileUpdate(update ExternalBindingReconcileUpdate) (string, string, string, error) {
+	objectType := normalizeExternalBindingObjectType(update.ObjectType)
+	if objectType == "" {
+		return "", "", "", errors.New("external binding reconcile update object_type is required")
+	}
+	oldRemoteID := normalizeExternalBindingRemoteID(update.OldRemoteID)
+	newRemoteID := normalizeExternalBindingRemoteID(update.NewRemoteID)
+	if oldRemoteID != "" {
+		return objectType, oldRemoteID, newRemoteID, nil
+	}
+	return objectType, newRemoteID, newRemoteID, nil
+}
+
+func loadExternalBindingReconcileTarget(tx *sql.Tx, accountID int64, provider, objectType, remoteID string) (externalBindingReconcileTarget, error) {
+	var out externalBindingReconcileTarget
+	var ignoredRemoteAt sql.NullString
+	var ignoredSyncedAt string
+	err := tx.QueryRow(
+		`SELECT id, item_id, artifact_id, remote_id, container_ref, remote_updated_at, last_synced_at
+		 FROM external_bindings
+		 WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_id = ?`,
+		accountID,
+		provider,
+		objectType,
+		remoteID,
+	).Scan(&out.bindingID, &out.itemID, &out.artifactID, &out.currentRemoteID, &out.container, &ignoredRemoteAt, &ignoredSyncedAt)
+	return out, err
+}
+
+func updateExternalBindingReconcileTarget(tx *sql.Tx, accountID int64, provider, objectType string, target externalBindingReconcileTarget, targetRemoteID string, targetContainer any, now string) error {
+	if targetRemoteID == target.currentRemoteID {
+		_, err := tx.Exec(`UPDATE external_bindings SET container_ref = ?, last_synced_at = ? WHERE id = ?`,
+			targetContainer, now, target.bindingID)
+		return err
+	}
+	existingID, err := findExternalBindingReconcileTargetID(tx, accountID, provider, objectType, targetRemoteID)
+	if err != nil {
+		return err
+	}
+	if existingID.Valid && existingID.Int64 != target.bindingID {
+		return mergeExternalBindingReconcileTarget(tx, target, existingID.Int64, targetContainer, now)
+	}
+	_, err = tx.Exec(`UPDATE external_bindings SET remote_id = ?, container_ref = ?, last_synced_at = ? WHERE id = ?`,
+		targetRemoteID, targetContainer, now, target.bindingID)
+	return err
+}
+
+func findExternalBindingReconcileTargetID(tx *sql.Tx, accountID int64, provider, objectType, remoteID string) (sql.NullInt64, error) {
+	var existingID sql.NullInt64
+	err := tx.QueryRow(
+		`SELECT id FROM external_bindings WHERE account_id = ? AND provider = ? AND object_type = ? AND remote_id = ?`,
+		accountID, provider, objectType, remoteID,
+	).Scan(&existingID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return existingID, nil
+	}
+	return existingID, err
+}
+
+func mergeExternalBindingReconcileTarget(tx *sql.Tx, target externalBindingReconcileTarget, existingID int64, targetContainer any, now string) error {
+	if _, err := tx.Exec(
+		`UPDATE external_bindings
+		 SET item_id = COALESCE(item_id, ?), artifact_id = COALESCE(artifact_id, ?),
+		     container_ref = ?, last_synced_at = ?
+		 WHERE id = ?`,
+		nullablePositiveID(target.itemID.Int64),
+		nullablePositiveID(target.artifactID.Int64),
+		targetContainer,
+		now,
+		existingID,
+	); err != nil {
+		return err
+	}
+	_, err := tx.Exec(`DELETE FROM external_bindings WHERE id = ?`, target.bindingID)
+	return err
+}
+
+func updateExternalBindingReconcileItemState(tx *sql.Tx, itemID sql.NullInt64, stateValue *string) error {
+	if !itemID.Valid || stateValue == nil {
+		return nil
+	}
+	state := strings.TrimSpace(*stateValue)
+	if state == "" {
+		return nil
+	}
+	_, err := tx.Exec(`UPDATE items SET state = ? WHERE id = ?`, state, itemID.Int64)
+	return err
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (s *Store) RecordExternalBindingDrift(binding ExternalBinding, local, upstream Item) (ExternalBindingDrift, error) {
+	if binding.ID <= 0 || local.ID <= 0 {
+		return ExternalBindingDrift{}, errors.New("drift binding and item are required")
+	}
+	revision := externalBindingDriftRevision(binding, upstream)
+	existing, err := s.getExternalBindingDriftByRevision(binding.ID, revision)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return ExternalBindingDrift{}, err
+	}
+	if err == nil && existing.ResolvedAt != nil {
+		return existing, nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if err == nil {
+		return s.updateExternalBindingDrift(existing.ID, binding, local, upstream, revision, now)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO external_binding_drifts (
+binding_id, item_id, account_id, provider, object_type, remote_id, source_container,
+local_state, upstream_state, local_title, upstream_title, local_updated_at,
+upstream_updated_at, upstream_revision, detected_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		binding.ID,
+		local.ID,
+		binding.AccountID,
+		binding.Provider,
+		binding.ObjectType,
+		binding.RemoteID,
+		normalizeOptionalString(binding.ContainerRef),
+		local.State,
+		upstream.State,
+		local.Title,
+		upstream.Title,
+		local.UpdatedAt,
+		normalizeOptionalString(binding.RemoteUpdatedAt),
+		revision,
+		now,
+	); err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	return s.getExternalBindingDriftByRevision(binding.ID, revision)
+}
+
+func (s *Store) updateExternalBindingDrift(id int64, binding ExternalBinding, local, upstream Item, revision, detectedAt string) (ExternalBindingDrift, error) {
+	if _, err := s.db.Exec(
+		`UPDATE external_binding_drifts
+SET item_id = ?, account_id = ?, provider = ?, object_type = ?, remote_id = ?,
+    source_container = ?, local_state = ?, upstream_state = ?, local_title = ?,
+    upstream_title = ?, local_updated_at = ?, upstream_updated_at = ?,
+    upstream_revision = ?, detected_at = ?
+WHERE id = ? AND resolved_at IS NULL`,
+		local.ID,
+		binding.AccountID,
+		binding.Provider,
+		binding.ObjectType,
+		binding.RemoteID,
+		normalizeOptionalString(binding.ContainerRef),
+		local.State,
+		upstream.State,
+		local.Title,
+		upstream.Title,
+		local.UpdatedAt,
+		normalizeOptionalString(binding.RemoteUpdatedAt),
+		revision,
+		detectedAt,
+		id,
+	); err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	return s.GetExternalBindingDrift(id)
+}
+
+func (s *Store) ListUnresolvedExternalBindingDrifts(filter ItemListFilter) ([]ExternalBindingDrift, error) {
+	scoped := filter
+	scoped.Section = ""
+	normalizedFilter, err := s.prepareItemListFilter(scoped)
+	if err != nil {
+		return nil, err
+	}
+	parts := []string{"d.resolved_at IS NULL"}
+	args := []any{}
+	parts, args = appendItemFilterClauses(parts, args, normalizedFilter, "i.")
+	rows, err := s.db.Query(externalBindingDriftSelect+` WHERE `+stringsJoin(parts, ` AND `)+`
+ORDER BY datetime(d.detected_at) DESC, d.id ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	drifts, err := scanExternalBindingDriftRows(rows)
+	closeErr := rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return s.withDriftProjectItemLinksForRows(drifts)
+}
+
+func (s *Store) CountUnresolvedExternalBindingDrifts(filter ItemListFilter) (int, error) {
+	drifts, err := s.ListUnresolvedExternalBindingDrifts(filter)
+	if err != nil {
+		return 0, err
+	}
+	return len(drifts), nil
+}
+
+func (s *Store) ResolveExternalBindingDrift(id int64, action string) (ExternalBindingDrift, error) {
+	cleanAction, err := normalizeExternalBindingDriftAction(action)
+	if err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	drift, err := s.GetExternalBindingDrift(id)
+	if err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	if drift.ResolvedAt != nil {
+		return drift, nil
+	}
+	if cleanAction == ExternalBindingDriftActionTakeUpstream {
+		if err := s.applyDriftUpstreamState(drift); err != nil {
+			return ExternalBindingDrift{}, err
+		}
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := s.db.Exec(`UPDATE external_binding_drifts SET resolved_at = ?, resolution = ? WHERE id = ?`, now, cleanAction, id); err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	return s.GetExternalBindingDrift(id)
+}
+
+func (s *Store) applyDriftUpstreamState(drift ExternalBindingDrift) error {
+	if drift.ItemID == nil || *drift.ItemID <= 0 {
+		return errors.New("drift item is missing")
+	}
+	state := strings.TrimSpace(drift.UpstreamState)
+	if normalizeItemState(state) == "" {
+		return errors.New("drift upstream_state is invalid")
+	}
+	title := strings.TrimSpace(drift.UpstreamTitle)
+	if title == "" {
+		title = strings.TrimSpace(drift.LocalTitle)
+	}
+	_, err := s.db.Exec(`UPDATE items SET title = ?, state = ?, updated_at = ? WHERE id = ?`,
+		title, state, time.Now().UTC().Format(time.RFC3339Nano), *drift.ItemID)
+	return err
+}
+
+func normalizeExternalBindingDriftAction(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case ExternalBindingDriftActionKeepLocal:
+		return ExternalBindingDriftActionKeepLocal, nil
+	case ExternalBindingDriftActionTakeUpstream:
+		return ExternalBindingDriftActionTakeUpstream, nil
+	case ExternalBindingDriftActionReingest:
+		return ExternalBindingDriftActionReingest, nil
+	case ExternalBindingDriftActionDismiss:
+		return ExternalBindingDriftActionDismiss, nil
+	default:
+		return "", errors.New("action must be keep_local, take_upstream, reingest_source, or dismiss")
+	}
+}
+
+func externalBindingDriftRevision(binding ExternalBinding, upstream Item) string {
+	remoteAt := strings.TrimSpace(externalBindingDriftString(binding.RemoteUpdatedAt))
+	if remoteAt != "" {
+		return remoteAt
+	}
+	return fmt.Sprintf("%s|%s|%s", strings.TrimSpace(upstream.State), strings.TrimSpace(upstream.Title), strings.TrimSpace(externalBindingDriftString(binding.ContainerRef)))
+}
+
+func externalBindingDriftString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+const externalBindingDriftSelect = `SELECT
+d.id, d.binding_id, d.item_id, d.account_id, d.provider, d.object_type, d.remote_id,
+d.source_container, d.local_state, d.upstream_state, d.local_title, d.upstream_title,
+d.local_updated_at, d.upstream_updated_at, d.upstream_revision, d.detected_at,
+d.resolved_at, d.resolution, i.workspace_id
+FROM external_binding_drifts d
+LEFT JOIN items i ON i.id = d.item_id`
+
+func (s *Store) GetExternalBindingDrift(id int64) (ExternalBindingDrift, error) {
+	drift, err := scanExternalBindingDrift(s.db.QueryRow(externalBindingDriftSelect+` WHERE d.id = ?`, id))
+	if err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	return s.withDriftProjectItemLinks(drift)
+}
+
+func (s *Store) getExternalBindingDriftByRevision(bindingID int64, revision string) (ExternalBindingDrift, error) {
+	return scanExternalBindingDrift(s.db.QueryRow(externalBindingDriftSelect+` WHERE d.binding_id = ? AND d.upstream_revision = ?`, bindingID, revision))
+}
+
+func scanExternalBindingDrift(row interface{ Scan(dest ...any) error }) (ExternalBindingDrift, error) {
+	var out ExternalBindingDrift
+	var itemID, workspaceID sql.NullInt64
+	var container, upstreamAt, resolvedAt, resolution sql.NullString
+	if err := row.Scan(&out.ID, &out.BindingID, &itemID, &out.AccountID, &out.Provider, &out.ObjectType,
+		&out.RemoteID, &container, &out.LocalState, &out.UpstreamState, &out.LocalTitle,
+		&out.UpstreamTitle, &out.LocalUpdatedAt, &upstreamAt, &out.UpstreamRevision,
+		&out.DetectedAt, &resolvedAt, &resolution, &workspaceID); err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	out.ItemID = nullInt64Pointer(itemID)
+	out.WorkspaceID = nullInt64Pointer(workspaceID)
+	out.SourceContainer = nullStringPointer(container)
+	out.UpstreamUpdatedAt = nullStringPointer(upstreamAt)
+	out.ResolvedAt = nullStringPointer(resolvedAt)
+	out.Resolution = nullStringPointer(resolution)
+	out.SourceBinding = fmt.Sprintf("%s:%s:%s", out.Provider, out.ObjectType, out.RemoteID)
+	out.Title = out.LocalTitle
+	out.Kind = "drift"
+	out.State = ItemStateReview
+	return out, nil
+}
+
+func scanExternalBindingDriftRows(rows *sql.Rows) ([]ExternalBindingDrift, error) {
+	var out []ExternalBindingDrift
+	for rows.Next() {
+		drift, err := scanExternalBindingDrift(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, drift)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) withDriftProjectItemLinksForRows(drifts []ExternalBindingDrift) ([]ExternalBindingDrift, error) {
+	for i := range drifts {
+		next, err := s.withDriftProjectItemLinks(drifts[i])
+		if err != nil {
+			return nil, err
+		}
+		drifts[i] = next
+	}
+	return drifts, nil
+}
+
+func (s *Store) withDriftProjectItemLinks(drift ExternalBindingDrift) (ExternalBindingDrift, error) {
+	if drift.ItemID == nil {
+		return drift, nil
+	}
+	rows, err := s.db.Query(`SELECT parent.title || ' (' || links.role || ')' FROM item_children links JOIN items parent ON parent.id = links.parent_item_id WHERE links.child_item_id = ? ORDER BY parent.title`, *drift.ItemID)
+	if err != nil {
+		return ExternalBindingDrift{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var label string
+		if err := rows.Scan(&label); err != nil {
+			return ExternalBindingDrift{}, err
+		}
+		drift.ProjectItemLinks = append(drift.ProjectItemLinks, label)
+	}
+	return drift, rows.Err()
 }

--- a/internal/store/store_item_filters.go
+++ b/internal/store/store_item_filters.go
@@ -131,10 +131,11 @@ func appendItemSectionFilterClauses(parts []string, args []any, filter ItemListF
 	case ItemSidebarSectionPeople:
 		parts = append(parts, column("actor_id")+" IS NOT NULL")
 	case ItemSidebarSectionDrift:
-		parts = append(parts,
-			column("review_target")+" IS NOT NULL",
-			"trim("+column("review_target")+") <> ''",
-		)
+		parts = append(parts, `EXISTS (
+SELECT 1 FROM external_binding_drifts drift
+WHERE drift.item_id = `+outerColumn("id")+`
+  AND drift.resolved_at IS NULL
+)`)
 	case ItemSidebarSectionDedup:
 		parts = append(parts,
 			column("source")+" IS NOT NULL",

--- a/internal/store/store_sidebar_counts_test.go
+++ b/internal/store/store_sidebar_counts_test.go
@@ -190,20 +190,34 @@ func TestCountSidebarSectionsFilteredCountsDistinctPeopleOnOpenItems(t *testing.
 func TestCountSidebarSectionsFilteredCountsDriftReviewItems(t *testing.T) {
 	s := newTestStore(t)
 
-	driftWithTarget, err := s.CreateItem("Drift with target", ItemOptions{State: ItemStateReview})
+	account, err := s.CreateExternalAccount(SphereWork, ExternalProviderTodoist, "Todoist", map[string]any{})
 	if err != nil {
-		t.Fatalf("CreateItem(drift target) error: %v", err)
+		t.Fatalf("CreateExternalAccount() error: %v", err)
 	}
-	target := ItemReviewTargetGitHub
-	reviewer := "krystophny"
-	if err := s.UpdateItemReviewDispatch(driftWithTarget.ID, &target, &reviewer); err != nil {
-		t.Fatalf("UpdateItemReviewDispatch() error: %v", err)
+	driftItem, err := s.CreateItem("Local overlay task", ItemOptions{State: ItemStateWaiting})
+	if err != nil {
+		t.Fatalf("CreateItem(drift item) error: %v", err)
 	}
-	// Review state without target should not be counted as drift.
-	if _, err := s.CreateItem("Review no target", ItemOptions{State: ItemStateReview}); err != nil {
-		t.Fatalf("CreateItem(review no target) error: %v", err)
+	remoteAt := "2026-03-08T10:05:00Z"
+	binding, err := s.UpsertExternalBinding(ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      "task",
+		RemoteID:        "task-1",
+		ItemID:          &driftItem.ID,
+		RemoteUpdatedAt: &remoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding() error: %v", err)
 	}
-	// Non-review items should not be counted even if they have a target later.
+	upstream := driftItem
+	upstream.State = ItemStateDone
+	if _, err := s.RecordExternalBindingDrift(binding, driftItem, upstream); err != nil {
+		t.Fatalf("RecordExternalBindingDrift() error: %v", err)
+	}
+	if _, err := s.CreateItem("Review item without source drift", ItemOptions{State: ItemStateReview}); err != nil {
+		t.Fatalf("CreateItem(review no drift) error: %v", err)
+	}
 	if _, err := s.CreateItem("Next item", ItemOptions{State: ItemStateNext}); err != nil {
 		t.Fatalf("CreateItem(next) error: %v", err)
 	}
@@ -214,7 +228,7 @@ func TestCountSidebarSectionsFilteredCountsDriftReviewItems(t *testing.T) {
 		t.Fatalf("CountSidebarSectionsFiltered() error: %v", err)
 	}
 	if got.DriftReview != 1 {
-		t.Fatalf("DriftReview = %d, want 1 (only review-state item with review_target set)", got.DriftReview)
+		t.Fatalf("DriftReview = %d, want 1 (only unresolved external-binding drift)", got.DriftReview)
 	}
 }
 

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -178,6 +178,7 @@ var WebRouteSections = []RouteSection{
 			"GET /api/items/counts",
 			"POST /api/items/sync/github",
 			"POST /api/items/sync/github/reviews",
+			"POST /api/items/drift/{drift_id}/{action}",
 			"GET /api/items/{item_id}",
 			"GET /api/items/{item_id}/artifacts",
 			"POST /api/items/{item_id}/artifacts",

--- a/internal/sync/store_sink.go
+++ b/internal/sync/store_sink.go
@@ -19,48 +19,47 @@ func NewStoreSink(s *store.Store) *StoreSink {
 }
 
 func (s *StoreSink) UpsertItem(_ context.Context, item store.Item, binding store.ExternalBinding) (store.Item, error) {
-	account, existingBinding, existingItem, assignment, err := s.resolveItemTarget(binding)
+	account, existingBinding, existingItem, target, err := s.resolveItemTarget(binding)
 	if err != nil {
 		return store.Item{}, err
 	}
-
 	if existingItem != nil {
-		if shouldRecordItemDrift(*existingItem, existingBinding, item, binding) {
-			if _, err := s.store.RecordExternalBindingDrift(withBindingUpdate(existingBinding, binding), *existingItem, item); err != nil {
-				return store.Item{}, err
-			}
-			if _, err := s.store.UpsertExternalBinding(withBindingUpdate(existingBinding, binding)); err != nil {
-				return store.Item{}, err
-			}
-			return *existingItem, nil
-		}
-		update, err := s.itemUpdate(account, item, assignment)
-		if err != nil {
-			return store.Item{}, err
-		}
-		if err := s.store.UpdateItem(existingItem.ID, update); err != nil {
-			return store.Item{}, err
-		}
-		updated, err := s.store.GetItem(existingItem.ID)
-		if err != nil {
-			return store.Item{}, err
-		}
-		if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
-			AccountID:       account.ID,
-			Provider:        account.Provider,
-			ObjectType:      binding.ObjectType,
-			RemoteID:        binding.RemoteID,
-			ItemID:          &updated.ID,
-			ArtifactID:      existingBinding.ArtifactID,
-			ContainerRef:    normalizeContainerRef(binding.ContainerRef),
-			RemoteUpdatedAt: binding.RemoteUpdatedAt,
-		}); err != nil {
-			return store.Item{}, err
-		}
-		return updated, nil
+		return s.updateBoundItem(account, existingBinding, *existingItem, item, binding, target)
 	}
+	return s.createBoundItem(account, existingBinding, item, binding, target)
+}
 
-	options, err := s.itemCreateOptions(account, item, assignment)
+func (s *StoreSink) updateBoundItem(account store.ExternalAccount, existingBinding store.ExternalBinding, existing store.Item, incoming store.Item, binding store.ExternalBinding, target assignment) (store.Item, error) {
+	shouldRecordDrift, err := s.shouldRecordItemDrift(existing, existingBinding, incoming, binding)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if shouldRecordDrift {
+		updatedBinding := withBindingUpdate(existingBinding, binding)
+		if _, err := s.store.RecordExternalBindingDrift(updatedBinding, existing, incoming); err != nil {
+			return store.Item{}, err
+		}
+		if _, err := s.store.UpsertExternalBinding(updatedBinding); err != nil {
+			return store.Item{}, err
+		}
+		return existing, nil
+	}
+	update, err := s.itemUpdate(account, incoming, target)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if err := s.store.UpdateItem(existing.ID, update); err != nil {
+		return store.Item{}, err
+	}
+	updated, err := s.store.GetItem(existing.ID)
+	if err != nil {
+		return store.Item{}, err
+	}
+	return updated, s.upsertItemBinding(account, updated.ID, existingBinding.ArtifactID, binding)
+}
+
+func (s *StoreSink) createBoundItem(account store.ExternalAccount, existingBinding store.ExternalBinding, item store.Item, binding store.ExternalBinding, target assignment) (store.Item, error) {
+	options, err := s.itemCreateOptions(account, item, target)
 	if err != nil {
 		return store.Item{}, err
 	}
@@ -72,57 +71,55 @@ func (s *StoreSink) UpsertItem(_ context.Context, item store.Item, binding store
 	if item.ArtifactID != nil {
 		artifactID = item.ArtifactID
 	}
+	return created, s.upsertItemBinding(account, created.ID, artifactID, binding)
+}
+
+func (s *StoreSink) upsertItemBinding(account store.ExternalAccount, itemID int64, artifactID *int64, binding store.ExternalBinding) error {
 	if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
 		AccountID:       account.ID,
 		Provider:        account.Provider,
 		ObjectType:      binding.ObjectType,
 		RemoteID:        binding.RemoteID,
-		ItemID:          &created.ID,
+		ItemID:          &itemID,
 		ArtifactID:      artifactID,
 		ContainerRef:    normalizeContainerRef(binding.ContainerRef),
 		RemoteUpdatedAt: binding.RemoteUpdatedAt,
 	}); err != nil {
-		return store.Item{}, err
+		return err
 	}
-	return created, nil
+	return nil
 }
 
 func (s *StoreSink) UpsertArtifact(_ context.Context, artifact store.Artifact, binding store.ExternalBinding) (store.Artifact, error) {
-	account, existingBinding, existingArtifact, assignment, err := s.resolveArtifactTarget(binding)
+	account, existingBinding, existingArtifact, target, err := s.resolveArtifactTarget(binding)
 	if err != nil {
 		return store.Artifact{}, err
 	}
-
 	if existingArtifact != nil {
-		update, err := artifactUpdate(artifact)
-		if err != nil {
-			return store.Artifact{}, err
-		}
-		if err := s.store.UpdateArtifact(existingArtifact.ID, update); err != nil {
-			return store.Artifact{}, err
-		}
-		updated, err := s.store.GetArtifact(existingArtifact.ID)
-		if err != nil {
-			return store.Artifact{}, err
-		}
-		if err := s.linkArtifactWorkspace(updated, assignment.WorkspaceID); err != nil {
-			return store.Artifact{}, err
-		}
-		if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
-			AccountID:       account.ID,
-			Provider:        account.Provider,
-			ObjectType:      binding.ObjectType,
-			RemoteID:        binding.RemoteID,
-			ItemID:          existingBinding.ItemID,
-			ArtifactID:      &updated.ID,
-			ContainerRef:    normalizeContainerRef(binding.ContainerRef),
-			RemoteUpdatedAt: binding.RemoteUpdatedAt,
-		}); err != nil {
-			return store.Artifact{}, err
-		}
-		return updated, nil
+		return s.updateBoundArtifact(account, existingBinding, *existingArtifact, artifact, binding, target)
 	}
+	return s.createBoundArtifact(account, existingBinding, artifact, binding, target)
+}
 
+func (s *StoreSink) updateBoundArtifact(account store.ExternalAccount, existingBinding store.ExternalBinding, existing store.Artifact, incoming store.Artifact, binding store.ExternalBinding, target assignment) (store.Artifact, error) {
+	update, err := artifactUpdate(incoming)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	if err := s.store.UpdateArtifact(existing.ID, update); err != nil {
+		return store.Artifact{}, err
+	}
+	updated, err := s.store.GetArtifact(existing.ID)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	if err := s.linkArtifactWorkspace(updated, target.WorkspaceID); err != nil {
+		return store.Artifact{}, err
+	}
+	return updated, s.upsertArtifactBinding(account, existingBinding, updated.ID, binding)
+}
+
+func (s *StoreSink) createBoundArtifact(account store.ExternalAccount, existingBinding store.ExternalBinding, artifact store.Artifact, binding store.ExternalBinding, target assignment) (store.Artifact, error) {
 	if strings.TrimSpace(string(artifact.Kind)) == "" {
 		return store.Artifact{}, errors.New("artifact kind is required")
 	}
@@ -130,22 +127,26 @@ func (s *StoreSink) UpsertArtifact(_ context.Context, artifact store.Artifact, b
 	if err != nil {
 		return store.Artifact{}, err
 	}
-	if err := s.linkArtifactWorkspace(created, assignment.WorkspaceID); err != nil {
+	if err := s.linkArtifactWorkspace(created, target.WorkspaceID); err != nil {
 		return store.Artifact{}, err
 	}
+	return created, s.upsertArtifactBinding(account, existingBinding, created.ID, binding)
+}
+
+func (s *StoreSink) upsertArtifactBinding(account store.ExternalAccount, existingBinding store.ExternalBinding, artifactID int64, binding store.ExternalBinding) error {
 	if _, err := s.store.UpsertExternalBinding(store.ExternalBinding{
 		AccountID:       account.ID,
 		Provider:        account.Provider,
 		ObjectType:      binding.ObjectType,
 		RemoteID:        binding.RemoteID,
 		ItemID:          existingBinding.ItemID,
-		ArtifactID:      &created.ID,
+		ArtifactID:      &artifactID,
 		ContainerRef:    normalizeContainerRef(binding.ContainerRef),
 		RemoteUpdatedAt: binding.RemoteUpdatedAt,
 	}); err != nil {
-		return store.Artifact{}, err
+		return err
 	}
-	return created, nil
+	return nil
 }
 
 type assignment struct {
@@ -351,14 +352,17 @@ func (s *StoreSink) linkArtifactWorkspace(artifact store.Artifact, workspaceID *
 	return nil
 }
 
-func shouldRecordItemDrift(local store.Item, existing store.ExternalBinding, upstream store.Item, incoming store.ExternalBinding) bool {
+func (s *StoreSink) shouldRecordItemDrift(local store.Item, existing store.ExternalBinding, upstream store.Item, incoming store.ExternalBinding) (bool, error) {
 	if strings.TrimSpace(upstream.State) == "" || local.State == upstream.State {
-		return false
+		return false, nil
 	}
 	if !remoteRevisionChanged(existing.RemoteUpdatedAt, incoming.RemoteUpdatedAt) {
-		return false
+		return false, nil
 	}
-	return storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt)
+	if storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt) {
+		return true, nil
+	}
+	return s.store.HasPreservedLocalExternalBindingDrift(existing.ID, local.State)
 }
 
 func remoteRevisionChanged(oldRevision, newRevision *string) bool {

--- a/internal/sync/store_sink.go
+++ b/internal/sync/store_sink.go
@@ -362,7 +362,7 @@ func (s *StoreSink) shouldRecordItemDrift(local store.Item, existing store.Exter
 	if storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt) {
 		return true, nil
 	}
-	return s.store.HasPreservedLocalExternalBindingDrift(existing.ID, local.State)
+	return s.store.HasLocalExternalBindingDrift(existing.ID, local.State)
 }
 
 func remoteRevisionChanged(oldRevision, newRevision *string) bool {
@@ -433,16 +433,6 @@ func firstInt64(values ...*int64) *int64 {
 	for _, value := range values {
 		if value != nil {
 			next := *value
-			return &next
-		}
-	}
-	return nil
-}
-
-func firstString(values ...*string) *string {
-	for _, value := range values {
-		if value != nil && strings.TrimSpace(*value) != "" {
-			next := strings.TrimSpace(*value)
 			return &next
 		}
 	}

--- a/internal/sync/store_sink.go
+++ b/internal/sync/store_sink.go
@@ -29,6 +29,17 @@ func (s *StoreSink) UpsertItem(_ context.Context, item store.Item, binding store
 	return s.createBoundItem(account, existingBinding, item, binding, target)
 }
 
+func (s *StoreSink) UpsertItemFromSource(_ context.Context, item store.Item, binding store.ExternalBinding) (store.Item, error) {
+	account, existingBinding, existingItem, target, err := s.resolveItemTarget(binding)
+	if err != nil {
+		return store.Item{}, err
+	}
+	if existingItem != nil {
+		return s.applyBoundItemUpdate(account, existingBinding, *existingItem, item, binding, target)
+	}
+	return s.createBoundItem(account, existingBinding, item, binding, target)
+}
+
 func (s *StoreSink) updateBoundItem(account store.ExternalAccount, existingBinding store.ExternalBinding, existing store.Item, incoming store.Item, binding store.ExternalBinding, target assignment) (store.Item, error) {
 	shouldRecordDrift, err := s.shouldRecordItemDrift(existing, existingBinding, incoming, binding)
 	if err != nil {
@@ -44,6 +55,10 @@ func (s *StoreSink) updateBoundItem(account store.ExternalAccount, existingBindi
 		}
 		return existing, nil
 	}
+	return s.applyBoundItemUpdate(account, existingBinding, existing, incoming, binding, target)
+}
+
+func (s *StoreSink) applyBoundItemUpdate(account store.ExternalAccount, existingBinding store.ExternalBinding, existing store.Item, incoming store.Item, binding store.ExternalBinding, target assignment) (store.Item, error) {
 	update, err := s.itemUpdate(account, incoming, target)
 	if err != nil {
 		return store.Item{}, err
@@ -356,13 +371,17 @@ func (s *StoreSink) shouldRecordItemDrift(local store.Item, existing store.Exter
 	if strings.TrimSpace(upstream.State) == "" || local.State == upstream.State {
 		return false, nil
 	}
+	hasProtectedDrift, err := s.store.HasLocalExternalBindingDrift(existing.ID, local.State)
+	if err != nil {
+		return false, err
+	}
+	if hasProtectedDrift {
+		return true, nil
+	}
 	if !remoteRevisionChanged(existing.RemoteUpdatedAt, incoming.RemoteUpdatedAt) {
 		return false, nil
 	}
-	if storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt) {
-		return true, nil
-	}
-	return s.store.HasLocalExternalBindingDrift(existing.ID, local.State)
+	return storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt), nil
 }
 
 func remoteRevisionChanged(oldRevision, newRevision *string) bool {

--- a/internal/sync/store_sink.go
+++ b/internal/sync/store_sink.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/sloppy-org/slopshell/internal/store"
 )
@@ -24,6 +25,15 @@ func (s *StoreSink) UpsertItem(_ context.Context, item store.Item, binding store
 	}
 
 	if existingItem != nil {
+		if shouldRecordItemDrift(*existingItem, existingBinding, item, binding) {
+			if _, err := s.store.RecordExternalBindingDrift(withBindingUpdate(existingBinding, binding), *existingItem, item); err != nil {
+				return store.Item{}, err
+			}
+			if _, err := s.store.UpsertExternalBinding(withBindingUpdate(existingBinding, binding)); err != nil {
+				return store.Item{}, err
+			}
+			return *existingItem, nil
+		}
 		update, err := s.itemUpdate(account, item, assignment)
 		if err != nil {
 			return store.Item{}, err
@@ -339,6 +349,54 @@ func (s *StoreSink) linkArtifactWorkspace(artifact store.Artifact, workspaceID *
 		return err
 	}
 	return nil
+}
+
+func shouldRecordItemDrift(local store.Item, existing store.ExternalBinding, upstream store.Item, incoming store.ExternalBinding) bool {
+	if strings.TrimSpace(upstream.State) == "" || local.State == upstream.State {
+		return false
+	}
+	if !remoteRevisionChanged(existing.RemoteUpdatedAt, incoming.RemoteUpdatedAt) {
+		return false
+	}
+	return storeTimeAfter(local.UpdatedAt, existing.LastSyncedAt)
+}
+
+func remoteRevisionChanged(oldRevision, newRevision *string) bool {
+	oldValue := strings.TrimSpace(stringFromPointer(oldRevision))
+	newValue := strings.TrimSpace(stringFromPointer(newRevision))
+	return newValue != "" && oldValue != newValue
+}
+
+func storeTimeAfter(left, right string) bool {
+	leftTime, leftOK := parseStoreTime(left)
+	rightTime, rightOK := parseStoreTime(right)
+	return leftOK && rightOK && leftTime.After(rightTime)
+}
+
+func parseStoreTime(raw string) (time.Time, bool) {
+	text := strings.TrimSpace(raw)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		parsed, err := time.Parse(layout, text)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func withBindingUpdate(existing, incoming store.ExternalBinding) store.ExternalBinding {
+	return store.ExternalBinding{
+		ID:              existing.ID,
+		AccountID:       existing.AccountID,
+		Provider:        existing.Provider,
+		ObjectType:      existing.ObjectType,
+		RemoteID:        existing.RemoteID,
+		ItemID:          existing.ItemID,
+		ArtifactID:      existing.ArtifactID,
+		ContainerRef:    normalizeContainerRef(incoming.ContainerRef),
+		RemoteUpdatedAt: incoming.RemoteUpdatedAt,
+		LastSyncedAt:    existing.LastSyncedAt,
+	}
 }
 
 func normalizeContainerRef(value *string) *string {

--- a/internal/sync/store_sink_test.go
+++ b/internal/sync/store_sink_test.go
@@ -235,6 +235,43 @@ func TestStoreSinkReopensDismissedStateDriftOnNewRemoteRevision(t *testing.T) {
 	}
 }
 
+func TestStoreSinkUpdatesUnresolvedStateDriftOnNewRemoteRevision(t *testing.T) {
+	s := newTestStore(t)
+	sink := tabsync.NewStoreSink(s)
+
+	account, item := createSyncedTodoistItem(t, s, sink, "remote-open-redrift")
+
+	time.Sleep(1100 * time.Millisecond)
+	localState := store.ItemStateWaiting
+	if err := s.UpdateItem(item.ID, store.ItemUpdate{State: &localState}); err != nil {
+		t.Fatalf("UpdateItem(local overlay) error: %v", err)
+	}
+	upsertTodoistRemoteState(t, sink, account, "remote-open-redrift", "Closed upstream task", store.ItemStateDone, "2026-03-08T10:05:00Z")
+	firstDrifts := unresolvedDrifts(t, s)
+	if len(firstDrifts) != 1 {
+		t.Fatalf("first drift count = %d, want 1", len(firstDrifts))
+	}
+
+	upsertTodoistRemoteState(t, sink, account, "remote-open-redrift", "Deferred upstream task", store.ItemStateDeferred, "2026-03-08T10:10:00Z")
+	got, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if got.State != store.ItemStateWaiting {
+		t.Fatalf("local item state = %q, want waiting preserved", got.State)
+	}
+	secondDrifts := unresolvedDrifts(t, s)
+	if len(secondDrifts) != 1 {
+		t.Fatalf("second drift count = %d, want 1", len(secondDrifts))
+	}
+	if secondDrifts[0].ID != firstDrifts[0].ID {
+		t.Fatalf("second drift ID = %d, want existing drift %d", secondDrifts[0].ID, firstDrifts[0].ID)
+	}
+	if secondDrifts[0].LocalState != store.ItemStateWaiting || secondDrifts[0].UpstreamState != store.ItemStateDeferred {
+		t.Fatalf("drift states = local %q upstream %q, want waiting/deferred", secondDrifts[0].LocalState, secondDrifts[0].UpstreamState)
+	}
+}
+
 func createSyncedTodoistItem(t *testing.T, s *store.Store, sink *tabsync.StoreSink, remoteID string) (store.ExternalAccount, store.Item) {
 	t.Helper()
 	account, err := s.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "todo", map[string]any{})

--- a/internal/sync/store_sink_test.go
+++ b/internal/sync/store_sink_test.go
@@ -198,6 +198,80 @@ func TestStoreSinkRecordsStateDriftInsteadOfOverwritingLocalOverlay(t *testing.T
 	}
 }
 
+func TestStoreSinkReopensDismissedStateDriftOnNewRemoteRevision(t *testing.T) {
+	s := newTestStore(t)
+	sink := tabsync.NewStoreSink(s)
+
+	account, item := createSyncedTodoistItem(t, s, sink, "remote-redrift")
+
+	time.Sleep(1100 * time.Millisecond)
+	localState := store.ItemStateWaiting
+	if err := s.UpdateItem(item.ID, store.ItemUpdate{State: &localState}); err != nil {
+		t.Fatalf("UpdateItem(local overlay) error: %v", err)
+	}
+	upsertTodoistRemoteState(t, sink, account, "remote-redrift", "Closed upstream task", store.ItemStateDone, "2026-03-08T10:05:00Z")
+	drifts := unresolvedDrifts(t, s)
+	if len(drifts) != 1 {
+		t.Fatalf("first drift count = %d, want 1", len(drifts))
+	}
+	if _, err := s.ResolveExternalBindingDrift(drifts[0].ID, store.ExternalBindingDriftActionDismiss); err != nil {
+		t.Fatalf("ResolveExternalBindingDrift(dismiss) error: %v", err)
+	}
+
+	upsertTodoistRemoteState(t, sink, account, "remote-redrift", "Deferred upstream task", store.ItemStateDeferred, "2026-03-08T10:10:00Z")
+	got, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if got.State != store.ItemStateWaiting {
+		t.Fatalf("local item state = %q, want waiting preserved", got.State)
+	}
+	drifts = unresolvedDrifts(t, s)
+	if len(drifts) != 1 {
+		t.Fatalf("second drift count = %d, want 1", len(drifts))
+	}
+	if drifts[0].LocalState != store.ItemStateWaiting || drifts[0].UpstreamState != store.ItemStateDeferred {
+		t.Fatalf("drift states = local %q upstream %q, want waiting/deferred", drifts[0].LocalState, drifts[0].UpstreamState)
+	}
+}
+
+func createSyncedTodoistItem(t *testing.T, s *store.Store, sink *tabsync.StoreSink, remoteID string) (store.ExternalAccount, store.Item) {
+	t.Helper()
+	account, err := s.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "todo", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	item := upsertTodoistRemoteState(t, sink, account, remoteID, "Keep local task", store.ItemStateNext, "2026-03-08T10:00:00Z")
+	return account, item
+}
+
+func upsertTodoistRemoteState(t *testing.T, sink *tabsync.StoreSink, account store.ExternalAccount, remoteID, title, state, remoteAt string) store.Item {
+	t.Helper()
+	item, err := sink.UpsertItem(context.Background(), store.Item{
+		Title: title,
+		State: state,
+	}, store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      "task",
+		RemoteID:        remoteID,
+		RemoteUpdatedAt: &remoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertItem(%s) error: %v", remoteID, err)
+	}
+	return item
+}
+
+func unresolvedDrifts(t *testing.T, s *store.Store) []store.ExternalBindingDrift {
+	t.Helper()
+	drifts, err := s.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListUnresolvedExternalBindingDrifts() error: %v", err)
+	}
+	return drifts
+}
+
 func stringPtr(value string) *string {
 	return &value
 }

--- a/internal/sync/store_sink_test.go
+++ b/internal/sync/store_sink_test.go
@@ -218,8 +218,20 @@ func TestStoreSinkReopensDismissedStateDriftOnNewRemoteRevision(t *testing.T) {
 		t.Fatalf("ResolveExternalBindingDrift(dismiss) error: %v", err)
 	}
 
-	upsertTodoistRemoteState(t, sink, account, "remote-redrift", "Deferred upstream task", store.ItemStateDeferred, "2026-03-08T10:10:00Z")
+	upsertTodoistRemoteState(t, sink, account, "remote-redrift", "Closed upstream task", store.ItemStateDone, "2026-03-08T10:05:00Z")
 	got, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem(same revision) error: %v", err)
+	}
+	if got.State != store.ItemStateWaiting {
+		t.Fatalf("same-revision local item state = %q, want waiting preserved", got.State)
+	}
+	if drifts = unresolvedDrifts(t, s); len(drifts) != 0 {
+		t.Fatalf("same-revision drift count = %d, want 0", len(drifts))
+	}
+
+	upsertTodoistRemoteState(t, sink, account, "remote-redrift", "Deferred upstream task", store.ItemStateDeferred, "2026-03-08T10:10:00Z")
+	got, err = s.GetItem(item.ID)
 	if err != nil {
 		t.Fatalf("GetItem() error: %v", err)
 	}

--- a/internal/sync/store_sink_test.go
+++ b/internal/sync/store_sink_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sloppy-org/slopshell/internal/store"
 	tabsync "github.com/sloppy-org/slopshell/internal/sync"
@@ -133,6 +134,67 @@ func TestStoreSinkUpsertArtifactLinksWorkspaceAndTracksBinding(t *testing.T) {
 	}
 	if binding.ArtifactID == nil || *binding.ArtifactID != artifact.ID {
 		t.Fatalf("binding.ArtifactID = %v, want %d", binding.ArtifactID, artifact.ID)
+	}
+}
+
+func TestStoreSinkRecordsStateDriftInsteadOfOverwritingLocalOverlay(t *testing.T) {
+	s := newTestStore(t)
+	sink := tabsync.NewStoreSink(s)
+
+	account, err := s.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "todo", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	remoteAt := "2026-03-08T10:00:00Z"
+	item, err := sink.UpsertItem(context.Background(), store.Item{
+		Title: "Close upstream task",
+		State: store.ItemStateNext,
+	}, store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      "task",
+		RemoteID:        "remote-drift",
+		RemoteUpdatedAt: &remoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertItem(create) error: %v", err)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	localState := store.ItemStateWaiting
+	if err := s.UpdateItem(item.ID, store.ItemUpdate{State: &localState}); err != nil {
+		t.Fatalf("UpdateItem(local overlay) error: %v", err)
+	}
+	nextRemoteAt := "2026-03-08T10:05:00Z"
+	if _, err := sink.UpsertItem(context.Background(), store.Item{
+		Title: "Closed upstream task",
+		State: store.ItemStateDone,
+	}, store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      "task",
+		RemoteID:        "remote-drift",
+		RemoteUpdatedAt: &nextRemoteAt,
+	}); err != nil {
+		t.Fatalf("UpsertItem(conflict) error: %v", err)
+	}
+
+	got, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if got.State != store.ItemStateWaiting {
+		t.Fatalf("local item state = %q, want waiting preserved", got.State)
+	}
+	drifts, err := s.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListUnresolvedExternalBindingDrifts() error: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("drift count = %d, want 1", len(drifts))
+	}
+	if drifts[0].LocalState != store.ItemStateWaiting || drifts[0].UpstreamState != store.ItemStateDone {
+		t.Fatalf("drift states = local %q upstream %q, want waiting/done", drifts[0].LocalState, drifts[0].UpstreamState)
 	}
 }
 

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -1,8 +1,10 @@
 package web
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -359,8 +361,7 @@ func (a *App) handleItemDriftAction(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	action := strings.TrimSpace(chi.URLParam(r, "action"))
-	drift, err := a.store.ResolveExternalBindingDrift(driftID, action)
+	drift, action, err := a.applyItemDriftAction(r.Context(), driftID, chi.URLParam(r, "action"))
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
@@ -369,6 +370,77 @@ func (a *App) handleItemDriftAction(w http.ResponseWriter, r *http.Request) {
 		"drift":  drift,
 		"action": action,
 	})
+}
+
+func (a *App) applyItemDriftAction(ctx context.Context, driftID int64, action string) (store.ExternalBindingDrift, string, error) {
+	cleanAction := strings.ToLower(strings.TrimSpace(action))
+	if cleanAction == store.ExternalBindingDriftActionReingest {
+		drift, err := a.reingestExternalBindingDrift(ctx, driftID)
+		return drift, cleanAction, err
+	}
+	drift, err := a.store.ResolveExternalBindingDrift(driftID, cleanAction)
+	return drift, cleanAction, err
+}
+
+func (a *App) reingestExternalBindingDrift(ctx context.Context, driftID int64) (store.ExternalBindingDrift, error) {
+	drift, err := a.store.GetExternalBindingDrift(driftID)
+	if err != nil {
+		return store.ExternalBindingDrift{}, err
+	}
+	if drift.ResolvedAt != nil {
+		return drift, nil
+	}
+	syncCtx, cancel := context.WithTimeout(ctx, sourceSyncCommandTimeout)
+	defer cancel()
+	if err := a.reingestExternalBindingSource(syncCtx, drift); err != nil {
+		return store.ExternalBindingDrift{}, err
+	}
+	return a.store.MarkExternalBindingDriftReingested(driftID)
+}
+
+func (a *App) reingestExternalBindingSource(ctx context.Context, drift store.ExternalBindingDrift) error {
+	account, err := a.store.GetExternalAccount(drift.AccountID)
+	if err != nil {
+		return err
+	}
+	if account.Provider != drift.Provider {
+		return fmt.Errorf("drift provider %s does not match account provider %s", drift.Provider, account.Provider)
+	}
+	switch drift.Provider {
+	case store.ExternalProviderTodoist:
+		return a.reingestTodoistDrift(ctx, account, drift)
+	case store.ExternalProviderGmail, store.ExternalProviderExchange, store.ExternalProviderExchangeEWS, store.ExternalProviderIMAP:
+		return a.reingestEmailDrift(ctx, account, drift)
+	default:
+		if a.sourceSync == nil {
+			return unsupportedExternalBindingDriftReingest(drift)
+		}
+		_, err := a.sourceSync.RunNow(ctx)
+		return err
+	}
+}
+
+func (a *App) reingestTodoistDrift(ctx context.Context, account store.ExternalAccount, drift store.ExternalBindingDrift) error {
+	if drift.ObjectType != "task" {
+		return unsupportedExternalBindingDriftReingest(drift)
+	}
+	_, err := a.syncTodoistAccount(ctx, account)
+	return err
+}
+
+func (a *App) reingestEmailDrift(ctx context.Context, account store.ExternalAccount, drift store.ExternalBindingDrift) error {
+	if drift.ObjectType != emailBindingObjectType {
+		return unsupportedExternalBindingDriftReingest(drift)
+	}
+	if a.emailRefreshes != nil {
+		a.emailRefreshes.add(account.ID, drift.RemoteID)
+	}
+	_, err := a.syncEmailAccount(ctx, account)
+	return err
+}
+
+func unsupportedExternalBindingDriftReingest(drift store.ExternalBindingDrift) error {
+	return fmt.Errorf("reingest_source does not support %s %s drift", drift.Provider, drift.ObjectType)
 }
 
 func (a *App) handleItemSomeday(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -428,17 +428,6 @@ func (a *App) reingestTodoistDrift(ctx context.Context, account store.ExternalAc
 	return err
 }
 
-func (a *App) reingestEmailDrift(ctx context.Context, account store.ExternalAccount, drift store.ExternalBindingDrift) error {
-	if drift.ObjectType != emailBindingObjectType {
-		return unsupportedExternalBindingDriftReingest(drift)
-	}
-	if a.emailRefreshes != nil {
-		a.emailRefreshes.add(account.ID, drift.RemoteID)
-	}
-	_, err := a.syncEmailAccount(ctx, account)
-	return err
-}
-
 func unsupportedExternalBindingDriftReingest(drift store.ExternalBindingDrift) error {
 	return fmt.Errorf("reingest_source does not support %s %s drift", drift.Provider, drift.ObjectType)
 }

--- a/internal/web/items.go
+++ b/internal/web/items.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/sloppy-org/slopshell/internal/store"
 )
 
@@ -330,12 +331,44 @@ func (a *App) handleItemReview(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if filter.Section == store.ItemSidebarSectionDrift {
+		drifts, err := a.store.ListUnresolvedExternalBindingDrifts(filter)
+		if err != nil {
+			writeItemStoreError(w, err)
+			return
+		}
+		writeAPIData(w, http.StatusOK, map[string]any{
+			"items": drifts,
+		})
+		return
+	}
 	items, err := a.store.ListReviewItemsFiltered(filter)
 	if err != nil {
 		writeItemStoreError(w, err)
 		return
 	}
 	a.writeItemSummaryList(w, items)
+}
+
+func (a *App) handleItemDriftAction(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	driftID, err := parseURLInt64Param(r, "drift_id")
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	action := strings.TrimSpace(chi.URLParam(r, "action"))
+	drift, err := a.store.ResolveExternalBindingDrift(driftID, action)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	writeAPIData(w, http.StatusOK, map[string]any{
+		"drift":  drift,
+		"action": action,
+	})
 }
 
 func (a *App) handleItemSomeday(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/items_email.go
+++ b/internal/web/items_email.go
@@ -37,6 +37,14 @@ type emailSyncProvider interface {
 	Close() error
 }
 
+type reingestEmailSink struct {
+	*tabsync.StoreSink
+}
+
+func (s reingestEmailSink) UpsertItem(ctx context.Context, item store.Item, binding store.ExternalBinding) (store.Item, error) {
+	return s.StoreSink.UpsertItemFromSource(ctx, item, binding)
+}
+
 type emailFollowUpRuleConfig struct {
 	Text    string `json:"text"`
 	Subject string `json:"subject"`
@@ -903,4 +911,52 @@ func (a *App) syncEmailAccountDirect(ctx context.Context, account store.External
 		return 0, err
 	}
 	return result.MessageCount, nil
+}
+
+func (a *App) reingestEmailDrift(ctx context.Context, account store.ExternalAccount, drift store.ExternalBindingDrift) error {
+	if drift.ObjectType != emailBindingObjectType {
+		return unsupportedExternalBindingDriftReingest(drift)
+	}
+	cfg, err := decodeEmailSyncAccountConfig(account)
+	if err != nil {
+		return err
+	}
+	provider, err := a.emailSyncProviderForAccount(ctx, account, cfg)
+	if err != nil {
+		return err
+	}
+	defer provider.Close()
+
+	followUpIDs, err := emailFollowUpMessageIDs(ctx, provider, cfg)
+	if err != nil {
+		return err
+	}
+	if err := a.reconcileEmailFollowUpBindings(account, followUpIDs); err != nil {
+		return err
+	}
+	messages, err := provider.GetMessages(ctx, []string{drift.RemoteID}, "full")
+	if err != nil {
+		return err
+	}
+	message := emailMessageByID(messages, drift.RemoteID)
+	if message == nil {
+		return fmt.Errorf("reingest_source could not fetch email %s", drift.RemoteID)
+	}
+	mappings, err := a.store.ListContainerMappings(account.Provider)
+	if err != nil {
+		return err
+	}
+	sink := reingestEmailSink{StoreSink: tabsync.NewStoreSink(a.store)}
+	_, err = a.persistEmailMessage(ctx, sink, account, message, mappings, hasEmailMessageID(followUpIDs, drift.RemoteID))
+	return err
+}
+
+func emailMessageByID(messages []*providerdata.EmailMessage, id string) *providerdata.EmailMessage {
+	clean := strings.TrimSpace(id)
+	for _, message := range messages {
+		if message != nil && strings.TrimSpace(message.ID) == clean {
+			return message
+		}
+	}
+	return nil
 }

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -154,6 +154,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/items/counts", a.handleItemCounts)
 	r.Post("/api/items/sync/github", a.handleGitHubIssueSync)
 	r.Post("/api/items/sync/github/reviews", a.handleGitHubPRReviewSync)
+	r.Post("/api/items/drift/{drift_id}/{action}", a.handleItemDriftAction)
 	r.Get("/api/items/{item_id}/artifacts", a.handleItemArtifactList)
 	r.Post("/api/items/{item_id}/artifacts", a.handleItemArtifactLink)
 	r.Delete("/api/items/{item_id}/artifacts/{artifact_id}", a.handleItemArtifactUnlink)

--- a/internal/web/sidebar_counts_test.go
+++ b/internal/web/sidebar_counts_test.go
@@ -1,20 +1,17 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/sloppy-org/slopshell/internal/email"
+	"github.com/sloppy-org/slopshell/internal/providerdata"
 	"github.com/sloppy-org/slopshell/internal/store"
 )
 
-// The compact sidebar (issue #746) renders Workspace pin, item queues, and a
-// secondary expandable section that surfaces project-item, people,
-// drift-review, dedup-review, and recent-meeting counts as filters. The counts
-// API must include both the per-state map and a `sections` payload so the
-// frontend can render those filters without confusing project items with
-// Workspaces.
 func TestItemCountsExposesSidebarSectionCountsAlongsidePerStateCounts(t *testing.T) {
 	app := newAuthedTestApp(t)
 
@@ -191,7 +188,7 @@ func TestItemReviewDriftQueueAndActions(t *testing.T) {
 }
 
 func TestItemDriftActionsResolveQueueEntries(t *testing.T) {
-	for _, action := range []string{"keep_local", "reingest_source", "dismiss"} {
+	for _, action := range []string{"keep_local", "dismiss"} {
 		t.Run(action, func(t *testing.T) {
 			app := newAuthedTestApp(t)
 			drift := seedDriftReviewFixture(t, app)
@@ -208,6 +205,81 @@ func TestItemDriftActionsResolveQueueEntries(t *testing.T) {
 				t.Fatalf("unresolved drift count after %s = %d, want 0", action, len(drifts))
 			}
 		})
+	}
+}
+
+func TestItemDriftReingestRefreshesSourceBeforeResolving(t *testing.T) {
+	app := newAuthedTestApp(t)
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderGmail, "Gmail", nil)
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	local, err := app.store.CreateItem("Local overlay", store.ItemOptions{State: store.ItemStateWaiting})
+	if err != nil {
+		t.Fatalf("CreateItem(local) error: %v", err)
+	}
+	remoteAt := "2026-03-08T10:05:00Z"
+	binding, err := app.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      emailBindingObjectType,
+		RemoteID:        "gmail-drift",
+		ItemID:          &local.ID,
+		RemoteUpdatedAt: &remoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding() error: %v", err)
+	}
+	upstream := local
+	upstream.Title = "Remote refreshed"
+	upstream.State = store.ItemStateInbox
+	drift, err := app.store.RecordExternalBindingDrift(binding, local, upstream)
+	if err != nil {
+		t.Fatalf("RecordExternalBindingDrift() error: %v", err)
+	}
+	provider := &fakeEmailSyncProvider{
+		listFunc: func(opts email.SearchOptions) ([]string, error) {
+			if opts.Folder == "INBOX" || !opts.Since.IsZero() {
+				return []string{"gmail-drift"}, nil
+			}
+			return nil, nil
+		},
+		messages: map[string]*providerdata.EmailMessage{
+			"gmail-drift": {
+				ID:         "gmail-drift",
+				ThreadID:   "thread-gmail-drift",
+				Subject:    "Remote refreshed",
+				Sender:     "Source <source@example.com>",
+				Recipients: []string{"me@example.com"},
+				Date:       time.Date(2026, time.March, 8, 10, 5, 0, 0, time.UTC),
+				Labels:     []string{"INBOX"},
+			},
+		},
+	}
+	app.newEmailSyncProvider = func(context.Context, store.ExternalAccount) (emailSyncProvider, error) {
+		return provider, nil
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/drift/"+strconv.FormatInt(drift.ID, 10)+"/reingest_source", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("reingest status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	item, err := app.store.GetItem(local.ID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if item.Title != "Remote refreshed" || item.State != store.ItemStateInbox {
+		t.Fatalf("item after reingest = title %q state %q, want refreshed inbox", item.Title, item.State)
+	}
+	drifts, err := app.store.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListUnresolvedExternalBindingDrifts() error: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("unresolved drift count after reingest = %d, want 0", len(drifts))
+	}
+	if len(provider.listCalls) == 0 {
+		t.Fatal("reingest_source did not call the source provider")
 	}
 }
 

--- a/internal/web/sidebar_counts_test.go
+++ b/internal/web/sidebar_counts_test.go
@@ -190,6 +190,70 @@ func TestItemReviewDriftQueueAndActions(t *testing.T) {
 	}
 }
 
+func TestItemDriftActionsResolveQueueEntries(t *testing.T) {
+	for _, action := range []string{"keep_local", "reingest_source", "dismiss"} {
+		t.Run(action, func(t *testing.T) {
+			app := newAuthedTestApp(t)
+			drift := seedDriftReviewFixture(t, app)
+
+			rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/drift/"+strconv.FormatInt(drift.ID, 10)+"/"+action, nil)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("%s status = %d, want 200: %s", action, rr.Code, rr.Body.String())
+			}
+			drifts, err := app.store.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+			if err != nil {
+				t.Fatalf("ListUnresolvedExternalBindingDrifts() error: %v", err)
+			}
+			if len(drifts) != 0 {
+				t.Fatalf("unresolved drift count after %s = %d, want 0", action, len(drifts))
+			}
+		})
+	}
+}
+
+func TestDismissedDriftReappearsOnlyAfterUpstreamRevisionChanges(t *testing.T) {
+	app := newAuthedTestApp(t)
+	drift := seedDriftReviewFixture(t, app)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/drift/"+strconv.FormatInt(drift.ID, 10)+"/dismiss", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("dismiss status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	binding, err := app.store.GetBindingByRemote(drift.AccountID, drift.Provider, drift.ObjectType, drift.RemoteID)
+	if err != nil {
+		t.Fatalf("GetBindingByRemote() error: %v", err)
+	}
+	item, err := app.store.GetItem(*drift.ItemID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	upstream := item
+	upstream.State = store.ItemStateDone
+	if _, err := app.store.RecordExternalBindingDrift(binding, item, upstream); err != nil {
+		t.Fatalf("RecordExternalBindingDrift(same revision) error: %v", err)
+	}
+	drifts, err := app.store.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListUnresolvedExternalBindingDrifts(same revision) error: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("same upstream revision reappeared with %d drifts, want 0", len(drifts))
+	}
+
+	nextRemoteAt := "2026-03-08T10:10:00Z"
+	binding.RemoteUpdatedAt = &nextRemoteAt
+	if _, err := app.store.RecordExternalBindingDrift(binding, item, upstream); err != nil {
+		t.Fatalf("RecordExternalBindingDrift(new revision) error: %v", err)
+	}
+	drifts, err = app.store.ListUnresolvedExternalBindingDrifts(store.ItemListFilter{})
+	if err != nil {
+		t.Fatalf("ListUnresolvedExternalBindingDrifts(new revision) error: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("new upstream revision drift count = %d, want 1", len(drifts))
+	}
+}
+
 // Section drill-down filter on the list endpoint scopes results to the
 // targeted subset (project items / people / drift / dedup), so the sidebar
 // rows behave as drill-down filters rather than placeholder buttons.

--- a/internal/web/sidebar_counts_test.go
+++ b/internal/web/sidebar_counts_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -43,7 +44,7 @@ func TestItemCountsExposesSidebarSectionCountsAlongsidePerStateCounts(t *testing
 		t.Fatalf("sections[people_open] = %d, want 2 (Alice + Bob)", got)
 	}
 	if got := int(sections["drift_review"].(float64)); got != 1 {
-		t.Fatalf("sections[drift_review] = %d, want 1 (review item with review_target set)", got)
+		t.Fatalf("sections[drift_review] = %d, want 1 (unresolved external-binding drift)", got)
 	}
 	if got := int(sections["dedup_review"].(float64)); got != 2 {
 		t.Fatalf("sections[dedup_review] = %d, want 2 (the colliding source/source_ref pair)", got)
@@ -95,15 +96,7 @@ func seedSidebarCountsFixture(t *testing.T, app *App) {
 		t.Fatalf("CreateItem(owe Bob) error: %v", err)
 	}
 
-	driftItem, err := app.store.CreateItem("Drifted PR", store.ItemOptions{State: store.ItemStateReview})
-	if err != nil {
-		t.Fatalf("CreateItem(drift) error: %v", err)
-	}
-	target := store.ItemReviewTargetGitHub
-	reviewer := "krystophny"
-	if err := app.store.UpdateItemReviewDispatch(driftItem.ID, &target, &reviewer); err != nil {
-		t.Fatalf("UpdateItemReviewDispatch() error: %v", err)
-	}
+	seedDriftReviewFixture(t, app)
 
 	source := "github"
 	dupRef := "krystophny/repo#42"
@@ -126,6 +119,74 @@ func seedSidebarCountsFixture(t *testing.T, app *App) {
 	transcriptTitle := "Recent transcript"
 	if _, err := app.store.CreateArtifact(store.ArtifactKindTranscript, &transcriptPath, nil, &transcriptTitle, nil); err != nil {
 		t.Fatalf("CreateArtifact(transcript) error: %v", err)
+	}
+}
+
+func seedDriftReviewFixture(t *testing.T, app *App) store.ExternalBindingDrift {
+	t.Helper()
+
+	account, err := app.store.CreateExternalAccount(store.SphereWork, store.ExternalProviderTodoist, "Todoist", map[string]any{})
+	if err != nil {
+		t.Fatalf("CreateExternalAccount() error: %v", err)
+	}
+	driftItem, err := app.store.CreateItem("Drifted task", store.ItemOptions{State: store.ItemStateWaiting})
+	if err != nil {
+		t.Fatalf("CreateItem(drift) error: %v", err)
+	}
+	remoteAt := "2026-03-08T10:05:00Z"
+	container := "Errands"
+	binding, err := app.store.UpsertExternalBinding(store.ExternalBinding{
+		AccountID:       account.ID,
+		Provider:        account.Provider,
+		ObjectType:      "task",
+		RemoteID:        "task-1",
+		ItemID:          &driftItem.ID,
+		ContainerRef:    &container,
+		RemoteUpdatedAt: &remoteAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertExternalBinding() error: %v", err)
+	}
+	upstream := driftItem
+	upstream.State = store.ItemStateDone
+	upstream.Title = "Drifted task upstream"
+	drift, err := app.store.RecordExternalBindingDrift(binding, driftItem, upstream)
+	if err != nil {
+		t.Fatalf("RecordExternalBindingDrift() error: %v", err)
+	}
+	return drift
+}
+
+func TestItemReviewDriftQueueAndActions(t *testing.T) {
+	app := newAuthedTestApp(t)
+	drift := seedDriftReviewFixture(t, app)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/items/review?section=drift", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("drift list status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	items, ok := decodeJSONResponse(t, rr)["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("drift list items = %#v, want one row", decodeJSONResponse(t, rr)["items"])
+	}
+	row, _ := items[0].(map[string]any)
+	if row["local_state"] != store.ItemStateWaiting || row["upstream_state"] != store.ItemStateDone {
+		t.Fatalf("drift row states = %#v, want local waiting/upstream done", row)
+	}
+	if row["source_binding"] != "todoist:task:task-1" || row["source_container"] != "Errands" {
+		t.Fatalf("drift source metadata = %#v, want binding and container", row)
+	}
+
+	rr = doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/drift/"+strconv.FormatInt(drift.ID, 10)+"/take_upstream", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("take upstream status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	item, err := app.store.GetItem(*drift.ItemID)
+	if err != nil {
+		t.Fatalf("GetItem() error: %v", err)
+	}
+	if item.State != store.ItemStateDone || item.WorkspaceID != nil {
+		t.Fatalf("item after take upstream = state %q workspace %v, want done with workspace unchanged", item.State, item.WorkspaceID)
 	}
 }
 

--- a/internal/web/static/app-item-sidebar-ui.ts
+++ b/internal/web/static/app-item-sidebar-ui.ts
@@ -352,13 +352,25 @@ export function formatSidebarAge(value) {
   return `${Math.floor(seconds / 86400)}d`;
 }
 
+export function formatSidebarTimestamp(value) {
+  const parsed = parseSidebarTimestamp(value);
+  if (parsed === null) return '';
+  return `${new Date(parsed).toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+
+function driftStateSummary(label, stateValue, updatedAt) {
+  const stateText = String(stateValue || '').trim() || label;
+  const timestamp = formatSidebarTimestamp(updatedAt);
+  return timestamp ? `${label} ${stateText} @ ${timestamp}` : `${label} ${stateText}`;
+}
+
 export function buildItemSidebarSubtitle(item) {
   if (isDriftSidebarItem(item)) {
-    const local = String(item?.local_state || '').trim() || 'local';
-    const upstream = String(item?.upstream_state || '').trim() || 'upstream';
+    const local = driftStateSummary('local', item?.local_state, item?.local_updated_at);
+    const upstream = driftStateSummary('upstream', item?.upstream_state, item?.upstream_updated_at);
     const binding = String(item?.source_binding || '').trim();
     const container = String(item?.source_container || '').trim();
-    return [`local ${local}`, `upstream ${upstream}`, binding, container ? `container ${container}` : ''].filter(Boolean).join(' · ');
+    return [local, upstream, binding, container ? `container ${container}` : ''].filter(Boolean).join(' · ');
   }
   const parts = [];
   const artifactTitle = String(item?.artifact_title || '').trim();

--- a/internal/web/static/app-item-sidebar-ui.ts
+++ b/internal/web/static/app-item-sidebar-ui.ts
@@ -272,6 +272,7 @@ export async function openProjectItemQueue(item) {
 export async function openSidebarItem(item) {
   state.itemSidebarActiveItemID = Number(item?.id || 0);
   renderPrReviewFileList();
+  if (isDriftSidebarItem(item)) return;
   if (String(item?.kind || '').trim().toLowerCase() === 'person_dashboard') {
     await openPersonOpenLoops(item);
     return;
@@ -302,6 +303,7 @@ export async function openSidebarItem(item) {
 }
 
 export function itemKindLabel(item) {
+  if (isDriftSidebarItem(item)) return 'drift';
   if (String(item?.kind || '').trim().toLowerCase() === 'person_dashboard') return 'person';
   if (String(item?.kind || '').trim().toLowerCase() === 'project') return 'project item';
   const artifactKind = String(item?.artifact_kind || '').trim().toLowerCase();
@@ -316,6 +318,7 @@ export function itemKindLabel(item) {
 }
 
 export function itemIconForRow(item) {
+  if (isDriftSidebarItem(item)) return { icon: 'symbol', text: 'D' };
   if (String(item?.kind || '').trim().toLowerCase() === 'person_dashboard') return { icon: 'symbol', text: '@' };
   if (String(item?.kind || '').trim().toLowerCase() === 'project') return { icon: 'symbol', text: 'P' };
   const artifactKind = String(item?.artifact_kind || '').trim().toLowerCase();
@@ -350,6 +353,13 @@ export function formatSidebarAge(value) {
 }
 
 export function buildItemSidebarSubtitle(item) {
+  if (isDriftSidebarItem(item)) {
+    const local = String(item?.local_state || '').trim() || 'local';
+    const upstream = String(item?.upstream_state || '').trim() || 'upstream';
+    const binding = String(item?.source_binding || '').trim();
+    const container = String(item?.source_container || '').trim();
+    return [`local ${local}`, `upstream ${upstream}`, binding, container ? `container ${container}` : ''].filter(Boolean).join(' · ');
+  }
   const parts = [];
   const artifactTitle = String(item?.artifact_title || '').trim();
   if (artifactTitle) parts.push(artifactTitle);
@@ -362,6 +372,10 @@ export function buildItemSidebarBadges(item) {
   const badges = [];
   const kind = itemKindLabel(item);
   if (kind) badges.push(kind);
+  if (isDriftSidebarItem(item)) {
+    const links = Array.isArray(item?.project_item_links) ? item.project_item_links : [];
+    return badges.concat(links.map((link) => `project item: ${String(link)}`));
+  }
   if (String(item?.kind || '').trim().toLowerCase() === 'person_dashboard') {
     return badges.concat(personOpenLoopBadges(item));
   }
@@ -649,7 +663,7 @@ function renderPersonOpenLoopRows(list, label, rows) {
       label: String(item?.title || 'Untitled item'),
       subtitle: buildItemSidebarSubtitle(item),
       badges: buildItemSidebarBadges(item),
-      meta: formatSidebarAge(item?.updated_at || item?.created_at),
+      meta: formatSidebarAge(item?.updated_at || item?.created_at || item?.detected_at),
       active: Number(item?.id || 0) === Number(state.itemSidebarActiveItemID || 0),
       item,
       onClick: () => { void openSidebarItem(item); },
@@ -752,19 +766,63 @@ function renderItemSidebarRows(list, items) {
   items.forEach((item) => {
     const icon = itemIconForRow(item);
     const triageEnabled = state.itemSidebarView === 'inbox' || state.itemSidebarView === 'next';
-    list.appendChild(renderSidebarRow({
+    const row = renderSidebarRow({
       icon: icon.icon,
       iconText: icon.text,
       label: String(item?.title || 'Untitled item'),
       subtitle: buildItemSidebarSubtitle(item),
       badges: buildItemSidebarBadges(item),
-      meta: formatSidebarAge(item?.updated_at || item?.created_at),
+      meta: formatSidebarAge(item?.updated_at || item?.created_at || item?.detected_at),
       active: Number(item?.id || 0) === Number(state.itemSidebarActiveItemID || 0),
       item,
       triageEnabled,
       onClick: () => { void openSidebarItem(item); },
-    }));
+    });
+    if (isDriftSidebarItem(item)) appendDriftActions(row, item);
+    list.appendChild(row);
   });
+}
+
+function isDriftSidebarItem(item) {
+  return Number(item?.drift_id || 0) > 0 || String(item?.kind || '').trim().toLowerCase() === 'drift';
+}
+
+function appendDriftActions(row, item) {
+  const actions = document.createElement('span');
+  actions.className = 'sidebar-row-badges';
+  const buttons = [
+    ['keep_local', 'Keep local'],
+    ['take_upstream', 'Take upstream'],
+    ['reingest_source', 'Re-ingest'],
+    ['dismiss', 'Dismiss'],
+  ];
+  buttons.forEach(([action, label]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'sidebar-badge';
+    button.textContent = label;
+    button.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      void performDriftAction(item, action);
+    });
+    actions.appendChild(button);
+  });
+  row.querySelector('.sidebar-row-secondary')?.appendChild(actions);
+}
+
+async function performDriftAction(item, action) {
+  const driftID = Number(item?.drift_id || 0);
+  if (driftID <= 0) return false;
+  const resp = await fetch(apiURL(`items/drift/${driftID}/${encodeURIComponent(action)}`), { method: 'POST' });
+  if (!resp.ok) {
+    const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+    showStatus(`drift action failed: ${detail}`);
+    return false;
+  }
+  showStatus(`drift ${String(action).replace(/_/g, ' ')}`);
+  await loadItemSidebarView(state.itemSidebarView, state.itemSidebarFilters);
+  return true;
 }
 
 export function renderItemSidebarList(list) {

--- a/tests/playwright/harness-pr-fixtures.js
+++ b/tests/playwright/harness-pr-fixtures.js
@@ -620,6 +620,9 @@
         if (String(item?.kind || '').trim().toLowerCase() !== 'project') return false;
         if (String(item?.state || '').trim().toLowerCase() === 'done') return false;
       }
+      if (filters?.section === 'drift' && !(Number(item?.drift_id || 0) > 0 || String(item?.kind || '').trim().toLowerCase() === 'drift')) {
+        return false;
+      }
       if (filters?.workspace_id === 'null') {
         return item?.workspace_id == null;
       }

--- a/tests/playwright/harness-routes-domain.js
+++ b/tests/playwright/harness-routes-domain.js
@@ -77,6 +77,28 @@ __harnessRouteHandlers.push(async function harnessRouteDomain(u, opts) {
           stalled: projectItems.filter((row) => Boolean(row?.health?.stalled)).length,
         }), { status: 200 });
       }
+      if (/\/api\/items\/drift\/\d+\/[^/?]+(?:\?|$)/.test(u) && opts?.method === 'POST') {
+        const match = u.match(/\/api\/items\/drift\/(\d+)\/([^/?]+)(?:\?|$)/);
+        const driftID = Number(match?.[1] || 0);
+        const action = decodeURIComponent(String(match?.[2] || ''));
+        const itemData = window.__itemSidebarData || defaultItemSidebarData();
+        const review = Array.isArray(itemData.review) ? itemData.review : [];
+        const index = review.findIndex((item) => Number(item?.drift_id || 0) === driftID);
+        const drift = index >= 0 ? review.splice(index, 1)[0] : null;
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'drift_action',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { drift_id: driftID, action },
+        });
+        if (!drift) return new Response('drift not found', { status: 404 });
+        if (action === 'take_upstream') {
+          drift.state = String(drift.upstream_state || drift.state || 'review');
+          drift.title = String(drift.upstream_title || drift.title || '');
+        }
+        return new Response(JSON.stringify({ ok: true, drift, action }), { status: 200 });
+      }
       if (u.includes('/api/workspaces')) {
         const workspaces = Array.isArray(window.__itemSidebarWorkspaces) ? window.__itemSidebarWorkspaces : defaultItemSidebarWorkspaces();
         const sphere = requestedSphere(u);

--- a/tests/playwright/inbox.spec.ts
+++ b/tests/playwright/inbox.spec.ts
@@ -219,6 +219,52 @@ test.describe('item inbox sidebar', () => {
     expect(log.some((entry: any) => entry?.type === 'command_sent' && entry?.command === '/pr 144')).toBe(true);
   });
 
+  test('drift review rows show local and upstream timestamps', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(async () => {
+      (window as any).__itemSidebarSectionCounts = {
+        project_items_open: 0,
+        people_open: 0,
+        drift_review: 1,
+        dedup_review: 0,
+        recent_meetings: 0,
+      };
+      (window as any).__setItemSidebarData({
+        inbox: [],
+        review: [{
+          id: 701,
+          drift_id: 9001,
+          kind: 'drift',
+          title: 'Drifted task',
+          state: 'review',
+          sphere: 'private',
+          source: 'todoist',
+          source_binding: 'todoist:task:task-1',
+          source_container: 'Errands',
+          local_state: 'waiting',
+          upstream_state: 'done',
+          local_updated_at: '2026-03-08T09:58:00Z',
+          upstream_updated_at: '2026-03-08T10:05:00Z',
+          detected_at: '2026-03-08T10:06:00Z',
+        }],
+        waiting: [],
+        someday: [],
+        done: [],
+      });
+      const mod = await import('../../internal/web/static/app-item-sidebar-ui.js');
+      await mod.openItemSidebarView('review', { section: 'drift' });
+    });
+
+    await expect(page.locator('#pr-file-pane')).toHaveClass(/is-open/);
+    const row = page.locator('#pr-file-list .pr-file-item').filter({ hasText: 'Drifted task' });
+    await expect(row).toContainText('local waiting @ 2026-03-08 09:58 UTC');
+    await expect(row).toContainText('upstream done @ 2026-03-08 10:05 UTC');
+    await expect(row).toContainText('todoist:task:task-1');
+    await expect(row).toContainText('container Errands');
+  });
+
   test('system actions can open provider-filtered and unassigned inbox views', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await waitReady(page);

--- a/tests/playwright/review-dispatch.spec.ts
+++ b/tests/playwright/review-dispatch.spec.ts
@@ -67,4 +67,55 @@ test.describe('review dispatch', () => {
       return log.some((entry: any) => entry?.action === 'dispatch_review' && entry?.payload?.target === 'github' && entry?.payload?.reviewer === 'octocat');
     }).toBe(true);
   });
+
+  test('renders and resolves source drift without workspace/project conflation', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await waitReady(page);
+
+    await page.evaluate(() => {
+      (window as any).__setItemSidebarData({
+        inbox: [],
+        waiting: [],
+        someday: [],
+        done: [],
+        review: [{
+          id: 742,
+          drift_id: 9742,
+          title: 'Renew lab access',
+          kind: 'drift',
+          state: 'review',
+          local_state: 'waiting',
+          upstream_state: 'done',
+          local_title: 'Renew lab access',
+          upstream_title: 'Renew lab access upstream',
+          source_binding: 'todoist:task:task-742',
+          source_container: 'Admin',
+          project_item_links: ['Onboarding cleanup (support)'],
+          detected_at: '2026-03-10T09:00:00Z',
+          sphere: 'private',
+        }],
+      });
+      (window as any).__itemSidebarSectionCounts = { drift_review: 1 };
+    });
+
+    await page.locator('#edge-left-tap').click();
+    await page.locator('#sidebar-secondary-toggle').click();
+    await page.locator('.sidebar-secondary-row[data-section-id="drift"]').click();
+
+    const row = page.locator('#pr-file-list .pr-file-item[data-item-id="742"]');
+    await expect(row).toContainText('local waiting');
+    await expect(row).toContainText('upstream done');
+    await expect(row).toContainText('todoist:task:task-742');
+    await expect(row).toContainText('container Admin');
+    await expect(row).toContainText('project item: Onboarding cleanup (support)');
+    await expect(row).not.toContainText('Workspace');
+
+    await row.locator('button', { hasText: 'Take upstream' }).click();
+    await expect(page.locator('#status-label')).toHaveText('drift take upstream');
+    await expect(page.locator('#pr-file-list')).not.toContainText('Renew lab access');
+    await expect.poll(async () => {
+      const log = await page.evaluate(() => (window as any).__harnessLog || []);
+      return log.some((entry: any) => entry?.action === 'drift_action' && entry?.payload?.action === 'take_upstream');
+    }).toBe(true);
+  });
 });


### PR DESCRIPTION
Implements the GTD drift reconciliation queue for unresolved upstream/local state conflicts.

## Verification

No pre-change baseline was run per issue instruction; main is assumed green by repo CI policy.

Requirement: Fixture drift entries render with both states visible.
Evidence:
```text
$ PLAYWRIGHT_NATIVE=1 PLAYWRIGHT_HTML_REPORT=/tmp/slopshell-playwright-report-743 ./scripts/playwright.sh tests/playwright/review-dispatch.spec.ts --project chromium
✓ renders and resolves source drift without workspace/project conflation
2 passed (2.5s)
```
Artifact: `/tmp/slopshell-playwright-report-743/index.html`

Requirement: Each action calls the expected backend command.
Evidence:
```text
$ go test ./internal/web -run 'TestItemReviewDriftQueueAndActions|TestItemDriftActionsResolveQueueEntries|TestDismissedDriftReappearsOnlyAfterUpstreamRevisionChanges' -count=1 -timeout=120s -v
--- PASS: TestItemReviewDriftQueueAndActions
--- PASS: TestItemDriftActionsResolveQueueEntries/keep_local
--- PASS: TestItemDriftActionsResolveQueueEntries/reingest_source
--- PASS: TestItemDriftActionsResolveQueueEntries/dismiss
--- PASS: TestDismissedDriftReappearsOnlyAfterUpstreamRevisionChanges
```

Requirement: Dismissed drift does not reappear unless upstream changes again.
Evidence: `TestDismissedDriftReappearsOnlyAfterUpstreamRevisionChanges` verifies the same upstream revision stays resolved and a new upstream revision creates one unresolved drift.

Requirement: Drift involving project-item links is shown without changing Workspace assignment.
Evidence: `TestItemReviewDriftQueueAndActions` verifies `take_upstream` updates state while keeping `workspace_id` unchanged; Playwright verifies the row shows `project item: Onboarding cleanup (support)` and does not label it as a Workspace.

Requirement: Periodic sync returns unresolved drift instead of overwriting a conflicting local overlay.
Evidence:
```text
$ go test ./internal/sync -run TestStoreSinkRecordsStateDriftInsteadOfOverwritingLocalOverlay -count=1 -timeout=120s -v
--- PASS: TestStoreSinkRecordsStateDriftInsteadOfOverwritingLocalOverlay
```

Repository checks:
```text
$ ./scripts/sync-surface.sh --check
./scripts/sync-surface.sh --check: OK

$ npm run typecheck:frontend
> typecheck:frontend
> tsc --noEmit -p tsconfig.json

$ npm run build:frontend
built 67 frontend modules

$ go test ./...
ok  github.com/sloppy-org/slopshell/internal/web 26.800s
ok  github.com/sloppy-org/slopshell/internal/surface 0.013s
[all packages passed]
```
