### PR TITLE
fix: playtest: yolo and silent toggles update runtime state and survi (fixes #704)

### DIFF
--- a/internal/web/runtime_prefs.go
+++ b/internal/web/runtime_prefs.go
@@ -295,10 +295,12 @@ func (a *App) handleRuntimeYoloModeUpdate(w http.ResponseWriter, r *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	enabled := a.yoloModeEnabled()
 	writeJSON(w, map[string]interface{}{
 		"ok":               true,
-		"enabled":          req.Enabled,
-		"execution_policy": executionPolicyForSession("chat", req.Enabled).Name,
+		"enabled":          enabled,
+		"safety_yolo_mode": enabled,
+		"execution_policy": executionPolicyForSession("chat", enabled).Name,
 	})
 }
 

--- a/internal/web/runtime_prefs_test.go
+++ b/internal/web/runtime_prefs_test.go
@@ -75,6 +75,9 @@ func TestRuntimeYoloModeUpdatePersists(t *testing.T) {
 	if got := strFromAny(setPayload["execution_policy"]); got != executionPolicyAutonomous {
 		t.Fatalf("execution_policy = %q, want %q", got, executionPolicyAutonomous)
 	}
+	if got := boolFromAny(setPayload["safety_yolo_mode"]); !got {
+		t.Fatalf("safety_yolo_mode = %v, want true", got)
+	}
 	rr := doAuthedJSONRequest(t, app.Router(), http.MethodGet, "/api/runtime", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("runtime status=%d body=%s", rr.Code, rr.Body.String())

--- a/internal/web/static/app-tts.ts
+++ b/internal/web/static/app-tts.ts
@@ -419,7 +419,9 @@ export async function setYoloMode(enabled) {
     const detail = (await resp.text()).trim() || `HTTP ${resp.status}`;
     throw new Error(detail);
   }
-  setYoloModeLocal(next, { persist: true, render: true });
+  const payload = await resp.json();
+  const persisted = parseOptionalBoolean(payload?.safety_yolo_mode);
+  setYoloModeLocal(persisted === null ? next : persisted, { persist: true, render: true });
 }
 
 export function toggleYoloMode() {

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -540,29 +540,19 @@ export function renderEdgeTopProjects() {
   }
 }
 
-export function renderEdgeTopModelButtons() {
-  const host = document.getElementById('edge-top-models');
-  if (!(host instanceof HTMLElement)) return;
-  host.innerHTML = '';
-  const project = activeProject();
+function createEdgeRuntimeSummary(project) {
   const focusSnapshot = normalizeWorkspaceFocusSnapshot(state.workspaceFocus);
   const hasBusyWork = normalizeWorkspaceBusyStates(state.workspaceBusyStates).some((entry) => entry.status !== 'idle');
-  const shell = document.createElement('div');
-  shell.className = 'edge-runtime-shell';
-
   const summary = document.createElement('div');
   summary.className = 'edge-runtime-summary';
-
   const kicker = document.createElement('div');
   kicker.className = 'edge-runtime-kicker';
   kicker.textContent = 'Today';
   summary.appendChild(kicker);
-
   const title = document.createElement('div');
   title.className = 'edge-runtime-title';
   title.textContent = String(project?.name || project?.id || 'No workspace selected').trim() || 'No workspace selected';
   summary.appendChild(title);
-
   const detail = document.createElement('div');
   detail.className = 'edge-runtime-detail';
   const detailParts = [];
@@ -592,9 +582,39 @@ export function renderEdgeTopModelButtons() {
   busy.textContent = workspaceBusyBadgeText(state.workspaceBusyStates);
   busy.title = workspaceBusyBadgeTitle(focusSnapshot, state.workspaceBusyStates);
   summary.appendChild(busy);
+  return summary;
+}
 
+function createEdgeRuntimeChip(text, title = '') {
+  const chip = document.createElement('span');
+  chip.className = 'edge-runtime-chip';
+  chip.textContent = text;
+  if (title) chip.title = title;
+  return chip;
+}
+
+function createEdgeRuntimeModelChip() {
+  const chip = createEdgeRuntimeChip((activeProjectChatModelAlias() || 'local').toUpperCase());
+  chip.setAttribute('role', 'button');
+  chip.tabIndex = 0;
+  chip.title = 'Workspace default model. Local stays the default; Spark, GPT, and Mini are used only by delegation.';
+  const activateLocal = () => {
+    if (activeProjectChatModelAlias() === 'local' || state.projectModelSwitchInFlight) return;
+    void switchProjectChatModel('local');
+  };
+  chip.addEventListener('click', activateLocal);
+  chip.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    activateLocal();
+  });
+  return chip;
+}
+
+function createEdgeRuntimeActions() {
   const actions = document.createElement('div');
   actions.className = 'edge-runtime-actions';
+
   const liveStatus = document.createElement('span');
   liveStatus.className = 'edge-live-status';
   if (state.liveSessionActive) {
@@ -607,49 +627,29 @@ export function renderEdgeTopModelButtons() {
     liveStatus.title = 'Use the Slopshell Circle for Dialogue, Meeting, Silent, and Stop.';
   }
   actions.appendChild(liveStatus);
-
-  const modelChip = document.createElement('span');
-  modelChip.className = 'edge-runtime-chip';
-  modelChip.textContent = (activeProjectChatModelAlias() || 'local').toUpperCase();
-  modelChip.setAttribute('role', 'button');
-  modelChip.tabIndex = 0;
-  modelChip.title = 'Workspace default model. Local stays the default; Spark, GPT, and Mini are used only by delegation.';
-  const activateLocal = () => {
-    if (activeProjectChatModelAlias() === 'local' || state.projectModelSwitchInFlight) return;
-    void switchProjectChatModel('local');
-  };
-  modelChip.addEventListener('click', activateLocal);
-  modelChip.addEventListener('keydown', (event) => {
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    event.preventDefault();
-    activateLocal();
-  });
-  actions.appendChild(modelChip);
+  actions.appendChild(createEdgeRuntimeModelChip());
 
   if (state.fastMode) {
-    const fastChip = document.createElement('span');
-    fastChip.className = 'edge-runtime-chip';
-    fastChip.textContent = 'FAST';
-    actions.appendChild(fastChip);
+    actions.appendChild(createEdgeRuntimeChip('FAST'));
   }
-
   if (state.yoloMode) {
-    const yoloChip = document.createElement('span');
-    yoloChip.className = 'edge-runtime-chip';
-    yoloChip.textContent = 'YOLO';
-    yoloChip.title = 'Autonomous execution policy is enabled.';
-    actions.appendChild(yoloChip);
+    actions.appendChild(createEdgeRuntimeChip('YOLO', 'Autonomous execution policy is enabled.'));
   }
-
   if (state.ttsEnabled) {
-    const voiceChip = document.createElement('span');
-    voiceChip.className = 'edge-runtime-chip';
-    voiceChip.textContent = state.ttsSilent ? 'Silent' : 'Voice';
-    actions.appendChild(voiceChip);
+    actions.appendChild(createEdgeRuntimeChip(state.ttsSilent ? 'Silent' : 'Voice'));
   }
+  return actions;
+}
 
-  shell.appendChild(summary);
-  shell.appendChild(actions);
+export function renderEdgeTopModelButtons() {
+  const host = document.getElementById('edge-top-models');
+  if (!(host instanceof HTMLElement)) return;
+  host.innerHTML = '';
+  const shell = document.createElement('div');
+  shell.className = 'edge-runtime-shell';
+
+  shell.appendChild(createEdgeRuntimeSummary(activeProject()));
+  shell.appendChild(createEdgeRuntimeActions());
   host.appendChild(shell);
 }
 

--- a/internal/web/static/app-workspace-runtime.ts
+++ b/internal/web/static/app-workspace-runtime.ts
@@ -633,6 +633,14 @@ export function renderEdgeTopModelButtons() {
     actions.appendChild(fastChip);
   }
 
+  if (state.yoloMode) {
+    const yoloChip = document.createElement('span');
+    yoloChip.className = 'edge-runtime-chip';
+    yoloChip.textContent = 'YOLO';
+    yoloChip.title = 'Autonomous execution policy is enabled.';
+    actions.appendChild(yoloChip);
+  }
+
   if (state.ttsEnabled) {
     const voiceChip = document.createElement('span');
     voiceChip.className = 'edge-runtime-chip';

--- a/tests/playwright/harness-routes-runtime.js
+++ b/tests/playwright/harness-routes-runtime.js
@@ -17,9 +17,11 @@ __harnessRouteHandlers.push(async function harnessRouteRuntime(u, opts) {
         try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
         if (Object.prototype.hasOwnProperty.call(body, 'silent_mode')) {
           runtimeState.silent_mode = Boolean(body.silent_mode);
+          window.__writeHarnessStoredBool?.('slopshell.harness.silentMode', runtimeState.silent_mode);
         }
         if (Object.prototype.hasOwnProperty.call(body, 'fast_mode')) {
           runtimeState.fast_mode = Boolean(body.fast_mode);
+          window.__writeHarnessStoredBool?.('slopshell.harness.fastMode', runtimeState.fast_mode);
         }
         if (typeof body?.tool === 'string') {
           const normalized = String(body.tool).trim().toLowerCase();
@@ -59,6 +61,25 @@ __harnessRouteHandlers.push(async function harnessRouteRuntime(u, opts) {
           active_sphere: runtimeState.active_sphere,
           turn_policy_profile: runtimeState.turn_policy_profile,
           turn_eval_logging_enabled: runtimeState.turn_eval_logging_enabled,
+        }), { status: 200 });
+      }
+      if (u.includes('/api/runtime/yolo') && opts?.method === 'POST') {
+        let body = {};
+        try { body = JSON.parse(String(opts?.body || '{}')); } catch (_) { body = {}; }
+        runtimeState.safety_yolo_mode = Boolean(body.enabled);
+        window.__writeHarnessStoredBool?.('slopshell.harness.safetyYoloMode', runtimeState.safety_yolo_mode);
+        window.__harnessLog.push({
+          type: 'api_fetch',
+          action: 'runtime_yolo',
+          method: opts?.method || 'POST',
+          url: u,
+          payload: { safety_yolo_mode: runtimeState.safety_yolo_mode },
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          enabled: runtimeState.safety_yolo_mode,
+          safety_yolo_mode: runtimeState.safety_yolo_mode,
+          execution_policy: runtimeState.safety_yolo_mode ? 'autonomous' : 'default',
         }), { status: 200 });
       }
       if (u.includes('/api/live-policy') && opts?.method === 'POST') {

--- a/tests/playwright/harness-setup.js
+++ b/tests/playwright/harness-setup.js
@@ -102,6 +102,20 @@
       return Boolean(window.__confirmResponse);
     };
     const harnessParams = new URL(window.location.href).searchParams;
+    function readHarnessStoredBool(key, fallback) {
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (raw === 'true') return true;
+        if (raw === 'false') return false;
+      } catch (_) {}
+      return fallback;
+    }
+    function writeHarnessStoredBool(key, value) {
+      try {
+        window.localStorage.setItem(key, value ? 'true' : 'false');
+      } catch (_) {}
+    }
+    window.__writeHarnessStoredBool = writeHarnessStoredBool;
     const runtimeState = {
       dev_mode: false,
       boot_id: 'test',
@@ -111,8 +125,9 @@
       turn_intelligence_enabled: true,
       turn_policy_profile: 'balanced',
       turn_eval_logging_enabled: true,
-      silent_mode: false,
-      fast_mode: false,
+      safety_yolo_mode: readHarnessStoredBool('slopshell.harness.safetyYoloMode', false),
+      silent_mode: readHarnessStoredBool('slopshell.harness.silentMode', false),
+      fast_mode: readHarnessStoredBool('slopshell.harness.fastMode', false),
       live_policy: harnessParams.get('live_policy') === 'meeting' ? 'meeting' : 'dialogue',
       tool: 'pointer',
       startup_behavior: 'resume_active',
@@ -202,6 +217,9 @@
       }
       if (Object.prototype.hasOwnProperty.call(next, 'turn_eval_logging_enabled')) {
         runtimeState.turn_eval_logging_enabled = Boolean(next.turn_eval_logging_enabled);
+      }
+      if (Object.prototype.hasOwnProperty.call(next, 'safety_yolo_mode')) {
+        runtimeState.safety_yolo_mode = Boolean(next.safety_yolo_mode);
       }
     };
     window.__getRuntimeState = () => ({ ...runtimeState });

--- a/tests/playwright/slopshell-circle.spec.ts
+++ b/tests/playwright/slopshell-circle.spec.ts
@@ -10,8 +10,7 @@ async function getLog(page: Page) {
   return page.evaluate(() => (window as any).__harnessLog.slice());
 }
 
-async function waitReady(page: Page) {
-  await page.goto('/tests/playwright/harness.html');
+async function waitForAppReady(page: Page) {
   await page.waitForFunction(() => {
     const app = (window as any)._slopshellApp;
     if (typeof app?.getState !== 'function') return false;
@@ -19,6 +18,11 @@ async function waitReady(page: Page) {
     return s.chatWs && s.chatWs.readyState === (window as any).WebSocket.OPEN;
   }, null, { timeout: 5_000 });
   await page.waitForTimeout(200);
+}
+
+async function waitReady(page: Page) {
+  await page.goto('/tests/playwright/harness.html');
+  await waitForAppReady(page);
 }
 
 async function switchToTestProject(page: Page) {
@@ -137,6 +141,40 @@ test('fast stays orthogonal and surfaces LOCAL plus FAST in runtime summary', as
   expect(log.some((entry: any) => entry?.type === 'api_fetch'
     && entry?.action === 'runtime_preferences'
     && entry?.payload?.fast_mode === true)).toBe(true);
+});
+
+test('yolo and silent toggles update runtime summary and survive reload', async ({ page }) => {
+  await clearLog(page);
+
+  await page.evaluate(async () => {
+    const mod = await import('/internal/web/static/app-tts.js');
+    await mod.setYoloMode(true);
+  });
+  await expect(page.locator('#edge-top-models .edge-runtime-chip')).toContainText(['LOCAL', 'YOLO', 'Voice']);
+
+  await openCircle(page);
+  await clickSegment(page, 'silent');
+  await expect(page.locator('#slopshell-circle-segment-silent')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('body')).toHaveClass(/silent-mode/);
+  await expect(page.locator('#edge-top-models .edge-runtime-chip')).toContainText(['LOCAL', 'YOLO', 'Silent']);
+
+  const log = await getLog(page);
+  expect(log.some((entry: any) => entry?.type === 'api_fetch'
+    && entry?.action === 'runtime_yolo'
+    && entry?.payload?.safety_yolo_mode === true)).toBe(true);
+  expect(log.some((entry: any) => entry?.type === 'api_fetch'
+    && entry?.action === 'runtime_preferences'
+    && entry?.payload?.silent_mode === true)).toBe(true);
+
+  await page.reload();
+  await waitForAppReady(page);
+  await switchToTestProject(page);
+
+  await expect(page.locator('#edge-top-models .edge-runtime-chip')).toContainText(['LOCAL', 'YOLO', 'Silent']);
+  await expect(page.locator('#slopshell-circle-segment-silent')).toHaveAttribute('aria-pressed', 'true');
+  const persisted = await page.evaluate(() => (window as any).__getRuntimeState?.());
+  expect(persisted?.safety_yolo_mode).toBe(true);
+  expect(persisted?.silent_mode).toBe(true);
 });
 
 test('corner placement persists across reloads', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Show persisted yolo mode in the live runtime summary as a YOLO chip.
- Echo `safety_yolo_mode` from the yolo preference endpoint and consume that persisted value in the frontend.
- Add Playwright harness coverage for yolo plus silent toggles updating the shell immediately and surviving refresh.

## Verification

### Test fails on main

Not rerun locally per the issue workflow. Issue #704 records the reproducible failure for:

```text
./scripts/playtest.sh --grep "yolo and silent toggles update runtime state and survive a refresh"
Error: expect(locator).toHaveClass(expected) failed
Locator: locator('#edge-top')
Expected pattern: /edge-active/
Received string: "edge-panel edge-top"
```

### Test passes after fix

Requirement: yolo toggle updates live shell immediately.
Evidence: `tests/playwright/slopshell-circle.spec.ts` toggles yolo through `setYoloMode(true)`, asserts runtime chips contain `LOCAL`, `YOLO`, `Voice`, and verifies harness API log `runtime_yolo` with `safety_yolo_mode === true`.

Requirement: silent toggle updates live shell immediately.
Evidence: the same Playwright test clicks the silent segment, asserts `body.silent-mode`, asserts chips contain `LOCAL`, `YOLO`, `Silent`, and verifies `runtime_preferences.silent_mode === true`.

Requirement: yolo and silent persist after refresh.
Evidence: the same Playwright test reloads the harness page, switches back to the test project, and asserts the chips still contain `LOCAL`, `YOLO`, `Silent`, the silent segment remains pressed, and runtime state has both `safety_yolo_mode` and `silent_mode` true.

```text
PLAYWRIGHT_OUTPUT_DIR=/tmp/issue-704-playwright ./scripts/playwright.sh tests/playwright/slopshell-circle.spec.ts --grep "yolo and silent toggles update runtime summary and survive reload"
✓  1 [chromium] › tests/playwright/slopshell-circle.spec.ts:146:5 › yolo and silent toggles update runtime summary and survive reload (737ms)
1 passed (1.7s)
```

```text
PLAYWRIGHT_OUTPUT_DIR=/tmp/issue-704-playwright-file ./scripts/playwright.sh tests/playwright/slopshell-circle.spec.ts
8 passed (6.0s)
```

```text
go test ./internal/web -run 'TestRuntime(YoloModeUpdatePersists|IncludesSafetyPreferences|PreferenceUpdatePersists)$'
ok  	github.com/sloppy-org/slopshell/internal/web	0.076s
```

```text
go test ./...
ok  	github.com/sloppy-org/slopshell/internal/web	27.439s
ok  	github.com/sloppy-org/slopshell/tests/services	(cached)
```

```text
npm run build:frontend
built 74 frontend modules
```

```text
npm run typecheck:frontend
tsc --noEmit -p tsconfig.json
```

```text
./scripts/sync-surface.sh --check
# exit 0, no diff

git diff --check
# exit 0, no whitespace errors
```

Artifacts/logs:
- `/tmp/issue-704-playwright.log`
- `/tmp/issue-704-playwright-file.log`
- `/tmp/issue-704-playwright`
- `/tmp/issue-704-playwright-file`
- `/tmp/issue-704-go-all.log`
- `/tmp/issue-704-build-frontend.log`
- `/tmp/issue-704-typecheck-frontend.log`
