### PR TITLE
fix: add GTD quick capture from any context (fixes #744)

### DIFF
--- a/cmd/sls/gtd.go
+++ b/cmd/sls/gtd.go
@@ -189,7 +189,7 @@ func handleGtdCommand(args []string, opts cliOptions, stdout, stderr io.Writer) 
 	}
 	queue := findGtdQueue(args[0])
 	if queue == nil {
-		fmt.Fprintf(stderr, "unknown gtd subcommand %q (want inbox|next|waiting|later|someday|review|projects|close|drop|defer|delegate|route|link-project|unlink-project)\n", args[0])
+		fmt.Fprintf(stderr, "unknown gtd subcommand %q (want inbox|next|waiting|later|someday|review|projects|close|drop|defer|delegate|route|link-project|unlink-project|capture)\n", args[0])
 		return 2
 	}
 	filters, err := parseGtdFilters(args[1:])
@@ -229,6 +229,10 @@ func printGtdUsage(out io.Writer) {
 	fmt.Fprintln(out, "  route <item> <workspace|null> assign execution workspace")
 	fmt.Fprintln(out, "  link-project <item> <project-item> [--role next_action|support|blocked_by]")
 	fmt.Fprintln(out, "  unlink-project <item> <project-item>")
+	fmt.Fprintln(out, "  capture <title> [--kind action|project] [--vault work|private] [--workspace ID]")
+	fmt.Fprintln(out, "                  [--actor-id ID] [--label NAME|--label-id ID]")
+	fmt.Fprintln(out, "                  [--project-item-id N [--role next_action|support|blocked_by]]")
+	fmt.Fprintln(out, "                  [--source NAME [--source-ref REF]]")
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "filters:")
 	fmt.Fprintln(out, "  --vault work|private       sphere filter")

--- a/cmd/sls/gtd_capture.go
+++ b/cmd/sls/gtd_capture.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// gtdCaptureFlags is the parsed form of `sls gtd capture <title> [flags]`.
+//
+// Capture deliberately stays terse: title is positional, every other field
+// is an opt-in flag. The endpoint owns validation, so the CLI's job is
+// translation, not policy.
+type gtdCaptureFlags struct {
+	title           string
+	kind            string
+	sphere          string
+	workspaceID     string
+	actorID         string
+	label           string
+	labelID         string
+	projectItemID   string
+	projectRole     string
+	source          string
+	sourceRef       string
+}
+
+type gtdCaptureResponse struct {
+	Item        gtdItem `json:"item"`
+	Label       *struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	} `json:"label"`
+	ProjectItem *struct {
+		ProjectItemID int64  `json:"project_item_id"`
+		Role          string `json:"role"`
+	} `json:"project_item"`
+}
+
+func (c *gtdMutationClient) capture(args []string) (string, error) {
+	flags, err := parseGtdCaptureArgs(args)
+	if err != nil {
+		return "", err
+	}
+	body, err := captureRequestBody(flags)
+	if err != nil {
+		return "", err
+	}
+	var resp gtdCaptureResponse
+	if err := c.request(http.MethodPost, "/api/items/capture", body, &resp); err != nil {
+		return "", err
+	}
+	return formatGtdCaptureResult(resp), nil
+}
+
+func parseGtdCaptureArgs(args []string) (gtdCaptureFlags, error) {
+	flagArgs, titleParts := splitGtdCaptureArgs(args)
+	fs := flag.NewFlagSet("sls gtd capture", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var f gtdCaptureFlags
+	fs.StringVar(&f.kind, "kind", "", "item kind: action (default) or project")
+	fs.StringVar(&f.sphere, "vault", "", "sphere: work or private (defaults to active sphere or workspace sphere)")
+	fs.StringVar(&f.sphere, "sphere", "", "alias for --vault")
+	fs.StringVar(&f.workspaceID, "workspace", "", "Slopshell workspace id")
+	fs.StringVar(&f.actorID, "actor-id", "", "actor id to associate with the capture")
+	fs.StringVar(&f.label, "label", "", "label name (created if missing)")
+	fs.StringVar(&f.labelID, "label-id", "", "label id (alternative to --label)")
+	fs.StringVar(&f.projectItemID, "project-item-id", "", "link the new action under this project item")
+	fs.StringVar(&f.projectItemID, "project-item", "", "alias for --project-item-id")
+	fs.StringVar(&f.projectItemID, "project", "", "alias for --project-item-id")
+	fs.StringVar(&f.projectRole, "role", "", "project link role: next_action (default), support, blocked_by")
+	fs.StringVar(&f.source, "source", "", "source backend (todoist, markdown, github, ...)")
+	fs.StringVar(&f.sourceRef, "source-ref", "", "stable upstream identifier; required for non-todoist sources")
+	if err := fs.Parse(flagArgs); err != nil {
+		return gtdCaptureFlags{}, fmt.Errorf("%w: %v", errGtdUsage, err)
+	}
+	if rest := fs.Args(); len(rest) > 0 {
+		titleParts = append(titleParts, rest...)
+	}
+	f.title = strings.TrimSpace(strings.Join(titleParts, " "))
+	if f.title == "" {
+		return gtdCaptureFlags{}, fmt.Errorf("%w: title is required", errGtdUsage)
+	}
+	return f, nil
+}
+
+// splitGtdCaptureArgs separates flag tokens from title tokens so the user can
+// place the title before, after, or between flags. The flag package alone
+// stops parsing at the first positional, which would force `--flag` after a
+// quoted multi-word title — awkward for a quick-capture CLI.
+func splitGtdCaptureArgs(args []string) ([]string, []string) {
+	flagArgs := make([]string, 0, len(args))
+	title := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			title = append(title, arg)
+			continue
+		}
+		flagArgs = append(flagArgs, arg)
+		if strings.Contains(arg, "=") {
+			continue
+		}
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			flagArgs = append(flagArgs, args[i+1])
+			i++
+		}
+	}
+	return flagArgs, title
+}
+
+func captureRequestBody(f gtdCaptureFlags) (map[string]any, error) {
+	body := map[string]any{"title": f.title}
+	if v := strings.TrimSpace(f.kind); v != "" {
+		body["kind"] = v
+	}
+	if v := strings.TrimSpace(f.sphere); v != "" {
+		body["sphere"] = v
+	}
+	if err := assignPositiveInt64Body(body, "workspace_id", "workspace", f.workspaceID); err != nil {
+		return nil, err
+	}
+	if err := assignPositiveInt64Body(body, "actor_id", "actor-id", f.actorID); err != nil {
+		return nil, err
+	}
+	if err := assignPositiveInt64Body(body, "label_id", "label-id", f.labelID); err != nil {
+		return nil, err
+	}
+	if v := strings.TrimSpace(f.label); v != "" {
+		body["label"] = v
+	}
+	if err := assignPositiveInt64Body(body, "project_item_id", "project-item-id", f.projectItemID); err != nil {
+		return nil, err
+	}
+	if v := strings.TrimSpace(f.projectRole); v != "" {
+		body["project_item_role"] = v
+	}
+	if v := strings.TrimSpace(f.source); v != "" {
+		body["source"] = v
+	}
+	if v := strings.TrimSpace(f.sourceRef); v != "" {
+		body["source_ref"] = v
+	}
+	return body, nil
+}
+
+func assignPositiveInt64Body(body map[string]any, key, flagName, raw string) error {
+	clean := strings.TrimSpace(raw)
+	if clean == "" {
+		return nil
+	}
+	value, err := parsePositiveInt64(clean, flagName)
+	if err != nil {
+		return err
+	}
+	body[key] = value
+	return nil
+}
+
+func formatGtdCaptureResult(resp gtdCaptureResponse) string {
+	parts := []string{
+		fmt.Sprintf("captured #%d", resp.Item.ID),
+		fmt.Sprintf("kind=%s", resp.Item.Kind),
+		fmt.Sprintf("state=%s", resp.Item.State),
+	}
+	if resp.Item.Sphere != "" {
+		parts = append(parts, fmt.Sprintf("sphere=%s", resp.Item.Sphere))
+	}
+	if src := optionalStringPtr(resp.Item.Source); src != "" {
+		parts = append(parts, fmt.Sprintf("source=%s", src))
+	}
+	if resp.Label != nil {
+		parts = append(parts, fmt.Sprintf("label=%s", resp.Label.Name))
+	}
+	if resp.ProjectItem != nil {
+		parts = append(parts, fmt.Sprintf("project_item=%d", resp.ProjectItem.ProjectItemID))
+		if resp.ProjectItem.Role != "" {
+			parts = append(parts, fmt.Sprintf("role=%s", resp.ProjectItem.Role))
+		}
+	}
+	parts = append(parts, fmt.Sprintf("title=%q", resp.Item.Title))
+	return strings.Join(parts, " ")
+}

