### PR TITLE
fix: playtest: mobile tap states reach the circle segments without overlap (fixes #708)

### DIFF
--- a/tests/playwright/slopshell-circle.spec.ts
+++ b/tests/playwright/slopshell-circle.spec.ts
@@ -190,27 +190,31 @@ test('corner placement persists across reloads', async ({ page }) => {
 });
 
 test.describe('mobile hit targets', () => {
-  test.use({ viewport: { width: 375, height: 667 } });
+  test.use({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
 
-  test('right edge strip does not steal live, silent, or tool taps', async ({ page }) => {
+  test('touch taps reach live, silent, fast, and tool segments', async ({ page }) => {
     await waitReady(page);
     await switchToTestProject(page);
     await clearLog(page);
 
-    await page.locator('#slopshell-circle-dot').click();
+    await page.locator('#slopshell-circle-dot').tap();
     await expect(page.locator('#slopshell-circle')).toHaveAttribute('data-state', 'expanded');
 
-    await page.locator('#slopshell-circle-segment-meeting').click();
+    await page.locator('#slopshell-circle-segment-dialogue').tap();
+    await expect(page.locator('#slopshell-circle-segment-dialogue')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Dialogue');
+
+    await page.locator('#slopshell-circle-segment-meeting').tap();
     await expect(page.locator('#slopshell-circle-segment-meeting')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.locator('#edge-top-models .edge-live-status')).toContainText('Meeting');
 
-    await page.locator('#slopshell-circle-segment-silent').click();
+    await page.locator('#slopshell-circle-segment-silent').tap();
     await expect(page.locator('#slopshell-circle-segment-silent')).toHaveAttribute('aria-pressed', 'true');
 
-    await page.locator('#slopshell-circle-segment-fast').click();
+    await page.locator('#slopshell-circle-segment-fast').tap();
     await expect(page.locator('#slopshell-circle-segment-fast')).toHaveAttribute('aria-pressed', 'true');
 
-    await page.locator('#slopshell-circle-segment-ink').click();
+    await page.locator('#slopshell-circle-segment-ink').tap();
     await expect(page.locator('#slopshell-circle-segment-ink')).toHaveAttribute('aria-pressed', 'true');
     await expect(page.locator('#slopshell-circle-dot')).toHaveAttribute('data-tool', 'ink');
 
@@ -218,6 +222,5 @@ test.describe('mobile hit targets', () => {
     expect(log.some((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'live_policy' && entry?.payload?.policy === 'meeting')).toBe(true);
     expect(log.some((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'runtime_preferences' && entry?.payload?.silent_mode === true)).toBe(true);
     expect(log.some((entry: any) => entry?.type === 'api_fetch' && entry?.action === 'runtime_preferences' && entry?.payload?.fast_mode === true)).toBe(true);
-
   });
 });


### PR DESCRIPTION
## Summary

Issue #708 reported the mobile playtest `mobile tap states reach the circle segments without overlap` failing with the silent toggle stuck at `aria-pressed=false` after a tap. The selectors in the failure log are the pre-rename `tabura-circle-*` ones, so the surrounding rename and toggle fixes (#704) plus the rebrand commits restored the live path. The playtest now passes deterministically on the live runtime, but the harness Playwright suite was still exercising the mobile circle with `.click()` from a desktop-input context, so the synthetic-click path that fires after `touchend` was untested. This change converts the `mobile hit targets` harness test to a true touch context (`hasTouch: true`, `isMobile: true`, `.tap()`) and adds the dialogue session segment so every circle kind (session, toggle, tool) is exercised by a real tap.

## Verification

### Live playtest passes (issue #708 reproducer)

```
$ export SLOPSHELL_TEST_SESSION_TOKEN=...; export E2E_AUDIO_FILE=/tmp/slopshell-playtest-speech.wav; export PLAYTEST_FILE_ISSUES=0
$ npx playwright test --config=playwright.playtest.config.ts \
    --grep "mobile tap states reach the circle segments without overlap"
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/playtest/playtest.spec.ts:167:7 › mobile capture route › mobile tap states reach the circle segments without overlap (4.0s)
  1 passed (4.9s)
```

Stability check (5/5 passes):

```
$ for i in 1 2 3 4 5; do npx playwright test --config=playwright.playtest.config.ts \
    --grep "mobile tap states reach the circle segments without overlap" 2>&1 | tail -2; done
  1 passed (4.8s)
  1 passed (4.9s)
  1 passed (4.8s)
  1 passed (4.9s)
  1 passed (4.9s)
```

### Harness regression test now uses real touch

`tests/playwright/slopshell-circle.spec.ts` mobile section: `viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true`, `.tap()` for dot + every segment, `aria-pressed='true'` asserted for `dialogue`, `meeting`, `silent`, `fast`, `ink`. Run:

```
$ npx playwright test tests/playwright/slopshell-circle.spec.ts --project=chromium
  ✓  8 [chromium] › tests/playwright/slopshell-circle.spec.ts:195:7 › mobile hit targets › touch taps reach live, silent, fast, and tool segments (1.5s)
  8 passed (6.3s)
```

### Backend and frontend type checks

```
$ go test ./internal/web/...
ok  	github.com/sloppy-org/slopshell/internal/web	27.440s

$ npm run typecheck:frontend
> tsc --noEmit -p tsconfig.json
(no output, exit 0)
```