### PR TITLE
fix: run shared flow contracts for iOS and Android in required CI (fixes #685)

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -73,3 +73,46 @@ jobs:
           name: slopshell-test-reports
           path: .slopshell/artifacts/test-reports
           if-no-files-found: error
+
+  android-flow-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Node deps
+        run: npm ci
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Android shared flow contract
+        run: npm run test:flows:android:contract:jvm
+
+  ios-flow-contract:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Node deps
+        run: npm ci
+
+      - name: Run iOS shared flow contract
+        run: npm run test:flows:ios:contract

--- a/docs/native-clients.md
+++ b/docs/native-clients.md
@@ -33,7 +33,11 @@ Use [`native-clients-plan.md`](native-clients-plan.md) for the architecture deci
    ```bash
    npm run test:flows:ios:contract
    npm run test:flows:android:contract
+   npm run test:flows:android:contract:jvm
    ```
+
+   `npm run test:flows:android:contract:jvm` is the JVM-only subset that hosted
+   CI uses; it does not require the Android SDK.
 
 3. Full native validation:
 
@@ -95,6 +99,26 @@ Use these checks before claiming the native slice is working:
 3. Server/web dialogue companion wiring:
 
    `npm run test:flows:native` already includes the shared Playwright flow suite, so the web/native circle contract stays in one validation path.
+
+4. Hosted CI coverage:
+
+   `.github/workflows/test-reports.yml` runs three required jobs in parallel on
+   every pull request and push to `main`:
+
+   - `reports` (ubuntu-latest) runs the shared web flow suite via
+     `npm run test:flows`.
+   - `android-flow-contract` (ubuntu-latest) runs
+     `npm run test:flows:android:contract:jvm`, executing the shared flows
+     against the JVM/Kotlin `FlowRunner` so the Android adapter must stay green
+     before merge.
+   - `ios-flow-contract` (macos-latest) runs `npm run test:flows:ios:contract`,
+     executing the shared flows against the Swift `FlowRunner` so the iOS
+     adapter must stay green before merge.
+
+   The simulator and emulator UI harnesses still run on the documented macOS
+   host (`faepmac1`) and on a local Android emulator through
+   `./scripts/test-native-flows.sh`; hosted CI cannot run those without
+   dedicated mobile infrastructure.
 
 The structural tests in `platforms/ios/project_files_test.go` and `platforms/android/project_files_test.go` are regression guards for packaging/layout. They are not completion evidence on their own.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:flows:ios:contract": "node ./scripts/sync-native-flow-fixtures.mjs --check && (cd platforms/ios && swift test)",
     "test:flows:android": "./scripts/test-native-flows.sh --android-only",
     "test:flows:android:contract": "SDK_ROOT=\"${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/android-sdk}}\"; export ANDROID_HOME=\"$SDK_ROOT\" ANDROID_SDK_ROOT=\"$SDK_ROOT\" PATH=\"$SDK_ROOT/platform-tools:$SDK_ROOT/emulator:$PATH\"; node ./scripts/sync-native-flow-fixtures.mjs --check && gradle -p platforms/android app:testDebugUnitTest && gradle -p platforms/android/flow-contracts test",
+    "test:flows:android:contract:jvm": "node ./scripts/sync-native-flow-fixtures.mjs --check && gradle -p platforms/android/flow-contracts test --console=plain --no-daemon",
     "test:flows:native:contract": "npm run test:flows:ios:contract && npm run test:flows:android:contract",
     "test:flows:native": "./scripts/test-native-flows.sh",
     "test:native-docs": "node ./scripts/check-native-validation-docs.mjs",

--- a/scripts/check-native-validation-docs.mjs
+++ b/scripts/check-native-validation-docs.mjs
@@ -12,6 +12,7 @@ const requiredScripts = [
   'test:flows:ios:contract',
   'test:flows:android',
   'test:flows:android:contract',
+  'test:flows:android:contract:jvm',
   'test:flows:native',
   'test:native-docs',
 ];
@@ -29,6 +30,7 @@ const nativeDocNeedles = [
   'npm run test:flows:native',
   'npm run test:flows:ios:contract',
   'npm run test:flows:android:contract',
+  'npm run test:flows:android:contract:jvm',
   'faepmac1',
 ];
 
@@ -41,11 +43,14 @@ for (const needle of nativeDocNeedles) {
 const flowDocNeedles = [
   'npm run test:flows:ios:contract',
   'npm run test:flows:android:contract',
+  'npm run test:flows:android:contract:jvm',
   'npm run test:flows:ios',
   'npm run test:flows:android',
   'npm run test:flows:native',
   'platforms/ios/SlopshellIOSUITests/Resources/flow-fixtures.json',
   'platforms/android/app/src/androidTest/assets/flow-fixtures.json',
+  'android-flow-contract',
+  'ios-flow-contract',
 ];
 
 for (const needle of flowDocNeedles) {
@@ -56,6 +61,20 @@ for (const needle of flowDocNeedles) {
 
 if (!workflow.includes('npm run test:native-docs')) {
   errors.push('workflow must run npm run test:native-docs');
+}
+
+const workflowNeedles = [
+  'android-flow-contract:',
+  'ios-flow-contract:',
+  'npm run test:flows:android:contract:jvm',
+  'npm run test:flows:ios:contract',
+  'macos-latest',
+];
+
+for (const needle of workflowNeedles) {
+  if (!workflow.includes(needle)) {
+    errors.push(`workflow must mention ${needle}`);
+  }
 }
 
 if (errors.length > 0) {

--- a/scripts/check-test-reports-workflow.mjs
+++ b/scripts/check-test-reports-workflow.mjs
@@ -40,6 +40,39 @@ if (uploadStep?.if !== expectedUploadGate) {
   errors.push(`expected upload step gate ${expectedUploadGate}, got ${JSON.stringify(uploadStep?.if)}`);
 }
 
+function requireFlowJob({ jobName, runsOn, stepName, scriptCommand }) {
+  const job = workflow?.jobs?.[jobName];
+  if (!job) {
+    errors.push(`expected ${jobName} job`);
+    return;
+  }
+  if (job['runs-on'] !== runsOn) {
+    errors.push(`expected ${jobName} to run on ${runsOn}, got ${JSON.stringify(job['runs-on'])}`);
+  }
+  const jobSteps = Array.isArray(job.steps) ? job.steps : [];
+  if (!jobSteps.some((step) => step?.name === stepName)) {
+    errors.push(`${jobName} must include the "${stepName}" step`);
+  }
+  const runCommands = jobSteps.map((step) => step?.run).filter(Boolean);
+  if (!runCommands.some((cmd) => cmd.includes(scriptCommand))) {
+    errors.push(`${jobName} must invoke ${scriptCommand}`);
+  }
+}
+
+requireFlowJob({
+  jobName: 'android-flow-contract',
+  runsOn: 'ubuntu-latest',
+  stepName: 'Run Android shared flow contract',
+  scriptCommand: 'npm run test:flows:android:contract:jvm',
+});
+
+requireFlowJob({
+  jobName: 'ios-flow-contract',
+  runsOn: 'macos-latest',
+  stepName: 'Run iOS shared flow contract',
+  scriptCommand: 'npm run test:flows:ios:contract',
+});
+
 if (errors.length > 0) {
   for (const err of errors) {
     console.error(`[workflow-check] ${err}`);
@@ -47,4 +80,4 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log('[workflow-check] Test Reports gating is limited to push events on main.');
+console.log('[workflow-check] Test Reports gating is limited to push events on main, with required iOS and Android flow contract jobs.');

--- a/tests/flows/README.md
+++ b/tests/flows/README.md
@@ -98,7 +98,8 @@ Native flow contract runners consume generated fixtures derived from the same YA
 
 - `node ./scripts/sync-native-flow-fixtures.mjs` refreshes the checked-in native fixtures.
 - `npm run test:flows:ios:contract` runs the Swift flow contract suite in `platforms/ios`.
-- `npm run test:flows:android:contract` runs the Android model/contract suites in `platforms/android`.
+- `npm run test:flows:android:contract` runs the Android model/contract suites in `platforms/android` (requires the Android SDK).
+- `npm run test:flows:android:contract:jvm` runs only the JVM-only flow contract suite under `platforms/android/flow-contracts` and is the path that hosted CI uses (no Android SDK needed).
 - `npm run test:flows:ios` runs the iOS simulator UI harness on `faepmac1`.
 - `npm run test:flows:android` runs the Android emulator UI harness locally.
 - `npm run test:flows:native` runs the full validation path: fixture sync, shared web flows, both native contract suites, Android UI, and iOS UI.
@@ -106,6 +107,23 @@ Native flow contract runners consume generated fixtures derived from the same YA
 The iOS contract runner is a Swift package. Run it on a machine with Swift
 available; for this repo the documented macOS host is `faepmac1`. The full iOS
 UI run is performed there through `./scripts/test-native-flows.sh`.
+
+CI coverage in `.github/workflows/test-reports.yml` runs three required jobs in
+parallel on every pull request and on push to `main`:
+
+- the `reports` job (ubuntu-latest) executes `npm run test:flows` for the web
+  Playwright adapter.
+- the `android-flow-contract` job (ubuntu-latest) executes
+  `npm run test:flows:android:contract:jvm`, proving that the shared flows
+  drive the Kotlin/JVM `FlowRunner` against the generated fixture for Android.
+- the `ios-flow-contract` job (macos-latest) executes
+  `npm run test:flows:ios:contract`, proving that the shared flows drive the
+  Swift `FlowRunner` against the generated fixture for iOS.
+
+Each job prints `<platform> PASS <flow_name>` per shared flow so the CI log
+makes per-platform parity obvious. UI-harness runs against simulators and
+emulators stay in `./scripts/test-native-flows.sh` because hosted CI cannot run
+those without dedicated mobile infrastructure.
 
 The generated fixture files live in the native test bundles and UI harness assets:
 


### PR DESCRIPTION
## Summary

- Wire the iOS and Android shared-flow contract suites into the required `.github/workflows/test-reports.yml` so cross-platform parity is enforced on every pull request and on push to `main`.
- Add a JVM-only `npm run test:flows:android:contract:jvm` script so hosted CI can run the Kotlin `FlowRunner` against the generated fixture without the Android SDK.
- Update the workflow-config and native-validation-docs checks plus the flow and native-clients docs so the new jobs and script stay enforced.

## Verification

Each acceptance criterion from #685 maps to a checked-in artifact and a real local command output below.

### Shared flows run on web (existing)
The `reports` job in `.github/workflows/test-reports.yml` continues to run `npm run test:flows`. Schema and coverage validation still pass locally:

```text
$ node ./tests/flows/validate.cjs
Validated 7 flow files against tests/flows/schema.json and the logical target contract.

$ node ./tests/flows/coverage.cjs
Flows: 7
Mode combinations covered: 30/30
Targets covered: canvas_viewport, indicator_border, indicator_override_clear, ...
Indicator states covered: idle, listening, paused, recording, working
```

### Shared flows run on Android
The Kotlin `FlowRunner` in `platforms/android/flow-contracts` consumes the same generated fixture and prints `android PASS <flow_name>` for every shared flow:

```text
$ npm run test:flows:android:contract:jvm
> node ./scripts/sync-native-flow-fixtures.mjs --check && gradle -p platforms/android/flow-contracts test --console=plain --no-daemon
...
FlowContractTest > sharedFlowsExecuteOnAndroidContract() STANDARD_OUT
    android PASS indicator_state_transitions
    android PASS indicator_tap_to_stop_dialogue
    android PASS slopshell_circle_combined_states
    android PASS slopshell_circle_multi_select_tool_and_session
    android PASS slopshell_circle_toggle_sessions
    android PASS slopshell_circle_toggle_silent
    android PASS slopshell_circle_select_ink_tool
FlowContractTest > sharedFlowsExecuteOnAndroidContract() PASSED
BUILD SUCCESSFUL in 5s
```

### Shared flows run on iOS
The `ios-flow-contract` job runs `npm run test:flows:ios:contract` on `macos-latest`, which executes `swift test` against the existing `SlopshellFlowContractTests` target. The Swift test prints `ios PASS <flow_name>` per flow (see `platforms/ios/Tests/SlopshellFlowContractTests/SlopshellFlowContractTests.swift`). Swift is not available on the local Linux dev box, so this lane is verified on the hosted macOS runner per the issue's "hosted CI constraints apply" clause.

### Platform adapters are checked in
`platforms/ios/Sources/SlopshellFlowContract/FlowRunner.swift` and `platforms/android/flow-contracts/src/test/kotlin/com/slopshell/android/flow/FlowRunner.kt` both consume the generated fixtures at `platforms/ios/Tests/SlopshellFlowContractTests/Resources/flow-fixtures.json` and `platforms/android/flow-contracts/src/test/resources/flow-fixtures.json`. Fixture sync stays a hard gate:

```text
$ node ./scripts/sync-native-flow-fixtures.mjs --check
(no diff; exits 0)
```

### CI or equivalent required automation runs all claimed platforms
`.github/workflows/test-reports.yml` now declares three jobs in parallel and they all share the same `pull_request` and `push: main` triggers:

- `reports` (ubuntu-latest) - web flow suite
- `android-flow-contract` (ubuntu-latest) - JVM Kotlin flow contract
- `ios-flow-contract` (macos-latest) - Swift flow contract

The workflow-config check enforces this shape:

```text
$ npm run test:workflow-config
[workflow-check] Test Reports gating is limited to push events on main, with required iOS and Android flow contract jobs.
```

### Coverage report still validates target/state/mode coverage
`tests/flows/coverage.cjs` still runs as part of `npm run test:flows`; the output above shows 30/30 mode combinations and the full target/indicator state set are still covered.

### Native validation docs check
`scripts/check-native-validation-docs.mjs` now requires the new script, the new docs anchors, and the two new workflow jobs:

```text
$ npm run test:native-docs
[native-docs-check] Native validation docs and scripts are aligned.
```

### Platform regression guards
`platforms/ios/project_files_test.go` and `platforms/android/project_files_test.go` still pass:

```text
$ go test ./platforms/ios/... ./platforms/android/...
ok  	github.com/sloppy-org/slopshell/platforms/android	0.002s
ok  	github.com/sloppy-org/slopshell/platforms/ios	0.002s
```

## Test plan

- [x] `npm run test:workflow-config`
- [x] `npm run test:native-docs`
- [x] `node ./tests/flows/validate.cjs`
- [x] `node ./tests/flows/coverage.cjs`
- [x] `node ./scripts/sync-native-flow-fixtures.mjs --check`
- [x] `npm run test:flows:android:contract:jvm`
- [x] `go test ./platforms/ios/... ./platforms/android/...`
- [ ] `npm run test:flows:ios:contract` - exercised by the new `ios-flow-contract` macos-latest job; swift is not available on the local dev box