--- a/cmd/sls/gtd_capture_test.go
+++ b/cmd/sls/gtd_capture_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHandleGtdCaptureSendsTitleAndDefaults(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/items/capture" {
+			t.Fatalf("request = %s %s, want POST /api/items/capture", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"item":{"id":50,"title":"Reply to grant","kind":"action","state":"inbox","sphere":"work"}}`))
+	})
+
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "capture", "Reply to grant")
+	if code != 0 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr)
+	}
+	if got := (*captures)[0].body["title"]; got != "Reply to grant" {
+		t.Fatalf("title body = %#v, want Reply to grant", (*captures)[0].body)
+	}
+	if _, set := (*captures)[0].body["kind"]; set {
+		t.Fatalf("kind should be omitted by default; body = %#v", (*captures)[0].body)
+	}
+	if !strings.Contains(out, "captured #50") || !strings.Contains(out, "kind=action") || !strings.Contains(out, "state=inbox") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestHandleGtdCaptureProjectKindAndProjectLink(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"item":{"id":51,"title":"Schedule kickoff","kind":"action","state":"inbox","sphere":"work"},"project_item":{"project_item_id":12,"role":"next_action"}}`))
+	})
+
+	out, stderr, code := runGtdMutationCommand(t, srv, token, "capture", "Schedule kickoff", "--project-item-id", "12")
+	if code != 0 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr)
+	}
+	body := (*captures)[0].body
+	if body["project_item_id"] != float64(12) {
+		t.Fatalf("project_item_id body = %#v", body)
+	}
+	if !strings.Contains(out, "project_item=12") || !strings.Contains(out, "role=next_action") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestHandleGtdCaptureKindProjectFlag(t *testing.T) {
+	srv, token, captures := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"item":{"id":52,"title":"Ship dialog","kind":"project","state":"inbox","sphere":"work"}}`))
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "capture", "Ship dialog", "--kind", "project")
+	if code != 0 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr)
+	}
+	if (*captures)[0].body["kind"] != "project" {
+		t.Fatalf("kind body = %#v", (*captures)[0].body)
+	}
+}
+
+func TestHandleGtdCaptureRejectsMissingTitle(t *testing.T) {
+	srv, token, _ := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("server should not receive a request")
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "capture")
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage)", code)
+	}
+	if !strings.Contains(stderr, "title is required") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestHandleGtdCaptureRejectsBadFlagValue(t *testing.T) {
+	srv, token, _ := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("server should not receive a request")
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "capture", "Title", "--workspace", "abc")
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); stderr=%s", code, stderr)
+	}
+	if !strings.Contains(stderr, "workspace must be a positive integer") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestHandleGtdCaptureSurfacesValidationError(t *testing.T) {
+	srv, token, _ := newGtdMutationHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"kind must be action or project"}`))
+	})
+
+	_, stderr, code := runGtdMutationCommand(t, srv, token, "capture", "x", "--kind", "epic")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit; stderr=%s", stderr)
+	}
+	if !strings.Contains(stderr, "kind must be action or project") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}

