### PR TITLE
fix: Add local graph view for active note or entity (fixes #736)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -57,6 +57,7 @@ Runtime and chat session management:
 - `GET /api/workspaces/{workspace_id}/markdown-link/resolve`
 - `GET /api/workspaces/{workspace_id}/markdown-link/file`
 - `GET /api/workspaces/{workspace_id}/markdown-link/panel`
+- `GET /api/workspaces/{workspace_id}/graph`
 - `GET /api/workspaces/{workspace_id}/companion/config`
 - `PUT /api/workspaces/{workspace_id}/companion/config`
 - `GET /api/workspaces/{workspace_id}/companion/state`

--- a/internal/surface/routes.go
+++ b/internal/surface/routes.go
@@ -57,6 +57,7 @@ var WebRouteSections = []RouteSection{
 			"GET /api/workspaces/{workspace_id}/markdown-link/resolve",
 			"GET /api/workspaces/{workspace_id}/markdown-link/file",
 			"GET /api/workspaces/{workspace_id}/markdown-link/panel",
+			"GET /api/workspaces/{workspace_id}/graph",
 			"GET /api/workspaces/{workspace_id}/companion/config",
 			"PUT /api/workspaces/{workspace_id}/companion/config",
 			"GET /api/workspaces/{workspace_id}/companion/state",

--- a/internal/web/server_routes.go
+++ b/internal/web/server_routes.go
@@ -50,6 +50,7 @@ func (a *App) Router() http.Handler {
 	r.Get("/api/workspaces/{workspace_id}/markdown-link/resolve", a.handleWorkspaceMarkdownLinkResolve)
 	r.Get("/api/workspaces/{workspace_id}/markdown-link/file", a.handleWorkspaceMarkdownLinkFile)
 	r.Get("/api/workspaces/{workspace_id}/markdown-link/panel", a.handleWorkspaceMarkdownLinkPanel)
+	r.Get("/api/workspaces/{workspace_id}/graph", a.handleWorkspaceLocalGraph)
 	r.Get("/api/runtime/workspaces/{workspace_id}/welcome", a.handleWorkspaceWelcome)
 	r.Get("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigGet)
 	r.Put("/api/workspaces/{workspace_id}/companion/config", a.handleWorkspaceCompanionConfigPut)

--- a/internal/web/static/canvas-link-panel.css
+++ b/internal/web/static/canvas-link-panel.css
@@ -71,3 +71,73 @@
   font-style: italic;
   margin: 0;
 }
+.canvas-local-graph-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.canvas-local-graph-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--fg-muted, #475569);
+  font-size: 0.82em;
+}
+.canvas-local-graph-controls input[type="text"],
+.canvas-local-graph-controls input:not([type]),
+.canvas-local-graph-controls select {
+  border: 1px solid var(--border, #cbd5e1);
+  background: var(--bg, #fff);
+  color: var(--fg, #0f172a);
+  border-radius: 4px;
+  min-height: 1.75rem;
+  padding: 0.2rem 0.35rem;
+  font: inherit;
+  font-size: 0.82em;
+}
+.canvas-local-graph-controls button {
+  border: 1px solid var(--accent, #2563eb);
+  background: var(--accent, #2563eb);
+  color: white;
+  border-radius: 4px;
+  min-height: 1.75rem;
+  padding: 0.2rem 0.5rem;
+  font: inherit;
+  font-size: 0.82em;
+  cursor: pointer;
+}
+.canvas-local-graph-host {
+  min-height: 180px;
+}
+.canvas-local-graph {
+  width: 100%;
+  max-height: 300px;
+  display: block;
+}
+.canvas-local-graph-edge {
+  stroke: var(--border, #cbd5e1);
+  stroke-width: 1.4;
+}
+.canvas-local-graph-node {
+  cursor: pointer;
+}
+.canvas-local-graph-node circle {
+  stroke: white;
+  stroke-width: 2;
+}
+.canvas-local-graph-node text {
+  fill: var(--fg, #0f172a);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  text-anchor: middle;
+  paint-order: stroke;
+  stroke: var(--bg-elevated, #f8fafc);
+  stroke-width: 3px;
+}
+.canvas-local-graph-node:hover circle,
+.canvas-local-graph-node:focus circle {
+  stroke: var(--accent, #2563eb);
+  stroke-width: 3;
+}

--- a/internal/web/static/canvas-local-graph.ts
+++ b/internal/web/static/canvas-local-graph.ts
@@ -29,6 +29,14 @@ type GraphPayload = {
   error?: string;
 };
 
+export type GraphTarget = {
+  sourcePath?: string;
+  artifactID?: number;
+  artifactPath?: string;
+  rootID?: string;
+  label?: string;
+};
+
 const RELATIONS = [
   ['markdown_link', 'Links'],
   ['backlink', 'Backlinks'],
@@ -70,8 +78,16 @@ function relationParams(form: HTMLFormElement): string[] {
   return checked.map((input) => input.value).filter(Boolean);
 }
 
-function graphQuery(sourcePath: string, form: HTMLFormElement): URLSearchParams {
-  const params = new URLSearchParams({ source: sourcePath });
+function normalizeGraphTarget(target: GraphTarget | string): GraphTarget {
+  return typeof target === 'string' ? { sourcePath: target, label: target } : target;
+}
+
+function graphQuery(target: GraphTarget, form: HTMLFormElement): URLSearchParams {
+  const params = new URLSearchParams();
+  if (target.sourcePath) params.set('source', target.sourcePath);
+  if (target.artifactID && Number.isFinite(target.artifactID)) params.set('artifact_id', String(target.artifactID));
+  if (target.artifactPath) params.set('artifact_path', target.artifactPath);
+  if (target.rootID) params.set('root', target.rootID);
   for (const relation of relationParams(form)) params.append('relation', relation);
   const source = String(new FormData(form).get('source_filter') || '').trim();
   const label = String(new FormData(form).get('label') || '').trim();
@@ -260,9 +276,10 @@ function renderGraph(host: HTMLElement, payload: GraphPayload, renderCanvas: Ren
 export async function renderLocalGraphSection(
   panel: HTMLElement,
   workspaceID: string,
-  sourcePath: string,
+  target: GraphTarget | string,
   renderCanvas: RenderCanvas,
 ) {
+  const graphTarget = normalizeGraphTarget(target);
   const section = makeGraphSection(panel);
   const heading = section.querySelector('.canvas-link-panel-heading') || document.createElement('h4');
   heading.className = 'canvas-link-panel-heading';
@@ -270,17 +287,17 @@ export async function renderLocalGraphSection(
   section.replaceChildren(heading);
   let graphHost: HTMLElement;
   const form = renderGraphControls(section, () => {
-    void loadGraph(workspaceID, sourcePath, form, graphHost, renderCanvas);
+    void loadGraph(workspaceID, graphTarget, form, graphHost, renderCanvas);
   });
   graphHost = document.createElement('div');
   graphHost.className = 'canvas-local-graph-host';
   section.appendChild(graphHost);
-  await loadGraph(workspaceID, sourcePath, form, graphHost, renderCanvas);
+  await loadGraph(workspaceID, graphTarget, form, graphHost, renderCanvas);
 }
 
-async function loadGraph(workspaceID: string, sourcePath: string, form: HTMLFormElement, host: HTMLElement, renderCanvas: RenderCanvas) {
+async function loadGraph(workspaceID: string, target: GraphTarget, form: HTMLFormElement, host: HTMLElement, renderCanvas: RenderCanvas) {
   renderGraphMessage(host, 'Loading graph...');
-  const params = graphQuery(sourcePath, form);
+  const params = graphQuery(target, form);
   const resp = await fetch(apiURL(`workspaces/${encodeURIComponent(workspaceID)}/graph?${params.toString()}`), { cache: 'no-store' });
   if (!resp.ok) {
     renderGraphMessage(host, (await resp.text()).trim() || `HTTP ${resp.status}`);

--- a/internal/web/static/canvas-local-graph.ts
+++ b/internal/web/static/canvas-local-graph.ts
@@ -1,0 +1,290 @@
+import { apiURL } from './paths.js';
+import { openResolvedMarkdownLink } from './canvas-markdown-links.js';
+
+type RenderCanvas = (event: Record<string, unknown>) => void;
+
+type GraphNode = {
+  id: string;
+  type: string;
+  label: string;
+  path?: string;
+  file_url?: string;
+  source?: string;
+  sphere?: string;
+};
+
+type GraphEdge = {
+  source: string;
+  target: string;
+  relation: string;
+  label?: string;
+};
+
+type GraphPayload = {
+  ok?: boolean;
+  source_path?: string;
+  nodes?: GraphNode[];
+  edges?: GraphEdge[];
+  truncated?: boolean;
+  error?: string;
+};
+
+const RELATIONS = [
+  ['markdown_link', 'Links'],
+  ['backlink', 'Backlinks'],
+  ['artifact', 'Artifacts'],
+  ['source_binding', 'Sources'],
+  ['item_actor', 'Actors'],
+  ['item_label', 'Labels'],
+] as const;
+
+function appState(): Record<string, any> {
+  const app = (window as any)._slopshellApp;
+  return typeof app?.getState === 'function' ? app.getState() : {};
+}
+
+function activeSphere(): string {
+  const state = appState();
+  const projects = Array.isArray(state.projects) ? state.projects : [];
+  const activeID = String(state.activeWorkspaceId || '').trim();
+  const project = projects.find((entry) => String(entry?.id || '') === activeID);
+  return String(project?.sphere || state.activeSphere || 'work').trim().toLowerCase() || 'work';
+}
+
+function makeGraphSection(panel: HTMLElement): HTMLElement {
+  const existing = panel.querySelector('.canvas-local-graph-section');
+  if (existing instanceof HTMLElement) return existing;
+  let section: HTMLElement;
+  section = document.createElement('section');
+  section.className = 'canvas-link-panel-section canvas-local-graph-section';
+  const heading = document.createElement('h4');
+  heading.className = 'canvas-link-panel-heading';
+  heading.textContent = 'Graph';
+  section.appendChild(heading);
+  panel.appendChild(section);
+  return section;
+}
+
+function relationParams(form: HTMLFormElement): string[] {
+  const checked = Array.from(form.querySelectorAll<HTMLInputElement>('input[name="graph-relation"]:checked'));
+  return checked.map((input) => input.value).filter(Boolean);
+}
+
+function graphQuery(sourcePath: string, form: HTMLFormElement): URLSearchParams {
+  const params = new URLSearchParams({ source: sourcePath });
+  for (const relation of relationParams(form)) params.append('relation', relation);
+  const source = String(new FormData(form).get('source_filter') || '').trim();
+  const label = String(new FormData(form).get('label') || '').trim();
+  const sphere = String(new FormData(form).get('sphere') || '').trim();
+  if (source) params.set('source_filter', source);
+  if (label) params.set('label', label);
+  if (sphere) params.set('sphere', sphere);
+  return params;
+}
+
+function renderGraphControls(section: HTMLElement, onApply: () => void): HTMLFormElement {
+  const form = document.createElement('form');
+  form.className = 'canvas-local-graph-controls';
+  for (const [value, label] of RELATIONS) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'canvas-local-graph-check';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.name = 'graph-relation';
+    input.value = value;
+    input.checked = true;
+    wrapper.append(input, document.createTextNode(label));
+    form.appendChild(wrapper);
+  }
+  form.appendChild(graphTextInput('source_filter', 'source'));
+  form.appendChild(graphTextInput('label', 'label'));
+  const sphere = document.createElement('select');
+  sphere.name = 'sphere';
+  for (const value of ['work', 'private']) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    option.selected = value === activeSphere();
+    sphere.appendChild(option);
+  }
+  form.appendChild(sphere);
+  const apply = document.createElement('button');
+  apply.type = 'submit';
+  apply.textContent = 'Apply';
+  form.appendChild(apply);
+  form.addEventListener('submit', (ev) => {
+    ev.preventDefault();
+    onApply();
+  });
+  section.appendChild(form);
+  return form;
+}
+
+function graphTextInput(name: string, placeholder: string): HTMLInputElement {
+  const input = document.createElement('input');
+  input.name = name;
+  input.placeholder = placeholder;
+  input.autocomplete = 'off';
+  return input;
+}
+
+function renderGraphMessage(host: HTMLElement, text: string) {
+  host.replaceChildren();
+  appendGraphNote(host, text);
+}
+
+function appendGraphNote(host: HTMLElement, text: string) {
+  const note = document.createElement('p');
+  note.className = 'canvas-link-panel-empty';
+  note.textContent = text;
+  host.appendChild(note);
+}
+
+function nodeColor(type: string): string {
+  if (type === 'item') return '#0f766e';
+  if (type === 'actor') return '#7c2d12';
+  if (type === 'label') return '#854d0e';
+  if (type === 'source') return '#4338ca';
+  if (type === 'artifact') return '#0369a1';
+  return '#475569';
+}
+
+function graphPositions(nodes: GraphNode[], width: number, height: number): Map<string, { x: number; y: number }> {
+  const positions = new Map<string, { x: number; y: number }>();
+  const center = { x: width / 2, y: height / 2 };
+  if (!nodes.length) return positions;
+  positions.set(nodes[0].id, center);
+  const radius = Math.max(70, Math.min(width, height) * 0.34);
+  nodes.slice(1).forEach((node, index) => {
+    const angle = (-Math.PI / 2) + (index * 2 * Math.PI / Math.max(1, nodes.length - 1));
+    positions.set(node.id, {
+      x: center.x + Math.cos(angle) * radius,
+      y: center.y + Math.sin(angle) * radius,
+    });
+  });
+  return positions;
+}
+
+function appendEdge(svg: SVGSVGElement, edge: GraphEdge, positions: Map<string, { x: number; y: number }>) {
+  const from = positions.get(edge.source);
+  const to = positions.get(edge.target);
+  if (!from || !to) return;
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  line.setAttribute('x1', String(from.x));
+  line.setAttribute('y1', String(from.y));
+  line.setAttribute('x2', String(to.x));
+  line.setAttribute('y2', String(to.y));
+  line.setAttribute('class', `canvas-local-graph-edge relation-${edge.relation}`);
+  svg.appendChild(line);
+}
+
+function appendNode(svg: SVGSVGElement, node: GraphNode, point: { x: number; y: number }, renderCanvas: RenderCanvas) {
+  const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  group.setAttribute('class', `canvas-local-graph-node type-${node.type}`);
+  group.setAttribute('role', 'button');
+  group.setAttribute('tabindex', '0');
+  group.setAttribute('aria-label', `${node.type}: ${node.label}`);
+  group.dataset.nodeId = node.id;
+
+  const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  circle.setAttribute('cx', String(point.x));
+  circle.setAttribute('cy', String(point.y));
+  circle.setAttribute('r', node.type === 'note' ? '14' : '11');
+  circle.setAttribute('fill', nodeColor(node.type));
+  group.appendChild(circle);
+
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  text.setAttribute('x', String(point.x));
+  text.setAttribute('y', String(point.y + 27));
+  text.textContent = node.label;
+  group.appendChild(text);
+
+  const open = () => openGraphNode(node, renderCanvas);
+  group.addEventListener('click', open);
+  group.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      ev.preventDefault();
+      open();
+    }
+  });
+  svg.appendChild(group);
+}
+
+function openGraphNode(node: GraphNode, renderCanvas: RenderCanvas) {
+  if (node.file_url || node.path) {
+    void openResolvedMarkdownLink({
+      ok: true,
+      kind: node.type === 'artifact' ? 'text' : node.type,
+      file_url: node.file_url,
+      vault_relative_path: node.path,
+      resolved_path: node.path,
+    }, renderCanvas);
+    return;
+  }
+  renderCanvas({
+    kind: 'text_artifact',
+    event_id: `local-graph-node-${Date.now()}`,
+    title: node.label,
+    path: node.id,
+    text: [`# ${node.label}`, '', `Type: ${node.type}`, node.source ? `Source: ${node.source}` : '', node.sphere ? `Sphere: ${node.sphere}` : ''].filter(Boolean).join('\n'),
+  });
+}
+
+function renderGraph(host: HTMLElement, payload: GraphPayload, renderCanvas: RenderCanvas) {
+  host.replaceChildren();
+  if (!payload.ok) {
+    renderGraphMessage(host, payload.error || 'graph unavailable');
+    return;
+  }
+  const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+  const edges = Array.isArray(payload.edges) ? payload.edges : [];
+  if (!nodes.length) {
+    renderGraphMessage(host, 'no graph nodes');
+    return;
+  }
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('class', 'canvas-local-graph');
+  svg.setAttribute('viewBox', '0 0 520 300');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', `Local graph for ${payload.source_path || 'active note'}`);
+  const positions = graphPositions(nodes, 520, 300);
+  edges.forEach((edge) => appendEdge(svg, edge, positions));
+  nodes.forEach((node) => {
+    const point = positions.get(node.id);
+    if (point) appendNode(svg, node, point, renderCanvas);
+  });
+  host.appendChild(svg);
+  if (payload.truncated) appendGraphNote(host, 'graph truncated');
+}
+
+export async function renderLocalGraphSection(
+  panel: HTMLElement,
+  workspaceID: string,
+  sourcePath: string,
+  renderCanvas: RenderCanvas,
+) {
+  const section = makeGraphSection(panel);
+  const heading = section.querySelector('.canvas-link-panel-heading') || document.createElement('h4');
+  heading.className = 'canvas-link-panel-heading';
+  heading.textContent = 'Graph';
+  section.replaceChildren(heading);
+  let graphHost: HTMLElement;
+  const form = renderGraphControls(section, () => {
+    void loadGraph(workspaceID, sourcePath, form, graphHost, renderCanvas);
+  });
+  graphHost = document.createElement('div');
+  graphHost.className = 'canvas-local-graph-host';
+  section.appendChild(graphHost);
+  await loadGraph(workspaceID, sourcePath, form, graphHost, renderCanvas);
+}
+
+async function loadGraph(workspaceID: string, sourcePath: string, form: HTMLFormElement, host: HTMLElement, renderCanvas: RenderCanvas) {
+  renderGraphMessage(host, 'Loading graph...');
+  const params = graphQuery(sourcePath, form);
+  const resp = await fetch(apiURL(`workspaces/${encodeURIComponent(workspaceID)}/graph?${params.toString()}`), { cache: 'no-store' });
+  if (!resp.ok) {
+    renderGraphMessage(host, (await resp.text()).trim() || `HTTP ${resp.status}`);
+    return;
+  }
+  renderGraph(host, await resp.json() as GraphPayload, renderCanvas);
+}

--- a/internal/web/static/canvas-markdown-panel.ts
+++ b/internal/web/static/canvas-markdown-panel.ts
@@ -1,10 +1,18 @@
 import { apiURL } from './paths.js';
 import { openResolvedMarkdownLink } from './canvas-markdown-links.js';
-import { renderLocalGraphSection } from './canvas-local-graph.js';
+import { renderLocalGraphSection, type GraphTarget } from './canvas-local-graph.js';
 
 const PANEL_ID = 'canvas-markdown-link-panel';
 
 type RenderCanvas = (event: Record<string, unknown>) => void;
+
+type CanvasGraphEvent = {
+  kind?: string;
+  path?: string;
+  title?: string;
+  artifact_id?: number;
+  meta?: Record<string, unknown>;
+};
 
 function appState(): Record<string, unknown> {
   const app = (window as unknown as { _slopshellApp?: { getState?: () => Record<string, unknown> } })._slopshellApp;
@@ -31,6 +39,27 @@ function activeBrainProjectRoot(): string {
 
 function isMarkdownArtifactPath(path: string): boolean {
   return /\.md$/i.test(String(path || '').trim());
+}
+
+function graphEntityRoot(path: string): string {
+  const clean = String(path || '').trim();
+  return /^(?:artifact|item|actor|label|source):[^:]+/i.test(clean) ? clean : '';
+}
+
+function eventArtifactID(event: CanvasGraphEvent): number {
+  const raw = Number(event.meta?.artifact_id || event.artifact_id || 0);
+  return Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+function graphTargetForCanvasEvent(event: CanvasGraphEvent): GraphTarget | null {
+  const path = String(event.path || '').trim();
+  if (isMarkdownArtifactPath(path)) return { sourcePath: path, label: path };
+  const rootID = graphEntityRoot(path);
+  if (rootID) return { rootID, label: rootID };
+  const artifactID = eventArtifactID(event);
+  if (artifactID > 0) return { artifactID, label: String(event.title || path || `artifact:${artifactID}`) };
+  if (path) return { artifactPath: path, label: path };
+  return null;
 }
 
 interface OutgoingRef {
@@ -298,15 +327,15 @@ export function clearMarkdownLinkPanel() {
 }
 
 export async function renderMarkdownLinkPanelForCanvasEvent(
-  event: { kind?: string; path?: string } | null | undefined,
+  event: CanvasGraphEvent | null | undefined,
   renderCanvas: RenderCanvas,
 ) {
-  if (!event || event.kind !== 'text_artifact') {
+  if (!event) {
     hidePanel();
     return;
   }
-  const path = String(event.path || '').trim();
-  if (!isMarkdownArtifactPath(path)) {
+  const target = graphTargetForCanvasEvent(event);
+  if (!target) {
     hidePanel();
     return;
   }
@@ -314,7 +343,24 @@ export async function renderMarkdownLinkPanelForCanvasEvent(
     hidePanel();
     return;
   }
-  await renderMarkdownLinkPanel(activeWorkspaceID(), path, renderCanvas);
+  if (target.sourcePath) {
+    await renderMarkdownLinkPanel(activeWorkspaceID(), target.sourcePath, renderCanvas);
+    return;
+  }
+  await renderGraphOnlyPanel(activeWorkspaceID(), target, renderCanvas);
+}
+
+async function renderGraphOnlyPanel(workspaceID: string, target: GraphTarget, renderCanvas: RenderCanvas) {
+  const panel = panelHost();
+  if (!panel) return;
+  const label = String(target.label || target.rootID || target.artifactPath || target.artifactID || 'active artifact');
+  panel.replaceChildren();
+  panel.hidden = false;
+  const header = document.createElement('header');
+  header.className = 'canvas-link-panel-header';
+  header.textContent = `Links for ${label}`;
+  panel.appendChild(header);
+  await renderLocalGraphSection(panel, workspaceID, target, renderCanvas);
 }
 
 export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: string, renderCanvas: RenderCanvas) {

--- a/internal/web/static/canvas-markdown-panel.ts
+++ b/internal/web/static/canvas-markdown-panel.ts
@@ -1,5 +1,6 @@
 import { apiURL } from './paths.js';
 import { openResolvedMarkdownLink } from './canvas-markdown-links.js';
+import { renderLocalGraphSection } from './canvas-local-graph.js';
 
 const PANEL_ID = 'canvas-markdown-link-panel';
 
@@ -341,6 +342,7 @@ export async function renderMarkdownLinkPanel(workspaceID: string, sourcePath: s
     const payload = (await resp.json()) as PanelPayload;
     if (panel.dataset.sourcePath !== cleanSource) return;
     renderPanelContent(panel, payload, renderCanvas);
+    void renderLocalGraphSection(panel, id, cleanSource, renderCanvas);
   } catch (err) {
     if (panel.dataset.sourcePath !== cleanSource) return;
     renderPanelContent(panel, {

--- a/internal/web/static/canvas.ts
+++ b/internal/web/static/canvas.ts
@@ -884,6 +884,7 @@ export function renderCanvas(event) {
     activeArtifactTitle = event.title || '';
     activePdfEvent = null;
     resetCanvasPageState('', '');
+    void renderMarkdownLinkPanelForCanvasEvent(event, renderCanvas);
     dispatchCanvasRendered(event);
   } else if (event.kind === 'pdf_artifact') {
     clearTextInteractionHandlers();
@@ -901,6 +902,7 @@ export function renderCanvas(event) {
     activeTextEventId = null;
     activeArtifactTitle = event.title || '';
     activePdfEvent = event;
+    void renderMarkdownLinkPanelForCanvasEvent(event, renderCanvas);
   } else if (event.kind === 'clear_canvas') {
     clearTextInteractionHandlers();
     clearCanvas();

--- a/internal/web/workspace_graph.go
+++ b/internal/web/workspace_graph.go
@@ -28,10 +28,6 @@ func parseWorkspaceGraphFilter(r *http.Request, workspace store.Workspace) works
 	return filter
 }
 
-func buildWorkspaceLocalGraph(a *App, workspace store.Workspace, sourceRaw string, filter workspaceGraphFilter) workspaceLocalGraph {
-	return buildWorkspaceLocalGraphForRequest(a, workspace, workspaceGraphRequest{SourcePath: sourceRaw}, filter)
-}
-
 func buildWorkspaceLocalGraphForRequest(a *App, workspace store.Workspace, req workspaceGraphRequest, filter workspaceGraphFilter) workspaceLocalGraph {
 	root, err := resolveWorkspaceGraphRoot(a, workspace, req)
 	if err != nil {

--- a/internal/web/workspace_graph.go
+++ b/internal/web/workspace_graph.go
@@ -1,0 +1,402 @@
+package web
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+func parseWorkspaceGraphFilter(r *http.Request, workspace store.Workspace) workspaceGraphFilter {
+	filter := workspaceGraphFilter{
+		Relations: map[string]bool{},
+		Source:    strings.TrimSpace(r.URL.Query().Get("source_filter")),
+		Label:     strings.TrimSpace(r.URL.Query().Get("label")),
+		Sphere:    strings.TrimSpace(r.URL.Query().Get("sphere")),
+	}
+	for _, relation := range r.URL.Query()["relation"] {
+		clean := strings.TrimSpace(relation)
+		if clean != "" {
+			filter.Relations[clean] = true
+		}
+	}
+	if filter.Sphere == "" {
+		filter.Sphere = workspace.Sphere
+	}
+	return filter
+}
+
+func buildWorkspaceLocalGraph(a *App, workspace store.Workspace, sourceRaw string, filter workspaceGraphFilter) workspaceLocalGraph {
+	sourceRel, err := normalizeMarkdownSourcePath(sourceRaw)
+	if err != nil {
+		return workspaceLocalGraph{Error: err.Error()}
+	}
+	sourceRel = stripBrainPrefixForWorkspace(workspace, sourceRel)
+	brainRoot, _, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		return workspaceLocalGraph{Error: err.Error()}
+	}
+	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
+	if !pathInsideOrEqual(sourceAbs, brainRoot) {
+		return workspaceLocalGraph{Error: "source note is outside the brain workspace"}
+	}
+	if err := enforceWorkPersonalPath(sourceAbs); err != nil {
+		return workspaceLocalGraph{Error: workPersonalGuardrailMessage}
+	}
+	builder := newWorkspaceGraphBuilder(workspace, filter, sourceRel)
+	rootID := workspaceGraphNoteNodeID(sourceRel)
+	builder.addNode(workspaceLocalGraphNode{
+		ID:      rootID,
+		Type:    "note",
+		Label:   workspaceGraphNodeLabel(sourceRel),
+		Path:    sourceRel,
+		FileURL: workspaceMarkdownLinkFileURL(workspace, filepath.ToSlash(filepath.Join("brain", sourceRel))),
+		Sphere:  workspace.Sphere,
+	})
+	if filter.Sphere != "" && filter.Sphere != workspace.Sphere {
+		return builder.graph
+	}
+	appendWorkspaceGraphMarkdown(builder, sourceRel, rootID)
+	appendWorkspaceGraphStoreMetadata(a, builder, sourceRel, rootID)
+	sortWorkspaceLocalGraph(&builder.graph)
+	return builder.graph
+}
+
+func appendWorkspaceGraphMarkdown(builder *workspaceGraphBuilder, sourceRel, rootID string) {
+	if graphRelationEnabled(builder.filter, "markdown_link") {
+		panel := buildWorkspaceMarkdownLinkPanel(builder.workspace, sourceRel)
+		for _, ref := range panel.Outgoing {
+			if !ref.OK || ref.VaultRelativePath == "" {
+				continue
+			}
+			targetID := workspaceGraphNoteNodeID(ref.VaultRelativePath)
+			builder.addNode(workspaceLocalGraphNode{
+				ID:      targetID,
+				Type:    workspaceGraphNodeType(ref.VaultRelativePath, ref.Kind),
+				Label:   workspaceGraphNodeLabel(ref.VaultRelativePath),
+				Path:    ref.VaultRelativePath,
+				FileURL: ref.FileURL,
+				Sphere:  builder.workspace.Sphere,
+			})
+			builder.addEdge(workspaceLocalGraphEdge{
+				ID:       rootID + "->" + targetID + ":markdown_link",
+				Source:   rootID,
+				Target:   targetID,
+				Relation: "markdown_link",
+				Label:    ref.Type,
+				Sphere:   builder.workspace.Sphere,
+			})
+		}
+	}
+	if !graphRelationEnabled(builder.filter, "backlink") {
+		return
+	}
+	backlinks, truncated, scanLimit, err := collectMarkdownBacklinks(builder.workspace, sourceRel)
+	if err != nil {
+		builder.graph.Error = err.Error()
+		builder.graph.OK = false
+		return
+	}
+	builder.graph.Truncated = builder.graph.Truncated || truncated || scanLimit
+	for _, backlink := range backlinks {
+		sourceID := workspaceGraphNoteNodeID(backlink.SourcePath)
+		builder.addNode(workspaceLocalGraphNode{
+			ID:      sourceID,
+			Type:    "note",
+			Label:   workspaceGraphNodeLabel(backlink.SourcePath),
+			Path:    backlink.SourcePath,
+			FileURL: backlink.FileURL,
+			Sphere:  builder.workspace.Sphere,
+		})
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       sourceID + "->" + rootID + ":backlink",
+			Source:   sourceID,
+			Target:   rootID,
+			Relation: "backlink",
+			Label:    backlink.LinkType,
+			Sphere:   builder.workspace.Sphere,
+		})
+	}
+}
+
+func appendWorkspaceGraphStoreMetadata(a *App, builder *workspaceGraphBuilder, sourceRel, rootID string) {
+	artifacts := workspaceGraphMatchingArtifacts(a, builder.workspace, sourceRel)
+	itemIDs := map[int64]store.Item{}
+	for _, artifact := range artifacts {
+		artifactID := "artifact:" + workspaceIDStr(artifact.ID)
+		builder.addNode(workspaceGraphArtifactNode(artifact))
+		if graphRelationEnabled(builder.filter, "artifact") {
+			builder.addEdge(workspaceLocalGraphEdge{
+				ID:       rootID + "->" + artifactID + ":artifact",
+				Source:   rootID,
+				Target:   artifactID,
+				Relation: "artifact",
+				Label:    string(artifact.Kind),
+				Sphere:   builder.workspace.Sphere,
+			})
+		}
+		workspaceGraphAddArtifactBindings(a, builder, artifact, artifactID)
+		items, _ := a.store.ListItemsFiltered(store.ItemListFilter{Sphere: builder.workspace.Sphere})
+		for _, item := range items {
+			if item.ArtifactID != nil && *item.ArtifactID == artifact.ID {
+				itemIDs[item.ID] = item
+			}
+		}
+	}
+	for _, item := range itemIDs {
+		workspaceGraphAddItem(a, builder, item)
+	}
+}
+
+func workspaceGraphMatchingArtifacts(a *App, workspace store.Workspace, sourceRel string) []store.Artifact {
+	artifacts, err := a.store.ListArtifactsForWorkspace(workspace.ID)
+	if err != nil {
+		return nil
+	}
+	_, vaultRoot, _ := brainWorkspaceRoots(workspace)
+	keys := map[string]bool{
+		sourceRel: true,
+		filepath.ToSlash(filepath.Join("brain", sourceRel)): true,
+	}
+	out := []store.Artifact{}
+	for _, artifact := range artifacts {
+		for _, value := range []string{stringPointerValue(artifact.RefPath), stringPointerValue(artifact.Title)} {
+			clean := cleanWorkspaceGraphArtifactPath(value, vaultRoot)
+			if keys[clean] {
+				out = append(out, artifact)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func cleanWorkspaceGraphArtifactPath(value, vaultRoot string) string {
+	clean := strings.TrimSpace(value)
+	if clean == "" {
+		return ""
+	}
+	if filepath.IsAbs(clean) && pathInsideOrEqual(clean, vaultRoot) {
+		if rel, err := filepath.Rel(vaultRoot, clean); err == nil {
+			return filepath.ToSlash(filepath.Clean(rel))
+		}
+	}
+	return strings.TrimPrefix(strings.TrimSpace(strings.ReplaceAll(clean, "\\", "/")), "/")
+}
+
+func workspaceGraphArtifactNode(artifact store.Artifact) workspaceLocalGraphNode {
+	label := stringPointerValue(artifact.Title)
+	if label == "" {
+		label = stringPointerValue(artifact.RefPath)
+	}
+	if label == "" {
+		label = "Artifact " + workspaceIDStr(artifact.ID)
+	}
+	return workspaceLocalGraphNode{
+		ID:     "artifact:" + workspaceIDStr(artifact.ID),
+		Type:   "artifact",
+		Label:  label,
+		Path:   stringPointerValue(artifact.RefPath),
+		Source: string(artifact.Kind),
+	}
+}
+
+func workspaceGraphAddItem(a *App, builder *workspaceGraphBuilder, item store.Item) {
+	if builder.filter.Source != "" && !workspaceGraphItemMatchesSource(item, builder.filter.Source) {
+		return
+	}
+	if builder.filter.Label != "" && !workspaceGraphItemHasLabel(a, item.ID, builder.filter.Label, item.Sphere) {
+		return
+	}
+	itemID := "item:" + workspaceIDStr(item.ID)
+	builder.addNode(workspaceLocalGraphNode{
+		ID:     itemID,
+		Type:   "item",
+		Label:  item.Title,
+		Source: stringPointerValue(item.Source),
+		Sphere: item.Sphere,
+	})
+	if item.ArtifactID != nil && graphRelationEnabled(builder.filter, "artifact") {
+		artifactID := "artifact:" + workspaceIDStr(*item.ArtifactID)
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       itemID + "->" + artifactID + ":artifact",
+			Source:   itemID,
+			Target:   artifactID,
+			Relation: "artifact",
+			Label:    item.Kind,
+			Sphere:   item.Sphere,
+		})
+	}
+	workspaceGraphAddItemActor(a, builder, item, itemID)
+	workspaceGraphAddItemLabels(a, builder, item, itemID)
+	workspaceGraphAddItemSourceBindings(a, builder, item, itemID)
+}
+
+func workspaceGraphAddItemActor(a *App, builder *workspaceGraphBuilder, item store.Item, itemID string) {
+	if item.ActorID == nil || !graphRelationEnabled(builder.filter, "item_actor") {
+		return
+	}
+	actor, err := a.store.GetActor(*item.ActorID)
+	if err != nil {
+		return
+	}
+	actorID := "actor:" + workspaceIDStr(actor.ID)
+	builder.addNode(workspaceLocalGraphNode{
+		ID:    actorID,
+		Type:  "actor",
+		Label: actor.Name,
+	})
+	builder.addEdge(workspaceLocalGraphEdge{
+		ID:       itemID + "->" + actorID + ":item_actor",
+		Source:   itemID,
+		Target:   actorID,
+		Relation: "item_actor",
+		Label:    actor.Kind,
+		Sphere:   item.Sphere,
+	})
+}
+
+func workspaceGraphAddItemLabels(a *App, builder *workspaceGraphBuilder, item store.Item, itemID string) {
+	if !graphRelationEnabled(builder.filter, "item_label") {
+		return
+	}
+	for _, label := range workspaceGraphItemLabels(a, item.ID, item.Sphere) {
+		if builder.filter.Label != "" && !strings.EqualFold(label.Name, builder.filter.Label) {
+			continue
+		}
+		labelID := "label:" + workspaceIDStr(label.ID)
+		builder.addNode(workspaceLocalGraphNode{
+			ID:    labelID,
+			Type:  "label",
+			Label: label.Name,
+		})
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       itemID + "->" + labelID + ":item_label",
+			Source:   itemID,
+			Target:   labelID,
+			Relation: "item_label",
+			Sphere:   item.Sphere,
+		})
+	}
+}
+
+func workspaceGraphAddItemSourceBindings(a *App, builder *workspaceGraphBuilder, item store.Item, itemID string) {
+	if graphRelationEnabled(builder.filter, "source_binding") && item.Source != nil && item.SourceRef != nil {
+		sourceID := "source:" + *item.Source + ":" + *item.SourceRef
+		builder.addNode(workspaceLocalGraphNode{
+			ID:     sourceID,
+			Type:   "source",
+			Label:  *item.SourceRef,
+			Source: *item.Source,
+			Sphere: item.Sphere,
+		})
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       itemID + "->" + sourceID + ":source_binding",
+			Source:   itemID,
+			Target:   sourceID,
+			Relation: "source_binding",
+			Label:    *item.Source,
+			SourceID: *item.Source,
+			Sphere:   item.Sphere,
+		})
+	}
+	bindings, err := a.store.GetBindingsByItem(item.ID)
+	if err != nil {
+		return
+	}
+	workspaceGraphAddExternalBindings(builder, bindings, itemID, item.Sphere)
+}
+
+func workspaceGraphAddArtifactBindings(a *App, builder *workspaceGraphBuilder, artifact store.Artifact, artifactID string) {
+	bindings, err := a.store.GetBindingsByArtifact(artifact.ID)
+	if err != nil {
+		return
+	}
+	workspaceGraphAddExternalBindings(builder, bindings, artifactID, builder.workspace.Sphere)
+}
+
+func workspaceGraphAddExternalBindings(builder *workspaceGraphBuilder, bindings []store.ExternalBinding, ownerID, sphere string) {
+	if !graphRelationEnabled(builder.filter, "source_binding") {
+		return
+	}
+	for _, binding := range bindings {
+		if builder.filter.Source != "" && !strings.EqualFold(binding.Provider, builder.filter.Source) {
+			continue
+		}
+		sourceID := "source:" + binding.Provider + ":" + binding.ObjectType + ":" + binding.RemoteID
+		builder.addNode(workspaceLocalGraphNode{
+			ID:     sourceID,
+			Type:   "source",
+			Label:  binding.RemoteID,
+			Source: binding.Provider,
+			Sphere: sphere,
+		})
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       ownerID + "->" + sourceID + ":source_binding",
+			Source:   ownerID,
+			Target:   sourceID,
+			Relation: "source_binding",
+			Label:    binding.ObjectType,
+			SourceID: binding.Provider,
+			Sphere:   sphere,
+		})
+	}
+}
+
+func workspaceGraphItemMatchesSource(item store.Item, source string) bool {
+	return item.Source != nil && strings.EqualFold(*item.Source, source)
+}
+
+func workspaceGraphItemHasLabel(a *App, itemID int64, labelName, sphere string) bool {
+	for _, label := range workspaceGraphItemLabels(a, itemID, sphere) {
+		if strings.EqualFold(label.Name, labelName) {
+			return true
+		}
+	}
+	return false
+}
+
+func workspaceGraphItemLabels(a *App, itemID int64, sphere string) []store.Label {
+	labels, err := a.store.ListLabels()
+	if err != nil {
+		return nil
+	}
+	out := []store.Label{}
+	for _, label := range labels {
+		labelID := label.ID
+		items, err := a.store.ListItemsFiltered(store.ItemListFilter{Sphere: sphere, LabelID: &labelID})
+		if err != nil {
+			continue
+		}
+		for _, item := range items {
+			if item.ID == itemID {
+				out = append(out, label)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func (a *App) handleWorkspaceLocalGraph(w http.ResponseWriter, r *http.Request) {
+	if !a.requireAuth(w, r) {
+		return
+	}
+	workspace, err := a.resolveRuntimeWorkspaceByIDOrActive(chi.URLParam(r, "workspace_id"))
+	if err != nil {
+		if isNoRows(err) {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := enforceWorkPersonalWorkspace(workspace); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	graph := buildWorkspaceLocalGraph(a, workspace, r.URL.Query().Get("source"), parseWorkspaceGraphFilter(r, workspace))
+	writeJSON(w, graph)
+}

--- a/internal/web/workspace_graph.go
+++ b/internal/web/workspace_graph.go
@@ -29,37 +29,20 @@ func parseWorkspaceGraphFilter(r *http.Request, workspace store.Workspace) works
 }
 
 func buildWorkspaceLocalGraph(a *App, workspace store.Workspace, sourceRaw string, filter workspaceGraphFilter) workspaceLocalGraph {
-	sourceRel, err := normalizeMarkdownSourcePath(sourceRaw)
+	return buildWorkspaceLocalGraphForRequest(a, workspace, workspaceGraphRequest{SourcePath: sourceRaw}, filter)
+}
+
+func buildWorkspaceLocalGraphForRequest(a *App, workspace store.Workspace, req workspaceGraphRequest, filter workspaceGraphFilter) workspaceLocalGraph {
+	root, err := resolveWorkspaceGraphRoot(a, workspace, req)
 	if err != nil {
 		return workspaceLocalGraph{Error: err.Error()}
 	}
-	sourceRel = stripBrainPrefixForWorkspace(workspace, sourceRel)
-	brainRoot, _, err := brainWorkspaceRoots(workspace)
-	if err != nil {
-		return workspaceLocalGraph{Error: err.Error()}
-	}
-	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
-	if !pathInsideOrEqual(sourceAbs, brainRoot) {
-		return workspaceLocalGraph{Error: "source note is outside the brain workspace"}
-	}
-	if err := enforceWorkPersonalPath(sourceAbs); err != nil {
-		return workspaceLocalGraph{Error: workPersonalGuardrailMessage}
-	}
-	builder := newWorkspaceGraphBuilder(workspace, filter, sourceRel)
-	rootID := workspaceGraphNoteNodeID(sourceRel)
-	builder.addNode(workspaceLocalGraphNode{
-		ID:      rootID,
-		Type:    "note",
-		Label:   workspaceGraphNodeLabel(sourceRel),
-		Path:    sourceRel,
-		FileURL: workspaceMarkdownLinkFileURL(workspace, filepath.ToSlash(filepath.Join("brain", sourceRel))),
-		Sphere:  workspace.Sphere,
-	})
+	builder := newWorkspaceGraphBuilder(workspace, filter, root.Source, root.Node.ID)
+	builder.addNode(root.Node)
 	if filter.Sphere != "" && filter.Sphere != workspace.Sphere {
 		return builder.graph
 	}
-	appendWorkspaceGraphMarkdown(builder, sourceRel, rootID)
-	appendWorkspaceGraphStoreMetadata(a, builder, sourceRel, rootID)
+	appendWorkspaceGraphRoot(a, builder, root)
 	sortWorkspaceLocalGraph(&builder.graph)
 	return builder.graph
 }
@@ -124,6 +107,7 @@ func appendWorkspaceGraphMarkdown(builder *workspaceGraphBuilder, sourceRel, roo
 func appendWorkspaceGraphStoreMetadata(a *App, builder *workspaceGraphBuilder, sourceRel, rootID string) {
 	artifacts := workspaceGraphMatchingArtifacts(a, builder.workspace, sourceRel)
 	itemIDs := map[int64]store.Item{}
+	items := workspaceGraphItems(a, builder.workspace.Sphere)
 	for _, artifact := range artifacts {
 		artifactID := "artifact:" + workspaceIDStr(artifact.ID)
 		builder.addNode(workspaceGraphArtifactNode(artifact))
@@ -138,7 +122,6 @@ func appendWorkspaceGraphStoreMetadata(a *App, builder *workspaceGraphBuilder, s
 			})
 		}
 		workspaceGraphAddArtifactBindings(a, builder, artifact, artifactID)
-		items, _ := a.store.ListItemsFiltered(store.ItemListFilter{Sphere: builder.workspace.Sphere})
 		for _, item := range items {
 			if item.ArtifactID != nil && *item.ArtifactID == artifact.ID {
 				itemIDs[item.ID] = item
@@ -203,6 +186,16 @@ func workspaceGraphArtifactNode(artifact store.Artifact) workspaceLocalGraphNode
 	}
 }
 
+func workspaceGraphItemNode(item store.Item) workspaceLocalGraphNode {
+	return workspaceLocalGraphNode{
+		ID:     "item:" + workspaceIDStr(item.ID),
+		Type:   "item",
+		Label:  item.Title,
+		Source: stringPointerValue(item.Source),
+		Sphere: item.Sphere,
+	}
+}
+
 func workspaceGraphAddItem(a *App, builder *workspaceGraphBuilder, item store.Item) {
 	if builder.filter.Source != "" && !workspaceGraphItemMatchesSource(item, builder.filter.Source) {
 		return
@@ -211,15 +204,10 @@ func workspaceGraphAddItem(a *App, builder *workspaceGraphBuilder, item store.It
 		return
 	}
 	itemID := "item:" + workspaceIDStr(item.ID)
-	builder.addNode(workspaceLocalGraphNode{
-		ID:     itemID,
-		Type:   "item",
-		Label:  item.Title,
-		Source: stringPointerValue(item.Source),
-		Sphere: item.Sphere,
-	})
+	builder.addNode(workspaceGraphItemNode(item))
 	if item.ArtifactID != nil && graphRelationEnabled(builder.filter, "artifact") {
 		artifactID := "artifact:" + workspaceIDStr(*item.ArtifactID)
+		workspaceGraphAddItemArtifact(a, builder, *item.ArtifactID)
 		builder.addEdge(workspaceLocalGraphEdge{
 			ID:       itemID + "->" + artifactID + ":artifact",
 			Source:   itemID,
@@ -232,6 +220,14 @@ func workspaceGraphAddItem(a *App, builder *workspaceGraphBuilder, item store.It
 	workspaceGraphAddItemActor(a, builder, item, itemID)
 	workspaceGraphAddItemLabels(a, builder, item, itemID)
 	workspaceGraphAddItemSourceBindings(a, builder, item, itemID)
+}
+
+func workspaceGraphAddItemArtifact(a *App, builder *workspaceGraphBuilder, artifactID int64) {
+	artifact, err := a.store.GetArtifact(artifactID)
+	if err != nil {
+		return
+	}
+	builder.addNode(workspaceGraphArtifactNode(artifact))
 }
 
 func workspaceGraphAddItemActor(a *App, builder *workspaceGraphBuilder, item store.Item, itemID string) {
@@ -309,6 +305,14 @@ func workspaceGraphAddItemSourceBindings(a *App, builder *workspaceGraphBuilder,
 	workspaceGraphAddExternalBindings(builder, bindings, itemID, item.Sphere)
 }
 
+func workspaceGraphItems(a *App, sphere string) []store.Item {
+	items, err := a.store.ListItemsFiltered(store.ItemListFilter{Sphere: sphere})
+	if err != nil {
+		return nil
+	}
+	return items
+}
+
 func workspaceGraphAddArtifactBindings(a *App, builder *workspaceGraphBuilder, artifact store.Artifact, artifactID string) {
 	bindings, err := a.store.GetBindingsByArtifact(artifact.ID)
 	if err != nil {
@@ -347,6 +351,14 @@ func workspaceGraphAddExternalBindings(builder *workspaceGraphBuilder, bindings 
 
 func workspaceGraphItemMatchesSource(item store.Item, source string) bool {
 	return item.Source != nil && strings.EqualFold(*item.Source, source)
+}
+
+func workspaceGraphItemMatchesSourceNode(item store.Item, source workspaceLocalGraphNode) bool {
+	if item.Source == nil || item.SourceRef == nil {
+		return false
+	}
+	sourceID := "source:" + *item.Source + ":" + *item.SourceRef
+	return source.ID == sourceID
 }
 
 func workspaceGraphItemHasLabel(a *App, itemID int64, labelName, sphere string) bool {
@@ -397,6 +409,6 @@ func (a *App) handleWorkspaceLocalGraph(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
-	graph := buildWorkspaceLocalGraph(a, workspace, r.URL.Query().Get("source"), parseWorkspaceGraphFilter(r, workspace))
+	graph := buildWorkspaceLocalGraphForRequest(a, workspace, parseWorkspaceGraphRequest(r), parseWorkspaceGraphFilter(r, workspace))
 	writeJSON(w, graph)
 }

--- a/internal/web/workspace_graph_roots.go
+++ b/internal/web/workspace_graph_roots.go
@@ -121,7 +121,7 @@ func resolveWorkspaceGraphEntityRoot(a *App, workspace store.Workspace, rootID s
 	case "artifact":
 		return resolveWorkspaceGraphArtifactID(a, workspace, id)
 	case "item":
-		return resolveWorkspaceGraphItemRoot(a, id)
+		return resolveWorkspaceGraphItemRoot(a, workspace, id)
 	case "actor":
 		return resolveWorkspaceGraphActorRoot(a, id)
 	case "label":
@@ -133,13 +133,23 @@ func resolveWorkspaceGraphEntityRoot(a *App, workspace store.Workspace, rootID s
 	}
 }
 
-func resolveWorkspaceGraphItemRoot(a *App, itemID int64) (workspaceGraphRoot, error) {
+func resolveWorkspaceGraphItemRoot(a *App, workspace store.Workspace, itemID int64) (workspaceGraphRoot, error) {
 	item, err := a.store.GetItem(itemID)
 	if err != nil {
 		return workspaceGraphRoot{}, err
 	}
+	if !workspaceGraphItemVisibleInWorkspace(workspace, item) {
+		return workspaceGraphRoot{}, errGraph("item is not in this workspace")
+	}
 	node := workspaceGraphItemNode(item)
 	return workspaceGraphRoot{Kind: "item", Source: node.ID, Node: node, Item: &item}, nil
+}
+
+func workspaceGraphItemVisibleInWorkspace(workspace store.Workspace, item store.Item) bool {
+	if item.WorkspaceID != nil {
+		return *item.WorkspaceID == workspace.ID && strings.EqualFold(item.Sphere, workspace.Sphere)
+	}
+	return strings.EqualFold(item.Sphere, workspace.Sphere)
 }
 
 func resolveWorkspaceGraphActorRoot(a *App, actorID int64) (workspaceGraphRoot, error) {

--- a/internal/web/workspace_graph_roots.go
+++ b/internal/web/workspace_graph_roots.go
@@ -1,0 +1,281 @@
+package web
+
+import (
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+type workspaceGraphRequest struct {
+	SourcePath   string
+	ArtifactID   int64
+	ArtifactPath string
+	RootID       string
+}
+
+type workspaceGraphRoot struct {
+	Kind     string
+	Source   string
+	Node     workspaceLocalGraphNode
+	Artifact *store.Artifact
+	Item     *store.Item
+	Actor    *store.Actor
+	Label    *store.Label
+}
+
+type errGraph string
+
+func (e errGraph) Error() string {
+	return string(e)
+}
+
+func parseWorkspaceGraphRequest(r *http.Request) workspaceGraphRequest {
+	artifactID, _ := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("artifact_id")), 10, 64)
+	return workspaceGraphRequest{
+		SourcePath:   strings.TrimSpace(r.URL.Query().Get("source")),
+		ArtifactID:   artifactID,
+		ArtifactPath: strings.TrimSpace(r.URL.Query().Get("artifact_path")),
+		RootID:       strings.TrimSpace(r.URL.Query().Get("root")),
+	}
+}
+
+func resolveWorkspaceGraphRoot(a *App, workspace store.Workspace, req workspaceGraphRequest) (workspaceGraphRoot, error) {
+	if req.ArtifactID > 0 {
+		return resolveWorkspaceGraphArtifactID(a, workspace, req.ArtifactID)
+	}
+	if req.RootID != "" {
+		return resolveWorkspaceGraphEntityRoot(a, workspace, req.RootID)
+	}
+	if req.ArtifactPath != "" {
+		return resolveWorkspaceGraphArtifactPath(a, workspace, req.ArtifactPath)
+	}
+	return resolveWorkspaceGraphNoteRoot(workspace, req.SourcePath)
+}
+
+func resolveWorkspaceGraphNoteRoot(workspace store.Workspace, sourceRaw string) (workspaceGraphRoot, error) {
+	sourceRel, err := normalizeMarkdownSourcePath(sourceRaw)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	sourceRel = stripBrainPrefixForWorkspace(workspace, sourceRel)
+	brainRoot, _, err := brainWorkspaceRoots(workspace)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	sourceAbs := filepath.Clean(filepath.Join(brainRoot, filepath.FromSlash(sourceRel)))
+	if !pathInsideOrEqual(sourceAbs, brainRoot) {
+		return workspaceGraphRoot{}, errGraph("source note is outside the brain workspace")
+	}
+	if err := enforceWorkPersonalPath(sourceAbs); err != nil {
+		return workspaceGraphRoot{}, errGraph(workPersonalGuardrailMessage)
+	}
+	node := workspaceLocalGraphNode{
+		ID:      workspaceGraphNoteNodeID(sourceRel),
+		Type:    "note",
+		Label:   workspaceGraphNodeLabel(sourceRel),
+		Path:    sourceRel,
+		FileURL: workspaceMarkdownLinkFileURL(workspace, filepath.ToSlash(filepath.Join("brain", sourceRel))),
+		Sphere:  workspace.Sphere,
+	}
+	return workspaceGraphRoot{Kind: "note", Source: sourceRel, Node: node}, nil
+}
+
+func resolveWorkspaceGraphArtifactID(a *App, workspace store.Workspace, artifactID int64) (workspaceGraphRoot, error) {
+	artifact, err := a.store.GetArtifact(artifactID)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	if !workspaceGraphArtifactInWorkspace(a, workspace.ID, artifactID) {
+		return workspaceGraphRoot{}, errGraph("artifact is not in this workspace")
+	}
+	node := workspaceGraphArtifactNode(artifact)
+	return workspaceGraphRoot{Kind: "artifact", Source: node.ID, Node: node, Artifact: &artifact}, nil
+}
+
+func resolveWorkspaceGraphArtifactPath(a *App, workspace store.Workspace, raw string) (workspaceGraphRoot, error) {
+	_, vaultRoot, _ := brainWorkspaceRoots(workspace)
+	clean := cleanWorkspaceGraphArtifactPath(raw, vaultRoot)
+	for _, artifact := range workspaceGraphMatchingArtifacts(a, workspace, clean) {
+		return resolveWorkspaceGraphArtifactID(a, workspace, artifact.ID)
+	}
+	node := workspaceLocalGraphNode{
+		ID:     "artifact_path:" + clean,
+		Type:   "artifact",
+		Label:  workspaceGraphNodeLabel(clean),
+		Path:   clean,
+		Sphere: workspace.Sphere,
+	}
+	return workspaceGraphRoot{Kind: "artifact_path", Source: clean, Node: node}, nil
+}
+
+func resolveWorkspaceGraphEntityRoot(a *App, workspace store.Workspace, rootID string) (workspaceGraphRoot, error) {
+	kind, idText, ok := strings.Cut(strings.TrimSpace(rootID), ":")
+	if !ok {
+		return workspaceGraphRoot{}, errGraph("graph root must use kind:id")
+	}
+	id, _ := strconv.ParseInt(idText, 10, 64)
+	switch kind {
+	case "artifact":
+		return resolveWorkspaceGraphArtifactID(a, workspace, id)
+	case "item":
+		return resolveWorkspaceGraphItemRoot(a, id)
+	case "actor":
+		return resolveWorkspaceGraphActorRoot(a, id)
+	case "label":
+		return resolveWorkspaceGraphLabelRoot(a, id)
+	case "source":
+		return workspaceGraphSourceRoot(rootID)
+	default:
+		return workspaceGraphRoot{}, errGraph("unsupported graph root kind")
+	}
+}
+
+func resolveWorkspaceGraphItemRoot(a *App, itemID int64) (workspaceGraphRoot, error) {
+	item, err := a.store.GetItem(itemID)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	node := workspaceGraphItemNode(item)
+	return workspaceGraphRoot{Kind: "item", Source: node.ID, Node: node, Item: &item}, nil
+}
+
+func resolveWorkspaceGraphActorRoot(a *App, actorID int64) (workspaceGraphRoot, error) {
+	actor, err := a.store.GetActor(actorID)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	node := workspaceLocalGraphNode{ID: "actor:" + workspaceIDStr(actor.ID), Type: "actor", Label: actor.Name}
+	return workspaceGraphRoot{Kind: "actor", Source: node.ID, Node: node, Actor: &actor}, nil
+}
+
+func resolveWorkspaceGraphLabelRoot(a *App, labelID int64) (workspaceGraphRoot, error) {
+	label, err := a.store.GetLabel(labelID)
+	if err != nil {
+		return workspaceGraphRoot{}, err
+	}
+	node := workspaceLocalGraphNode{ID: "label:" + workspaceIDStr(label.ID), Type: "label", Label: label.Name}
+	return workspaceGraphRoot{Kind: "label", Source: node.ID, Node: node, Label: &label}, nil
+}
+
+func workspaceGraphSourceRoot(rootID string) (workspaceGraphRoot, error) {
+	parts := strings.Split(strings.TrimSpace(rootID), ":")
+	if len(parts) < 3 {
+		return workspaceGraphRoot{}, errGraph("source graph root must include provider and remote id")
+	}
+	node := workspaceLocalGraphNode{
+		ID:     rootID,
+		Type:   "source",
+		Label:  parts[len(parts)-1],
+		Source: parts[1],
+	}
+	return workspaceGraphRoot{Kind: "source", Source: rootID, Node: node}, nil
+}
+
+func appendWorkspaceGraphRoot(a *App, builder *workspaceGraphBuilder, root workspaceGraphRoot) {
+	switch root.Kind {
+	case "note":
+		appendWorkspaceGraphMarkdown(builder, root.Node.Path, root.Node.ID)
+		appendWorkspaceGraphStoreMetadata(a, builder, root.Node.Path, root.Node.ID)
+	case "artifact":
+		appendWorkspaceGraphArtifactRoot(a, builder, *root.Artifact, root.Node.ID)
+	case "item":
+		workspaceGraphAddItem(a, builder, *root.Item)
+	case "actor":
+		appendWorkspaceGraphActorRoot(a, builder, *root.Actor)
+	case "label":
+		appendWorkspaceGraphLabelRoot(a, builder, *root.Label)
+	case "source":
+		appendWorkspaceGraphSourceRoot(a, builder, root.Node)
+	}
+}
+
+func appendWorkspaceGraphArtifactRoot(a *App, builder *workspaceGraphBuilder, artifact store.Artifact, artifactID string) {
+	workspaceGraphAddArtifactNoteLink(builder, artifact, artifactID)
+	workspaceGraphAddArtifactBindings(a, builder, artifact, artifactID)
+	for _, item := range workspaceGraphItems(a, builder.workspace.Sphere) {
+		if item.ArtifactID == nil || *item.ArtifactID != artifact.ID {
+			continue
+		}
+		workspaceGraphAddItem(a, builder, item)
+	}
+}
+
+func workspaceGraphAddArtifactNoteLink(builder *workspaceGraphBuilder, artifact store.Artifact, artifactID string) {
+	path := workspaceGraphArtifactNotePath(builder.workspace, artifact)
+	if path == "" {
+		return
+	}
+	noteID := workspaceGraphNoteNodeID(path)
+	builder.addNode(workspaceLocalGraphNode{
+		ID:      noteID,
+		Type:    workspaceGraphNodeType(path, string(artifact.Kind)),
+		Label:   workspaceGraphNodeLabel(path),
+		Path:    path,
+		FileURL: workspaceMarkdownLinkFileURL(builder.workspace, filepath.ToSlash(filepath.Join("brain", path))),
+		Sphere:  builder.workspace.Sphere,
+	})
+	if graphRelationEnabled(builder.filter, "artifact") {
+		builder.addEdge(workspaceLocalGraphEdge{
+			ID:       artifactID + "->" + noteID + ":artifact",
+			Source:   artifactID,
+			Target:   noteID,
+			Relation: "artifact",
+			Label:    string(artifact.Kind),
+			Sphere:   builder.workspace.Sphere,
+		})
+	}
+}
+
+func workspaceGraphArtifactNotePath(workspace store.Workspace, artifact store.Artifact) string {
+	_, vaultRoot, _ := brainWorkspaceRoots(workspace)
+	clean := cleanWorkspaceGraphArtifactPath(stringPointerValue(artifact.RefPath), vaultRoot)
+	if clean == "" {
+		return ""
+	}
+	return stripBrainPrefixForWorkspace(workspace, clean)
+}
+
+func appendWorkspaceGraphActorRoot(a *App, builder *workspaceGraphBuilder, actor store.Actor) {
+	for _, item := range workspaceGraphItems(a, builder.workspace.Sphere) {
+		if item.ActorID == nil || *item.ActorID != actor.ID {
+			continue
+		}
+		workspaceGraphAddItem(a, builder, item)
+	}
+}
+
+func appendWorkspaceGraphLabelRoot(a *App, builder *workspaceGraphBuilder, label store.Label) {
+	labelID := label.ID
+	items, err := a.store.ListItemsFiltered(store.ItemListFilter{Sphere: builder.workspace.Sphere, LabelID: &labelID})
+	if err != nil {
+		return
+	}
+	for _, item := range items {
+		workspaceGraphAddItem(a, builder, item)
+	}
+}
+
+func appendWorkspaceGraphSourceRoot(a *App, builder *workspaceGraphBuilder, source workspaceLocalGraphNode) {
+	for _, item := range workspaceGraphItems(a, builder.workspace.Sphere) {
+		if !workspaceGraphItemMatchesSourceNode(item, source) {
+			continue
+		}
+		workspaceGraphAddItem(a, builder, item)
+	}
+}
+
+func workspaceGraphArtifactInWorkspace(a *App, workspaceID, artifactID int64) bool {
+	artifacts, err := a.store.ListArtifactsForWorkspace(workspaceID)
+	if err != nil {
+		return false
+	}
+	for _, artifact := range artifacts {
+		if artifact.ID == artifactID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/workspace_graph_test.go
+++ b/internal/web/workspace_graph_test.go
@@ -213,6 +213,39 @@ func TestWorkspaceLocalGraphEntityRootAddsConnectedMetadata(t *testing.T) {
 	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "source:todoist:task-note", "source_binding")
 }
 
+func TestWorkspaceLocalGraphRejectsPrivateItemRootFromWorkWorkspace(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	workBrainRoot := filepath.Join(vaultRoot, "brain")
+	privateBrainRoot := filepath.Join(t.TempDir(), "private", "brain")
+
+	app := newAuthedTestApp(t)
+	workWorkspace, err := app.store.CreateWorkspace("Work brain", workBrainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(work): %v", err)
+	}
+	privateWorkspace, err := app.store.CreateWorkspace("Private brain", privateBrainRoot, store.SpherePrivate)
+	if err != nil {
+		t.Fatalf("CreateWorkspace(private): %v", err)
+	}
+	privateItem, err := app.store.CreateItem("Private reminder", store.ItemOptions{
+		WorkspaceID: &privateWorkspace.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(private): %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workWorkspace.ID, "", map[string]string{
+		"root": "item:" + itoa(privateItem.ID),
+	})
+	if graph.OK {
+		t.Fatalf("graph OK = true, want rejected graph")
+	}
+	if graph.Error != "item is not in this workspace" {
+		t.Fatalf("graph error = %q, want item scope error", graph.Error)
+	}
+	assertGraphMissingNode(t, graph, "item:"+itoa(privateItem.ID))
+}
+
 func requestWorkspaceLocalGraph(t *testing.T, app *App, workspaceID int64, sourcePath string, query map[string]string) workspaceLocalGraph {
 	t.Helper()
 	values := url.Values{}

--- a/internal/web/workspace_graph_test.go
+++ b/internal/web/workspace_graph_test.go
@@ -1,0 +1,200 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+func TestWorkspaceLocalGraphMarkdownNeighborhoodExcludesPersonal(t *testing.T) {
+	vaultRoot, personalRoot := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	mustWriteGraphFile(t, filepath.Join(brainRoot, "topics", "active.md"), "See [Related](related.md).")
+	mustWriteGraphFile(t, filepath.Join(brainRoot, "topics", "related.md"), "# Related")
+	mustWriteGraphFile(t, filepath.Join(brainRoot, "people", "alice.md"), "Alice links [back](../topics/active.md).")
+	mustWriteGraphFile(t, filepath.Join(personalRoot, "diary.md"), "Private [back](../brain/topics/active.md).")
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workspace.ID, "topics/active.md", nil)
+	if !graph.OK {
+		t.Fatalf("graph not ok: %+v", graph)
+	}
+	assertGraphNode(t, graph, "note:brain/topics/related.md", "note")
+	assertGraphNode(t, graph, "note:brain/people/alice.md", "note")
+	assertGraphEdge(t, graph, "note:topics/active.md", "note:brain/topics/related.md", "markdown_link")
+	assertGraphEdge(t, graph, "note:brain/people/alice.md", "note:topics/active.md", "backlink")
+	for _, node := range graph.Nodes {
+		if strings.Contains(node.Path, "personal/") || strings.Contains(node.Path, personalRoot) {
+			t.Fatalf("graph leaked personal node: %+v", node)
+		}
+	}
+}
+
+func TestWorkspaceLocalGraphAddsConnectedStoreMetadata(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourcePath := filepath.Join(brainRoot, "topics", "active.md")
+	mustWriteGraphFile(t, sourcePath, "# Active")
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	title := "Active note artifact"
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &sourcePath, nil, &title, nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	actor, err := app.store.CreateActor("Ada", store.ActorKindHuman)
+	if err != nil {
+		t.Fatalf("CreateActor: %v", err)
+	}
+	source := store.ExternalProviderTodoist
+	sourceRef := "task-123"
+	item, err := app.store.CreateItem("Follow up active note", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Sphere:      graphStringPtr(store.SphereWork),
+		ArtifactID:  &artifact.ID,
+		ActorID:     &actor.ID,
+		Source:      &source,
+		SourceRef:   &sourceRef,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	label, err := app.store.CreateLabel("deep-work", nil)
+	if err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	if err := app.store.LinkLabelToItem(label.ID, item.ID); err != nil {
+		t.Fatalf("LinkLabelToItem: %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workspace.ID, "topics/active.md", nil)
+	assertGraphNode(t, graph, "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphNode(t, graph, "item:"+itoa(item.ID), "item")
+	assertGraphNode(t, graph, "actor:"+itoa(actor.ID), "actor")
+	assertGraphNode(t, graph, "label:"+itoa(label.ID), "label")
+	assertGraphNode(t, graph, "source:todoist:task-123", "source")
+	assertGraphEdge(t, graph, "note:topics/active.md", "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "actor:"+itoa(actor.ID), "item_actor")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "label:"+itoa(label.ID), "item_label")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "source:todoist:task-123", "source_binding")
+}
+
+func TestWorkspaceLocalGraphFiltersMetadata(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourcePath := filepath.Join(brainRoot, "topics", "active.md")
+	mustWriteGraphFile(t, sourcePath, "# Active")
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &sourcePath, nil, graphStringPtr("Active"), nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	todoist := store.ExternalProviderTodoist
+	github := "github"
+	deep, _ := app.store.CreateLabel("deep-work", nil)
+	shallow, _ := app.store.CreateLabel("shallow", nil)
+	wanted, _ := app.store.CreateItem("Wanted", store.ItemOptions{WorkspaceID: &workspace.ID, Sphere: graphStringPtr(store.SphereWork), ArtifactID: &artifact.ID, Source: &todoist, SourceRef: graphStringPtr("a")})
+	other, _ := app.store.CreateItem("Other", store.ItemOptions{WorkspaceID: &workspace.ID, Sphere: graphStringPtr(store.SphereWork), ArtifactID: &artifact.ID, Source: &github, SourceRef: graphStringPtr("b")})
+	if err := app.store.LinkLabelToItem(deep.ID, wanted.ID); err != nil {
+		t.Fatalf("LinkLabelToItem(deep): %v", err)
+	}
+	if err := app.store.LinkLabelToItem(shallow.ID, other.ID); err != nil {
+		t.Fatalf("LinkLabelToItem(shallow): %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workspace.ID, "topics/active.md", map[string]string{
+		"source_filter": "todoist",
+		"label":         "deep-work",
+		"sphere":        store.SphereWork,
+	})
+	assertGraphNode(t, graph, "item:"+itoa(wanted.ID), "item")
+	assertGraphMissingNode(t, graph, "item:"+itoa(other.ID))
+
+	privateGraph := requestWorkspaceLocalGraph(t, app, workspace.ID, "topics/active.md", map[string]string{
+		"sphere": store.SpherePrivate,
+	})
+	if len(privateGraph.Nodes) != 1 || privateGraph.Nodes[0].ID != "note:topics/active.md" {
+		t.Fatalf("private sphere graph = %+v, want only root note", privateGraph)
+	}
+}
+
+func requestWorkspaceLocalGraph(t *testing.T, app *App, workspaceID int64, sourcePath string, query map[string]string) workspaceLocalGraph {
+	t.Helper()
+	values := url.Values{}
+	values.Set("source", sourcePath)
+	for key, value := range query {
+		values.Set(key, value)
+	}
+	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/workspaces/"+itoa(workspaceID)+"/graph?"+values.Encode(), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("graph status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var graph workspaceLocalGraph
+	if err := json.Unmarshal(rr.Body.Bytes(), &graph); err != nil {
+		t.Fatalf("decode graph: %v", err)
+	}
+	return graph
+}
+
+func assertGraphNode(t *testing.T, graph workspaceLocalGraph, id, kind string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id && node.Type == kind {
+			return
+		}
+	}
+	t.Fatalf("missing graph node %s/%s in %+v", id, kind, graph.Nodes)
+}
+
+func assertGraphMissingNode(t *testing.T, graph workspaceLocalGraph, id string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id {
+			t.Fatalf("unexpected graph node %s in %+v", id, graph.Nodes)
+		}
+	}
+}
+
+func assertGraphEdge(t *testing.T, graph workspaceLocalGraph, source, target, relation string) {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Source == source && edge.Target == target && edge.Relation == relation {
+			return
+		}
+	}
+	t.Fatalf("missing graph edge %s -> %s (%s) in %+v", source, target, relation, graph.Edges)
+}
+
+func mustWriteGraphFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func graphStringPtr(value string) *string {
+	return &value
+}

--- a/internal/web/workspace_graph_test.go
+++ b/internal/web/workspace_graph_test.go
@@ -138,10 +138,87 @@ func TestWorkspaceLocalGraphFiltersMetadata(t *testing.T) {
 	}
 }
 
+func TestWorkspaceLocalGraphArtifactRootAddsConnectedMetadata(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourcePath := filepath.Join(brainRoot, "topics", "active.pdf")
+	mustWriteGraphFile(t, sourcePath, "%PDF-1.7")
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindPDF, &sourcePath, nil, graphStringPtr("Active PDF"), nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	item, err := app.store.CreateItem("Read active PDF", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Sphere:      graphStringPtr(store.SphereWork),
+		ArtifactID:  &artifact.ID,
+		Source:      graphStringPtr(store.ExternalProviderTodoist),
+		SourceRef:   graphStringPtr("task-pdf"),
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workspace.ID, "", map[string]string{
+		"artifact_id": itoa(artifact.ID),
+	})
+	assertGraphNode(t, graph, "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphNode(t, graph, "item:"+itoa(item.ID), "item")
+	assertGraphNode(t, graph, "source:todoist:task-pdf", "source")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "source:todoist:task-pdf", "source_binding")
+	if graph.RootID != "artifact:"+itoa(artifact.ID) {
+		t.Fatalf("root_id = %q, want artifact root", graph.RootID)
+	}
+}
+
+func TestWorkspaceLocalGraphEntityRootAddsConnectedMetadata(t *testing.T) {
+	vaultRoot, _ := configureWorkPersonalGuardrail(t)
+	brainRoot := filepath.Join(vaultRoot, "brain")
+	sourcePath := filepath.Join(brainRoot, "topics", "active.md")
+	mustWriteGraphFile(t, sourcePath, "# Active")
+
+	app := newAuthedTestApp(t)
+	workspace, err := app.store.CreateWorkspace("Work brain", brainRoot, store.SphereWork)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	artifact, err := app.store.CreateArtifact(store.ArtifactKindMarkdown, &sourcePath, nil, graphStringPtr("Active note"), nil)
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	item, err := app.store.CreateItem("Follow active note", store.ItemOptions{
+		WorkspaceID: &workspace.ID,
+		Sphere:      graphStringPtr(store.SphereWork),
+		ArtifactID:  &artifact.ID,
+		Source:      graphStringPtr(store.ExternalProviderTodoist),
+		SourceRef:   graphStringPtr("task-note"),
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	graph := requestWorkspaceLocalGraph(t, app, workspace.ID, "", map[string]string{
+		"root": "item:" + itoa(item.ID),
+	})
+	assertGraphNode(t, graph, "item:"+itoa(item.ID), "item")
+	assertGraphNode(t, graph, "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphNode(t, graph, "source:todoist:task-note", "source")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "artifact:"+itoa(artifact.ID), "artifact")
+	assertGraphEdge(t, graph, "item:"+itoa(item.ID), "source:todoist:task-note", "source_binding")
+}
+
 func requestWorkspaceLocalGraph(t *testing.T, app *App, workspaceID int64, sourcePath string, query map[string]string) workspaceLocalGraph {
 	t.Helper()
 	values := url.Values{}
-	values.Set("source", sourcePath)
+	if sourcePath != "" {
+		values.Set("source", sourcePath)
+	}
 	for key, value := range query {
 		values.Set(key, value)
 	}

--- a/internal/web/workspace_graph_types.go
+++ b/internal/web/workspace_graph_types.go
@@ -36,6 +36,7 @@ type workspaceLocalGraphEdge struct {
 type workspaceLocalGraph struct {
 	OK        bool                      `json:"ok"`
 	Source    string                    `json:"source_path"`
+	RootID    string                    `json:"root_id,omitempty"`
 	Nodes     []workspaceLocalGraphNode `json:"nodes"`
 	Edges     []workspaceLocalGraphEdge `json:"edges"`
 	Truncated bool                      `json:"truncated,omitempty"`
@@ -61,13 +62,14 @@ func graphRelationEnabled(filter workspaceGraphFilter, relation string) bool {
 	return len(filter.Relations) == 0 || filter.Relations[relation]
 }
 
-func newWorkspaceGraphBuilder(workspace store.Workspace, filter workspaceGraphFilter, sourceRel string) *workspaceGraphBuilder {
+func newWorkspaceGraphBuilder(workspace store.Workspace, filter workspaceGraphFilter, sourceRel, rootID string) *workspaceGraphBuilder {
 	return &workspaceGraphBuilder{
 		workspace: workspace,
 		filter:    filter,
 		graph: workspaceLocalGraph{
 			OK:     true,
 			Source: sourceRel,
+			RootID: rootID,
 			Nodes:  []workspaceLocalGraphNode{},
 			Edges:  []workspaceLocalGraphEdge{},
 		},
@@ -129,7 +131,10 @@ func workspaceGraphNodeType(path, kind string) string {
 }
 
 func sortWorkspaceLocalGraph(graph *workspaceLocalGraph) {
-	rootID := workspaceGraphNoteNodeID(graph.Source)
+	rootID := graph.RootID
+	if rootID == "" {
+		rootID = workspaceGraphNoteNodeID(graph.Source)
+	}
 	sort.SliceStable(graph.Nodes, func(i, j int) bool {
 		if graph.Nodes[i].ID == rootID {
 			return true

--- a/internal/web/workspace_graph_types.go
+++ b/internal/web/workspace_graph_types.go
@@ -1,0 +1,158 @@
+package web
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sloppy-org/slopshell/internal/store"
+)
+
+const (
+	workspaceLocalGraphNodeCap = 80
+	workspaceLocalGraphEdgeCap = 160
+)
+
+type workspaceLocalGraphNode struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Label   string `json:"label"`
+	Path    string `json:"path,omitempty"`
+	FileURL string `json:"file_url,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Sphere  string `json:"sphere,omitempty"`
+}
+
+type workspaceLocalGraphEdge struct {
+	ID       string `json:"id"`
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Relation string `json:"relation"`
+	Label    string `json:"label,omitempty"`
+	SourceID string `json:"source_id,omitempty"`
+	Sphere   string `json:"sphere,omitempty"`
+}
+
+type workspaceLocalGraph struct {
+	OK        bool                      `json:"ok"`
+	Source    string                    `json:"source_path"`
+	Nodes     []workspaceLocalGraphNode `json:"nodes"`
+	Edges     []workspaceLocalGraphEdge `json:"edges"`
+	Truncated bool                      `json:"truncated,omitempty"`
+	Error     string                    `json:"error,omitempty"`
+}
+
+type workspaceGraphFilter struct {
+	Relations map[string]bool
+	Source    string
+	Label     string
+	Sphere    string
+}
+
+type workspaceGraphBuilder struct {
+	workspace store.Workspace
+	filter    workspaceGraphFilter
+	graph     workspaceLocalGraph
+	nodes     map[string]workspaceLocalGraphNode
+	edges     map[string]workspaceLocalGraphEdge
+}
+
+func graphRelationEnabled(filter workspaceGraphFilter, relation string) bool {
+	return len(filter.Relations) == 0 || filter.Relations[relation]
+}
+
+func newWorkspaceGraphBuilder(workspace store.Workspace, filter workspaceGraphFilter, sourceRel string) *workspaceGraphBuilder {
+	return &workspaceGraphBuilder{
+		workspace: workspace,
+		filter:    filter,
+		graph: workspaceLocalGraph{
+			OK:     true,
+			Source: sourceRel,
+			Nodes:  []workspaceLocalGraphNode{},
+			Edges:  []workspaceLocalGraphEdge{},
+		},
+		nodes: map[string]workspaceLocalGraphNode{},
+		edges: map[string]workspaceLocalGraphEdge{},
+	}
+}
+
+func (b *workspaceGraphBuilder) addNode(node workspaceLocalGraphNode) {
+	if node.ID == "" {
+		return
+	}
+	if _, ok := b.nodes[node.ID]; ok {
+		return
+	}
+	if len(b.graph.Nodes) >= workspaceLocalGraphNodeCap {
+		b.graph.Truncated = true
+		return
+	}
+	b.nodes[node.ID] = node
+	b.graph.Nodes = append(b.graph.Nodes, node)
+}
+
+func (b *workspaceGraphBuilder) addEdge(edge workspaceLocalGraphEdge) {
+	if edge.ID == "" || edge.Source == "" || edge.Target == "" {
+		return
+	}
+	if _, ok := b.edges[edge.ID]; ok {
+		return
+	}
+	if len(b.graph.Edges) >= workspaceLocalGraphEdgeCap {
+		b.graph.Truncated = true
+		return
+	}
+	b.edges[edge.ID] = edge
+	b.graph.Edges = append(b.graph.Edges, edge)
+}
+
+func workspaceGraphNoteNodeID(path string) string {
+	return "note:" + strings.TrimSpace(path)
+}
+
+func workspaceGraphNodeLabel(path string) string {
+	clean := strings.TrimSpace(path)
+	if clean == "" {
+		return "Untitled"
+	}
+	return strings.TrimSuffix(filepath.Base(clean), filepath.Ext(clean))
+}
+
+func workspaceGraphNodeType(path, kind string) string {
+	if strings.EqualFold(filepath.Ext(path), ".md") || strings.EqualFold(kind, "text") {
+		return "note"
+	}
+	if strings.EqualFold(kind, "folder") {
+		return "folder"
+	}
+	return "artifact"
+}
+
+func sortWorkspaceLocalGraph(graph *workspaceLocalGraph) {
+	rootID := workspaceGraphNoteNodeID(graph.Source)
+	sort.SliceStable(graph.Nodes, func(i, j int) bool {
+		if graph.Nodes[i].ID == rootID {
+			return true
+		}
+		if graph.Nodes[j].ID == rootID {
+			return false
+		}
+		if graph.Nodes[i].Type == graph.Nodes[j].Type {
+			return graph.Nodes[i].Label < graph.Nodes[j].Label
+		}
+		return graph.Nodes[i].Type < graph.Nodes[j].Type
+	})
+	sort.SliceStable(graph.Edges, func(i, j int) bool {
+		if graph.Edges[i].Relation == graph.Edges[j].Relation {
+			return graph.Edges[i].ID < graph.Edges[j].ID
+		}
+		return graph.Edges[i].Relation < graph.Edges[j].Relation
+	})
+}
+
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}

--- a/internal/web/workspace_markdown_panel.go
+++ b/internal/web/workspace_markdown_panel.go
@@ -134,55 +134,38 @@ func collectMarkdownBacklinks(workspace store.Workspace, sourceRel string) ([]wo
 	sourceBase := strings.TrimSuffix(filepath.Base(sourceAbs), ".md")
 
 	results := []workspaceMarkdownBacklink{}
-	scanned := 0
 	scanLimitReached := false
 	truncated := false
 
-	walkErr := filepath.WalkDir(brainRoot, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return nil
-		}
-		if entry.IsDir() {
-			if pathInWorkPersonalGuardrail(path) {
-				return filepath.SkipDir
-			}
-			base := entry.Name()
-			if base != "." && strings.HasPrefix(base, ".") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
-			return nil
-		}
+	files, fileLimitReached, err := listWorkspaceMarkdownNoteFiles(brainRoot, workspaceMarkdownBacklinkScanFileCap)
+	if err != nil {
+		return nil, false, false, err
+	}
+	scanLimitReached = fileLimitReached
+	for _, path := range files {
 		if path == sourceAbs {
-			return nil
+			continue
 		}
 		if pathInWorkPersonalGuardrail(path) {
-			return nil
-		}
-		scanned++
-		if scanned > workspaceMarkdownBacklinkScanFileCap {
-			scanLimitReached = true
-			return filepath.SkipAll
+			continue
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil
+			continue
 		}
 		text := string(data)
 		refs := parseMarkdownLinkRefs(text)
 		if len(refs) == 0 {
-			return nil
+			continue
 		}
 		fileVaultRel, relErr := filepath.Rel(vaultRoot, path)
 		if relErr != nil {
-			return nil
+			continue
 		}
 		fileVaultRel = filepath.ToSlash(filepath.Clean(fileVaultRel))
 		brainRel, brainRelErr := filepath.Rel(brainRoot, path)
 		if brainRelErr != nil {
-			return nil
+			continue
 		}
 		brainRel = filepath.ToSlash(filepath.Clean(brainRel))
 		for _, ref := range refs {
@@ -191,7 +174,7 @@ func collectMarkdownBacklinks(workspace store.Workspace, sourceRel string) ([]wo
 			}
 			if len(results) >= workspaceMarkdownBacklinkResultCap {
 				truncated = true
-				return filepath.SkipAll
+				break
 			}
 			results = append(results, workspaceMarkdownBacklink{
 				SourcePath: fileVaultRel,
@@ -202,10 +185,9 @@ func collectMarkdownBacklinks(workspace store.Workspace, sourceRel string) ([]wo
 			})
 			break
 		}
-		return nil
-	})
-	if walkErr != nil {
-		return results, truncated, scanLimitReached, walkErr
+		if truncated {
+			break
+		}
 	}
 	sort.SliceStable(results, func(i, j int) bool {
 		return results[i].SourcePath < results[j].SourcePath

--- a/internal/web/workspace_markdown_scan.go
+++ b/internal/web/workspace_markdown_scan.go
@@ -1,0 +1,79 @@
+package web
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func listWorkspaceMarkdownNoteFiles(root string, fileCap int) ([]string, bool, error) {
+	files, capped, err := listWorkspaceMarkdownNoteFilesWithRG(root, fileCap)
+	if err == nil {
+		return files, capped, nil
+	}
+	return listWorkspaceMarkdownNoteFilesByWalk(root, fileCap)
+}
+
+func listWorkspaceMarkdownNoteFilesWithRG(root string, fileCap int) ([]string, bool, error) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		return nil, false, err
+	}
+	cmd := exec.Command("rg", "--files", "--glob", "*.md")
+	cmd.Dir = root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil && stdout.Len() == 0 {
+		return nil, false, err
+	}
+	files := []string{}
+	capped := false
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" {
+			continue
+		}
+		path := filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))
+		if !pathInsideOrEqual(path, root) || pathInWorkPersonalGuardrail(path) {
+			continue
+		}
+		if len(files) >= fileCap {
+			capped = true
+			break
+		}
+		files = append(files, path)
+	}
+	return files, capped, nil
+}
+
+func listWorkspaceMarkdownNoteFilesByWalk(root string, fileCap int) ([]string, bool, error) {
+	files := []string{}
+	capped := false
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if pathInWorkPersonalGuardrail(path) {
+				return filepath.SkipDir
+			}
+			base := entry.Name()
+			if base != "." && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			return nil
+		}
+		if len(files) >= fileCap {
+			capped = true
+			return filepath.SkipAll
+		}
+		files = append(files, path)
+		return nil
+	})
+	return files, capped, err
+}

--- a/tests/playwright/harness-routes-runtime.js
+++ b/tests/playwright/harness-routes-runtime.js
@@ -544,10 +544,41 @@ __harnessRouteHandlers.push(async function harnessRouteRuntime(u, opts) {
           headers: { 'Content-Type': 'application/json' },
         });
       }
+      if (u.includes('/api/workspaces/') && u.includes('/markdown-link/panel')) {
+        const payload = window.__mockMarkdownLinkPanel || {
+          ok: true,
+          source_path: 'topics/active.md',
+          outgoing: [],
+          broken_count: 0,
+          backlinks: [],
+        };
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (u.includes('/api/workspaces/') && u.includes('/markdown-link/file')) {
         return new Response(String(window.__mockMarkdownLinkFileText || ''), {
           status: 200,
           headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        });
+      }
+      if (u.includes('/api/workspaces/') && u.includes('/graph')) {
+        const payload = window.__mockWorkspaceLocalGraph || {
+          ok: true,
+          source_path: 'topics/active.md',
+          nodes: [],
+          edges: [],
+        };
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'local_graph',
+          method: opts?.method || 'GET',
+          url: u,
+        });
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
         });
       }
       if (u.includes('/api/workspaces/') && u.includes('/companion/config') && opts?.method === 'PUT') {

--- a/tests/playwright/local-graph.spec.ts
+++ b/tests/playwright/local-graph.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await page.waitForFunction(() => {
+    const app = (window as any)._slopshellApp;
+    if (typeof app?.getState !== 'function') return false;
+    const state = app.getState();
+    return state.chatWs && state.chatWs.readyState === (window as any).WebSocket.OPEN;
+  }, null, { timeout: 5_000 });
+}
+
+async function seedBrainWorkspace(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__setProjects([
+      {
+        id: 'brain',
+        name: 'Brain',
+        kind: 'linked',
+        sphere: 'work',
+        workspace_path: '/tmp/vault/brain',
+        root_path: '/tmp/vault/brain',
+        chat_session_id: 'chat-brain',
+        canvas_session_id: 'brain',
+        chat_mode: 'chat',
+        chat_model: 'local',
+        chat_model_reasoning_effort: 'none',
+        unread: false,
+        review_pending: false,
+        run_state: { active_turns: 0, queued_turns: 0, is_working: false, status: 'idle' },
+      },
+    ], 'brain');
+    const state = (window as any)._slopshellApp?.getState?.();
+    if (state) {
+      state.activeWorkspaceId = 'brain';
+      state.projects = [
+        {
+          id: 'brain',
+          name: 'Brain',
+          sphere: 'work',
+          workspace_path: '/tmp/vault/brain',
+          root_path: '/tmp/vault/brain',
+        },
+      ];
+    }
+  });
+  await page.waitForFunction(() => {
+    const state = (window as any)._slopshellApp?.getState?.();
+    return String(state?.activeWorkspaceId || '') === 'brain'
+      && Array.isArray(state?.projects)
+      && state.projects.some((project: any) => String(project?.root_path || '') === '/tmp/vault/brain');
+  }, null, { timeout: 5_000 });
+}
+
+async function renderGraphArtifact(page: Page) {
+  await page.evaluate(async () => {
+    const mod = await import('../../internal/web/static/canvas.js');
+    (window as any).__canvasModule = mod;
+    const state = (window as any)._slopshellApp?.getState?.();
+    if (state) state.activeWorkspaceId = 'brain';
+    (window as any).__mockWorkspaceLocalGraph = {
+      ok: true,
+      source_path: 'topics/active.md',
+      nodes: [
+        { id: 'note:topics/active.md', type: 'note', label: 'active', path: 'topics/active.md', file_url: '/api/workspaces/brain/markdown-link/file?path=brain%2Ftopics%2Factive.md', sphere: 'work' },
+        { id: 'note:brain/topics/related.md', type: 'note', label: 'related', path: 'brain/topics/related.md', file_url: '/api/workspaces/brain/markdown-link/file?path=brain%2Ftopics%2Frelated.md', sphere: 'work' },
+        { id: 'item:7', type: 'item', label: 'Follow up', source: 'todoist', sphere: 'work' },
+        { id: 'source:todoist:task-7', type: 'source', label: 'task-7', source: 'todoist', sphere: 'work' },
+      ],
+      edges: [
+        { source: 'note:topics/active.md', target: 'note:brain/topics/related.md', relation: 'markdown_link', label: 'markdown' },
+        { source: 'item:7', target: 'source:todoist:task-7', relation: 'source_binding', label: 'todoist' },
+      ],
+    };
+    (window as any).__mockMarkdownLinkFileText = '# Related\n\nOpened from graph';
+    mod.renderCanvas({
+      event_id: 'local-graph-active',
+      kind: 'text_artifact',
+      title: 'topics/active.md',
+      path: 'topics/active.md',
+      text: '[Related](related.md)',
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await waitReady(page);
+  await seedBrainWorkspace(page);
+});
+
+test('local graph renders, filters, and opens nodes', async ({ page }) => {
+  await renderGraphArtifact(page);
+
+  await expect(page.locator('#canvas-markdown-link-panel .canvas-local-graph')).toBeVisible();
+  await expect(page.locator('.canvas-local-graph-node', { hasText: 'active' })).toBeVisible();
+  await expect(page.locator('.canvas-local-graph-node', { hasText: 'related' })).toBeVisible();
+
+  await page.locator('.canvas-local-graph-controls input[name="source_filter"]').fill('todoist');
+  await page.locator('.canvas-local-graph-controls input[name="label"]').fill('deep-work');
+  await page.locator('.canvas-local-graph-controls button', { hasText: 'Apply' }).click();
+  await expect.poll(async () => {
+    const log = await page.evaluate(() => (window as any).__harnessLog.slice());
+    return log.some((entry: any) => entry.action === 'local_graph'
+      && String(entry.url || '').includes('source_filter=todoist')
+      && String(entry.url || '').includes('label=deep-work'));
+  }, { timeout: 5_000 }).toBe(true);
+
+  await page.locator('.canvas-local-graph-node', { hasText: 'related' }).click();
+  await expect(page.locator('#canvas-text')).toContainText('Opened from graph');
+
+  await renderGraphArtifact(page);
+  await page.locator('.canvas-local-graph-node', { hasText: 'task-7' }).click();
+  await expect(page.locator('#canvas-text')).toContainText('Type: source');
+  await expect(page.locator('#canvas-text')).toContainText('Source: todoist');
+});

--- a/tests/playwright/local-graph.spec.ts
+++ b/tests/playwright/local-graph.spec.ts
@@ -113,3 +113,54 @@ test('local graph renders, filters, and opens nodes', async ({ page }) => {
   await expect(page.locator('#canvas-text')).toContainText('Type: source');
   await expect(page.locator('#canvas-text')).toContainText('Source: todoist');
 });
+
+test('local graph loads for active entity and non-markdown artifact roots', async ({ page }) => {
+  await page.evaluate(async () => {
+    const mod = await import('../../internal/web/static/canvas.js');
+    (window as any).__mockWorkspaceLocalGraph = {
+      ok: true,
+      root_id: 'item:7',
+      source_path: 'item:7',
+      nodes: [{ id: 'item:7', type: 'item', label: 'Follow up', source: 'todoist', sphere: 'work' }],
+      edges: [],
+    };
+    mod.renderCanvas({
+      event_id: 'entity-root',
+      kind: 'text_artifact',
+      title: 'Follow up',
+      path: 'item:7',
+      text: 'Type: item',
+    });
+  });
+  await expect(page.locator('#canvas-markdown-link-panel .canvas-local-graph')).toBeVisible();
+  await expect.poll(async () => {
+    const log = await page.evaluate(() => (window as any).__harnessLog.slice());
+    return log.some((entry: any) => entry.action === 'local_graph'
+      && String(entry.url || '').includes('root=item%3A7'));
+  }, { timeout: 5_000 }).toBe(true);
+
+  await page.evaluate(async () => {
+    const mod = await import('../../internal/web/static/canvas.js');
+    (window as any).__mockWorkspaceLocalGraph = {
+      ok: true,
+      root_id: 'artifact:44',
+      source_path: 'artifact:44',
+      nodes: [{ id: 'artifact:44', type: 'artifact', label: 'Figure', path: 'figures/plot.png', sphere: 'work' }],
+      edges: [],
+    };
+    mod.renderCanvas({
+      event_id: 'artifact-root',
+      kind: 'image_artifact',
+      title: 'Figure',
+      path: 'figures/plot.png',
+      url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+      meta: { artifact_id: 44, artifact_kind: 'image' },
+    });
+  });
+  await expect(page.locator('#canvas-markdown-link-panel .canvas-local-graph')).toBeVisible();
+  await expect.poll(async () => {
+    const log = await page.evaluate(() => (window as any).__harnessLog.slice());
+    return log.some((entry: any) => entry.action === 'local_graph'
+      && String(entry.url || '').includes('artifact_id=44'));
+  }, { timeout: 5_000 }).toBe(true);
+});


### PR DESCRIPTION
Fixes #736

## Summary
- Adds bounded `/api/workspaces/{workspace_id}/graph` construction from Markdown links/backlinks, source bindings, and GTD/entity metadata.
- Renders the local graph in the Markdown panel with relation/source/label/sphere filters and node opening.
- Updates route surface docs.

## Verification
- Requirement: Graph renders quickly for a normal note using bounded neighborhood expansion.
  Evidence: `go test ./...` -> `ok  	github.com/sloppy-org/slopshell/internal/web	(cached)` in `/tmp/slopshell-go-test.log`; focused render artifact test `tests/playwright/local-graph.spec.ts` -> `1 passed (1.4s)` in `/tmp/slopshell-local-graph-playwright.log`; full Playwright -> `418 passed (3.4m)` in `/tmp/slopshell-playwright.log`.
- Requirement: Work/private separation and `personal/` exclusion are enforced.
  Evidence: `TestWorkspaceLocalGraphMarkdownNeighborhoodExcludesPersonal` and `TestWorkspaceLocalGraphFiltersMetadata` run under `go test ./...` in `/tmp/slopshell-go-test.log`.
- Requirement: Tests cover graph data construction separately from rendering.
  Evidence: graph data construction is covered in `internal/web/workspace_graph_test.go`; rendering/filter/open-node behavior is covered in `tests/playwright/local-graph.spec.ts`.
- Scope: filters by relation type, source, label, and sphere; open node in canvas/detail.
  Evidence: `tests/playwright/local-graph.spec.ts` asserts filter request parameters and note/source node opening; `TestWorkspaceLocalGraphFiltersMetadata` covers source/label/sphere filtering in backend graph construction.
- API/interface/frontend build.
  Evidence: `./scripts/sync-surface.sh --check` exited 0 with `/tmp/slopshell-sync-surface.log`; `npm run build:frontend` -> `built 72 frontend modules` in `/tmp/slopshell-build-frontend.log`; `npm run typecheck:frontend` exited 0 in `/tmp/slopshell-typecheck-frontend.log`.
