### PR TITLE
fix: collapse edge-active duplicate of edge-pinned (fixes #703)

### DIFF
--- a/internal/web/static/app-canvas-transport.ts
+++ b/internal/web/static/app-canvas-transport.ts
@@ -103,7 +103,7 @@ export function applyCanvasArtifactEvent(payload) {
   state.canvasActionThisTurn = state.canvasActionThisTurn || realArtifact;
   if (isMobileSilent() && realArtifact) {
     const edgeRight = document.getElementById('edge-right');
-    if (edgeRight) edgeRight.classList.remove('edge-active', 'edge-pinned');
+    if (edgeRight) edgeRight.classList.remove('edge-pinned');
   }
 }
 

--- a/internal/web/static/app-chat-transport.ts
+++ b/internal/web/static/app-chat-transport.ts
@@ -743,7 +743,7 @@ export function handleChatEvent(payload) {
       if (state.canvasActionThisTurn) {
         // LLM touched the canvas this turn — keep showing the document.
         const edgeRight = document.getElementById('edge-right');
-        if (edgeRight) edgeRight.classList.remove('edge-active', 'edge-pinned');
+        if (edgeRight) edgeRight.classList.remove('edge-pinned');
       }
       hideOverlay();
       state.canvasActionThisTurn = false;

--- a/internal/web/static/app-chat-ui.ts
+++ b/internal/web/static/app-chat-ui.ts
@@ -740,7 +740,7 @@ export function openComposerAt(x, y, anchor = null, initialText = '') {
     const input = document.getElementById('chat-pane-input');
     setInputAnchor(anchor);
     if (edgeRight instanceof HTMLElement) {
-      edgeRight.classList.add('edge-active', 'edge-pinned');
+      edgeRight.classList.add('edge-pinned');
     }
     if (input instanceof HTMLTextAreaElement) {
       input.focus();

--- a/internal/web/static/app-edge-panels.ts
+++ b/internal/web/static/app-edge-panels.ts
@@ -44,11 +44,7 @@ export function edgePanelsAreOpen() {
 
 function togglePanel(panel) {
   if (!(panel instanceof HTMLElement)) return;
-  if (panel.classList.contains('edge-pinned')) {
-    panel.classList.remove('edge-pinned', 'edge-active');
-  } else {
-    panel.classList.add('edge-active', 'edge-pinned');
-  }
+  panel.classList.toggle('edge-pinned');
 }
 
 export function toggleFileSidebarFromEdge() {
@@ -111,7 +107,7 @@ export function initEdgePanels() {
       clearInkDraft();
       clearCanvas();
       hideCanvasColumn();
-      if (edgeTop) edgeTop.classList.remove('edge-active', 'edge-pinned');
+      if (edgeTop) edgeTop.classList.remove('edge-pinned');
     });
   }
 
@@ -244,8 +240,8 @@ export function initEdgePanels() {
 export function closeEdgePanels() {
   const edgeTop = document.getElementById('edge-top');
   const edgeRight = document.getElementById('edge-right');
-  if (edgeTop) edgeTop.classList.remove('edge-active', 'edge-pinned');
-  if (edgeRight) edgeRight.classList.remove('edge-active', 'edge-pinned');
+  if (edgeTop) edgeTop.classList.remove('edge-pinned');
+  if (edgeRight) edgeRight.classList.remove('edge-pinned');
   if (state.prReviewDrawerOpen) {
     setPrReviewDrawerOpen(false);
   }

--- a/internal/web/static/app-init.ts
+++ b/internal/web/static/app-init.ts
@@ -826,7 +826,7 @@ export function bindUi() {
     if (ev.key.length === 1 && !isTextInputVisible()) {
       const edgeR = document.getElementById('edge-right');
       const cpInput = document.getElementById('chat-pane-input');
-      const chatPaneOpen = edgeR && (edgeR.classList.contains('edge-active') || edgeR.classList.contains('edge-pinned'));
+      const chatPaneOpen = edgeR && edgeR.classList.contains('edge-pinned');
       if (chatPaneOpen && cpInput instanceof HTMLTextAreaElement && !window.matchMedia('(max-width: 767px)').matches) {
         cancelLiveSessionListen();
         cpInput.focus();

--- a/internal/web/static/edge-panels.css
+++ b/internal/web/static/edge-panels.css
@@ -57,7 +57,6 @@ body.black-screen .edge-left-tap:active {
   border-left: 1px solid var(--border);
 }
 
-.edge-right.edge-active,
 .edge-right.edge-pinned {
   transform: translateX(0);
   pointer-events: auto;
@@ -175,7 +174,6 @@ body.panel-motion-enabled {
   transform: translateY(-100%);
 }
 
-.edge-top.edge-active,
 .edge-top.edge-pinned {
   transform: translateY(0);
   z-index: 440;

--- a/tests/playtest/playtest.spec.ts
+++ b/tests/playtest/playtest.spec.ts
@@ -56,7 +56,7 @@ test.describe('live playtest smoke', () => {
 
     await page.keyboard.press('Escape');
     await expect(page.locator('#edge-right')).not.toHaveClass(/edge-pinned/);
-    await expect(page.locator('#edge-top')).not.toHaveClass(/edge-active/);
+    await expect(page.locator('#edge-top')).not.toHaveClass(/edge-pinned/);
   });
 
   test('slopshell circle stays readable and drives all desktop click states', async ({ page }, testInfo) => {

--- a/tests/playwright/canvas.spec.ts
+++ b/tests/playwright/canvas.spec.ts
@@ -931,13 +931,12 @@ test.describe('canvas - edge panels', () => {
 
     const edgeRight = page.locator('#edge-right');
     const initialClasses = await edgeRight.getAttribute('class');
-    expect(initialClasses).not.toContain('edge-active');
+    expect(initialClasses).not.toContain('edge-pinned');
 
     await page.mouse.move(1275, 360);
     await page.waitForTimeout(100);
 
     const classes = await edgeRight.getAttribute('class');
-    expect(classes).not.toContain('edge-active');
     expect(classes).not.toContain('edge-pinned');
   });
 
@@ -949,7 +948,6 @@ test.describe('canvas - edge panels', () => {
     await page.waitForTimeout(100);
 
     const classes = await edgeTop.getAttribute('class');
-    expect(classes).not.toContain('edge-active');
     expect(classes).not.toContain('edge-pinned');
   });
 
@@ -965,7 +963,6 @@ test.describe('canvas - edge panels', () => {
     await page.waitForTimeout(100);
 
     const classes = await edgeTop.getAttribute('class');
-    expect(classes).not.toContain('edge-active');
     expect(classes).not.toContain('edge-pinned');
   });
 
@@ -983,7 +980,6 @@ test.describe('canvas - edge panels', () => {
     await page.waitForTimeout(100);
     const classes = await edgeRight.getAttribute('class');
     expect(classes).not.toContain('edge-pinned');
-    expect(classes).not.toContain('edge-active');
   });
 
   test('chat log appears in right edge panel', async ({ page }) => {
@@ -1069,7 +1065,6 @@ test.describe('canvas - edge panels', () => {
 
     const classes = await edgeRight.getAttribute('class');
     expect(classes).not.toContain('edge-pinned');
-    expect(classes).not.toContain('edge-active');
   });
 
   test('touch tap inside pinned chat panel does not cancel default focus flow', async ({ page }) => {
@@ -1126,7 +1121,6 @@ test.describe('canvas - edge panels', () => {
 
     const classes = await edgeTop.getAttribute('class');
     expect(classes).not.toContain('edge-pinned');
-    expect(classes).not.toContain('edge-active');
   });
 
   test('touch tap on the sidebar edge strip hides the file sidebar drawer', async ({ page }) => {

--- a/tests/playwright/ui-system.spec.ts
+++ b/tests/playwright/ui-system.spec.ts
@@ -356,7 +356,6 @@ test.describe('tabula rasa button', () => {
     // Top panel should be unpinned
     const topClasses = await page.locator('#edge-top').getAttribute('class');
     expect(topClasses).not.toContain('edge-pinned');
-    expect(topClasses).not.toContain('edge-active');
 
     // hasArtifact should be false
     const hasArtifact = await page.evaluate(() => (window as any)._slopshellApp?.getState?.().hasArtifact);


### PR DESCRIPTION
## Summary

The edge panels carried two synonymous CSS classes (`edge-active` and
`edge-pinned`) for the same open state. The CSS treated them identically and
every code path added or removed them in lockstep, but they drifted apart when
the playtest was migrated from a hover trigger to a click trigger: the click
path only sets `edge-pinned`, while the test still asserted `edge-active`.

Keep `edge-pinned` as the single source of truth. Drop `edge-active` from the
runtime, the stylesheet, and the test assertions.

## Verification

### Failing playtest now passes

`tests/playtest/playtest.spec.ts::edge chrome opens and escape collapses the live shell` is the test from issue #703.

```
$ SLOPSHELL_TEST_SESSION_TOKEN=$TOKEN E2E_AUDIO_FILE=/tmp/slopshell-playtest-speech.wav \
    npx playwright test --config=playwright.playtest.config.ts \
    --grep "edge chrome opens and escape collapses the live shell"
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/playtest/playtest.spec.ts:33:7 › live playtest smoke › edge chrome opens and escape collapses the live shell (2.8s)
  1 passed (3.8s)
```

### Edge panel suite green

All edge panel coverage in `tests/playwright/canvas.spec.ts` and `tests/playwright/ui-system.spec.ts` runs against the unified class.

```
$ PLAYWRIGHT_NATIVE=1 ./scripts/playwright.sh --grep "edge"
  21 passed (12.1s)
```

### No regression in adjacent suites

The chromium pass over canvas, ui-system, silent-mode, inbox, inbox-triage, live-meeting, workspace-routing, and pr-review-mode (every spec that referenced the merged classes) is clean.

```
$ PLAYWRIGHT_NATIVE=1 npx playwright test \
    tests/playwright/canvas.spec.ts \
    tests/playwright/ui-system.spec.ts \
    tests/playwright/silent-mode.spec.ts \
    tests/playwright/inbox.spec.ts \
    tests/playwright/inbox-triage.spec.ts \
    tests/playwright/live-meeting.spec.ts \
    tests/playwright/workspace-routing.spec.ts \
    tests/playwright/pr-review-mode.spec.ts \
    --project chromium
  177 passed (1.7m)
```

### Backend unaffected

```
$ go test ./internal/web/...
ok  	github.com/sloppy-org/slopshell/internal/web	27.658s
```

### Surface inventory still in sync

```
$ ./scripts/sync-surface.sh --check
exit=0
```