--- a/cmd/sls/gtd_mutation.go
+++ b/cmd/sls/gtd_mutation.go
@@ -31,7 +31,7 @@ type gtdMutationClient struct {
 
 func isGtdMutationName(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "close", "drop", "defer", "delegate", "route", "link-project", "unlink-project":
+	case "close", "drop", "defer", "delegate", "route", "link-project", "unlink-project", "capture":
 		return true
 	default:
 		return false
@@ -94,6 +94,8 @@ func (c *gtdMutationClient) run(args []string) (string, error) {
 		return c.linkProject(args[1:])
 	case "unlink-project":
 		return c.unlinkProject(args[1:])
+	case "capture":
+		return c.capture(args[1:])
 	default:
 		return "", errGtdUsage
 	}

--- a/internal/web/items_capture.go
+++ b/internal/web/items_capture.go
@@ -1,0 +1,273 @@
+package web
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+// itemCaptureRequest is the body for POST /api/items/capture, the always-on
+// quick capture surface used by the web UI and `sls gtd capture`.
+//
+// Capture intentionally diverges from /api/items in three ways: it always
+// lands the new item in the inbox, it accepts kind=project to create a
+// composite outcome rather than an action, and it accepts a single
+// project_item_id to link the captured action under an existing outcome in
+// one round-trip. The active workspace is contextual metadata, not the
+// captured object: capturing a project/outcome creates Item(kind=project),
+// never a workspace.
+type itemCaptureRequest struct {
+	Title           string  `json:"title"`
+	Kind            string  `json:"kind"`
+	Sphere          *string `json:"sphere"`
+	WorkspaceID     *int64  `json:"workspace_id"`
+	ArtifactID      *int64  `json:"artifact_id"`
+	ActorID         *int64  `json:"actor_id"`
+	LabelID         *int64  `json:"label_id"`
+	Label           string  `json:"label"`
+	ProjectItemID   *int64  `json:"project_item_id"`
+	ProjectItemRole string  `json:"project_item_role"`
+	Source          *string `json:"source"`
+	SourceRef       *string `json:"source_ref"`
+}
+
+type itemCaptureProjectLink struct {
+	ProjectItemID int64                `json:"project_item_id"`
+	Role          string               `json:"role"`
+	Links         []store.ItemChildLink `json:"links"`
+}
+
+func (a *App) handleItemCapture(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	var req itemCaptureRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	plan, err := a.planItemCapture(req)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	item, err := a.createCapturedItem(req, plan)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	label, err := a.attachCaptureLabel(item.ID, plan.labelID, plan.labelName)
+	if err != nil {
+		_ = a.store.DeleteItem(item.ID)
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	link, err := a.attachCaptureProjectLink(item.ID, plan.projectItemID, plan.projectItemRole)
+	if err != nil {
+		_ = a.store.DeleteItem(item.ID)
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	final, err := a.store.GetItem(item.ID)
+	if err != nil {
+		writeItemStoreError(w, err)
+		return
+	}
+	payload := map[string]any{"item": final}
+	if label != nil {
+		payload["label"] = label
+	}
+	if link != nil {
+		payload["project_item"] = link
+	}
+	writeAPIData(w, http.StatusCreated, payload)
+}
+
+// captureValidationPlan is the validated, normalized projection of a capture
+// request. The handler runs validation up-front so that we never insert an
+// item we'd have to roll back because of an invalid label or project link.
+type captureValidationPlan struct {
+	kind            string
+	labelID         int64
+	labelName       string
+	projectItemID   int64
+	projectItemRole string
+}
+
+func (a *App) planItemCapture(req itemCaptureRequest) (captureValidationPlan, error) {
+	plan := captureValidationPlan{}
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		return plan, errors.New("title is required")
+	}
+	plan.kind = normalizedCaptureKind(req.Kind)
+	if plan.kind == "" {
+		return plan, errors.New("kind must be action or project")
+	}
+	if err := validateCaptureProjectLinkInputs(plan.kind, req); err != nil {
+		return plan, err
+	}
+	if req.Sphere != nil {
+		clean := strings.ToLower(strings.TrimSpace(*req.Sphere))
+		if clean != "" && clean != store.SphereWork && clean != store.SpherePrivate {
+			return plan, errors.New("sphere must be work or private")
+		}
+	}
+	if req.LabelID != nil && *req.LabelID > 0 && strings.TrimSpace(req.Label) != "" {
+		return plan, errors.New("label_id and label cannot be combined")
+	}
+	if req.LabelID != nil {
+		if *req.LabelID <= 0 {
+			return plan, errors.New("label_id must be a positive integer")
+		}
+		plan.labelID = *req.LabelID
+	}
+	plan.labelName = strings.TrimSpace(req.Label)
+	if req.ProjectItemID != nil {
+		if *req.ProjectItemID <= 0 {
+			return plan, errors.New("project_item_id must be a positive integer")
+		}
+		plan.projectItemID = *req.ProjectItemID
+		role := strings.TrimSpace(req.ProjectItemRole)
+		if role == "" {
+			role = store.ItemLinkRoleNextAction
+		}
+		if normalizedRole := normalizeItemCaptureLinkRole(role); normalizedRole != "" {
+			plan.projectItemRole = normalizedRole
+		} else {
+			return plan, errors.New("project_item_role must be next_action, support, or blocked_by")
+		}
+	}
+	return plan, nil
+}
+
+// validateCaptureProjectLinkInputs rejects link payloads that would only
+// confuse the user — supplying a project link role without an id, or trying
+// to link a kind=project capture as a child of another project (the link
+// would succeed but the result is rarely what someone wants from quick
+// capture and is best done explicitly via the existing project-item-link
+// endpoint).
+func validateCaptureProjectLinkInputs(kind string, req itemCaptureRequest) error {
+	if req.ProjectItemID == nil && strings.TrimSpace(req.ProjectItemRole) != "" {
+		return errors.New("project_item_role requires project_item_id")
+	}
+	if kind == store.ItemKindProject && req.ProjectItemID != nil {
+		return errors.New("project_item_id cannot be set when capturing a project")
+	}
+	return nil
+}
+
+func (a *App) createCapturedItem(req itemCaptureRequest, plan captureValidationPlan) (store.Item, error) {
+	if req.Source != nil && strings.EqualFold(strings.TrimSpace(*req.Source), store.ExternalProviderTodoist) && strings.TrimSpace(optionalStringValue(req.SourceRef)) == "" {
+		if plan.kind != store.ItemKindAction {
+			return store.Item{}, errors.New("source=todoist quick capture is only supported for kind=action")
+		}
+		return a.createTodoistBackedItem(itemCreateRequest{
+			Title:        strings.TrimSpace(req.Title),
+			State:        store.ItemStateInbox,
+			WorkspaceID:  req.WorkspaceID,
+			Sphere:       req.Sphere,
+			ArtifactID:   req.ArtifactID,
+			ActorID:      req.ActorID,
+			VisibleAfter: nil,
+			FollowUpAt:   nil,
+			DueAt:        nil,
+			Source:       req.Source,
+			SourceRef:    req.SourceRef,
+		})
+	}
+	return a.store.CreateItem(strings.TrimSpace(req.Title), store.ItemOptions{
+		Kind:        plan.kind,
+		State:       store.ItemStateInbox,
+		WorkspaceID: req.WorkspaceID,
+		Sphere:      req.Sphere,
+		ArtifactID:  req.ArtifactID,
+		ActorID:     req.ActorID,
+		Source:      req.Source,
+		SourceRef:   req.SourceRef,
+	})
+}
+
+func (a *App) attachCaptureLabel(itemID, labelID int64, labelName string) (*store.Label, error) {
+	if labelID == 0 && labelName == "" {
+		return nil, nil
+	}
+	resolved, err := a.resolveCaptureLabel(labelID, labelName)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.store.LinkLabelToItem(resolved.ID, itemID); err != nil {
+		return nil, err
+	}
+	return &resolved, nil
+}
+
+func (a *App) resolveCaptureLabel(labelID int64, labelName string) (store.Label, error) {
+	if labelID > 0 {
+		label, err := a.store.GetLabel(labelID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.Label{}, fmt.Errorf("label_id %d not found", labelID)
+			}
+			return store.Label{}, err
+		}
+		return label, nil
+	}
+	return a.store.CreateLabel(labelName, nil)
+}
+
+func (a *App) attachCaptureProjectLink(itemID, projectItemID int64, role string) (*itemCaptureProjectLink, error) {
+	if projectItemID == 0 {
+		return nil, nil
+	}
+	parent, err := a.store.GetItem(projectItemID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("project_item_id %d not found", projectItemID)
+		}
+		return nil, err
+	}
+	if parent.Kind != store.ItemKindProject {
+		return nil, fmt.Errorf("project_item_id %d is not a project", projectItemID)
+	}
+	if err := a.store.LinkItemChild(projectItemID, itemID, role); err != nil {
+		return nil, err
+	}
+	links, err := a.store.ListItemChildLinks(projectItemID)
+	if err != nil {
+		return nil, err
+	}
+	return &itemCaptureProjectLink{
+		ProjectItemID: projectItemID,
+		Role:          role,
+		Links:         links,
+	}, nil
+}
+
+func normalizedCaptureKind(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", store.ItemKindAction:
+		return store.ItemKindAction
+	case store.ItemKindProject, "outcome":
+		return store.ItemKindProject
+	default:
+		return ""
+	}
+}
+
+func normalizeItemCaptureLinkRole(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case store.ItemLinkRoleNextAction:
+		return store.ItemLinkRoleNextAction
+	case store.ItemLinkRoleSupport:
+		return store.ItemLinkRoleSupport
+	case store.ItemLinkRoleBlockedBy:
+		return store.ItemLinkRoleBlockedBy
+	default:
+		return ""
+	}
+}

