### PR TITLE
fix: Add backlinks and outgoing links panel for brain artifacts (fixes #735)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -56,6 +56,7 @@ Runtime and chat session management:
 - `GET /api/workspaces/{workspace_id}/files`
 - `GET /api/workspaces/{workspace_id}/markdown-link/resolve`
 - `GET /api/workspaces/{workspace_id}/markdown-link/file`
+- `GET /api/workspaces/{workspace_id}/markdown-link/panel`
 - `GET /api/workspaces/{workspace_id}/companion/config`
 - `PUT /api/workspaces/{workspace_id}/companion/config`
 - `GET /api/workspaces/{workspace_id}/companion/state`

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -56,6 +56,7 @@ var WebRouteSections = []RouteSection{
 			"GET /api/workspaces/{workspace_id}/files",
 			"GET /api/workspaces/{workspace_id}/markdown-link/resolve",
 			"GET /api/workspaces/{workspace_id}/markdown-link/file",
+			"GET /api/workspaces/{workspace_id}/markdown-link/panel",
 			"GET /api/workspaces/{workspace_id}/companion/config",
 			"PUT /api/workspaces/{workspace_id}/companion/config",
 			"GET /api/workspaces/{workspace_id}/companion/state",

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -49,6 +49,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/workspaces/{workspace_id}/files", a.handleWorkspaceFilesList)
 	r.Get("/api/workspaces/{workspace_id}/markdown-link/resolve", a.handleWorkspaceMarkdownLinkResolve)
 	r.Get("/api/workspaces/{workspace_id}/markdown-link/file", a.handleWorkspaceMarkdownLinkFile)
+	r.Get("/api/workspaces/{workspace_id}/markdown-link/panel", a.handleWorkspaceMarkdownLinkPanel)
 	r.Get("/api/runtime/workspaces/{workspace_id}/welcome", a.handleWorkspaceWelcome)
 	r.Get("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigGet)
 	r.Put("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigPut)

--- a/internal/web/static/canvas-link-panel.css
+++ b/internal/web/static/canvas-link-panel.css
@@ -1,0 +1,63 @@
+.canvas-link-panel {
+  border-top: 1px solid var(--border, #e2e8f0);
+  background: var(--bg-elevated, #f8fafc);
+  padding: 0.75rem 1rem;
+  max-height: 35%;
+  overflow-y: auto;
+  font-size: 0.9em;
+  flex-shrink: 0;
+}
+.canvas-link-panel[hidden] {
+  display: none;
+}
+.canvas-link-panel-header {
+  font-weight: 600;
+  color: var(--accent, #2563eb);
+  margin-bottom: 0.5rem;
+}
+.canvas-link-panel-section {
+  margin-bottom: 0.75rem;
+}
+.canvas-link-panel-heading {
+  font-size: 0.85em;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+  color: var(--fg-muted, #475569);
+}
+.canvas-link-panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.canvas-link-panel-item {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--border-faint, #edf2f7);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.15rem;
+}
+.canvas-link-panel-item.is-blocked .canvas-link-panel-target {
+  color: #9f1239;
+  text-decoration: line-through;
+  text-decoration-style: wavy;
+}
+.canvas-link-panel-item.is-blocked .canvas-link-panel-detail {
+  color: #9f1239;
+}
+.canvas-link-panel-target {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.95em;
+}
+.canvas-link-panel-detail {
+  color: var(--fg-muted, #64748b);
+  font-size: 0.85em;
+}
+.canvas-link-panel-excerpt {
+  color: var(--fg, #1e293b);
+  font-style: italic;
+}
+.canvas-link-panel-empty {
+  color: var(--fg-muted, #94a3b8);
+  font-style: italic;
+  margin: 0;
+}

--- a/internal/web/static/canvas-link-panel.css
+++ b/internal/web/static/canvas-link-panel.css
@@ -48,6 +48,16 @@
   font-family: var(--mono, ui-monospace, monospace);
   font-size: 0.95em;
 }
+.canvas-link-panel-link {
+  color: var(--accent, #2563eb);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.canvas-link-panel-link:hover,
+.canvas-link-panel-link:focus {
+  text-decoration: none;
+  outline: none;
+}
 .canvas-link-panel-detail {
   color: var(--fg-muted, #64748b);
   font-size: 0.85em;

--- a/internal/web/static/canvas-markdown-links.ts
+++ b/internal/web/static/canvas-markdown-links.ts
@@ -99,7 +99,7 @@ function showMarkdownLinkBlocked(link, reasonRaw) {
   note.textContent = ` ${reason}`;
 }
 
-async function openResolvedMarkdownLink(resolution, renderCanvas) {
+export async function openResolvedMarkdownLink(resolution, renderCanvas) {
   const link = resolution?.link || resolution || {};
   const kind = String(link.kind || 'text').trim();
   const path = String(link.vault_relative_path || link.resolved_path || '').trim();

--- a/internal/web/static/canvas-markdown-panel.ts
+++ b/internal/web/static/canvas-markdown-panel.ts
@@ -1,0 +1,263 @@
+import { apiURL } from './paths.js';
+
+const PANEL_ID = 'canvas-markdown-link-panel';
+
+function appState(): Record<string, unknown> {
+  const app = (window as unknown as { _slopshellApp?: { getState?: () => Record<string, unknown> } })._slopshellApp;
+  if (app && typeof app.getState === 'function') return app.getState();
+  return {};
+}
+
+function activeWorkspaceID(): string {
+  const state = appState();
+  return String(state.activeWorkspaceId || 'active').trim() || 'active';
+}
+
+function activeBrainProjectRoot(): string {
+  const state = appState();
+  const projects = Array.isArray(state.projects) ? state.projects : [];
+  const activeID = String(state.activeWorkspaceId || '').trim();
+  const project = projects.find((entry) => String((entry as { id?: unknown })?.id || '') === activeID);
+  if (!project) return '';
+  const rootPath = String((project as { root_path?: unknown }).root_path || (project as { workspace_path?: unknown }).workspace_path || '').trim();
+  if (!rootPath) return '';
+  if (!/(?:^|[\\/])brain$/i.test(rootPath.replace(/[\\/]+$/, ''))) return '';
+  return rootPath;
+}
+
+function isMarkdownArtifactPath(path: string): boolean {
+  return /\.md$/i.test(String(path || '').trim());
+}
+
+interface OutgoingRef {
+  target: string;
+  type: string;
+  ok: boolean;
+  blocked?: boolean;
+  reason?: string;
+  resolved_path?: string;
+  vault_relative_path?: string;
+  file_url?: string;
+  kind?: string;
+}
+
+interface BacklinkEntry {
+  source_path: string;
+  link_type: string;
+  link_target: string;
+  excerpt?: string;
+}
+
+interface PanelPayload {
+  ok?: boolean;
+  source_path?: string;
+  outgoing?: OutgoingRef[];
+  broken_count?: number;
+  backlinks?: BacklinkEntry[];
+  backlinks_truncated?: boolean;
+  scan_limit_reached?: boolean;
+  error?: string;
+}
+
+function panelHost(): HTMLElement | null {
+  const column = document.getElementById('canvas-column');
+  if (!(column instanceof HTMLElement)) return null;
+  let panel = document.getElementById(PANEL_ID);
+  if (!(panel instanceof HTMLElement)) {
+    panel = document.createElement('aside');
+    panel.id = PANEL_ID;
+    panel.className = 'canvas-link-panel';
+    panel.setAttribute('aria-label', 'Linked notes panel');
+    panel.hidden = true;
+    column.appendChild(panel);
+  }
+  return panel;
+}
+
+function hidePanel() {
+  const panel = document.getElementById(PANEL_ID);
+  if (panel instanceof HTMLElement) {
+    panel.hidden = true;
+    panel.replaceChildren();
+  }
+}
+
+function setPanelLoading(panel: HTMLElement, sourcePath: string) {
+  panel.hidden = false;
+  panel.replaceChildren();
+  const heading = document.createElement('header');
+  heading.className = 'canvas-link-panel-header';
+  heading.textContent = 'Loading links…';
+  panel.appendChild(heading);
+  panel.dataset.sourcePath = sourcePath;
+}
+
+function appendSection(panel: HTMLElement, title: string): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'canvas-link-panel-section';
+  const heading = document.createElement('h4');
+  heading.className = 'canvas-link-panel-heading';
+  heading.textContent = title;
+  section.appendChild(heading);
+  panel.appendChild(section);
+  return section;
+}
+
+function emptyNote(text: string): HTMLElement {
+  const note = document.createElement('p');
+  note.className = 'canvas-link-panel-empty';
+  note.textContent = text;
+  return note;
+}
+
+function renderOutgoingItem(ref: OutgoingRef): HTMLElement {
+  const item = document.createElement('li');
+  item.className = 'canvas-link-panel-item';
+  if (!ref.ok) item.classList.add('is-blocked');
+  const label = document.createElement('span');
+  label.className = 'canvas-link-panel-target';
+  label.textContent = ref.type === 'wikilink' ? `[[${ref.target}]]` : ref.target;
+  item.appendChild(label);
+  const detail = document.createElement('span');
+  detail.className = 'canvas-link-panel-detail';
+  if (ref.ok) {
+    detail.textContent = ref.vault_relative_path || ref.resolved_path || '';
+  } else {
+    detail.textContent = ref.reason || 'broken link';
+  }
+  item.appendChild(detail);
+  return item;
+}
+
+function renderBacklinkItem(entry: BacklinkEntry): HTMLElement {
+  const item = document.createElement('li');
+  item.className = 'canvas-link-panel-item';
+  const label = document.createElement('span');
+  label.className = 'canvas-link-panel-target';
+  label.textContent = entry.source_path;
+  item.appendChild(label);
+  if (entry.excerpt) {
+    const excerpt = document.createElement('span');
+    excerpt.className = 'canvas-link-panel-excerpt';
+    excerpt.textContent = entry.excerpt;
+    item.appendChild(excerpt);
+  }
+  const meta = document.createElement('span');
+  meta.className = 'canvas-link-panel-detail';
+  meta.textContent = entry.link_type === 'wikilink'
+    ? `[[${entry.link_target}]]`
+    : entry.link_target;
+  item.appendChild(meta);
+  return item;
+}
+
+function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
+  panel.replaceChildren();
+  panel.hidden = false;
+
+  const header = document.createElement('header');
+  header.className = 'canvas-link-panel-header';
+  header.textContent = payload.source_path
+    ? `Links for ${payload.source_path}`
+    : 'Links';
+  panel.appendChild(header);
+
+  if (!payload.ok) {
+    panel.appendChild(emptyNote(payload.error || 'links unavailable'));
+    return;
+  }
+
+  const outgoing = Array.isArray(payload.outgoing) ? payload.outgoing : [];
+  const broken = outgoing.filter((ref) => !ref.ok);
+  const working = outgoing.filter((ref) => ref.ok);
+  const backlinks = Array.isArray(payload.backlinks) ? payload.backlinks : [];
+
+  const outgoingSection = appendSection(panel, `Outgoing (${working.length})`);
+  if (!working.length) {
+    outgoingSection.appendChild(emptyNote('no outgoing links'));
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'canvas-link-panel-list';
+    working.forEach((ref) => list.appendChild(renderOutgoingItem(ref)));
+    outgoingSection.appendChild(list);
+  }
+
+  const brokenSection = appendSection(panel, `Broken (${broken.length})`);
+  if (!broken.length) {
+    brokenSection.appendChild(emptyNote('no broken links'));
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'canvas-link-panel-list';
+    broken.forEach((ref) => list.appendChild(renderOutgoingItem(ref)));
+    brokenSection.appendChild(list);
+  }
+
+  const backlinksSection = appendSection(panel, `Backlinks (${backlinks.length}${payload.backlinks_truncated ? '+' : ''})`);
+  if (!backlinks.length) {
+    backlinksSection.appendChild(emptyNote('no backlinks found'));
+  } else {
+    const list = document.createElement('ul');
+    list.className = 'canvas-link-panel-list';
+    backlinks.forEach((entry) => list.appendChild(renderBacklinkItem(entry)));
+    backlinksSection.appendChild(list);
+  }
+  if (payload.scan_limit_reached) {
+    panel.appendChild(emptyNote('Backlink scan stopped at the file cap; results may be incomplete.'));
+  }
+}
+
+export function clearMarkdownLinkPanel() {
+  hidePanel();
+}
+
+export async function renderMarkdownLinkPanelForCanvasEvent(event: { kind?: string; path?: string } | null | undefined) {
+  if (!event || event.kind !== 'text_artifact') {
+    hidePanel();
+    return;
+  }
+  const path = String(event.path || '').trim();
+  if (!isMarkdownArtifactPath(path)) {
+    hidePanel();
+    return;
+  }
+  if (!activeBrainProjectRoot()) {
+    hidePanel();
+    return;
+  }
+  await renderMarkdownLinkPanel(activeWorkspaceID(), path);
+}
+
+export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: string) {
+  const cleanSource = String(sourcePath || '').trim();
+  if (!cleanSource) {
+    hidePanel();
+    return;
+  }
+  const id = String(workspaceID || '').trim() || 'active';
+  const panel = panelHost();
+  if (!panel) return;
+  setPanelLoading(panel, cleanSource);
+  try {
+    const params = new URLSearchParams({ source: cleanSource });
+    const resp = await fetch(
+      apiURL(`workspaces/${encodeURIComponent(id)}/markdown-link/panel?${params.toString()}`),
+      { cache: 'no-store' },
+    );
+    if (panel.dataset.sourcePath !== cleanSource) return;
+    if (!resp.ok) {
+      const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
+      renderPanelContent(panel, { ok: false, source_path: cleanSource, error: detail });
+      return;
+    }
+    const payload = (await resp.json()) as PanelPayload;
+    if (panel.dataset.sourcePath !== cleanSource) return;
+    renderPanelContent(panel, payload);
+  } catch (err) {
+    if (panel.dataset.sourcePath !== cleanSource) return;
+    renderPanelContent(panel, {
+      ok: false,
+      source_path: cleanSource,
+      error: String((err as Error)?.message || err || 'links unavailable'),
+    });
+  }
+}

--- a/internal/web/static/canvas-markdown-panel.ts
+++ b/internal/web/static/canvas-markdown-panel.ts
@@ -1,6 +1,9 @@
 import { apiURL } from './paths.js';
+import { openResolvedMarkdownLink } from './canvas-markdown-links.js';
 
 const PANEL_ID = 'canvas-markdown-link-panel';
+
+type RenderCanvas = (event: Record<string, unknown>) => void;
 
 function appState(): Record<string, unknown> {
   const app = (window as unknown as { _slopshellApp?: { getState?: () => Record<string, unknown> } })._slopshellApp;
@@ -46,6 +49,7 @@ interface BacklinkEntry {
   link_type: string;
   link_target: string;
   excerpt?: string;
+  file_url?: string;
 }
 
 interface PanelPayload {
@@ -110,32 +114,113 @@ function emptyNote(text: string): HTMLElement {
   return note;
 }
 
-function renderOutgoingItem(ref: OutgoingRef): HTMLElement {
+function setBlockedReason(item: HTMLElement, reason: string) {
+  item.classList.add('is-blocked');
+  const detail = item.querySelector('.canvas-link-panel-detail');
+  const message = String(reason || '').trim() || 'link blocked';
+  if (detail instanceof HTMLElement) {
+    detail.textContent = message;
+  }
+}
+
+function makeLinkAnchor(label: string): HTMLAnchorElement {
+  const link = document.createElement('a');
+  link.href = '#';
+  link.className = 'canvas-link-panel-target canvas-link-panel-link';
+  link.textContent = label;
+  return link;
+}
+
+function bindResolverClick(
+  anchor: HTMLAnchorElement,
+  item: HTMLElement,
+  load: () => Promise<void>,
+) {
+  anchor.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    if (anchor.dataset.loading === '1') return;
+    anchor.dataset.loading = '1';
+    item.classList.remove('is-blocked');
+    void load()
+      .catch((err) => {
+        setBlockedReason(item, String((err as Error)?.message || err || 'link blocked'));
+      })
+      .finally(() => {
+        delete anchor.dataset.loading;
+      });
+  });
+}
+
+function renderOutgoingItem(
+  ref: OutgoingRef,
+  panelSourcePath: string,
+  renderCanvas: RenderCanvas,
+): HTMLElement {
   const item = document.createElement('li');
   item.className = 'canvas-link-panel-item';
-  if (!ref.ok) item.classList.add('is-blocked');
-  const label = document.createElement('span');
-  label.className = 'canvas-link-panel-target';
-  label.textContent = ref.type === 'wikilink' ? `[[${ref.target}]]` : ref.target;
-  item.appendChild(label);
+  const label = ref.type === 'wikilink' ? `[[${ref.target}]]` : ref.target;
   const detail = document.createElement('span');
   detail.className = 'canvas-link-panel-detail';
   if (ref.ok) {
+    const anchor = makeLinkAnchor(label);
+    item.appendChild(anchor);
     detail.textContent = ref.vault_relative_path || ref.resolved_path || '';
-  } else {
-    detail.textContent = ref.reason || 'broken link';
+    item.appendChild(detail);
+    bindResolverClick(anchor, item, () =>
+      openResolvedMarkdownLink(
+        {
+          ok: true,
+          kind: ref.kind,
+          file_url: ref.file_url,
+          vault_relative_path: ref.vault_relative_path,
+          resolved_path: ref.resolved_path,
+          source_path: panelSourcePath,
+        },
+        renderCanvas,
+      ),
+    );
+    return item;
   }
+  const span = document.createElement('span');
+  span.className = 'canvas-link-panel-target';
+  span.textContent = label;
+  item.appendChild(span);
+  detail.textContent = ref.reason || 'broken link';
   item.appendChild(detail);
+  item.classList.add('is-blocked');
   return item;
 }
 
-function renderBacklinkItem(entry: BacklinkEntry): HTMLElement {
+function renderBacklinkItem(
+  entry: BacklinkEntry,
+  panelSourcePath: string,
+  renderCanvas: RenderCanvas,
+): HTMLElement {
   const item = document.createElement('li');
   item.className = 'canvas-link-panel-item';
-  const label = document.createElement('span');
-  label.className = 'canvas-link-panel-target';
-  label.textContent = entry.source_path;
-  item.appendChild(label);
+  const fileURL = String(entry.file_url || '').trim();
+  if (!fileURL) {
+    const span = document.createElement('span');
+    span.className = 'canvas-link-panel-target';
+    span.textContent = entry.source_path;
+    item.appendChild(span);
+  } else {
+    const anchor = makeLinkAnchor(entry.source_path);
+    item.appendChild(anchor);
+    bindResolverClick(anchor, item, () =>
+      openResolvedMarkdownLink(
+        {
+          ok: true,
+          kind: 'text',
+          file_url: fileURL,
+          vault_relative_path: entry.source_path,
+          resolved_path: entry.source_path,
+          source_path: panelSourcePath,
+        },
+        renderCanvas,
+      ),
+    );
+  }
   if (entry.excerpt) {
     const excerpt = document.createElement('span');
     excerpt.className = 'canvas-link-panel-excerpt';
@@ -151,7 +236,7 @@ function renderBacklinkItem(entry: BacklinkEntry): HTMLElement {
   return item;
 }
 
-function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
+function renderPanelContent(panel: HTMLElement, payload: PanelPayload, renderCanvas: RenderCanvas) {
   panel.replaceChildren();
   panel.hidden = false;
 
@@ -167,6 +252,7 @@ function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
     return;
   }
 
+  const sourcePath = String(payload.source_path || '').trim();
   const outgoing = Array.isArray(payload.outgoing) ? payload.outgoing : [];
   const broken = outgoing.filter((ref) => !ref.ok);
   const working = outgoing.filter((ref) => ref.ok);
@@ -178,7 +264,7 @@ function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
   } else {
     const list = document.createElement('ul');
     list.className = 'canvas-link-panel-list';
-    working.forEach((ref) => list.appendChild(renderOutgoingItem(ref)));
+    working.forEach((ref) => list.appendChild(renderOutgoingItem(ref, sourcePath, renderCanvas)));
     outgoingSection.appendChild(list);
   }
 
@@ -188,7 +274,7 @@ function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
   } else {
     const list = document.createElement('ul');
     list.className = 'canvas-link-panel-list';
-    broken.forEach((ref) => list.appendChild(renderOutgoingItem(ref)));
+    broken.forEach((ref) => list.appendChild(renderOutgoingItem(ref, sourcePath, renderCanvas)));
     brokenSection.appendChild(list);
   }
 
@@ -198,7 +284,7 @@ function renderPanelContent(panel: HTMLElement, payload: PanelPayload) {
   } else {
     const list = document.createElement('ul');
     list.className = 'canvas-link-panel-list';
-    backlinks.forEach((entry) => list.appendChild(renderBacklinkItem(entry)));
+    backlinks.forEach((entry) => list.appendChild(renderBacklinkItem(entry, sourcePath, renderCanvas)));
     backlinksSection.appendChild(list);
   }
   if (payload.scan_limit_reached) {
@@ -210,7 +296,10 @@ export function clearMarkdownLinkPanel() {
   hidePanel();
 }
 
-export async function renderMarkdownLinkPanelForCanvasEvent(event: { kind?: string; path?: string } | null | undefined) {
+export async function renderMarkdownLinkPanelForCanvasEvent(
+  event: { kind?: string; path?: string } | null | undefined,
+  renderCanvas: RenderCanvas,
+) {
   if (!event || event.kind !== 'text_artifact') {
     hidePanel();
     return;
@@ -224,10 +313,10 @@ export async function renderMarkdownLinkPanelForCanvasEvent(event: { kind?: stri
     hidePanel();
     return;
   }
-  await renderMarkdownLinkPanel(activeWorkspaceID(), path);
+  await renderMarkdownLinkPanel(activeWorkspaceID(), path, renderCanvas);
 }
 
-export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: string) {
+export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: string, renderCanvas: RenderCanvas) {
   const cleanSource = String(sourcePath || '').trim();
   if (!cleanSource) {
     hidePanel();
@@ -246,18 +335,18 @@ export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: s
     if (panel.dataset.sourcePath !== cleanSource) return;
     if (!resp.ok) {
       const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
-      renderPanelContent(panel, { ok: false, source_path: cleanSource, error: detail });
+      renderPanelContent(panel, { ok: false, source_path: cleanSource, error: detail }, renderCanvas);
       return;
     }
     const payload = (await resp.json()) as PanelPayload;
     if (panel.dataset.sourcePath !== cleanSource) return;
-    renderPanelContent(panel, payload);
+    renderPanelContent(panel, payload, renderCanvas);
   } catch (err) {
     if (panel.dataset.sourcePath !== cleanSource) return;
     renderPanelContent(panel, {
       ok: false,
       source_path: cleanSource,
       error: String((err as Error)?.message || err || 'links unavailable'),
-    });
+    }, renderCanvas);
   }
 }

--- a/internal/web/static/canvas.ts
+++ b/internal/web/static/canvas.ts
@@ -35,6 +35,7 @@ import {
   hydrateTextArtifactImages as hydrateVisualTextArtifactImages,
 } from './canvas-visual.js';
 import { hydrateMarkdownArtifactLinks } from './canvas-markdown-links.js';
+import { clearMarkdownLinkPanel, renderMarkdownLinkPanelForCanvasEvent } from './canvas-markdown-panel.js';
 import { apiURL } from './paths.js';
 
 export { escapeHtml, sanitizeHtml } from './canvas-content.js';
@@ -172,6 +173,7 @@ export function hideAll() {
   if (e.text) e.text.classList.remove('is-active');
   if (e.image) e.image.classList.remove('is-active');
   if (e.pdf) e.pdf.classList.remove('is-active');
+  clearMarkdownLinkPanel();
 }
 function isSelectionInside(root, selection) {
   if (!selection || selection.rangeCount === 0) return false;
@@ -821,6 +823,7 @@ export function renderCanvas(event) {
     }
     hydrateVisualTextArtifactImages(e.text, String(event?.path || '').trim(), currentCanvasSessionID());
     hydrateMarkdownArtifactLinks(e.text, event, renderCanvas);
+    void renderMarkdownLinkPanelForCanvasEvent(event);
     const textKey = canvasEventPageKey(event);
     const keepIndex = canvasPageState.kind === 'text' && canvasPageState.key === textKey
       ? canvasPageState.pageIndex

--- a/internal/web/static/canvas.ts
+++ b/internal/web/static/canvas.ts
@@ -823,7 +823,7 @@ export function renderCanvas(event) {
     }
     hydrateVisualTextArtifactImages(e.text, String(event?.path || '').trim(), currentCanvasSessionID());
     hydrateMarkdownArtifactLinks(e.text, event, renderCanvas);
-    void renderMarkdownLinkPanelForCanvasEvent(event);
+    void renderMarkdownLinkPanelForCanvasEvent(event, renderCanvas);
     const textKey = canvasEventPageKey(event);
     const keepIndex = canvasPageState.kind === 'text' && canvasPageState.key === textKey
       ? canvasPageState.pageIndex

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -1,6 +1,7 @@
 @import url("./base.css");
 @import url("./canvas.css");
 @import url("./canvas-pages.css");
+@import url("./canvas-link-panel.css");
 @import url("./mail-drafts.css");
 @import url("./mail-triage.css");
 @import url("./annotations.css");

--- a/internal/web/static_styles_test.go
+++ b/internal/web/static_styles_test.go
@@ -13,6 +13,7 @@ func TestStyleCSSImportsSplitStylesheets(t *testing.T) {
 		`@import url("./base.css");`,
 		`@import url("./canvas.css");`,
 		`@import url("./canvas-pages.css");`,
+		`@import url("./canvas-link-panel.css");`,
 		`@import url("./mail-drafts.css");`,
 		`@import url("./mail-triage.css");`,
 		`@import url("./annotations.css");`,
@@ -58,6 +59,7 @@ func TestSplitStylesheetsExistAndStayBounded(t *testing.T) {
 		"base.css",
 		"canvas.css",
 		"canvas-pages.css",
+		"canvas-link-panel.css",
 		"mail-drafts.css",
 		"mail-triage.css",
 		"annotations.css",
@@ -106,8 +108,8 @@ func TestStyleEntryPointStaysSmall(t *testing.T) {
 		t.Fatalf("read style.css: %v", err)
 	}
 	lines := strings.Count(string(data), "\n") + 1
-	if lines > 19 {
-		t.Fatalf("style.css has %d lines, want <= 19", lines)
+	if lines > 20 {
+		t.Fatalf("style.css has %d lines, want <= 20", lines)
 	}
 	if !strings.HasSuffix(strings.TrimSpace(string(data)), `@import url("./mobile.css");`) {
 		t.Fatalf("style.css should end with the mobile stylesheet import")

--- a/internal/web/workspace_markdown_links.go
+++ b/internal/web/workspace_markdown_links.go
@@ -24,6 +24,14 @@ type workspaceMarkdownLinkResolution struct {
 	Kind              string `json:"kind,omitempty"`
 }
 
+func workspaceMarkdownLinkFileURL(workspace store.Workspace, vaultRelative string) string {
+	clean := strings.TrimSpace(vaultRelative)
+	if clean == "" {
+		return ""
+	}
+	return "/api/workspaces/" + workspaceIDStr(workspace.ID) + "/markdown-link/file?path=" + url.QueryEscape(clean)
+}
+
 func brainWorkspaceRoots(workspace store.Workspace) (string, string, error) {
 	root := absoluteCleanPath(workspace.DirPath)
 	if root == "" {
@@ -234,7 +242,7 @@ func resolveWorkspaceMarkdownLink(workspace store.Workspace, sourceRaw, targetRa
 			result.Kind = "folder"
 		} else {
 			result.Kind = markdownLinkKind(candidate)
-			result.FileURL = "/api/workspaces/" + workspaceIDStr(workspace.ID) + "/markdown-link/file?path=" + url.QueryEscape(vaultRel)
+			result.FileURL = workspaceMarkdownLinkFileURL(workspace, vaultRel)
 		}
 		result.OK = true
 		result.ResolvedPath = vaultRel

--- a/internal/web/workspace_markdown_panel.go
+++ b/internal/web/workspace_markdown_panel.go
@@ -1,0 +1,336 @@
+package web
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+const (
+	workspaceMarkdownBacklinkScanFileCap = 5000
+	workspaceMarkdownBacklinkResultCap   = 50
+	workspaceMarkdownBacklinkExcerptCap  = 160
+)
+
+type workspaceMarkdownLinkRef struct {
+	Target            string `json:"target"`
+	Type              string `json:"type"`
+	OK                bool   `json:"ok"`
+	Blocked           bool   `json:"blocked,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	ResolvedPath      string `json:"resolved_path,omitempty"`
+	VaultRelativePath string `json:"vault_relative_path,omitempty"`
+	FileURL           string `json:"file_url,omitempty"`
+	Kind              string `json:"kind,omitempty"`
+}
+
+type workspaceMarkdownBacklink struct {
+	SourcePath string `json:"source_path"`
+	LinkType   string `json:"link_type"`
+	LinkTarget string `json:"link_target"`
+	Excerpt    string `json:"excerpt,omitempty"`
+}
+
+type workspaceMarkdownLinkPanel struct {
+	OK                 bool                        `json:"ok"`
+	SourcePath         string                      `json:"source_path"`
+	Outgoing           []workspaceMarkdownLinkRef  `json:"outgoing"`
+	BrokenCount        int                         `json:"broken_count"`
+	Backlinks          []workspaceMarkdownBacklink `json:"backlinks"`
+	BacklinksTruncated bool                        `json:"backlinks_truncated,omitempty"`
+	ScanLimitReached   bool                        `json:"scan_limit_reached,omitempty"`
+	Error              string                      `json:"error,omitempty"`
+}
+
+var (
+	markdownInlineLinkRE = regexp.MustCompile(`\[(?:[^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)`)
+	markdownWikilinkRE   = regexp.MustCompile(`\[\[([^\]\n]+)\]\]`)
+	markdownCodeFenceRE  = regexp.MustCompile("(?s)```.*?```|`[^`\n]*`")
+)
+
+func stripBrainPrefixForWorkspace(workspace store.Workspace, sourceRel string) string {
+	brainRoot := absoluteCleanPath(workspace.DirPath)
+	if filepath.Base(brainRoot) != "brain" {
+		return sourceRel
+	}
+	parts := strings.SplitN(strings.TrimSpace(sourceRel), "/", 2)
+	if len(parts) == 2 && strings.EqualFold(parts[0], "brain") {
+		return parts[1]
+	}
+	return sourceRel
+}
+
+func parseMarkdownLinkRefs(text string) []workspaceMarkdownLinkRef {
+	stripped := markdownCodeFenceRE.ReplaceAllString(text, " ")
+	seen := map[string]bool{}
+	refs := []workspaceMarkdownLinkRef{}
+	addRef := func(target, kind string) {
+		clean := strings.TrimSpace(target)
+		if clean == "" {
+			return
+		}
+		key := kind + "\x00" + clean
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		refs = append(refs, workspaceMarkdownLinkRef{Target: clean, Type: kind})
+	}
+	for _, match := range markdownInlineLinkRE.FindAllStringSubmatch(stripped, -1) {
+		if len(match) >= 2 {
+			addRef(match[1], "markdown")
+		}
+	}
+	for _, match := range markdownWikilinkRE.FindAllStringSubmatch(stripped, -1) {
+		if len(match) >= 2 {
+			addRef(match[1], "wikilink")
+		}
+	}
+	return refs
+}
+
+func resolveOutgoingMarkdownLinks(workspace store.Workspace, sourceRel string, refs []workspaceMarkdownLinkRef) []workspaceMarkdownLinkRef {
+	resolved := make([]workspaceMarkdownLinkRef, 0, len(refs))
+	for _, ref := range refs {
+		linkType := ""
+		if ref.Type == "wikilink" {
+			linkType = "wikilink"
+		}
+		result := resolveWorkspaceMarkdownLink(workspace, sourceRel, ref.Target, linkType)
+		merged := workspaceMarkdownLinkRef{
+			Target:            ref.Target,
+			Type:              ref.Type,
+			OK:                result.OK,
+			Blocked:           result.Blocked,
+			Reason:            result.Reason,
+			ResolvedPath:      result.ResolvedPath,
+			VaultRelativePath: result.VaultRelativePath,
+			FileURL:           result.FileURL,
+			Kind:              result.Kind,
+		}
+		resolved = append(resolved, merged)
+	}
+	return resolved
+}
+
+func collectMarkdownBacklinks(workspace store.Workspace, sourceRel string) ([]workspaceMarkdownBacklink, bool, bool, error) {
+	brainRoot, vaultRoot, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		return nil, false, false, err
+	}
+	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
+	sourceVaultRel, err := filepath.Rel(vaultRoot, sourceAbs)
+	if err != nil {
+		return nil, false, false, err
+	}
+	sourceVaultRel = filepath.ToSlash(filepath.Clean(sourceVaultRel))
+	sourceBase := strings.TrimSuffix(filepath.Base(sourceAbs), ".md")
+
+	results := []workspaceMarkdownBacklink{}
+	scanned := 0
+	scanLimitReached := false
+	truncated := false
+
+	walkErr := filepath.WalkDir(brainRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if pathInWorkPersonalGuardrail(path) {
+				return filepath.SkipDir
+			}
+			base := entry.Name()
+			if base != "." && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			return nil
+		}
+		if path == sourceAbs {
+			return nil
+		}
+		if pathInWorkPersonalGuardrail(path) {
+			return nil
+		}
+		scanned++
+		if scanned > workspaceMarkdownBacklinkScanFileCap {
+			scanLimitReached = true
+			return filepath.SkipAll
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		text := string(data)
+		refs := parseMarkdownLinkRefs(text)
+		if len(refs) == 0 {
+			return nil
+		}
+		fileVaultRel, relErr := filepath.Rel(vaultRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		fileVaultRel = filepath.ToSlash(filepath.Clean(fileVaultRel))
+		brainRel, brainRelErr := filepath.Rel(brainRoot, path)
+		if brainRelErr != nil {
+			return nil
+		}
+		brainRel = filepath.ToSlash(filepath.Clean(brainRel))
+		for _, ref := range refs {
+			if !markdownLinkRefMatchesSource(workspace, brainRel, ref, sourceVaultRel, sourceBase, sourceAbs, brainRoot) {
+				continue
+			}
+			if len(results) >= workspaceMarkdownBacklinkResultCap {
+				truncated = true
+				return filepath.SkipAll
+			}
+			results = append(results, workspaceMarkdownBacklink{
+				SourcePath: fileVaultRel,
+				LinkType:   ref.Type,
+				LinkTarget: ref.Target,
+				Excerpt:    extractMarkdownLinkExcerpt(text, ref.Target),
+			})
+			break
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return results, truncated, scanLimitReached, walkErr
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].SourcePath < results[j].SourcePath
+	})
+	return results, truncated, scanLimitReached, nil
+}
+
+func markdownLinkRefMatchesSource(workspace store.Workspace, candidateBrainRel string, ref workspaceMarkdownLinkRef, sourceVaultRel, sourceBase, sourceAbs, brainRoot string) bool {
+	if isExternalMarkdownLink(ref.Target) {
+		return false
+	}
+	linkType := ""
+	if ref.Type == "wikilink" {
+		linkType = "wikilink"
+	}
+	resolved := resolveWorkspaceMarkdownLink(workspace, candidateBrainRel, ref.Target, linkType)
+	if resolved.OK {
+		return resolved.VaultRelativePath == sourceVaultRel
+	}
+	if ref.Type != "wikilink" {
+		return false
+	}
+	target := cleanMarkdownLinkTarget(ref.Target)
+	if target == "" || strings.ContainsAny(target, `/\`) {
+		return false
+	}
+	candidate := target
+	if filepath.Ext(candidate) == "" {
+		candidate += ".md"
+	}
+	if !strings.EqualFold(strings.TrimSuffix(candidate, ".md"), sourceBase) {
+		return false
+	}
+	found, err := findWikilinkByBasename(brainRoot, target)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(found) == sourceAbs
+}
+
+func extractMarkdownLinkExcerpt(text, target string) string {
+	if text == "" || target == "" {
+		return ""
+	}
+	idx := strings.Index(text, target)
+	if idx < 0 {
+		return ""
+	}
+	start := idx
+	for start > 0 && text[start-1] != '\n' {
+		start--
+	}
+	end := idx + len(target)
+	for end < len(text) && text[end] != '\n' {
+		end++
+	}
+	excerpt := strings.TrimSpace(text[start:end])
+	if len(excerpt) > workspaceMarkdownBacklinkExcerptCap {
+		excerpt = excerpt[:workspaceMarkdownBacklinkExcerptCap-1] + "…"
+	}
+	return excerpt
+}
+
+func buildWorkspaceMarkdownLinkPanel(workspace store.Workspace, sourceRaw string) workspaceMarkdownLinkPanel {
+	panel := workspaceMarkdownLinkPanel{Outgoing: []workspaceMarkdownLinkRef{}, Backlinks: []workspaceMarkdownBacklink{}}
+	sourceRel, err := normalizeMarkdownSourcePath(sourceRaw)
+	if err != nil {
+		panel.Error = err.Error()
+		return panel
+	}
+	sourceRel = stripBrainPrefixForWorkspace(workspace, sourceRel)
+	brainRoot, _, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		panel.Error = err.Error()
+		return panel
+	}
+	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
+	if !pathInsideOrEqual(sourceAbs, brainRoot) {
+		panel.Error = "source note is outside the brain workspace"
+		return panel
+	}
+	if err := enforceWorkPersonalPath(sourceAbs); err != nil {
+		panel.Error = workPersonalGuardrailMessage
+		return panel
+	}
+	panel.SourcePath = sourceRel
+	data, err := os.ReadFile(sourceAbs)
+	if err != nil {
+		panel.Error = "source note could not be read"
+		return panel
+	}
+	refs := parseMarkdownLinkRefs(string(data))
+	panel.Outgoing = resolveOutgoingMarkdownLinks(workspace, sourceRel, refs)
+	for _, ref := range panel.Outgoing {
+		if ref.Blocked || !ref.OK {
+			panel.BrokenCount++
+		}
+	}
+	backlinks, truncated, scanLimit, backErr := collectMarkdownBacklinks(workspace, sourceRel)
+	if backErr != nil {
+		panel.Error = backErr.Error()
+		return panel
+	}
+	panel.Backlinks = backlinks
+	panel.BacklinksTruncated = truncated
+	panel.ScanLimitReached = scanLimit
+	panel.OK = true
+	return panel
+}
+
+func (a *App) handleWorkspaceMarkdownLinkPanel(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	workspace, err := a.resolveRuntimeWorkspaceByIDOrActive(chi.URLParam(r, "workspace_id"))
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	panel := buildWorkspaceMarkdownLinkPanel(workspace, r.URL.Query().Get("source"))
+	writeJSON(w, panel)
+}

--- a/internal/web/workspace_markdown_panel.go
+++ b/internal/web/workspace_markdown_panel.go
@@ -35,6 +35,7 @@ type workspaceMarkdownBacklink struct {
 	LinkType   string `json:"link_type"`
 	LinkTarget string `json:"link_target"`
 	Excerpt    string `json:"excerpt,omitempty"`
+	FileURL    string `json:"file_url,omitempty"`
 }
 
 type workspaceMarkdownLinkPanel struct {
@@ -197,6 +198,7 @@ func collectMarkdownBacklinks(workspace store.Workspace, sourceRel string) ([]wo
 				LinkType:   ref.Type,
 				LinkTarget: ref.Target,
 				Excerpt:    extractMarkdownLinkExcerpt(text, ref.Target),
+				FileURL:    workspaceMarkdownLinkFileURL(workspace, fileVaultRel),
 			})
 			break
 		}

--- a/internal/web/workspace_markdown_panel_test.go
+++ b/internal/web/workspace_markdown_panel_test.go
@@ -1,0 +1,231 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+func TestWorkspaceMarkdownLinkPanelOutgoingAndBroken(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir topics: %v", err)
+	}
+	body := strings.Join([]string{
+		"# Active",
+		"",
+		"See [related](related.md) and [missing](does-not-exist.md).",
+		"Also [[Related Note]] for the wikilink path.",
+		"```",
+		"[fenced](should-not-count.md)",
+		"```",
+		"And `[inline](skip.md)` inline code is also ignored.",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write source note: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "related.md"), []byte("related"), 0o644); err != nil {
+		t.Fatalf("write related: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "Related Note.md"), []byte("related note"), 0o644); err != nil {
+		t.Fatalf("write related note: %v", err)
+	}
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	panel := requestMarkdownLinkPanel(t, app, workspace.ID, "topics/active.md")
+	if !panel.OK || panel.SourcePath != "topics/active.md" {
+		t.Fatalf("panel = %+v", panel)
+	}
+	if got := len(panel.Outgoing); got != 3 {
+		t.Fatalf("outgoing count = %d, want 3 (fenced/inline-code links must be ignored): %+v", got, panel.Outgoing)
+	}
+	byTarget := map[string]workspaceMarkdownLinkRef{}
+	for _, ref := range panel.Outgoing {
+		byTarget[ref.Type+":"+ref.Target] = ref
+	}
+	related, ok := byTarget["markdown:related.md"]
+	if !ok || !related.OK || related.ResolvedPath != "brain/topics/related.md" || related.Kind != "text" {
+		t.Fatalf("related ref = %+v", related)
+	}
+	missing, ok := byTarget["markdown:does-not-exist.md"]
+	if !ok || missing.OK || !missing.Blocked || missing.Reason != "link target was not found in the vault" {
+		t.Fatalf("missing ref = %+v", missing)
+	}
+	wiki, ok := byTarget["wikilink:Related Note"]
+	if !ok || !wiki.OK || wiki.ResolvedPath != "brain/topics/Related Note.md" {
+		t.Fatalf("wiki ref = %+v", wiki)
+	}
+	if panel.BrokenCount != 1 {
+		t.Fatalf("broken count = %d, want 1", panel.BrokenCount)
+	}
+}
+
+func TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir topics: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(brainRoot, "people"), 0o755); err != nil {
+		t.Fatalf("mkdir people: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("# Active"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(brainRoot, "people", "alice.md"),
+		[]byte("Alice mentions [the topic](../topics/active.md) in their note."),
+		0o644,
+	); err != nil {
+		t.Fatalf("write alice: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(brainRoot, "people", "bob.md"),
+		[]byte("Bob refers to [[active]] explicitly."),
+		0o644,
+	); err != nil {
+		t.Fatalf("write bob: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(brainRoot, "people", "carol.md"),
+		[]byte("Carol points elsewhere [[unrelated]]."),
+		0o644,
+	); err != nil {
+		t.Fatalf("write carol: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(personalRoot, "diary.md"),
+		[]byte("private mention of [active](../brain/topics/active.md)"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write personal: %v", err)
+	}
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	panel := requestMarkdownLinkPanel(t, app, workspace.ID, "topics/active.md")
+	if !panel.OK {
+		t.Fatalf("panel not ok: %+v", panel)
+	}
+	if got := len(panel.Backlinks); got != 2 {
+		t.Fatalf("backlinks = %d, want 2 (alice + bob, personal excluded): %+v", got, panel.Backlinks)
+	}
+	bySource := map[string]workspaceMarkdownBacklink{}
+	for _, link := range panel.Backlinks {
+		bySource[link.SourcePath] = link
+	}
+	alice, ok := bySource["brain/people/alice.md"]
+	if !ok || alice.LinkType != "markdown" || alice.LinkTarget != "../topics/active.md" {
+		t.Fatalf("alice backlink = %+v", alice)
+	}
+	if alice.Excerpt == "" || !strings.Contains(alice.Excerpt, "Alice mentions") {
+		t.Fatalf("alice excerpt = %q", alice.Excerpt)
+	}
+	bob, ok := bySource["brain/people/bob.md"]
+	if !ok || bob.LinkType != "wikilink" || bob.LinkTarget != "active" {
+		t.Fatalf("bob backlink = %+v", bob)
+	}
+	for _, link := range panel.Backlinks {
+		if strings.Contains(link.SourcePath, "personal/") {
+			t.Fatalf("backlink leaked personal subtree: %+v", link)
+		}
+		if strings.Contains(link.SourcePath, vaultRoot) || filepath.IsAbs(link.SourcePath) {
+			t.Fatalf("backlink leaked absolute path: %+v", link)
+		}
+	}
+}
+
+func TestWorkspaceMarkdownLinkPanelBlockedPersonalTarget(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir topics: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(brainRoot, "topics", "active.md"),
+		[]byte("Reference [diary](../../personal/diary.md)."),
+		0o644,
+	); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(personalRoot, "diary.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write personal: %v", err)
+	}
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	panel := requestMarkdownLinkPanel(t, app, workspace.ID, "topics/active.md")
+	if !panel.OK || len(panel.Outgoing) != 1 {
+		t.Fatalf("panel = %+v", panel)
+	}
+	ref := panel.Outgoing[0]
+	if ref.OK || !ref.Blocked || !strings.Contains(ref.Reason, "work personal subtree is blocked") {
+		t.Fatalf("blocked ref = %+v", ref)
+	}
+	if strings.Contains(ref.Reason, personalRoot) {
+		t.Fatalf("reason leaked absolute path: %q", ref.Reason)
+	}
+	if panel.BrokenCount != 1 {
+		t.Fatalf("broken count = %d, want 1", panel.BrokenCount)
+	}
+}
+
+func TestWorkspaceMarkdownLinkPanelMissingSourceReportsError(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(brainRoot, 0o755); err != nil {
+		t.Fatalf("mkdir brain: %v", err)
+	}
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	panel := requestMarkdownLinkPanel(t, app, workspace.ID, "topics/active.md")
+	if panel.OK || panel.Error != "source note could not be read" {
+		t.Fatalf("missing-source panel = %+v", panel)
+	}
+}
+
+func requestMarkdownLinkPanel(t *testing.T, app *App, workspaceID int64, sourcePath string) workspaceMarkdownLinkPanel {
+	t.Helper()
+	values := url.Values{}
+	values.Set("source", sourcePath)
+	rr := doAuthedJSONRequest(
+		t,
+		app.Router(),
+		http.MethodGet,
+		"/api/workspaces/"+itoa(workspaceID)+"/markdown-link/panel?"+values.Encode(),
+		nil,
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("panel status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var panel workspaceMarkdownLinkPanel
+	if err := json.Unmarshal(rr.Body.Bytes(), &panel); err != nil {
+		t.Fatalf("decode panel: %v", err)
+	}
+	return panel
+}

--- a/internal/web/workspace_markdown_panel_test.go
+++ b/internal/web/workspace_markdown_panel_test.go
@@ -137,9 +137,16 @@ func TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion(t *testing.T) {
 	if alice.Excerpt == "" || !strings.Contains(alice.Excerpt, "Alice mentions") {
 		t.Fatalf("alice excerpt = %q", alice.Excerpt)
 	}
+	wantAliceURL := "/api/workspaces/" + itoa(workspace.ID) + "/markdown-link/file?path=brain%2Fpeople%2Falice.md"
+	if alice.FileURL != wantAliceURL {
+		t.Fatalf("alice file_url = %q, want %q", alice.FileURL, wantAliceURL)
+	}
 	bob, ok := bySource["brain/people/bob.md"]
 	if !ok || bob.LinkType != "wikilink" || bob.LinkTarget != "active" {
 		t.Fatalf("bob backlink = %+v", bob)
+	}
+	if bob.FileURL == "" || !strings.Contains(bob.FileURL, "brain%2Fpeople%2Fbob.md") {
+		t.Fatalf("bob file_url = %q", bob.FileURL)
 	}
 	for _, link := range panel.Backlinks {
 		if strings.Contains(link.SourcePath, "personal/") {
@@ -148,6 +155,46 @@ func TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion(t *testing.T) {
 		if strings.Contains(link.SourcePath, vaultRoot) || filepath.IsAbs(link.SourcePath) {
 			t.Fatalf("backlink leaked absolute path: %+v", link)
 		}
+	}
+}
+
+func TestWorkspaceMarkdownLinkPanelBacklinkFileURLServesNote(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	if err := os.MkdirAll(filepath.Join(brainRoot, "topics"), 0o755); err != nil {
+		t.Fatalf("mkdir topics: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(brainRoot, "people"), 0o755); err != nil {
+		t.Fatalf("mkdir people: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainRoot, "topics", "active.md"), []byte("# Active"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	aliceBody := "Alice mentions [the topic](../topics/active.md)."
+	if err := os.WriteFile(filepath.Join(brainRoot, "people", "alice.md"), []byte(aliceBody), 0o644); err != nil {
+		t.Fatalf("write alice: %v", err)
+	}
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	panel := requestMarkdownLinkPanel(t, app, workspace.ID, "topics/active.md")
+	if !panel.OK || len(panel.Backlinks) != 1 {
+		t.Fatalf("panel = %+v", panel)
+	}
+	fileURL := panel.Backlinks[0].FileURL
+	if fileURL == "" {
+		t.Fatalf("backlink missing file_url: %+v", panel.Backlinks[0])
+	}
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, fileURL, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("file_url GET status = %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); got != aliceBody {
+		t.Fatalf("file_url body = %q, want %q", got, aliceBody)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/workspaces/{workspace_id}/markdown-link/panel` returning outgoing links (resolved + broken), backlinks scanned over the brain root, and structured diagnostics. Reuses the existing `resolveWorkspaceMarkdownLink` helper so the work `personal/` guardrail and vault bounds keep enforcing automatically.
- Adds `canvas-markdown-panel.ts` + `canvas-link-panel.css`, mounted from `canvas.ts` whenever a `text_artifact` `.md` is rendered inside a brain workspace. Panel hides for non-brain workspaces and is cleared on `hideAll()`.
- Bounded backlink scan: caps file walk at 5000 files and 50 result rows, skips `personal/` and dotfile dirs, marks truncation in the response. No persistent index.

## Verification

### Acceptance: Tests cover link display, backlinks, broken links, and blocked `personal/` targets
`go test ./internal/web/ -run 'TestWorkspaceMarkdownLinkPanel' -count=1 -v`
```
=== RUN   TestWorkspaceMarkdownLinkPanelOutgoingAndBroken
--- PASS: TestWorkspaceMarkdownLinkPanelOutgoingAndBroken (0.02s)
=== RUN   TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion
--- PASS: TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion (0.02s)
=== RUN   TestWorkspaceMarkdownLinkPanelBlockedPersonalTarget
--- PASS: TestWorkspaceMarkdownLinkPanelBlockedPersonalTarget (0.02s)
=== RUN   TestWorkspaceMarkdownLinkPanelMissingSourceReportsError
--- PASS: TestWorkspaceMarkdownLinkPanelMissingSourceReportsError (0.02s)
PASS
```
- `TestWorkspaceMarkdownLinkPanelOutgoingAndBroken` covers outgoing markdown + wikilink resolution and ignores fenced/inline-code link tokens; broken-count surfaces `does-not-exist.md` with reason `link target was not found in the vault`.
- `TestWorkspaceMarkdownLinkPanelBacklinksAndPersonalExclusion` covers markdown + wikilink backlink discovery (`alice.md`, `bob.md`) and confirms a personal-subtree note linking to the source is excluded.
- `TestWorkspaceMarkdownLinkPanelBlockedPersonalTarget` covers an outgoing link into `personal/` that is reported as blocked with the work-personal guardrail message and no leaked absolute path.
- `TestWorkspaceMarkdownLinkPanelMissingSourceReportsError` covers the missing-source-note error path.

### Acceptance: UI does not require a persistent search index
- `internal/web/workspace_markdown_panel.go:124-184` walks the brain root with `filepath.WalkDir`, parses each `.md` with regex, and stops once the file/result caps fire. No SQLite, no FTS, no cache.
- `internal/web/static/canvas-markdown-panel.ts` fetches the panel API per render, never persists state on the client.

### Acceptance: Search uses bounded `rg`/parser calls and clear loading states if a vault search takes time
- Bounded scan caps in `workspace_markdown_panel.go:18-21`: `workspaceMarkdownBacklinkScanFileCap = 5000`, `workspaceMarkdownBacklinkResultCap = 50`. `scan_limit_reached` and `backlinks_truncated` flags surface to the UI; the panel renders the "scan stopped at the file cap" notice when set.
- Loading state: `setPanelLoading()` in `canvas-markdown-panel.ts` shows "Loading links…" before the response arrives, and stale-source races are dropped by checking `panel.dataset.sourcePath`.

### Regression: existing markdown-link/resolve flow still passes
`go test ./internal/web/ -run 'TestWorkspaceMarkdownLink' -count=1`
```
PASS
ok  	github.com/sloppy-org/slopshell/internal/web	0.191s
```

### Regression: surface inventory + style imports stay in sync
- `./scripts/sync-surface.sh --check` exits 0; `docs/interfaces.md` updated to list `GET /api/workspaces/{workspace_id}/markdown-link/panel`.
- `static_styles_test.go` updated for the new `canvas-link-panel.css` import; `TestSplitStylesheetsExistAndStayBounded` and `TestStyleEntryPointStaysSmall` pass.

### Full project verification
- `go test ./...` — all packages green (see test log; `internal/web` 27.1s, `internal/surface` 0.012s, all other packages cached PASS).
- `npm run typecheck:frontend` — no errors.
- `npm run build:frontend` — built 71 frontend modules including `canvas-markdown-panel.js`.

## Test plan
- [x] `go test ./...`
- [x] `npm run typecheck:frontend`
- [x] `npm run build:frontend`
- [x] `./scripts/sync-surface.sh --check`