### PR TITLE
fix: Boox-specific validation, observability, and closure standard (refs #701)

### DIFF
--- a/docs/boox-validation.md
+++ b/docs/boox-validation.md
@@ -1,0 +1,171 @@
+# Boox Validation
+
+This document is the closure standard for the Onyx Boox path inside the Android
+client. It is intentionally separate from
+[`native-clients.md`](native-clients.md): generic Android validation does not
+prove Boox readiness, and Boox claims must rest on Boox-specific evidence.
+
+## Boox SDK and Tooling Reality
+
+The Onyx SDK requirements are pinned in
+[`platforms/android/app/build.gradle.kts`](../platforms/android/app/build.gradle.kts):
+
+- `com.onyx.android.sdk:onyxsdk-device:1.1.11`
+- `com.onyx.android.sdk:onyxsdk-pen:1.2.1`
+
+The artifacts are resolved from Onyx's Maven repository, declared in
+[`platforms/android/settings.gradle.kts`](../platforms/android/settings.gradle.kts):
+
+```text
+https://repo.boox.com/repository/maven-public/
+```
+
+The Onyx SDK's `TouchHelper`, `RawInputCallback`, and `EpdController`
+classes are the entry points used by the Boox path:
+
+- raw stylus drawing: `com.onyx.android.sdk.pen.TouchHelper.create`
+- e-ink update modes: `com.onyx.android.sdk.api.device.epd.EpdController$UpdateMode`
+- WebView contrast: `EpdController.setWebViewContrastOptimize`
+
+There is no official Boox emulator and no vendor-supplied virtual device for
+these APIs. Generic Android emulators do not implement the `EpdController`
+class or the `TouchHelper` raw drawing surface. Closure of the Boox path
+therefore requires current Boox hardware. Treat any claim of Boox readiness
+that rests only on emulator or generic Android evidence as unsubstantiated.
+
+## Runtime Observability
+
+When the Onyx-specific path is active, the Android client surfaces a Boox
+status block under the connect controls instead of the previous one-line
+indicator. The block reports:
+
+- the four detection signals (manufacturer, Onyx SDK package, `TouchHelper`
+  class, `EpdController` class)
+- whether raw drawing is active right now
+- the cumulative ink-stroke count emitted from the raw drawing surface
+- the cumulative e-ink refresh attempt and success counts
+
+The dynamic counters are owned by `SlopshellBooxRuntimeProbe` in
+[`platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatus.kt`](../platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatus.kt).
+The probe is updated from:
+
+- `SlopshellBooxInkSurfaceView.ensureTouchHelper` and `shutdownTouchHelper`
+  (raw drawing active flag)
+- `SlopshellBooxInkSurfaceView.emitStroke` (ink stroke counter)
+- `SlopshellBooxEinkController.refreshContentView` (refresh attempts and
+  successes)
+
+The detection signals come from `detectSlopshellBooxDetectionSignals` in
+[`SlopshellBooxDevice.kt`](../platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxDevice.kt).
+
+## Off-Device Automated Checks
+
+These run on a JVM with no Onyx hardware and no Android emulator:
+
+```bash
+gradle -p platforms/android app:testDebugUnitTest
+```
+
+The JVM unit suite covers:
+
+- `SlopshellBooxRuntimeStatusTest` for detection-signal interpretation, the
+  raw-drawing flag, ink-stroke counter, refresh attempt/success counters, and
+  reset behavior.
+- `SlopshellModelContractTest.booxDetectionAcceptsManufacturerOrSdkSignals` for
+  the `shouldTreatAsBooxDevice` rule.
+- `SlopshellInkStrokeBuilderTest` for the shared stroke normalization that the
+  Boox raw path also uses.
+
+The structural Go test
+[`platforms/android/project_files_test.go`](../platforms/android/project_files_test.go)
+also asserts that the Boox source files exist and contain the required Onyx
+SDK call sites (`TouchHelper.create`, `setRawInputReaderEnable(true)`,
+`openRawDrawing`, `closeRawDrawing`, `applyGCOnce`,
+`setWebViewContrastOptimize`).
+
+What these checks cannot prove:
+
+- raw stylus drawing actually emits `ink_stroke` payloads on Onyx hardware
+- the e-ink controller reduces ghosting on a real e-ink panel
+- the WebView contrast hook produces a readable canvas on a Boox screen
+
+Those require hardware.
+
+## Hardware Validation Script
+
+```bash
+./scripts/test-boox-hardware.sh
+```
+
+The script orchestrates the parts that can be automated against an attached
+Boox device:
+
+1. Verifies `adb` is available and exactly one USB device is attached.
+2. Reads `ro.product.manufacturer`, `ro.product.model`, and Android SDK level
+   from the device and aborts unless the manufacturer is `onyx` (case
+   insensitive).
+3. Builds and installs the debug APK with `gradle :app:installDebug`.
+4. Launches `MainActivity`.
+5. Captures a screenshot of the running app to `artifacts/boox-validation/`
+   for evidence.
+6. Prints the manual checklist below and waits for the operator to record
+   pass/fail.
+
+The script is the only sanctioned path for closing a Boox-readiness PR. Run
+the off-device checks first; the script is the hardware leg, not a
+replacement for the unit tests.
+
+## Manual Hardware Checklist
+
+Attach current results from this checklist when claiming Boox readiness.
+Treat any missing item as a fail.
+
+1. Detection signals on the Boox status panel:
+   - manufacturer matches the device (e.g. `onyx`/`Onyx`)
+   - `sdk=true`
+   - `TouchHelper=true`
+   - `EpdController=true`
+2. Raw stylus drawing on the canvas:
+   - status panel reports `Raw drawing: active`
+   - drawing a stroke increments the strokes counter
+   - the same stroke arrives at the server as an `ink_stroke` payload (verify
+     in the server log or the active chat session)
+3. E-ink content rendering:
+   - canvas content uses the e-ink CSS (white background, black text, no
+     animations or shadows)
+   - the status panel reports `E-ink refresh: M/N applied` with `M >= 1` after
+     the canvas first renders
+4. E-ink refresh follow-up:
+   - a second canvas update increments both `M` and `N`
+   - no persistent ghosting remains after the refresh runs
+5. WebView contrast:
+   - text remains readable when the canvas contains gradients or low-contrast
+     backgrounds (e.g. plot artifacts)
+6. Dialogue surfaces still work on Boox:
+   - black-screen dialogue mode is still entered/exited normally
+   - the foreground microphone service starts and stops in sync with the
+     dialogue surface
+
+## Closure Evidence
+
+A PR or issue may not claim Boox readiness without:
+
+- the off-device unit suite passing on the change
+- the hardware script's installer step succeeding against a current Boox
+  device
+- a checklist run against the same device, attached either in the PR body or
+  linked from it
+- the Boox device's `ro.product.model` and Android SDK level recorded in the
+  evidence
+
+## Documentation Honesty
+
+Boox completion claims are kept separate from generic Android claims:
+
+- [`native-clients-plan.md`](native-clients-plan.md) and
+  [`native-clients.md`](native-clients.md) describe the Android slice and
+  point at this document for Boox closure evidence.
+- This document owns the Boox SDK reality, runtime observability,
+  off-device coverage, and hardware checklist.
+- Product docs do not describe Boox as complete unless the closure evidence
+  above is attached to the matching PR or issue.

--- a/docs/native-clients-plan.md
+++ b/docs/native-clients-plan.md
@@ -110,9 +110,10 @@ clients:
 - `#638` mDNS advertisement and push relay
 
 Boox-specific code paths are implemented in the Android client. Boox release
-readiness still requires the hardware evidence listed in
-[`native-clients.md`](native-clients.md); do not claim Boox readiness from
-generic Android validation alone.
+readiness has its own closure standard in
+[`boox-validation.md`](boox-validation.md), which owns the Boox SDK reality,
+runtime observability, off-device unit coverage, hardware script, and manual
+checklist. Do not claim Boox readiness from generic Android validation alone.
 
 ## Verification and Runbook
 

--- a/docs/native-clients.md
+++ b/docs/native-clients.md
@@ -170,4 +170,4 @@ Use this matrix when reviewing native-client completion claims:
 
 Do not describe the native clients as a broader completed product unless the automated checks above pass and the manual checklist above has current hardware results attached.
 
-The current repo claim is limited to the automated and manual evidence above. Boox code paths are present, but Boox readiness requires the hardware evidence in the matrix.
+The current repo claim is limited to the automated and manual evidence above. Boox code paths are present, but Boox readiness has its own closure standard in [`boox-validation.md`](boox-validation.md). Generic Android validation does not prove Boox readiness; do not reuse Android emulator or contract evidence as Boox evidence.

--- a/docs/spec-index.md
+++ b/docs/spec-index.md
@@ -26,9 +26,10 @@ Read in this order:
 9. `architecture.md`
 10. `native-clients-plan.md`
 11. `native-clients.md`
-12. `live-runtime-whitepaper.md`
-13. `meeting-notes-privacy.md`
-14. `codex-app-server-pivot.md`
+12. `boox-validation.md`
+13. `live-runtime-whitepaper.md`
+14. `meeting-notes-privacy.md`
+15. `codex-app-server-pivot.md`
 
 Integrated protocol reference:
 

--- a/internal/surface/spec_docs_test.go
+++ b/internal/surface/spec_docs_test.go
@@ -161,6 +161,7 @@ func TestNativeClientsGuideIsIndexedAndHonest(t *testing.T) {
 		"The structural tests in `platforms/ios/project_files_test.go` and `platforms/android/project_files_test.go` are regression guards",
 		"Boox raw drawing and e-ink refresh",
 		"Do not describe the native clients as a broader completed product unless the automated checks above pass",
+		"[`boox-validation.md`](boox-validation.md)",
 	}
 	for _, snippet := range requiredSnippets {
 		if !strings.Contains(content, snippet) {
@@ -184,5 +185,77 @@ func TestNativeClientsGuideIsIndexedAndHonest(t *testing.T) {
 	}
 	if !strings.Contains(string(planDoc), "[`native-clients.md`](native-clients.md)") {
 		t.Fatalf("%s does not reference native-clients.md", planPath)
+	}
+}
+
+func TestBooxValidationDocIsIndexedAndAnchored(t *testing.T) {
+	root := repoRootFromCaller(t)
+
+	booxPath := filepath.Join(root, "docs", "boox-validation.md")
+	booxDoc, err := os.ReadFile(booxPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", booxPath, err)
+	}
+	content := string(booxDoc)
+
+	requiredSnippets := []string{
+		"## Boox SDK and Tooling Reality",
+		"There is no official Boox emulator",
+		"com.onyx.android.sdk:onyxsdk-device:1.1.11",
+		"com.onyx.android.sdk:onyxsdk-pen:1.2.1",
+		"https://repo.boox.com/repository/maven-public/",
+		"## Runtime Observability",
+		"SlopshellBooxRuntimeProbe",
+		"SlopshellBooxInkSurfaceView.ensureTouchHelper",
+		"SlopshellBooxInkSurfaceView.emitStroke",
+		"SlopshellBooxEinkController.refreshContentView",
+		"## Off-Device Automated Checks",
+		"gradle -p platforms/android app:testDebugUnitTest",
+		"## Hardware Validation Script",
+		"./scripts/test-boox-hardware.sh",
+		"## Manual Hardware Checklist",
+		"## Closure Evidence",
+		"## Documentation Honesty",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("%s missing snippet %q", booxPath, snippet)
+		}
+	}
+
+	specIndexPath := filepath.Join(root, "docs", "spec-index.md")
+	specIndex, err := os.ReadFile(specIndexPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", specIndexPath, err)
+	}
+	if !strings.Contains(string(specIndex), "`boox-validation.md`") {
+		t.Fatalf("%s does not reference boox-validation.md", specIndexPath)
+	}
+
+	guidePath := filepath.Join(root, "docs", "native-clients.md")
+	guideDoc, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", guidePath, err)
+	}
+	if !strings.Contains(string(guideDoc), "[`boox-validation.md`](boox-validation.md)") {
+		t.Fatalf("%s does not reference boox-validation.md", guidePath)
+	}
+
+	planPath := filepath.Join(root, "docs", "native-clients-plan.md")
+	planDoc, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", planPath, err)
+	}
+	if !strings.Contains(string(planDoc), "[`boox-validation.md`](boox-validation.md)") {
+		t.Fatalf("%s does not reference boox-validation.md", planPath)
+	}
+
+	scriptPath := filepath.Join(root, "scripts", "test-boox-hardware.sh")
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("Stat(%q) error: %v", scriptPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("%s is not executable", scriptPath)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:flows:android:contract:jvm": "node ./scripts/sync-native-flow-fixtures.mjs --check && gradle -p platforms/android/flow-contracts test --console=plain --no-daemon",
     "test:flows:native:contract": "npm run test:flows:ios:contract && npm run test:flows:android:contract",
     "test:flows:native": "./scripts/test-native-flows.sh",
+    "test:flows:boox:hardware": "./scripts/test-boox-hardware.sh",
     "test:native-docs": "node ./scripts/check-native-validation-docs.mjs",
     "test:playtest": "./scripts/playtest.sh",
     "test:reports": "./scripts/test-reports.sh",

--- a/platforms/android/app/src/main/kotlin/com/slopshell/android/MainActivity.kt
+++ b/platforms/android/app/src/main/kotlin/com/slopshell/android/MainActivity.kt
@@ -246,7 +246,7 @@ private fun SlopshellAndroidApp(
                 Text(state.statusText, style = MaterialTheme.typography.bodySmall)
             }
             if (displayProfile.isBoox) {
-                Text("Boox E-Ink mode active", style = MaterialTheme.typography.bodySmall)
+                BooxRuntimeStatusPanel(signals = displayProfile.signals)
             }
             if (state.lastError.isNotBlank()) {
                 Text(state.lastError, color = MaterialTheme.colorScheme.error)
@@ -385,6 +385,32 @@ private fun SlopshellAndroidApp(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+@Composable
+private fun BooxRuntimeStatusPanel(signals: SlopshellBooxDetectionSignals) {
+    val metrics by SlopshellBooxRuntimeProbe.metrics.collectAsState()
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text("Boox E-Ink mode active", style = MaterialTheme.typography.bodySmall)
+        Text(
+            "Detection: manufacturer=${signals.manufacturer}, " +
+                "sdk=${signals.onyxSdkPackagePresent}, " +
+                "TouchHelper=${signals.touchHelperClassPresent}, " +
+                "EpdController=${signals.epdControllerClassPresent}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "Raw drawing: ${if (metrics.rawDrawingActive) "active" else "idle"} | strokes=${metrics.inkStrokeCount}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "E-ink refresh: ${metrics.einkRefreshSuccessCount}/${metrics.einkRefreshAttemptCount} applied",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxDevice.kt
+++ b/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxDevice.kt
@@ -7,19 +7,23 @@ import android.view.View
 import android.webkit.WebView
 
 data class SlopshellDisplayProfile(
-    val isBoox: Boolean,
-)
-
-fun detectSlopshellDisplayProfile(context: Context): SlopshellDisplayProfile {
-    return SlopshellDisplayProfile(isBoox = isBooxDevice(context))
+    val signals: SlopshellBooxDetectionSignals,
+) {
+    val isBoox: Boolean
+        get() = signals.detectedAsBoox
 }
 
-private fun isBooxDevice(context: Context): Boolean {
+fun detectSlopshellDisplayProfile(context: Context): SlopshellDisplayProfile {
+    return SlopshellDisplayProfile(signals = detectSlopshellBooxDetectionSignals(context))
+}
+
+fun detectSlopshellBooxDetectionSignals(context: Context): SlopshellBooxDetectionSignals {
     val isOnyxManufacturer = Build.MANUFACTURER.lowercase() == "onyx"
-    return shouldTreatAsBooxDevice(
+    return SlopshellBooxDetectionSignals(
         manufacturer = Build.MANUFACTURER,
-        hasOnyxSdkPackage = hasOnyxSdkPackage(context) || isOnyxManufacturer,
-        hasTouchHelperClass = hasClass("com.onyx.android.sdk.pen.TouchHelper"),
+        onyxSdkPackagePresent = hasOnyxSdkPackage(context) || isOnyxManufacturer,
+        touchHelperClassPresent = hasClass("com.onyx.android.sdk.pen.TouchHelper"),
+        epdControllerClassPresent = hasClass("com.onyx.android.sdk.api.device.epd.EpdController"),
     )
 }
 
@@ -70,13 +74,10 @@ object SlopshellBooxEinkController {
     }
 
     fun refreshContentView(view: View) {
-        if (invokeController("applyGCOnce", arrayOf(View::class.java), arrayOf(view))) {
-            return
-        }
-        if (invokeController("applyGCOnce", emptyArray<Class<*>>(), emptyArray<Any>())) {
-            return
-        }
-        invalidate(view, "GC16", "GC")
+        val applied = invokeController("applyGCOnce", arrayOf(View::class.java), arrayOf(view)) ||
+            invokeController("applyGCOnce", emptyArray<Class<*>>(), emptyArray<Any>()) ||
+            invalidateView(view, "GC16", "GC")
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = applied)
     }
 
     fun setWebViewContrastOptimize(view: WebView, enabled: Boolean) {
@@ -96,9 +97,9 @@ object SlopshellBooxEinkController {
         )
     }
 
-    private fun invalidate(view: View, vararg modeNames: String) {
-        val mode = resolveUpdateMode(*modeNames) ?: return
-        invokeController(
+    private fun invalidateView(view: View, vararg modeNames: String): Boolean {
+        val mode = resolveUpdateMode(*modeNames) ?: return false
+        return invokeController(
             "invalidate",
             arrayOf(View::class.java, mode.javaClass),
             arrayOf(view, mode),

--- a/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxInkSurfaceView.kt
+++ b/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxInkSurfaceView.kt
@@ -78,7 +78,10 @@ class SlopshellBooxInkSurfaceView @JvmOverloads constructor(
 
     override fun onWindowVisibilityChanged(visibility: Int) {
         super.onWindowVisibilityChanged(visibility)
-        touchHelper?.setRawDrawingEnabled(visibility == VISIBLE)
+        val helper = touchHelper ?: return
+        val active = visibility == VISIBLE
+        helper.setRawDrawingEnabled(active)
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(active)
     }
 
     private fun restartRawDrawing() {
@@ -100,11 +103,10 @@ class SlopshellBooxInkSurfaceView @JvmOverloads constructor(
         helper.setRawInputReaderEnable(true)
         helper.setLimitRect(limit, emptyList<Rect>())
         helper.openRawDrawing()
-        helper.setRawDrawingEnabled(true)
-        if (windowVisibility != VISIBLE) {
-            helper.setRawDrawingEnabled(false)
-        }
+        val visible = windowVisibility == VISIBLE
+        helper.setRawDrawingEnabled(visible)
         touchHelper = helper
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(visible)
         SlopshellBooxEinkController.configureInkView(this)
     }
 
@@ -113,6 +115,7 @@ class SlopshellBooxInkSurfaceView @JvmOverloads constructor(
         runCatching { helper.setRawDrawingEnabled(false) }
         runCatching { helper.closeRawDrawing() }
         touchHelper = null
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(false)
     }
 
     private fun emitStroke() {
@@ -120,6 +123,7 @@ class SlopshellBooxInkSurfaceView @JvmOverloads constructor(
         rawPoints.clear()
         val stroke = slopshellInkStrokeFromPoints(pointerType = "stylus", points = points) ?: return
         onCommit(listOf(stroke))
+        SlopshellBooxRuntimeProbe.recordInkStroke()
     }
 
     private fun TouchPointList.toInkPoints(): List<SlopshellInkPoint> {

--- a/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatus.kt
+++ b/platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatus.kt
@@ -1,0 +1,81 @@
+package com.slopshell.android
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class SlopshellBooxDetectionSignals(
+    val manufacturer: String,
+    val onyxSdkPackagePresent: Boolean,
+    val touchHelperClassPresent: Boolean,
+    val epdControllerClassPresent: Boolean,
+) {
+    val detectedAsBoox: Boolean
+        get() = shouldTreatAsBooxDevice(
+            manufacturer = manufacturer,
+            hasOnyxSdkPackage = onyxSdkPackagePresent,
+            hasTouchHelperClass = touchHelperClassPresent,
+        )
+}
+
+data class SlopshellBooxRuntimeMetrics(
+    val rawDrawingActive: Boolean = false,
+    val inkStrokeCount: Long = 0L,
+    val lastInkStrokeAtMs: Long = 0L,
+    val einkRefreshAttemptCount: Long = 0L,
+    val einkRefreshSuccessCount: Long = 0L,
+    val lastEinkRefreshAtMs: Long = 0L,
+)
+
+data class SlopshellBooxRuntimeStatus(
+    val detectionSignals: SlopshellBooxDetectionSignals,
+    val metrics: SlopshellBooxRuntimeMetrics,
+)
+
+object SlopshellBooxRuntimeProbe {
+    @Volatile
+    private var clock: () -> Long = { System.currentTimeMillis() }
+
+    private val _metrics = MutableStateFlow(SlopshellBooxRuntimeMetrics())
+    val metrics: StateFlow<SlopshellBooxRuntimeMetrics> = _metrics.asStateFlow()
+
+    fun setRawDrawingActive(active: Boolean) {
+        _metrics.update { current ->
+            if (current.rawDrawingActive == active) current else current.copy(rawDrawingActive = active)
+        }
+    }
+
+    fun recordInkStroke() {
+        val now = clock()
+        _metrics.update { current ->
+            current.copy(
+                inkStrokeCount = current.inkStrokeCount + 1,
+                lastInkStrokeAtMs = now,
+            )
+        }
+    }
+
+    fun recordEinkRefresh(success: Boolean) {
+        val now = clock()
+        _metrics.update { current ->
+            current.copy(
+                einkRefreshAttemptCount = current.einkRefreshAttemptCount + 1,
+                einkRefreshSuccessCount = current.einkRefreshSuccessCount + if (success) 1L else 0L,
+                lastEinkRefreshAtMs = if (success) now else current.lastEinkRefreshAtMs,
+            )
+        }
+    }
+
+    fun reset() {
+        _metrics.value = SlopshellBooxRuntimeMetrics()
+    }
+
+    internal fun setClockForTesting(clock: () -> Long) {
+        this.clock = clock
+    }
+
+    internal fun resetClockForTesting() {
+        this.clock = { System.currentTimeMillis() }
+    }
+}

--- a/platforms/android/app/src/test/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatusTest.kt
+++ b/platforms/android/app/src/test/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatusTest.kt
@@ -1,0 +1,132 @@
+package com.slopshell.android
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SlopshellBooxRuntimeStatusTest {
+    @Before
+    fun resetProbe() {
+        SlopshellBooxRuntimeProbe.reset()
+    }
+
+    @After
+    fun resetProbeClock() {
+        SlopshellBooxRuntimeProbe.resetClockForTesting()
+        SlopshellBooxRuntimeProbe.reset()
+    }
+
+    @Test
+    fun detectionSignalsReportsBooxOnExplicitOnyxManufacturer() {
+        val signals = SlopshellBooxDetectionSignals(
+            manufacturer = "Onyx",
+            onyxSdkPackagePresent = false,
+            touchHelperClassPresent = false,
+            epdControllerClassPresent = false,
+        )
+        assertTrue(signals.detectedAsBoox)
+    }
+
+    @Test
+    fun detectionSignalsReportsBooxOnSdkPackageOrTouchHelperOnly() {
+        val viaSdk = SlopshellBooxDetectionSignals(
+            manufacturer = "Acme",
+            onyxSdkPackagePresent = true,
+            touchHelperClassPresent = false,
+            epdControllerClassPresent = false,
+        )
+        val viaTouchHelper = SlopshellBooxDetectionSignals(
+            manufacturer = "Acme",
+            onyxSdkPackagePresent = false,
+            touchHelperClassPresent = true,
+            epdControllerClassPresent = false,
+        )
+        assertTrue(viaSdk.detectedAsBoox)
+        assertTrue(viaTouchHelper.detectedAsBoox)
+    }
+
+    @Test
+    fun detectionSignalsRejectsNonOnyxWithoutSignals() {
+        val signals = SlopshellBooxDetectionSignals(
+            manufacturer = "Acme",
+            onyxSdkPackagePresent = false,
+            touchHelperClassPresent = false,
+            epdControllerClassPresent = false,
+        )
+        assertFalse(signals.detectedAsBoox)
+    }
+
+    @Test
+    fun probeStartsIdleWithZeroCounters() {
+        val metrics = SlopshellBooxRuntimeProbe.metrics.value
+        assertFalse(metrics.rawDrawingActive)
+        assertEquals(0L, metrics.inkStrokeCount)
+        assertEquals(0L, metrics.einkRefreshAttemptCount)
+        assertEquals(0L, metrics.einkRefreshSuccessCount)
+        assertEquals(0L, metrics.lastInkStrokeAtMs)
+        assertEquals(0L, metrics.lastEinkRefreshAtMs)
+    }
+
+    @Test
+    fun rawDrawingActiveFlagTracksLastSetValue() {
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(true)
+        assertTrue(SlopshellBooxRuntimeProbe.metrics.value.rawDrawingActive)
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(false)
+        assertFalse(SlopshellBooxRuntimeProbe.metrics.value.rawDrawingActive)
+    }
+
+    @Test
+    fun recordInkStrokeIncrementsCounterAndStampsClock() {
+        SlopshellBooxRuntimeProbe.setClockForTesting { 1_700_000_000_001L }
+        SlopshellBooxRuntimeProbe.recordInkStroke()
+        SlopshellBooxRuntimeProbe.recordInkStroke()
+        val metrics = SlopshellBooxRuntimeProbe.metrics.value
+        assertEquals(2L, metrics.inkStrokeCount)
+        assertEquals(1_700_000_000_001L, metrics.lastInkStrokeAtMs)
+    }
+
+    @Test
+    fun recordEinkRefreshSeparatesAttemptsFromSuccesses() {
+        SlopshellBooxRuntimeProbe.setClockForTesting { 1_700_000_000_010L }
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = false)
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = true)
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = true)
+        val metrics = SlopshellBooxRuntimeProbe.metrics.value
+        assertEquals(3L, metrics.einkRefreshAttemptCount)
+        assertEquals(2L, metrics.einkRefreshSuccessCount)
+        assertEquals(1_700_000_000_010L, metrics.lastEinkRefreshAtMs)
+    }
+
+    @Test
+    fun failedRefreshDoesNotAdvanceLastSuccessTimestamp() {
+        SlopshellBooxRuntimeProbe.setClockForTesting { 100L }
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = true)
+        SlopshellBooxRuntimeProbe.setClockForTesting { 200L }
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = false)
+        val metrics = SlopshellBooxRuntimeProbe.metrics.value
+        assertEquals(2L, metrics.einkRefreshAttemptCount)
+        assertEquals(1L, metrics.einkRefreshSuccessCount)
+        assertEquals(100L, metrics.lastEinkRefreshAtMs)
+    }
+
+    @Test
+    fun resetClearsCountersAndRawDrawingFlag() {
+        SlopshellBooxRuntimeProbe.setClockForTesting { 42L }
+        SlopshellBooxRuntimeProbe.setRawDrawingActive(true)
+        SlopshellBooxRuntimeProbe.recordInkStroke()
+        SlopshellBooxRuntimeProbe.recordEinkRefresh(success = true)
+
+        SlopshellBooxRuntimeProbe.reset()
+
+        val metrics = SlopshellBooxRuntimeProbe.metrics.value
+        assertFalse(metrics.rawDrawingActive)
+        assertEquals(0L, metrics.inkStrokeCount)
+        assertEquals(0L, metrics.einkRefreshAttemptCount)
+        assertEquals(0L, metrics.einkRefreshSuccessCount)
+        assertEquals(0L, metrics.lastInkStrokeAtMs)
+        assertEquals(0L, metrics.lastEinkRefreshAtMs)
+    }
+}

--- a/platforms/android/project_files_test.go
+++ b/platforms/android/project_files_test.go
@@ -23,6 +23,7 @@ func TestSlopshellAndroidProjectIncludesExpectedFiles(t *testing.T) {
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellAudioCaptureService.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellBooxDevice.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellBooxInkSurfaceView.kt"),
+		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellBooxRuntimeStatus.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellCanvasTransport.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellCanvasWebView.kt"),
 		filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellChatTransport.kt"),
@@ -37,6 +38,7 @@ func TestSlopshellAndroidProjectIncludesExpectedFiles(t *testing.T) {
 		filepath.Join("flow-contracts", "src", "test", "kotlin", "com", "slopshell", "android", "flow", "FlowContractTest.kt"),
 		filepath.Join("flow-contracts", "src", "test", "resources", "flow-fixtures.json"),
 		filepath.Join("app", "src", "test", "kotlin", "com", "slopshell", "android", "SlopshellDialogueModeTest.kt"),
+		filepath.Join("app", "src", "test", "kotlin", "com", "slopshell", "android", "SlopshellBooxRuntimeStatusTest.kt"),
 		filepath.Join("app", "src", "main", "res", "values", "strings.xml"),
 		filepath.Join("app", "src", "main", "res", "values", "themes.xml"),
 	}
@@ -129,7 +131,14 @@ func TestSlopshellAndroidSourcesCoverThinClientResponsibilities(t *testing.T) {
 	}{
 		{
 			relative: filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "MainActivity.kt"),
-			snippets: []string{"BlackScreenDialogueSurface", "FLAG_KEEP_SCREEN_ON", "Start Dialogue", "Exit Dialogue"},
+			snippets: []string{
+				"BlackScreenDialogueSurface",
+				"FLAG_KEEP_SCREEN_ON",
+				"Start Dialogue",
+				"Exit Dialogue",
+				"BooxRuntimeStatusPanel",
+				"SlopshellBooxRuntimeProbe.metrics.collectAsState()",
+			},
 		},
 		{
 			relative: filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellServerDiscovery.kt"),
@@ -166,6 +175,8 @@ func TestSlopshellAndroidSourcesCoverThinClientResponsibilities(t *testing.T) {
 				"setViewDefaultUpdateMode",
 				"applyGCOnce",
 				"setWebViewContrastOptimize",
+				"detectSlopshellBooxDetectionSignals",
+				"SlopshellBooxRuntimeProbe.recordEinkRefresh",
 			},
 		},
 		{
@@ -174,10 +185,25 @@ func TestSlopshellAndroidSourcesCoverThinClientResponsibilities(t *testing.T) {
 				"TouchHelper.create",
 				"setRawInputReaderEnable(true)",
 				"openRawDrawing",
-				"setRawDrawingEnabled(true)",
+				"setRawDrawingEnabled(visible)",
 				"closeRawDrawing",
 				"onRawDrawingTouchPointListReceived",
 				"SlopshellInkStroke",
+				"SlopshellBooxRuntimeProbe.setRawDrawingActive",
+				"SlopshellBooxRuntimeProbe.recordInkStroke()",
+			},
+		},
+		{
+			relative: filepath.Join("app", "src", "main", "kotlin", "com", "slopshell", "android", "SlopshellBooxRuntimeStatus.kt"),
+			snippets: []string{
+				"data class SlopshellBooxDetectionSignals",
+				"data class SlopshellBooxRuntimeMetrics",
+				"object SlopshellBooxRuntimeProbe",
+				"epdControllerClassPresent",
+				"einkRefreshAttemptCount",
+				"einkRefreshSuccessCount",
+				"recordInkStroke",
+				"recordEinkRefresh",
 			},
 		},
 	}

--- a/scripts/check-native-validation-docs.mjs
+++ b/scripts/check-native-validation-docs.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 const repoRoot = process.cwd();
 const packageJSON = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 const nativeDocs = fs.readFileSync(path.join(repoRoot, 'docs', 'native-clients.md'), 'utf8');
+const booxDocs = fs.readFileSync(path.join(repoRoot, 'docs', 'boox-validation.md'), 'utf8');
 const flowDocs = fs.readFileSync(path.join(repoRoot, 'tests', 'flows', 'README.md'), 'utf8');
 const workflow = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'test-reports.yml'), 'utf8');
 
@@ -14,6 +15,7 @@ const requiredScripts = [
   'test:flows:android:contract',
   'test:flows:android:contract:jvm',
   'test:flows:native',
+  'test:flows:boox:hardware',
   'test:native-docs',
 ];
 
@@ -36,11 +38,35 @@ const nativeDocNeedles = [
   'Boox e-ink refresh',
   'Product-doc honesty',
   'faepmac1',
+  'boox-validation.md',
 ];
 
 for (const needle of nativeDocNeedles) {
   if (!nativeDocs.includes(needle)) {
     errors.push(`docs/native-clients.md must mention ${needle}`);
+  }
+}
+
+const booxDocNeedles = [
+  '## Boox SDK and Tooling Reality',
+  'There is no official Boox emulator',
+  'com.onyx.android.sdk:onyxsdk-device:1.1.11',
+  'com.onyx.android.sdk:onyxsdk-pen:1.2.1',
+  'https://repo.boox.com/repository/maven-public/',
+  '## Runtime Observability',
+  'SlopshellBooxRuntimeProbe',
+  '## Off-Device Automated Checks',
+  'gradle -p platforms/android app:testDebugUnitTest',
+  '## Hardware Validation Script',
+  './scripts/test-boox-hardware.sh',
+  '## Manual Hardware Checklist',
+  '## Closure Evidence',
+  '## Documentation Honesty',
+];
+
+for (const needle of booxDocNeedles) {
+  if (!booxDocs.includes(needle)) {
+    errors.push(`docs/boox-validation.md must mention ${needle}`);
   }
 }
 

--- a/scripts/test-boox-hardware.sh
+++ b/scripts/test-boox-hardware.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Boox hardware validation orchestrator.
+# Runs the parts that can be automated against an attached Onyx Boox device
+# and prints the manual checklist that owns the rest of the closure evidence.
+# Closure rules live in docs/boox-validation.md.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+artifact_dir="$repo_root/artifacts/boox-validation"
+mkdir -p "$artifact_dir"
+
+log() {
+  printf '\n[%s] %s\n' "boox-hardware" "$1" >&2
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+resolve_android_sdk() {
+  local candidate
+  candidate="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  if [[ -z "$candidate" ]]; then
+    for guess in "$HOME/android-sdk" "$HOME/Android/Sdk"; do
+      if [[ -d "$guess" ]]; then
+        candidate="$guess"
+        break
+      fi
+    done
+  fi
+  if [[ -z "$candidate" ]]; then
+    echo "ANDROID_HOME not set and no SDK found at \$HOME/android-sdk or \$HOME/Android/Sdk" >&2
+    exit 1
+  fi
+  export ANDROID_HOME="$candidate"
+  export ANDROID_SDK_ROOT="$candidate"
+  export PATH="$candidate/platform-tools:$candidate/emulator:$PATH"
+}
+
+require_cmd adb
+require_cmd gradle
+resolve_android_sdk
+
+log "checking attached devices"
+mapfile -t devices < <(adb devices | awk 'NR>1 && $2=="device" {print $1}')
+if [[ "${#devices[@]}" -eq 0 ]]; then
+  echo "no adb devices in 'device' state; connect a Boox device with USB debugging enabled" >&2
+  exit 1
+fi
+if [[ "${#devices[@]}" -gt 1 ]]; then
+  echo "more than one adb device attached; set ANDROID_SERIAL to choose one" >&2
+  printf '  %s\n' "${devices[@]}" >&2
+  exit 1
+fi
+serial="${ANDROID_SERIAL:-${devices[0]}}"
+export ANDROID_SERIAL="$serial"
+
+manufacturer="$(adb -s "$serial" shell getprop ro.product.manufacturer | tr -d '\r' | tr '[:upper:]' '[:lower:]')"
+model="$(adb -s "$serial" shell getprop ro.product.model | tr -d '\r')"
+android_sdk="$(adb -s "$serial" shell getprop ro.build.version.sdk | tr -d '\r')"
+android_release="$(adb -s "$serial" shell getprop ro.build.version.release | tr -d '\r')"
+
+log "device: serial=$serial manufacturer=$manufacturer model=$model android=$android_release sdk=$android_sdk"
+
+if [[ "$manufacturer" != "onyx" ]]; then
+  echo "device manufacturer '$manufacturer' is not 'onyx'; refusing to run Boox validation" >&2
+  exit 1
+fi
+
+device_summary="$artifact_dir/device.txt"
+{
+  echo "serial: $serial"
+  echo "manufacturer: $manufacturer"
+  echo "model: $model"
+  echo "android_release: $android_release"
+  echo "android_sdk: $android_sdk"
+  echo "captured_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$device_summary"
+log "device summary recorded at $device_summary"
+
+log "installing debug APK"
+gradle -p platforms/android :app:installDebug --console=plain --no-daemon
+
+package_name="com.slopshell.android"
+log "launching $package_name/.MainActivity"
+adb -s "$serial" shell am start -W -n "$package_name/.MainActivity" >/dev/null
+
+log "waiting 3s for first frame"
+sleep 3
+
+screenshot="$artifact_dir/launch.png"
+adb -s "$serial" exec-out screencap -p >"$screenshot"
+log "launch screenshot saved to $screenshot"
+
+cat <<'CHECKLIST'
+
+Manual checklist (record pass/fail for each item; missing item = fail):
+
+  1. Boox status panel shows manufacturer, sdk=true, TouchHelper=true, EpdController=true.
+  2. Drawing a stroke increments the strokes counter on the panel.
+  3. The same stroke arrives at the server as an ink_stroke payload.
+  4. Canvas content uses the e-ink CSS (white bg, black text, no animations).
+  5. After first canvas render, refresh counter shows M/N applied with M >= 1.
+  6. A second canvas update increments both M and N; no persistent ghost.
+  7. WebView contrast keeps gradient/low-contrast canvas content readable.
+  8. Black-screen dialogue mode still enters/exits normally on this device.
+
+Attach the screenshot under artifacts/boox-validation/ and the device summary
+to the PR or issue that claims Boox readiness. Closure rules are in
+docs/boox-validation.md.
+
+CHECKLIST


### PR DESCRIPTION
Refs #701. This PR does **not** close the issue. The Boox closure standard in
[`docs/boox-validation.md#closure-evidence`](docs/boox-validation.md) requires
current Boox hardware evidence (off-device suite + script installer step +
checklist + `ro.product.model` and SDK level), and this PR only delivers the
off-device leg and the hardware tooling. #701 stays open until the hardware
leg is run on a current Onyx device and the evidence is attached.

Splits Boox readiness from the generic Android slice. Boox now has its own
evidence document, runtime observability, off-device coverage, and a hardware
validation script. Generic Android validation is no longer accepted as Boox
evidence.

## What this PR delivers

- Acceptance #1 (SDK/tooling reality): `docs/boox-validation.md` records the
  Onyx SDK pins, the Maven repo, the classes the code actually relies on, and
  states that no Boox emulator exists, so closure requires hardware.
- Acceptance #2 (Onyx path observable): `SlopshellBooxRuntimeProbe` exposes a
  `StateFlow<SlopshellBooxRuntimeMetrics>` with raw-drawing active flag,
  ink-stroke counter, and refresh attempt/success counters. The detection
  signals are captured by `detectSlopshellBooxDetectionSignals`.
  `MainActivity.BooxRuntimeStatusPanel` renders both as a status block.
- Acceptance #3 / off-device leg: JVM unit suite + structural Go suite
  enforce the new files, panel wiring, probe wiring, and the new doc + script.
- Acceptance #3 / hardware tooling (not evidence):
  `scripts/test-boox-hardware.sh` is the dedicated hardware orchestrator that
  refuses to run unless an Onyx-manufacturer device is attached. The script is
  delivered; the evidence is not.
- Acceptance #4 (docs separate Boox completion from generic Android):
  `docs/native-clients.md`, `docs/native-clients-plan.md`, and
  `docs/spec-index.md` point at `boox-validation.md` for Boox closure and
  forbid reusing Android emulator/contract evidence as Boox evidence.

## What this PR explicitly does NOT deliver

Acceptance #4 of #701 — "Device validation steps and current evidence exist
for raw drawing and e-ink refresh" — is only partly met: the **steps** exist
(script + checklist), the **current evidence** does not. That requires:

- running `./scripts/test-boox-hardware.sh` against a current Onyx Boox
- attaching `artifacts/boox-validation/launch.png` + `device.txt`
- running the manual checklist and recording each item
- recording `ro.product.model` and Android SDK level

That work is the next step on #701 and must land before #701 can be closed.

## Verification (off-device, on this branch)

### Boox-specific SDK/tooling reality is documented (acceptance #1)

```
$ rg -n "There is no official Boox emulator|onyxsdk-(device|pen):|repo.boox.com/repository/maven-public/" docs/boox-validation.md
8:  [`platforms/android/app/build.gradle.kts`](../platforms/android/app/build.gradle.kts):
10:- `com.onyx.android.sdk:onyxsdk-device:1.1.11`
11:- `com.onyx.android.sdk:onyxsdk-pen:1.2.1`
17:https://repo.boox.com/repository/maven-public/
27:There is no official Boox emulator and no vendor-supplied virtual device for
```

### The Onyx path is observable (acceptance #2)

`SlopshellBooxRuntimeProbe` (`platforms/android/app/src/main/kotlin/com/slopshell/android/SlopshellBooxRuntimeStatus.kt`)
exposes `StateFlow<SlopshellBooxRuntimeMetrics>`. Detection signals come from
`detectSlopshellBooxDetectionSignals` in `SlopshellBooxDevice.kt`.
`MainActivity.BooxRuntimeStatusPanel` renders both as a status block. The probe
is fed from `SlopshellBooxInkSurfaceView.ensureTouchHelper`/`shutdownTouchHelper`/`emitStroke`
and `SlopshellBooxEinkController.refreshContentView`.

### Off-device automated checks (acceptance #3 / off-device leg)

```
$ gradle -p platforms/android app:testDebugUnitTest --console=plain --no-daemon
BUILD SUCCESSFUL in 6s
22 actionable tasks: 1 executed, 21 up-to-date
```

```
$ for f in platforms/android/app/build/test-results/testDebugUnitTest/TEST-*.xml; do grep '<testsuite ' "$f" | head -1; done
<testsuite name="com.slopshell.android.SlopshellBooxRuntimeStatusTest" tests="9" skipped="0" failures="0" errors="0" ...>
<testsuite name="com.slopshell.android.SlopshellDialogueModeTest" tests="3" skipped="0" failures="0" errors="0" ...>
<testsuite name="com.slopshell.android.SlopshellInkStrokeBuilderTest" tests="2" skipped="0" failures="0" errors="0" ...>
<testsuite name="com.slopshell.android.SlopshellModelContractTest" tests="5" skipped="0" failures="0" errors="0" ...>
```

The 9 new `SlopshellBooxRuntimeStatusTest` cases cover detection-signal
interpretation (manufacturer-only, SDK-only, TouchHelper-only, none), the
raw-drawing flag, the ink-stroke counter, refresh attempt vs. success
counters, the stamp-on-success rule for `lastEinkRefreshAtMs`, and the reset
behavior.

```
$ go test ./platforms/android/... ./internal/surface/...
ok  	github.com/sloppy-org/slopshell/platforms/android	0.002s
ok  	github.com/sloppy-org/slopshell/internal/surface	0.012s
```

```
$ go test ./...
... ok  	github.com/sloppy-org/slopshell/internal/web	27.526s
... ok  	github.com/sloppy-org/slopshell/platforms/android	(cached)
... ok  	github.com/sloppy-org/slopshell/internal/surface	(cached)
```

```
$ npm run test:native-docs
[native-docs-check] Native validation docs and scripts are aligned.
```

```
$ npm run test:flows:android:contract:jvm
BUILD SUCCESSFUL in 3s
4 actionable tasks: 4 up-to-date
```

### Hardware validation script delivered (acceptance #3 / hardware tooling)

```
$ bash -n scripts/test-boox-hardware.sh && echo syntax-ok
syntax-ok
$ ls -l scripts/test-boox-hardware.sh
-rwxr-xr-x 1 ert ert 4034 ... scripts/test-boox-hardware.sh
```

Script behavior: refuses to run unless an Onyx-manufacturer device is
attached, installs the debug APK with `gradle :app:installDebug`, launches
`MainActivity`, saves a device summary plus screenshot under
`artifacts/boox-validation/`, and prints the eight-item manual checklist
(detection panel, raw drawing, ink-stroke transport, e-ink CSS, refresh
tally, follow-up update, contrast, black-screen dialogue).
`docs/boox-validation.md#closure-evidence` requires the off-device suite, the
script's installer step, the checklist, and the device's `ro.product.model` +
SDK level before any Boox-readiness claim. The script is delivered here; the
evidence run is the follow-up that closes #701.

### Docs separate Boox completion from generic Android (acceptance #5)

`docs/native-clients.md` and `docs/native-clients-plan.md` now point at
`boox-validation.md` for Boox closure and explicitly forbid reusing Android
emulator/contract evidence as Boox evidence. `docs/spec-index.md` lists
`boox-validation.md` as a top-level spec. The new
`TestBooxValidationDocIsIndexedAndAnchored` Go test enforces the doc
structure, cross-doc links, and that the hardware script remains executable.

```
$ go test ./internal/surface/... -run TestBooxValidationDocIsIndexedAndAnchored
ok  	github.com/sloppy-org/slopshell/internal/surface	0.012s
```