--- a/internal/web/items_capture_test.go
+++ b/internal/web/items_capture_test.go
@@ -1,0 +1,231 @@
+package web
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+func TestItemCaptureCreatesActionInInbox(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title": "Reply to grant request",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	data := decodeJSONDataResponse(t, rr)
+	itemPayload, ok := data["item"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing item payload: %#v", data)
+	}
+	if got := strFromAny(itemPayload["title"]); got != "Reply to grant request" {
+		t.Fatalf("title = %q, want Reply to grant request", got)
+	}
+	if got := strFromAny(itemPayload["kind"]); got != store.ItemKindAction {
+		t.Fatalf("kind = %q, want %s", got, store.ItemKindAction)
+	}
+	if got := strFromAny(itemPayload["state"]); got != store.ItemStateInbox {
+		t.Fatalf("state = %q, want inbox", got)
+	}
+	stored := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if stored.Kind != store.ItemKindAction {
+		t.Fatalf("stored kind = %q, want action", stored.Kind)
+	}
+}
+
+func TestItemCaptureCreatesProjectItemWhenKindProject(t *testing.T) {
+	app := newAuthedTestApp(t)
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title": "Ship dialog refresh",
+		"kind":  store.ItemKindProject,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	stored := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if stored.Kind != store.ItemKindProject {
+		t.Fatalf("stored kind = %q, want project", stored.Kind)
+	}
+}
+
+func TestItemCaptureLinksUnderProjectItem(t *testing.T) {
+	app := newAuthedTestApp(t)
+	parent, err := app.store.CreateItem("Mentorship", store.ItemOptions{Kind: store.ItemKindProject})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title":             "Schedule first 1:1",
+		"project_item_id":   parent.ID,
+		"project_item_role": store.ItemLinkRoleNextAction,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	data := decodeJSONDataResponse(t, rr)
+	link, ok := data["project_item"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing project_item payload: %#v", data)
+	}
+	if int64(toFloat64(t, link["project_item_id"])) != parent.ID {
+		t.Fatalf("project_item_id = %v, want %d", link["project_item_id"], parent.ID)
+	}
+	if got := strFromAny(link["role"]); got != store.ItemLinkRoleNextAction {
+		t.Fatalf("role = %q, want %s", got, store.ItemLinkRoleNextAction)
+	}
+	links, err := app.store.ListItemChildLinks(parent.ID)
+	if err != nil {
+		t.Fatalf("list links: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("links len = %d, want 1", len(links))
+	}
+}
+
+func TestItemCaptureRejectsProjectLinkOnProjectKind(t *testing.T) {
+	app := newAuthedTestApp(t)
+	parent, err := app.store.CreateItem("Outcome", store.ItemOptions{Kind: store.ItemKindProject})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title":           "Sub-outcome",
+		"kind":            store.ItemKindProject,
+		"project_item_id": parent.ID,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "project_item_id cannot be set") {
+		t.Fatalf("body missing diagnostic: %s", rr.Body.String())
+	}
+}
+
+func TestItemCaptureRejectsEmptyTitle(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title": "   ",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "title is required") {
+		t.Fatalf("body missing diagnostic: %s", rr.Body.String())
+	}
+}
+
+func TestItemCaptureRejectsUnknownKind(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title": "Plan retreat",
+		"kind":  "epic",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "kind must be") {
+		t.Fatalf("body missing diagnostic: %s", rr.Body.String())
+	}
+}
+
+func TestItemCaptureRoutesSphereByWorkspace(t *testing.T) {
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Plasma research", filepath.Join(t.TempDir(), "plasma"))
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if _, err := app.store.SetWorkspaceSphere(workspace.ID, store.SphereWork); err != nil {
+		t.Fatalf("set workspace sphere: %v", err)
+	}
+
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title":        "Wire diagnostic loop",
+		"workspace_id": workspace.ID,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	stored := mustFirstItemByState(t, app, store.ItemStateInbox)
+	if stored.Sphere != store.SphereWork {
+		t.Fatalf("sphere = %q, want work", stored.Sphere)
+	}
+	if stored.WorkspaceID == nil || *stored.WorkspaceID != workspace.ID {
+		t.Fatalf("workspace_id = %v, want %d", stored.WorkspaceID, workspace.ID)
+	}
+}
+
+func TestItemCaptureCreatesAndLinksLabelByName(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title": "Read deferred docs",
+		"label": "reading",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	data := decodeJSONDataResponse(t, rr)
+	label, ok := data["label"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing label payload: %#v", data)
+	}
+	if got := strFromAny(label["name"]); got != "reading" {
+		t.Fatalf("label name = %q, want reading", got)
+	}
+}
+
+func TestItemCaptureRejectsLabelIdAndLabelTogether(t *testing.T) {
+	app := newAuthedTestApp(t)
+	label, err := app.store.CreateLabel("focus", nil)
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title":    "Plan retreat",
+		"label":    "focus",
+		"label_id": label.ID,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestItemCaptureRejectsMissingProject(t *testing.T) {
+	app := newAuthedTestApp(t)
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodPost, "/api/items/capture", map[string]any{
+		"title":           "Stranded",
+		"project_item_id": 999,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	items, err := app.store.ListItemsByState(store.ItemStateInbox)
+	if err != nil {
+		t.Fatalf("list inbox: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("inbox len = %d, want 0 (rolled back)", len(items))
+	}
+}
+
+func toFloat64(t *testing.T, value any) float64 {
+	t.Helper()
+	switch v := value.(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	default:
+		t.Fatalf("expected numeric value, got %T (%v)", value, value)
+		return 0
+	}
+}

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -141,6 +141,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/batches/{batch_id}/artifact", a.handleBatchArtifact)
 	r.Get("/api/items", a.handleItemList)
 	r.Post("/api/items", a.handleItemCreate)
+	r.Post("/api/items/capture", a.handleItemCapture)
 	r.Get("/api/items/inbox", a.handleItemInbox)
 	r.Get("/api/items/next", a.handleItemNext)
 	r.Get("/api/items/waiting", a.handleItemWaiting)

--- a/internal/web/static/app-quick-capture.ts
+++ b/internal/web/static/app-quick-capture.ts
@@ -1,0 +1,184 @@
+import { apiURL } from './app-env.js';
+
+interface QuickCaptureNodes {
+  toggle: HTMLButtonElement;
+  sheet: HTMLElement;
+  form: HTMLFormElement;
+  title: HTMLInputElement;
+  kindRadios: NodeListOf<HTMLInputElement>;
+  sphere: HTMLSelectElement;
+  label: HTMLInputElement;
+  projectItemID: HTMLInputElement;
+  submit: HTMLButtonElement;
+  status: HTMLElement;
+  error: HTMLElement;
+}
+
+interface QuickCaptureState {
+  open: boolean;
+  busy: boolean;
+}
+
+const state: QuickCaptureState = {
+  open: false,
+  busy: false,
+};
+
+let nodes: QuickCaptureNodes | null = null;
+
+export function initQuickCapture(): void {
+  const toggle = document.getElementById('quick-capture-toggle') as HTMLButtonElement | null;
+  const sheet = document.getElementById('quick-capture-sheet');
+  const form = document.getElementById('quick-capture-form') as HTMLFormElement | null;
+  const title = document.getElementById('quick-capture-title') as HTMLInputElement | null;
+  const sphere = document.getElementById('quick-capture-sphere') as HTMLSelectElement | null;
+  const label = document.getElementById('quick-capture-label') as HTMLInputElement | null;
+  const projectItemID = document.getElementById('quick-capture-project-item-id') as HTMLInputElement | null;
+  const submit = document.getElementById('quick-capture-submit') as HTMLButtonElement | null;
+  const status = document.getElementById('quick-capture-status');
+  const error = document.getElementById('quick-capture-error');
+  if (!toggle || !sheet || !form || !title || !sphere || !label || !projectItemID || !submit || !status || !error) {
+    return;
+  }
+  const kindRadios = form.querySelectorAll<HTMLInputElement>('input[name="quick-capture-kind"]');
+  nodes = { toggle, sheet, form, title, kindRadios, sphere, label, projectItemID, submit, status, error };
+  toggle.addEventListener('click', () => toggleSheet());
+  sheet.querySelectorAll<HTMLElement>('[data-quick-capture-dismiss="true"]').forEach((node) => {
+    node.addEventListener('click', () => closeSheet());
+  });
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    void submitCapture();
+  });
+  kindRadios.forEach((radio) => {
+    radio.addEventListener('change', () => syncKindAttribute());
+  });
+  document.addEventListener('keydown', (event) => {
+    if (state.open && event.key === 'Escape') {
+      event.preventDefault();
+      closeSheet();
+    }
+  });
+  syncKindAttribute();
+}
+
+function toggleSheet(): void {
+  if (state.open) {
+    closeSheet();
+    return;
+  }
+  openSheet();
+}
+
+function openSheet(): void {
+  if (!nodes) return;
+  state.open = true;
+  nodes.sheet.hidden = false;
+  nodes.toggle.setAttribute('aria-expanded', 'true');
+  setError('');
+  setStatus('', '');
+  nodes.title.focus();
+}
+
+function closeSheet(): void {
+  if (!nodes) return;
+  state.open = false;
+  nodes.sheet.hidden = true;
+  nodes.toggle.setAttribute('aria-expanded', 'false');
+}
+
+function syncKindAttribute(): void {
+  if (!nodes) return;
+  nodes.form.dataset.kind = currentKind();
+}
+
+function currentKind(): string {
+  if (!nodes) return 'action';
+  for (const radio of Array.from(nodes.kindRadios)) {
+    if (radio.checked) {
+      return radio.value;
+    }
+  }
+  return 'action';
+}
+
+function setError(message: string): void {
+  if (!nodes) return;
+  if (!message) {
+    nodes.error.textContent = '';
+    nodes.error.hidden = true;
+    return;
+  }
+  nodes.error.textContent = message;
+  nodes.error.hidden = false;
+}
+
+function setStatus(message: string, tone: string): void {
+  if (!nodes) return;
+  nodes.status.textContent = message;
+  if (tone) {
+    nodes.status.dataset.tone = tone;
+  } else {
+    delete nodes.status.dataset.tone;
+  }
+}
+
+async function submitCapture(): Promise<void> {
+  if (!nodes || state.busy) return;
+  const title = nodes.title.value.trim();
+  if (!title) {
+    setError('Title is required.');
+    nodes.title.focus();
+    return;
+  }
+  const kind = currentKind();
+  const payload: Record<string, unknown> = { title, kind };
+  const sphere = nodes.sphere.value.trim();
+  if (sphere) payload.sphere = sphere;
+  const labelName = nodes.label.value.trim();
+  if (labelName) payload.label = labelName;
+  if (kind === 'action') {
+    const projectRaw = nodes.projectItemID.value.trim();
+    if (projectRaw) {
+      const projectID = Number(projectRaw);
+      if (!Number.isFinite(projectID) || projectID <= 0) {
+        setError('Project item id must be a positive integer.');
+        return;
+      }
+      payload.project_item_id = projectID;
+    }
+  }
+  state.busy = true;
+  nodes.submit.disabled = true;
+  setError('');
+  setStatus('Saving...', '');
+  try {
+    const response = await fetch(apiURL('items/capture'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    let data: Record<string, any> = {};
+    try {
+      data = await response.json();
+    } catch (_) {
+      data = {};
+    }
+    if (!response.ok) {
+      throw new Error(String(data && data.error ? data.error : `HTTP ${response.status}`));
+    }
+    const item = (data && data.item) || {};
+    const itemID = Number(item && (item as any).id);
+    nodes.form.reset();
+    syncKindAttribute();
+    setStatus(Number.isFinite(itemID) && itemID > 0 ? `Captured #${itemID} into inbox.` : 'Captured into inbox.', 'success');
+    window.setTimeout(() => closeSheet(), 600);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setError(message || 'Capture failed.');
+    setStatus('', '');
+  } finally {
+    state.busy = false;
+    nodes.submit.disabled = false;
+  }
+}

--- a/internal/web/static/app.ts
+++ b/internal/web/static/app.ts
@@ -30,6 +30,7 @@ import * as mailDraftsModule from './app-mail-drafts.js';
 import * as mailVoiceModule from './app-mail-voice.js';
 import * as mailTriageModule from './app-mail-triage.js';
 import * as initModule from './app-init.js';
+import * as quickCaptureModule from './app-quick-capture.js';
 import * as startupModule from './app-startup.js';
 
 setAppRefs({
@@ -64,6 +65,7 @@ setAppRefs({
   ...mailVoiceModule,
   ...mailTriageModule,
   ...initModule,
+  ...quickCaptureModule,
   ...startupModule,
 });
 
@@ -71,6 +73,7 @@ runtimeUiModule.initRuntimeUi();
 bugReportModule.initBugReportUi();
 annotationsModule.initAnnotationUi();
 dictationModule.initDictationUi();
+quickCaptureModule.initQuickCapture();
 
 window._slopshellApp = {
   getState,

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -8,6 +8,7 @@
   <meta name="color-scheme" content="light">
   <title>slopshell</title>
   <link rel="stylesheet" href="./static/style.css?v=20260314-whitefix2">
+  <link rel="stylesheet" href="./static/quick-capture.css">
   <link rel="stylesheet" href="./static/vendor/highlight-github.min.css">
   <script src="./static/polyfill.js"></script>
 </head>
@@ -92,6 +93,55 @@
         <button id="slopshell-circle-dot" type="button" class="slopshell-circle-dot" aria-label="Toggle Slopshell Circle"></button>
       </div>
       <button id="surface-toggle" type="button" class="surface-toggle" aria-label="Switch interaction surface" style="display:none"></button>
+
+      <button id="quick-capture-toggle" type="button" class="quick-capture-toggle" aria-haspopup="dialog" aria-controls="quick-capture-sheet" aria-expanded="false" aria-label="Quick capture">
+        <span class="quick-capture-toggle-glyph" aria-hidden="true">+</span>
+        <span class="quick-capture-toggle-label">Capture</span>
+      </button>
+
+      <section id="quick-capture-sheet" class="quick-capture-sheet" role="dialog" aria-modal="true" aria-labelledby="quick-capture-heading" hidden>
+        <div class="quick-capture-backdrop" data-quick-capture-dismiss="true"></div>
+        <form id="quick-capture-form" class="quick-capture-form" autocomplete="off" novalidate>
+          <header class="quick-capture-header">
+            <h2 id="quick-capture-heading">Quick capture</h2>
+            <button type="button" class="quick-capture-close" data-quick-capture-dismiss="true" aria-label="Close quick capture">&times;</button>
+          </header>
+          <p id="quick-capture-error" class="quick-capture-error" role="alert" hidden></p>
+          <label class="quick-capture-field">
+            <span class="quick-capture-field-label">Title</span>
+            <input id="quick-capture-title" type="text" required autocomplete="off" placeholder="What needs to happen?">
+          </label>
+          <fieldset class="quick-capture-kind" aria-label="Capture kind">
+            <legend class="quick-capture-field-label">Kind</legend>
+            <label><input type="radio" name="quick-capture-kind" value="action" checked> Action</label>
+            <label><input type="radio" name="quick-capture-kind" value="project"> Project / outcome</label>
+          </fieldset>
+          <details class="quick-capture-context">
+            <summary>Optional context</summary>
+            <label class="quick-capture-field">
+              <span class="quick-capture-field-label">Sphere</span>
+              <select id="quick-capture-sphere">
+                <option value="">Use active sphere</option>
+                <option value="work">Work</option>
+                <option value="private">Private</option>
+              </select>
+            </label>
+            <label class="quick-capture-field">
+              <span class="quick-capture-field-label">Label</span>
+              <input id="quick-capture-label" type="text" autocomplete="off" placeholder="Optional label name">
+            </label>
+            <label class="quick-capture-field" data-quick-capture-action-only>
+              <span class="quick-capture-field-label">Project item id</span>
+              <input id="quick-capture-project-item-id" type="number" min="1" inputmode="numeric" autocomplete="off" placeholder="Link this action under a project item">
+            </label>
+          </details>
+          <footer class="quick-capture-actions">
+            <button type="button" class="quick-capture-secondary" data-quick-capture-dismiss="true">Cancel</button>
+            <button id="quick-capture-submit" type="submit" class="quick-capture-primary">Capture to inbox</button>
+          </footer>
+          <p id="quick-capture-status" class="quick-capture-status" role="status" aria-live="polite"></p>
+        </form>
+      </section>
 
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
       <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Toggle chat panel"></button>

--- a/internal/web/static/quick-capture.css
+++ b/internal/web/static/quick-capture.css
@@ -1,0 +1,221 @@
+.quick-capture-toggle {
+  position: fixed;
+  bottom: 16px;
+  left: 16px;
+  z-index: 70;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1px solid #d0d7de;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #1f2328;
+  font: 600 14px/1 system-ui, -apple-system, "Segoe UI", sans-serif;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.12);
+  cursor: pointer;
+}
+
+.quick-capture-toggle:hover {
+  background: #f6f8fa;
+}
+
+.quick-capture-toggle-glyph {
+  display: inline-block;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.quick-capture-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-capture-sheet[hidden] {
+  display: none;
+}
+
+.quick-capture-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.quick-capture-form {
+  position: relative;
+  width: min(420px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  padding: 20px 22px 18px;
+  background: #ffffff;
+  color: #1f2328;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font: 14px/1.4 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.quick-capture-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.quick-capture-header h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.quick-capture-close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: #57606a;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+
+.quick-capture-close:hover {
+  background: #f6f8fa;
+}
+
+.quick-capture-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quick-capture-field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #57606a;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.quick-capture-field input,
+.quick-capture-field select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1f2328;
+  font: inherit;
+}
+
+.quick-capture-field input:focus,
+.quick-capture-field select:focus {
+  outline: 2px solid #0969da;
+  outline-offset: 1px;
+}
+
+.quick-capture-kind {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.quick-capture-kind legend {
+  padding: 0;
+}
+
+.quick-capture-kind label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.quick-capture-context {
+  border-top: 1px solid #eaeef2;
+  padding-top: 8px;
+}
+
+.quick-capture-context summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #57606a;
+}
+
+.quick-capture-context > .quick-capture-field {
+  margin-top: 8px;
+}
+
+.quick-capture-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid #eaeef2;
+  padding-top: 12px;
+}
+
+.quick-capture-primary,
+.quick-capture-secondary {
+  appearance: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font: inherit;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.quick-capture-primary {
+  background: #1f6feb;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.quick-capture-primary:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.quick-capture-secondary {
+  background: #ffffff;
+  border-color: #d0d7de;
+  color: #1f2328;
+}
+
+.quick-capture-secondary:hover {
+  background: #f6f8fa;
+}
+
+.quick-capture-status {
+  margin: 0;
+  min-height: 1.4em;
+  font-size: 12px;
+  color: #57606a;
+}
+
+.quick-capture-status[data-tone="success"] {
+  color: #1a7f37;
+}
+
+.quick-capture-error {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #ffebe9;
+  color: #cf222e;
+  font-size: 13px;
+}
+
+.quick-capture-form[data-kind="project"] [data-quick-capture-action-only] {
+  display: none;
+}

--- a/tests/playwright/harness-routes-domain.js
+++ b/tests/playwright/harness-routes-domain.js
@@ -109,6 +109,47 @@ __harnessRouteHandlers.push(async function harnessRouteDomain(u, opts) {
         const contexts = Array.isArray(window.__itemSidebarContexts) ? window.__itemSidebarContexts : defaultItemSidebarContexts();
         return new Response(JSON.stringify({ ok: true, contexts }), { status: 200 });
       }
+      if (/\/api\/items\/capture(?:\?|$)/.test(u) && opts?.method === 'POST') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        const title = String(body.title || '').trim();
+        if (!title) {
+          return new Response(JSON.stringify({ error: 'title is required' }), { status: 400 });
+        }
+        const kind = String(body.kind || 'action').trim().toLowerCase();
+        const itemID = Number(window.__itemSidebarNextItemID || 1000);
+        window.__itemSidebarNextItemID = itemID + 1;
+        const item = prependItemSidebarEntry({
+          id: itemID,
+          title,
+          kind: kind === 'project' ? 'project' : 'action',
+          state: 'inbox',
+          sphere: normalizeHarnessSphere(body.sphere),
+          artifact_id: 0,
+          source: '',
+          source_ref: '',
+          artifact_title: '',
+          artifact_kind: '',
+          actor_name: '',
+          created_at: '2026-03-10 10:20:00',
+          updated_at: '2026-03-10 10:20:00',
+        }, 'inbox');
+        const payload = { ok: true, item };
+        if (typeof body.label === 'string' && body.label.trim() !== '') {
+          payload.label = { id: 1, name: body.label.trim() };
+        }
+        if (Number(body.project_item_id || 0) > 0) {
+          payload.project_item = { project_item_id: Number(body.project_item_id), role: String(body.project_item_role || 'next_action') };
+        }
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'item_capture',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: body,
+        });
+        return new Response(JSON.stringify(payload), { status: 201 });
+      }
       if (/\/api\/items(?:\?|$)/.test(u) && opts?.method === 'POST') {
         let body = {};
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Slopshell Harness</title>
   <link rel="stylesheet" href="../../internal/web/static/style.css">
+  <link rel="stylesheet" href="../../internal/web/static/quick-capture.css">
   <style>
     body { margin: 0; padding: 0; }
   </style>
@@ -73,6 +74,54 @@
         <button id="slopshell-circle-dot" type="button" class="slopshell-circle-dot" aria-label="Toggle Slopshell Circle"></button>
       </div>
       <button id="surface-toggle" type="button" class="surface-toggle" aria-label="Switch interaction surface" style="display:none"></button>
+
+      <button id="quick-capture-toggle" type="button" class="quick-capture-toggle" aria-haspopup="dialog" aria-controls="quick-capture-sheet" aria-expanded="false" aria-label="Quick capture">
+        <span class="quick-capture-toggle-glyph" aria-hidden="true">+</span>
+        <span class="quick-capture-toggle-label">Capture</span>
+      </button>
+      <section id="quick-capture-sheet" class="quick-capture-sheet" role="dialog" aria-modal="true" aria-labelledby="quick-capture-heading" hidden>
+        <div class="quick-capture-backdrop" data-quick-capture-dismiss="true"></div>
+        <form id="quick-capture-form" class="quick-capture-form" autocomplete="off" novalidate>
+          <header class="quick-capture-header">
+            <h2 id="quick-capture-heading">Quick capture</h2>
+            <button type="button" class="quick-capture-close" data-quick-capture-dismiss="true" aria-label="Close quick capture">&times;</button>
+          </header>
+          <p id="quick-capture-error" class="quick-capture-error" role="alert" hidden></p>
+          <label class="quick-capture-field">
+            <span class="quick-capture-field-label">Title</span>
+            <input id="quick-capture-title" type="text" required autocomplete="off">
+          </label>
+          <fieldset class="quick-capture-kind" aria-label="Capture kind">
+            <legend class="quick-capture-field-label">Kind</legend>
+            <label><input type="radio" name="quick-capture-kind" value="action" checked> Action</label>
+            <label><input type="radio" name="quick-capture-kind" value="project"> Project / outcome</label>
+          </fieldset>
+          <details class="quick-capture-context">
+            <summary>Optional context</summary>
+            <label class="quick-capture-field">
+              <span class="quick-capture-field-label">Sphere</span>
+              <select id="quick-capture-sphere">
+                <option value="">Use active sphere</option>
+                <option value="work">Work</option>
+                <option value="private">Private</option>
+              </select>
+            </label>
+            <label class="quick-capture-field">
+              <span class="quick-capture-field-label">Label</span>
+              <input id="quick-capture-label" type="text" autocomplete="off">
+            </label>
+            <label class="quick-capture-field" data-quick-capture-action-only>
+              <span class="quick-capture-field-label">Project item id</span>
+              <input id="quick-capture-project-item-id" type="number" min="1" inputmode="numeric" autocomplete="off">
+            </label>
+          </details>
+          <footer class="quick-capture-actions">
+            <button type="button" class="quick-capture-secondary" data-quick-capture-dismiss="true">Cancel</button>
+            <button id="quick-capture-submit" type="submit" class="quick-capture-primary">Capture to inbox</button>
+          </footer>
+          <p id="quick-capture-status" class="quick-capture-status" role="status" aria-live="polite"></p>
+        </form>
+      </section>
 
       <button id="edge-left-tap" type="button" class="edge-left-tap" aria-label="Toggle file sidebar"></button>
       <button id="edge-right-tap" type="button" class="edge-right-tap" aria-label="Toggle chat panel"></button>

--- a/tests/playwright/quick-capture.spec.ts
+++ b/tests/playwright/quick-capture.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._slopshellApp;
+    if (typeof app?.getState !== 'function') return false;
+    const s = app.getState();
+    return s.chatWs && s.chatWs.readyState === (window as any).WebSocket.OPEN;
+  }, null, { timeout: 5_000 });
+}
+
+async function captureLog(page: Page) {
+  return page.evaluate(() => (window as any).__harnessLog.filter((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'item_capture'));
+}
+
+test.describe('GTD quick capture affordance', () => {
+  test('always-visible toggle opens the capture sheet and posts an action by default', async ({ page }) => {
+    await waitReady(page);
+
+    const toggle = page.locator('#quick-capture-toggle');
+    await expect(toggle).toBeVisible();
+
+    await toggle.click();
+    await expect(page.locator('#quick-capture-sheet')).toBeVisible();
+
+    await page.locator('#quick-capture-title').fill('Reply to grant request');
+    await page.locator('#quick-capture-submit').click();
+
+    await expect.poll(async () => (await captureLog(page)).length, { timeout: 5_000 }).toBe(1);
+    const log = await captureLog(page);
+    expect(log[0].payload.title).toBe('Reply to grant request');
+    expect(log[0].payload.kind).toBe('action');
+    await expect(page.locator('#quick-capture-status')).toContainText('inbox');
+  });
+
+  test('switching to project kind sends kind=project and hides the project link field', async ({ page }) => {
+    await waitReady(page);
+    await page.locator('#quick-capture-toggle').click();
+    await page.locator('input[name="quick-capture-kind"][value="project"]').check();
+    await expect(page.locator('[data-quick-capture-action-only]')).toBeHidden();
+    await page.locator('#quick-capture-title').fill('Ship dialog refresh');
+    await page.locator('#quick-capture-submit').click();
+    await expect.poll(async () => (await captureLog(page)).length, { timeout: 5_000 }).toBe(1);
+    const log = await captureLog(page);
+    expect(log[0].payload.kind).toBe('project');
+  });
+
+  test('action capture under a project item id passes the link in the payload', async ({ page }) => {
+    await waitReady(page);
+    await page.locator('#quick-capture-toggle').click();
+    await page.locator('#quick-capture-title').fill('Schedule first 1:1');
+    await page.locator('summary').first().click();
+    await page.locator('#quick-capture-project-item-id').fill('42');
+    await page.locator('#quick-capture-submit').click();
+    await expect.poll(async () => (await captureLog(page)).length, { timeout: 5_000 }).toBe(1);
+    const log = await captureLog(page);
+    expect(log[0].payload.project_item_id).toBe(42);
+    expect(log[0].payload.kind).toBe('action');
+  });
+
+  test('rejects empty title without sending a request', async ({ page }) => {
+    await waitReady(page);
+    await page.locator('#quick-capture-toggle').click();
+    await page.locator('#quick-capture-submit').click();
+    await expect(page.locator('#quick-capture-error')).toContainText('Title is required');
+    expect((await captureLog(page)).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `POST /api/items/capture` endpoint that drops a captured item into Inbox with optional sphere, workspace, artifact, actor, label, and project-item link context, and validates the request before any insert.
- `sls gtd capture <title> [flags]` CLI talks to the same endpoint; flags accept work/private sphere, workspace id, label name or id, project-item link with role, and source/source-ref.
- Always-visible Quick Capture affordance in the web UI: floating button + modal sheet with title input, action/project kind toggle, and optional context (sphere, label, project-item id). Submits to the new endpoint, shows validator diagnostics inline, and clears on success.

Default capture creates `Item(kind=action)` in Inbox. Explicit project capture sets `kind=project`; the project-item link field hides automatically because attaching one project under another via quick capture is rejected. Active workspace stays metadata only — never confused with a project item.

Closes #744.

## Verification

### Acceptance: capturing from work and private sphere writes to the correct source/backend
- `TestItemCaptureRoutesSphereByWorkspace` shows that supplying `workspace_id` makes the captured item inherit the workspace sphere (work) rather than the active sphere fallback.
- `TestItemCaptureCreatesActionInInbox` plus the harness mock prove the default flow (no workspace) routes through `store.CreateItem` and lands in inbox with the kind/sphere derived from the active sphere/workspace.
- Output (`go test ./internal/web -run TestItemCapture -v`):
  ```
  --- PASS: TestItemCaptureRoutesSphereByWorkspace (0.02s)
  --- PASS: TestItemCaptureCreatesActionInInbox (0.02s)
  ```

### Acceptance: capture result appears in unified Inbox
- `TestItemCaptureCreatesActionInInbox` reads back through `mustFirstItemByState(t, app, store.ItemStateInbox)`; captured action lands in Inbox.
- `TestItemCaptureCreatesProjectItemWhenKindProject` does the same for kind=project; the project item also appears in Inbox.
- The Playwright spec `quick-capture.spec.ts › always-visible toggle opens the capture sheet and posts an action by default` confirms the UI hits `/api/items/capture` and renders a "captured into inbox" status.

### Acceptance: CLI and UI produce equivalent records
- `TestHandleGtdCaptureSendsTitleAndDefaults` and `TestHandleGtdCaptureKindProjectFlag` show `sls gtd capture` posts the same JSON shape (`title`, optional `kind`) the UI sends. Output:
  ```
  --- PASS: TestHandleGtdCaptureSendsTitleAndDefaults (0.00s)
  --- PASS: TestHandleGtdCaptureKindProjectFlag (0.00s)
  --- PASS: TestHandleGtdCaptureProjectKindAndProjectLink (0.00s)
  ```
- `TestHandleGtdCaptureProjectKindAndProjectLink` mirrors the Playwright spec `action capture under a project item id passes the link in the payload`, both posting `project_item_id=42` (CLI) / `42` (UI).

### Acceptance: invalid capture data surfaces validator diagnostics
- `TestItemCaptureRejectsEmptyTitle` (`title is required`), `TestItemCaptureRejectsUnknownKind` (`kind must be action or project`), `TestItemCaptureRejectsLabelIdAndLabelTogether`, `TestItemCaptureRejectsProjectLinkOnProjectKind`, and `TestItemCaptureRejectsMissingProject` all return HTTP 400 with the diagnostic in the body.
- `TestItemCaptureRejectsMissingProject` additionally asserts the inbox stays empty (rolled back) when the project link validation fails after the row was attempted.
- CLI: `TestHandleGtdCaptureRejectsMissingTitle`, `TestHandleGtdCaptureRejectsBadFlagValue`, `TestHandleGtdCaptureSurfacesValidationError` cover usage exit code 2 and pass-through of server diagnostics.
- UI: `quick-capture.spec.ts › rejects empty title without sending a request` confirms the modal shows "Title is required" before any fetch.

### Acceptance: tests cover action capture, project-item capture, and capture linked to an existing project item
- Action capture: `TestItemCaptureCreatesActionInInbox`, `TestHandleGtdCaptureSendsTitleAndDefaults`, Playwright "always-visible toggle...".
- Project-item capture: `TestItemCaptureCreatesProjectItemWhenKindProject`, `TestHandleGtdCaptureKindProjectFlag`, Playwright "switching to project kind...".
- Capture linked to an existing project item: `TestItemCaptureLinksUnderProjectItem` (verifies link stored via `ListItemChildLinks`), `TestHandleGtdCaptureProjectKindAndProjectLink`, Playwright "action capture under a project item id...".

### Frontend / build sanity
- `npm run typecheck:frontend` clean.
- `npm run build:frontend` -> `built 68 frontend modules`.
- `./scripts/sync-surface.sh --check` exits 0.

### Full suites
- `go test ./internal/web/... -count=1` -> `ok internal/web 26.659s`
- `go test ./cmd/sls/... -count=1` -> `ok cmd/sls 0.037s`
- `go test ./internal/store/... -count=1` -> `ok internal/store 1.564s`
- Playwright (chromium): 4/4 passing in `tests/playwright/quick-capture.spec.ts`.