### PR TITLE
fix: playtest: live local llm answers typed turns in usual a (fixes #712)

### DIFF
--- a/tests/playtest/playtest.spec.ts
+++ b/tests/playtest/playtest.spec.ts
@@ -137,8 +137,9 @@ test.describe('live playtest smoke', () => {
 
     await clearLiveChat(sessionToken);
     await openLiveApp(page, sessionToken);
-    await openTopEdge(page);
     await waitForLiveAppReady(page);
+    await setCircleToggle(page, 'fast', false);
+    await setCircleToggle(page, 'silent', false);
 
     const usualCount = await page.locator('#chat-history .chat-message.chat-assistant:not(.is-pending)').count();
     await submitPrompt(page, 'Reply with the single word ORBIT.');


### PR DESCRIPTION
## Summary

- The "live local llm answers typed turns in usual and fast modes" playtest called `openTopEdge(page)` — a setup step lifted from the edge-chrome smoke test that probed the top edge panel and asserted the now-removed `edge-active` class. After commit d11208b reconciled the `openTopEdge` assertion, the call still pulled top-edge UI semantics into a test about typed turns.
- Slopshell persists `silent` and `fast` server-side across browser contexts, so the prior `slopshell-circle` playtest left `fast=on` and `silent=on`. The "usual mode" prompt then ran with `fast=on`, contradicting the test name.
- The fix drops the unrelated `openTopEdge` step and resets `fast` and `silent` to `false` through the slopshell circle before the first prompt. The test now verifies a true usual turn followed by a true fast turn regardless of prior test residue.

## Verification

### Issue requirement: openTopEdge edge-active assertion should not break the LLM playtest

The original failure was `expect(locator).toHaveClass(expected) failed Locator: locator('#edge-top') Expected pattern: /edge-active/ Received string: "edge-panel edge-top"` inside `openTopEdge`. This test no longer calls `openTopEdge`, so the failure mode cannot recur from this path.

```diff
-    await openTopEdge(page);
     await waitForLiveAppReady(page);
+    await setCircleToggle(page, 'fast', false);
+    await setCircleToggle(page, 'silent', false);
```

### Issue requirement: Usual and fast turns should both reach the live runtime

The test still submits a prompt expecting `orbit`, then toggles fast on and submits a prompt expecting `rivet`. Adding the explicit `setCircleToggle('fast', false)` before the first prompt ensures the "usual" turn really runs in usual mode (no carryover from the previous `slopshell-circle` playtest, which leaves `fast=on` and `silent=on` server-side via `updateRuntimePreferences`). The fast turn still toggles fast on between prompts.

### Backend tests pass

`go test ./internal/web/...` exercises the chat command, runtime preferences, and `/clear` paths used by the playtest helpers (`clearLiveChat`, `setCircleToggle`):

```
ok  	github.com/sloppy-org/slopshell/internal/web	27.651s
```

### Frontend build is clean

```
$ npm run build:frontend
> tsc -p ... && node ./scripts/build-frontend.mjs
built 74 frontend modules
```

### Playwright spec parses

```
$ E2E_AUDIO_FILE=/tmp/dummy.wav npx playwright test --config=playwright.playtest.config.ts --list
[chromium] › playtest/playtest.spec.ts:128:7 › live playtest smoke › live local llm answers typed turns in usual and fast modes
Total: 55 tests in 14 files
```

### Live playtest

The test runs against a live runtime with `slopshell-llm.service`, `slopshell-piper-tts.service`, `slopshell-stt.service`, and `slopshell-codex-app-server.service` active. Reproduce locally with:

```
./scripts/playtest.sh --grep "live local llm answers typed turns in usual and fast modes"
```

This host does not run `slopshell-llm.service` (it follows the WireGuard `slopcode-llamacpp` topology), so the live LLM round-trip was not exercised here. The fix is structural — it removes a stale UI dependency and an explicit state reset — so a runtime smoke pass against a host that does run `slopshell-llm.service` is the final verification step.